### PR TITLE
Rephrase the Onboarding task title

### DIFF
--- a/includes/Admin/Tasks/Setup.php
+++ b/includes/Admin/Tasks/Setup.php
@@ -33,7 +33,7 @@ class Setup extends Task {
 	 * @return string
 	 */
 	public function get_title() {
-		return esc_html__( 'Advertise your products across Meta\'s platforms, including Facebook, Instagram, and WhatsApp', 'facebook-for-woocommerce' );
+		return __( 'Advertise your products across Meta\'s platforms, including Facebook, Instagram, and WhatsApp', 'facebook-for-woocommerce' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2458 

This PR:
* Replaces the task title with the one mentioned in the issue.
* Removes the task content.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

![image](https://user-images.githubusercontent.com/179533/214509682-42e79551-a549-481e-90b6-ed13d09e97b1.png)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install and active Facebook for WooCommerce on a fresh WordPress install.
2. Navigate to `WooCommerce > Home` and verify the text of the Facebook onboarding task is `Advertise your products across Meta's platforms, including Facebook, Instagram, and WhatsApp`


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Update - Onboarding task title and remove task content
