### PR TITLE
Adds backward compatibility for WC 6.1, 6.2, 6.3. (#2362)

### DIFF
--- a/includes/Admin/Tasks/Setup.php
+++ b/includes/Admin/Tasks/Setup.php
@@ -82,9 +82,6 @@ class Setup extends Task {
 			return parent::get_parent_id();
 		}
 
-		if ( ! $this->task_list ) {
-			return '';
-		}
-		return $this->task_list->get_list_id();
+		return 'extended'; // The parent task list id.
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2362 .

This PR implements the `get_parent_id` method in the `Setup` Task class as it is declared as `abstract` in WooCommerce versions mentioned.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install and activate WooCommerce `6.2`.
2. Install this PR and verify the task Setup Facebook for WooCommerce is displayed properly in WooCommerce > Home.
3. Update WooCommerce to version `7.1`
4. Verify the task Setup Facebook for WooCommerce is displayed properly in WooCommerce > Home.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Add backward compatibility for WC 6.1, 6.2, and 6.3 versions.
