### PR TITLE
Adding event filtering. Only AddToCart events should be deferred.

### DIFF
--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -283,11 +283,13 @@ class WC_Facebookcommerce_Pixel {
 		 * @param string $method     Name of the pixel's fbq() function to call.
 		 */
 		public function inject_event( $event_name, $params, $method = 'track' ) {
-			// If we have add to cart redirect enabled, we must defer the events to render them the next page load.
-			$should_defer = 'yes' === get_option( 'woocommerce_cart_redirect_after_add', 'no' );
 			if ( WC_Facebookcommerce_Utils::isWoocommerceIntegration() ) {
 				$code = $this->get_event_code( $event_name, self::build_params( $params, $event_name ), $method );
-				if ( $should_defer ) {
+
+				// If we have add to cart redirect enabled, we must defer the AddToCart events to render them the next page load.
+				$is_redirect    = 'yes' === get_option( 'woocommerce_cart_redirect_after_add', 'no' );
+				$is_add_to_cart = 'AddToCart' === $event_name;
+				if ( $is_redirect && $is_add_to_cart ) {
 					WC_Facebookcommerce_Utils::add_deferred_event( $code );
 				} else {
 					WC_Facebookcommerce_Utils::wc_enqueue_js( $code );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2731 .

Not all events must be deferred if the `redirect to cart after add` setting is ON. Defer only AddToCart events.

### Changelog entry

> Fix - Defer only AddToCart events if applicable.
