### PR TITLE
Add new style feed enabled/disabled info to the wctracker.

### DIFF
--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -136,6 +136,13 @@ class Tracker {
 		 */
 		$data['extensions']['facebook-for-woocommerce']['product-feed-config'] = get_transient( self::TRANSIENT_WCTRACKER_FB_FEED_CONFIG );
 
+		/**
+		 * Detect if the user has enabled the new experimental feed generator feature.
+		 *
+		 * @since x.x.x
+		 */
+		$data['extensions']['facebook-for-woocommerce']['new-feed-generator-enabled'] = wc_bool_to_string( facebook_for_woocommerce()->get_integration()->is_new_style_feed_generation_enabled() );
+
 		return $data;
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This is a supplementary PR to the #2099. This adds a new field to the tracker data that checks if merchants are switching to the new generator.

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
1. Using `wp wc tracker snapshot --format=json` check if the new field `new-feed-generator-enabled' is picked up in the snapshot
2. Change the setting 'Experimental! Enable new style...`
![image](https://user-images.githubusercontent.com/17271089/137733214-e6078f29-6d29-4a9c-ba29-a6b6e079c92a.png)
3. Check again the snapshot data to see if the value has changed.

### TODO

- [ ] After the merge make sure that this change is documented and information about this new tracked field is available to the users.

### Changelog entry

<!-- Add suggested changelog entry here. For example: -->
New - Add tracking of the experimental feed generator feature.
<!-- See [previous releases](../../releases) for more examples. -->
