### PR TITLE
Fix product local non-latin attribute names sync into Facebook

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -814,9 +814,8 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 							if ( ! isset( $product_data['custom_data'] ) ) {
 								$product_data['custom_data'] = array();
 							}
-
+							$new_name                                 = wc_attribute_label( $new_name, $product );
 							$product_data['custom_data'][ $new_name ] = urldecode( $option_values[0] );
-
 							break;
 					}//end switch
 				} else {


### PR DESCRIPTION
When you have local product attribute names to be all non-latin characters and you sync that to Facebook, you get corrupted attribute names.

### Changes proposed in this Pull Request:

Properly prepare attribute names before the sync by taking original attribute names from parent product instead of using adjusted meta_key values from the database as attribute name.

Closes #2130.

### Screenshots:

Before:

<img width="1036" alt="_4__Facebook" src="https://user-images.githubusercontent.com/9010963/165249317-02509040-81eb-4501-92d1-6ff50f9b4a3e.png">

After:

<img width="1036" alt="_4__Facebook" src="https://user-images.githubusercontent.com/9010963/165249593-5102740a-3451-46a3-a628-c417ca671243.png">

### Detailed test instructions:

1. Create variable product.
2. Add Custom product attribute in a language which has no latin characters in its alphabet (on the screen below I added two of such attributes).

<img width="1227" alt="Notification_Center" src="https://user-images.githubusercontent.com/9010963/165250410-77f213cd-5907-41d1-86ac-a8f0cdb15726.png">

3. Create Variations with those attributes.

<img width="1223" alt="Cursor_and_Edit_product_“V-Neck_T-Shirt_UTF8_Compatible_12345678910111213141516”_‹_WordPress-Facebook_—_WordPress" src="https://user-images.githubusercontent.com/9010963/165251136-5a7023ed-b332-4606-9c8c-314fb84efe2e.png">

4. Sync product to Facebook.

<img width="290" alt="Edit_product_“V-Neck_T-Shirt_UTF8_Compatible_12345678910111213141516”_‹_WordPress-Facebook_—_WordPress" src="https://user-images.githubusercontent.com/9010963/165251098-9164bf33-e75e-40b3-9b59-659500910d95.png">

5. Visit product page on Facebook to see the results. You should see attribute names are readable in their corresponding languages instead of a mix of numbers and percent characters (like on the images under Screenshots section of this PR)

### Changelog entry

> Fix - Non-latin custom product attribute names sync
