### PR TITLE
Removes escaping known outputs

### DIFF
--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -146,7 +146,7 @@ class WC_Facebookcommerce_Pixel {
 			ob_start();
 
 			?>
-			<script <?php echo esc_html( self::get_script_attributes() ); ?>>
+			<script <?php echo self::get_script_attributes(); // phpcs:ignore WordPress.Security.EscapeOutput.Output ?>>
 				!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
 					n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
 					n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
@@ -154,7 +154,7 @@ class WC_Facebookcommerce_Pixel {
 					document,'script','https://connect.facebook.net/en_US/fbevents.js');
 			</script>
 			<!-- WooCommerce Facebook Integration Begin -->
-			<script <?php echo esc_html( self::get_script_attributes() ); ?>>
+			<script <?php echo self::get_script_attributes(); // phpcs:ignore WordPress.Security.EscapeOutput.Output ?>>
 
 				<?php echo $this->get_pixel_init_code(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 
@@ -264,7 +264,7 @@ class WC_Facebookcommerce_Pixel {
 
 			?>
 			<!-- Facebook Pixel Event Code -->
-			<script <?php echo esc_html( self::get_script_attributes() ); ?>>
+			<script <?php echo self::get_script_attributes(); // phpcs:ignore WordPress.Security.EscapeOutput.Output ?>>
 				<?php echo $this->get_event_code( $event_name, $params, $method ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</script>
 			<!-- End Facebook Pixel Event Code -->
@@ -328,7 +328,7 @@ class WC_Facebookcommerce_Pixel {
 
 			?>
 			<!-- Facebook Pixel Event Code -->
-			<script <?php echo esc_html( self::get_script_attributes() ); ?>>
+			<script <?php echo self::get_script_attributes(); // phpcs:ignore WordPress.Security.EscapeOutput.Output ?>>
 				document.addEventListener( '<?php echo esc_js( $listener ); ?>', function (event) {
 					<?php echo $code; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				}, false );
@@ -378,7 +378,7 @@ class WC_Facebookcommerce_Pixel {
 
 			?>
 			<!-- Facebook Pixel Event Code -->
-			<script <?php echo esc_html( self::get_script_attributes() ); ?>>
+			<script <?php echo self::get_script_attributes(); // phpcs:ignore WordPress.Security.EscapeOutput.Output ?>>
 				function handle<?php echo $event_name; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>Event() {
 					<?php echo $code; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					// Some weird themes (hi, Basel) are running this script twice, so two listeners are added and we need to remove them after running one.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2534.
Closes #2533.

This PR removes the escaping added to `get_script_attributes` output.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Follow the instructions in #2534 
2. The issue should be resolved in this PR.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Pixel code not activated on checkout
