### PR TITLE
Adds a tooltip to Facebook sync status

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -458,8 +458,20 @@ class Admin {
 			return;
 		}
 
-		$product = wc_get_product( $post );
-		if ( $product && Products::is_sync_enabled_for_product( $product ) ) {
+		$product        = wc_get_product( $post );
+		$should_sync    = false;
+		$no_sync_reason = '';
+
+		if ( $product instanceof \WC_Product ) {
+			try {
+				facebook_for_woocommerce()->get_product_sync_validator( $product )->validate();
+				$should_sync = true;
+			} catch ( \Exception $e ) {
+				$no_sync_reason = $e->getMessage();
+			}
+		}
+
+		if ( $should_sync ) {
 			if ( Products::is_product_visible( $product ) ) {
 				esc_html_e( 'Sync and show', 'facebook-for-woocommerce' );
 			} else {
@@ -467,6 +479,9 @@ class Admin {
 			}
 		} else {
 			esc_html_e( 'Do not sync', 'facebook-for-woocommerce' );
+			if ( ! empty( $no_sync_reason ) ) {
+				echo wc_help_tip( $no_sync_reason );
+			}
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2616.

When filtering products in the WooCommerce admin, the Facebook Sync status displayed in the column conflicts with the status chosen. This is because the Facebook Sync status is a product metadata whereas the displayed status is the actual sync validation based on various conditions. The list of conditions can be viewed [here](https://github.com/woocommerce/facebook-for-woocommerce/blob/develop/includes/ProductSync/ProductValidator.php#L134-L142).

This PR will add a tool tip to the conflicting status to explain why the status is `Do not sync`. This tooltip should resolve the confusion around filtering reported in #2616.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

<!--- Optional --->
![image](https://github.com/woocommerce/facebook-for-woocommerce/assets/179533/78141a7b-f521-4ce9-bb9c-37462ea0cd17)

The Product Facebook Sync is set to Sync and show, but the visibility is set to hidden.

![image](https://github.com/woocommerce/facebook-for-woocommerce/assets/179533/faa99007-c251-46f4-9ee9-e2dce2c1d4f4)

Tooltip to display why the product status is `Do not Sync`.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install and activate WooCommerce.
2. Install and activate Facebook for WooCommerce.
3. Click on any of the product to open the Edit Product screen.
4. Scroll down to the Product data tabs and choose the Facebook product tab.
5. Choose `Sync and show` for the `Facebook Sync` field.
6. Set the `Catalog Visibility` to `hidden` and click `Update`.
7. In the Products admin screen, the Facebook Sync status for the product will be shown as `Do not sync`, and a `?` tooltip icon will be displayed. The message should read `This product cannot be synced to Facebook because it is hidden from your store catalog.`.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Issues with Facebook Sync status display while product filtering in admin.
