### PR TITLE
Fix `phpcs` violations in `includes/API` folder

### DIFF
--- a/includes/API/Catalog/Product_Group/Products/Read/Request.php
+++ b/includes/API/Catalog/Product_Group/Products/Read/Request.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\API\Catalog\Product_Group\Products\Read;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 use WooCommerce\Facebook\API;
 

--- a/includes/API/Catalog/Product_Group/Products/Read/Response.php
+++ b/includes/API/Catalog/Product_Group/Products/Read/Response.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\API\Catalog\Product_Group\Products\Read;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 use WooCommerce\Facebook\API;
 

--- a/includes/API/Catalog/Product_Item/Find/Request.php
+++ b/includes/API/Catalog/Product_Item/Find/Request.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\API\Catalog\Product_Item\Find;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 use WooCommerce\Facebook\API;
 
@@ -46,7 +45,7 @@ class Request extends API\Request {
 	 */
 	public function __construct( $catalog_id, $retailer_id ) {
 
-		parent::__construct( "catalog:{$catalog_id}:" . base64_encode( $retailer_id ), 'GET' );
+		parent::__construct( "catalog:{$catalog_id}:" . base64_encode( $retailer_id ), 'GET' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 	}
 
 

--- a/includes/API/Catalog/Request.php
+++ b/includes/API/Catalog/Request.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\API\Catalog;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 use WooCommerce\Facebook\API\Request as ApiRequest;
 
@@ -20,8 +19,7 @@ use WooCommerce\Facebook\API\Request as ApiRequest;
  *
  * @link https://developers.facebook.com/docs/marketing-api/reference/product-catalog/v13.0
  */
-class Request extends ApiRequest
-{
+class Request extends ApiRequest {
 	/**
 	 * Gets the rate limit ID.
 	 *
@@ -38,6 +36,6 @@ class Request extends ApiRequest
 	 * @param string $catalog_id catalog ID
 	 */
 	public function __construct( string $catalog_id ) {
-		parent::__construct("/{$catalog_id}?fields=name", 'GET');
+		parent::__construct( "/{$catalog_id}?fields=name", 'GET' );
 	}
 }

--- a/includes/API/Catalog/Send_Item_Updates/Request.php
+++ b/includes/API/Catalog/Send_Item_Updates/Request.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\API\Catalog\Send_Item_Updates;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 use WooCommerce\Facebook\API;
 

--- a/includes/API/Catalog/Send_Item_Updates/Response.php
+++ b/includes/API/Catalog/Send_Item_Updates/Response.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\API\Catalog\Send_Item_Updates;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Send_Item_Updates API response object

--- a/includes/API/Exceptions/ConnectApiException.php
+++ b/includes/API/Exceptions/ConnectApiException.php
@@ -1,9 +1,8 @@
 <?php
-// phpcs:ignoreFile
 
 namespace WooCommerce\Facebook\API\Exceptions;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Class Connect_WC_API_Exception.

--- a/includes/API/Exceptions/Request_Limit_Reached.php
+++ b/includes/API/Exceptions/Request_Limit_Reached.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\API\Exceptions;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
 

--- a/includes/API/FBE/Configuration/Messenger.php
+++ b/includes/API/FBE/Configuration/Messenger.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/FBE/Configuration/Update/Request.php
+++ b/includes/API/FBE/Configuration/Update/Request.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\API\FBE\Configuration\Update;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 use WooCommerce\Facebook\API\FBE\Configuration;
 

--- a/includes/API/FBE/Installation/Read/Request.php
+++ b/includes/API/FBE/Installation/Read/Request.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\API\FBE\Installation\Read;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 use WooCommerce\Facebook\API\FBE\Installation;
 

--- a/includes/API/FBE/Installation/Read/Response.php
+++ b/includes/API/FBE/Installation/Read/Response.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\FBE\Installation\Read;

--- a/includes/API/FBE/Installation/Request.php
+++ b/includes/API/FBE/Installation/Request.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\API\FBE\Installation;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 use WooCommerce\Facebook\API;
 

--- a/includes/API/Pixel/Events/Request.php
+++ b/includes/API/Pixel/Events/Request.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\API\Pixel\Events;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 use WooCommerce\Facebook\API;
 use WooCommerce\Facebook\Events\Event;

--- a/includes/API/ProductCatalog/Products/Id/Request.php
+++ b/includes/API/ProductCatalog/Products/Id/Request.php
@@ -19,7 +19,7 @@ class Request extends ApiRequest {
 	 * @param string $facebook_product_retailer_id Facebook Product Retailer ID.
 	 */
 	public function __construct( string $facebook_product_catalog_id, string $facebook_product_retailer_id ) {
-		$path = "catalog:{$facebook_product_catalog_id}:" . base64_encode( $facebook_product_retailer_id );
+		$path = "catalog:{$facebook_product_catalog_id}:" . base64_encode( $facebook_product_retailer_id ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 		parent::__construct( "/{$path}/?fields=id,product_group{id}", 'GET' );
 	}
 }

--- a/includes/API/Traits/Idempotent_Request.php
+++ b/includes/API/Traits/Idempotent_Request.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\API\Traits;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Idempotent request trait.

--- a/includes/API/Traits/Rate_Limited_API.php
+++ b/includes/API/Traits/Rate_Limited_API.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\API\Traits;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Rate limited API trait.

--- a/includes/API/Traits/Rate_Limited_Request.php
+++ b/includes/API/Traits/Rate_Limited_Request.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\API\Traits;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Rate limited request trait.

--- a/includes/API/Traits/Rate_Limited_Response.php
+++ b/includes/API/Traits/Rate_Limited_Response.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\API\Traits;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Rate limited response trait.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Related to https://github.com/woocommerce/facebook-for-woocommerce/issues/2372

This PR removes the `phpcs:ignoreFile` across all the files inside `includes/API` and fixes the resulting `phpcs` violations.

There are a few Warnings in phpcs. This PR does not handle them to avoid making any breaking changes.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Additional details:
* Replaces `or` with `||`
* Removes incorrect spacing
* Adds `phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode`. `base64_encode` is used to encode the retail ID before making the request. So it is safe.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Fix phpcs violations in the includes/API folder.
