### PR TITLE
PHP 8.4 remove warnings from implicitly nullable parameters

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1207,7 +1207,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 * @param string|null         $fb_product_group_id
 	 * @return string
 	 */
-	public function create_product_simple( WC_Facebook_Product $woo_product, string $fb_product_group_id = null ): string {
+	public function create_product_simple( WC_Facebook_Product $woo_product, ?string $fb_product_group_id = null ): string {
 		$retailer_id = WC_Facebookcommerce_Utils::get_fb_retailer_id( $woo_product );
 
 		if ( ! $fb_product_group_id ) {

--- a/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
+++ b/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
@@ -47,7 +47,7 @@ class Enhanced_Catalog_Attribute_Fields {
 	 */
 	private $category_handler;
 
-	public function __construct( $page_type, \WP_Term $term = null, \WC_Product $product = null ) {
+	public function __construct( $page_type, ?\WP_Term $term = null, ?\WC_Product $product = null ) {
 		$this->page_type        = $page_type;
 		$this->term             = $term;
 		$this->product          = $product;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "facebook-for-woocommerce",
-      "version": "3.2.10",
+      "version": "3.3.0",
       "license": "GPL-2.0",
       "devDependencies": {
         "@wordpress/env": "^9.10.0",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2822 .

Fix implicitly nullable parameters

- [ ] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Changelog entry

> Tweak: PHP 8.4 compatibility.
