### PR TITLE
Add rich text description to woo product sync to meta

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -46,7 +46,7 @@
 /* Match WooCommerce field hover states */
 #facebook_options .wp-editor-container:hover {
     border-color: #666;
-}bfbufrcchcciitbjlkvfikulfthcgtn
+}
 
 /* add padding-top for first radio button in variation fields */
 #woocommerce-product-data .woocommerce_variation .fb-product-image-source-field .wc-radios li:first-child {

--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -18,41 +18,6 @@
 	padding-bottom: 0;
 }
 
-/* Align the editor with other WooCommerce fields */
-#facebook_options .wp-editor-wrap {
-    padding: 5px 20px 5px 162px !important;
-    margin: 6px 0 !important;
-    position: relative;
-}
-
-/* Position the label like other WooCommerce fields */
-#facebook_options .wp-editor-wrap label {
-    float: left;
-    width: 150px;
-    padding: 0;
-    margin: 0 0 0 -150px;
-    color: #666;
-    font-size: 12px;
-    font-weight: 600;
-    line-height: 24px;
-}
-
-/* Match WooCommerce field styling */
-#facebook_options .wp-editor-container {
-    border: 1px solid #8c8f94;
-    clear: both;
-    background: #fff;
-}
-
-/* Adjust editor width to match other fields */
-#facebook_options .wp-editor-wrap {
-    max-width: calc(100% - 20px);
-}
-
-/* Style the toolbar to match WooCommerce */
-#facebook_options .mce-toolbar {
-    background: #f6f7f7;
-}
 
 /* Ensure proper spacing between fields */
 #facebook_options .options_group {
@@ -61,12 +26,6 @@
     border-bottom: 1px solid #eee;
 }
 
-/* For variation editors - apply same styles */
-.woocommerce_variable_attributes .wp-editor-wrap {
-    padding: 5px 20px 5px 162px !important;
-    margin: 6px 0 !important;
-    position: relative;
-}
 
 .woocommerce_variable_attributes .wp-editor-wrap label {
     float: left;
@@ -150,4 +109,21 @@
 /* adjusts widths of the products table, same as WooCommerce categories and tags */
 .column-facebook_sync {
 	width: 11% !important;
+}
+
+.woocommerce_options_panel .wp-editor-container {
+    margin-left: 162px;
+    width: calc(80% - 182px);
+}
+
+.woocommerce_options_panel .wp-editor-tabs {
+    margin-left: 162px;
+}
+
+/* Ensure the label aligns properly */
+.woocommerce_options_panel label[for="fb_product_description"] {
+    float: left;
+    width: 150px;
+    padding: 0;
+    margin: 0 0 0 12px;
 }

--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -18,6 +18,77 @@
 	padding-bottom: 0;
 }
 
+/* Align the editor with other WooCommerce fields */
+#facebook_options .wp-editor-wrap {
+    padding: 5px 20px 5px 162px !important;
+    margin: 6px 0 !important;
+    position: relative;
+}
+
+/* Position the label like other WooCommerce fields */
+#facebook_options .wp-editor-wrap label {
+    float: left;
+    width: 150px;
+    padding: 0;
+    margin: 0 0 0 -150px;
+    color: #666;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 24px;
+}
+
+/* Match WooCommerce field styling */
+#facebook_options .wp-editor-container {
+    border: 1px solid #8c8f94;
+    clear: both;
+    background: #fff;
+}
+
+/* Adjust editor width to match other fields */
+#facebook_options .wp-editor-wrap {
+    max-width: calc(100% - 20px);
+}
+
+/* Style the toolbar to match WooCommerce */
+#facebook_options .mce-toolbar {
+    background: #f6f7f7;
+}
+
+/* Ensure proper spacing between fields */
+#facebook_options .options_group {
+    padding: 0;
+    border-top: 1px solid #fff;
+    border-bottom: 1px solid #eee;
+}
+
+/* For variation editors - apply same styles */
+.woocommerce_variable_attributes .wp-editor-wrap {
+    padding: 5px 20px 5px 162px !important;
+    margin: 6px 0 !important;
+    position: relative;
+}
+
+.woocommerce_variable_attributes .wp-editor-wrap label {
+    float: left;
+    width: 150px;
+    padding: 0;
+    margin: 0 0 0 -150px;
+    color: #666;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 24px;
+}
+
+/* Ensure editor area has proper height */
+.wp-editor-area {
+    min-height: 100px;
+}
+
+/* Match WooCommerce field hover states */
+#facebook_options .wp-editor-container:hover {
+    border-color: #666;
+}bfbufrcchcciitbjlkvfikulfthcgtn
+
 /* add padding-top for first radio button in variation fields */
 #woocommerce-product-data .woocommerce_variation .fb-product-image-source-field .wc-radios li:first-child {
 	padding-top: 10px;

--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -111,23 +111,15 @@
 	width: 11% !important;
 }
 
-.wp-editor-container {
-    border: 1px solid #dcdcde;
-}
-
-/* Ensure the border remains visible in text mode */
-.wp-editor-container textarea.wp-editor-area {
-    border: 1px solid #dcdcde;
-    box-sizing: border-box;
-}
-
 .woocommerce_options_panel .wp-editor-container {
     margin-left: 162px;
     width: calc(100% - 182px);
+    max-width: 550px;
 }
 
 .woocommerce_options_panel .wp-editor-tabs {
     margin-left: 162px;
+    max-width: 550px;
 }
 
 /* Ensure the label aligns properly */
@@ -136,4 +128,10 @@
     width: 150px;
     padding: 0;
     margin: 0 0 0 12px;
+}
+
+/* Ensure the wp-editor-wrap takes full width */
+.wp-editor-wrap {
+    width: 100%;
+    max-width: 100%;
 }

--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -111,9 +111,19 @@
 	width: 11% !important;
 }
 
+.wp-editor-container {
+    border: 1px solid #dcdcde;
+}
+
+/* Ensure the border remains visible in text mode */
+.wp-editor-container textarea.wp-editor-area {
+    border: 1px solid #dcdcde;
+    box-sizing: border-box;
+}
+
 .woocommerce_options_panel .wp-editor-container {
     margin-left: 162px;
-    width: calc(80% - 182px);
+    width: calc(100% - 182px);
 }
 
 .woocommerce_options_panel .wp-editor-tabs {

--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -31,7 +31,6 @@
     float: left;
     width: 150px;
     padding: 0;
-    margin: 0 0 0 -150px;
     color: #666;
     font-size: 12px;
     font-weight: 600;
@@ -41,6 +40,7 @@
 /* Ensure editor area has proper height */
 .wp-editor-area {
     min-height: 100px;
+	color: #000000
 }
 
 /* Match WooCommerce field hover states */

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -867,13 +867,10 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) {
-    		$woo_product->set_description( wp_strip_all_tags( wp_unslash( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ), true ) );
-		}
-		
-		if ( isset( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) {
+			$woo_product->set_description( sanitize_text_field( wp_unslash( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) );
 			$woo_product->set_rich_text_description( $_POST[ self::FB_PRODUCT_DESCRIPTION ] );
 		}
-
+		
 		if ( isset( $_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ] ) ) {
 			$woo_product->set_price( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ] ) ) );
 		}

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -870,7 +870,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			$woo_product->set_description( sanitize_text_field( wp_unslash( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) );
 			$woo_product->set_rich_text_description( $_POST[ self::FB_PRODUCT_DESCRIPTION ] );
 		}
-				
+		
 		if ( isset( $_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ] ) ) {
 			$woo_product->set_price( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ] ) ) );
 		}

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -870,7 +870,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			$woo_product->set_description( sanitize_text_field( wp_unslash( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) );
 			$woo_product->set_rich_text_description( $_POST[ self::FB_PRODUCT_DESCRIPTION ] );
 		}
-		
+				
 		if ( isset( $_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ] ) ) {
 			$woo_product->set_price( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ] ) ) );
 		}

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -867,11 +867,12 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) {
-			$woo_product->set_description( sanitize_text_field( wp_unslash( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) );
+			error_log('FB Product Description POST value: ' . print_r($_POST[ self::FB_PRODUCT_DESCRIPTION ], true));
+			error_log('Sanitize ' . print_r( wp_strip_all_tags( wp_unslash( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ), true ) , true));
+    		$woo_product->set_description( wp_strip_all_tags( wp_unslash( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ), true ) );
 		}
 		
 		if ( isset( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) {
-			// error_log('FB Product Description POST value: ' . print_r($_POST[ self::FB_PRODUCT_DESCRIPTION ], true));
 			$woo_product->set_rich_text_description( $_POST[ self::FB_PRODUCT_DESCRIPTION ] );
 		}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -867,8 +867,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) {
-			error_log('FB Product Description POST value: ' . print_r($_POST[ self::FB_PRODUCT_DESCRIPTION ], true));
-			error_log('Sanitize ' . print_r( wp_strip_all_tags( wp_unslash( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ), true ) , true));
     		$woo_product->set_description( wp_strip_all_tags( wp_unslash( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ), true ) );
 		}
 		

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -135,7 +135,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	public const FB_PRODUCT_GROUP_ID    = 'fb_product_group_id';
 	public const FB_PRODUCT_ITEM_ID     = 'fb_product_item_id';
 	public const FB_PRODUCT_DESCRIPTION = 'fb_product_description';
-
+	public const FB_RICH_TEXT_DESCRIPTION = 'fb_rich_text_description';
 	/** @var string the API flag to set a product as visible in the Facebook shop */
 	public const FB_SHOP_PRODUCT_VISIBLE = 'published';
 
@@ -871,7 +871,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		}
 		
 		if ( isset( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) {
-			error_log('FB Product Description POST value: ' . print_r($_POST[ self::FB_PRODUCT_DESCRIPTION ], true));
+			// error_log('FB Product Description POST value: ' . print_r($_POST[ self::FB_PRODUCT_DESCRIPTION ], true));
 			$woo_product->set_rich_text_description( $_POST[ self::FB_PRODUCT_DESCRIPTION ] );
 		}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -869,6 +869,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		if ( isset( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) {
 			$woo_product->set_description( sanitize_text_field( wp_unslash( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) );
 		}
+		
+		if ( isset( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) {
+			error_log('FB Product Description POST value: ' . print_r($_POST[ self::FB_PRODUCT_DESCRIPTION ], true));
+			$woo_product->set_rich_text_description( $_POST[ self::FB_PRODUCT_DESCRIPTION ] );
+		}
 
 		if ( isset( $_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ] ) ) {
 			$woo_product->set_price( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ] ) ) );

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1181,7 +1181,6 @@ class Admin {
 		$is_visible   = ( $visibility = get_post_meta( $post->ID, Products::VISIBILITY_META_KEY, true ) ) ? wc_string_to_bool( $visibility ) : true;
 		$product 	  = wc_get_product( $post );
 
-		$description  = get_post_meta( $post->ID, \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, true );
 		$rich_text_description  = get_post_meta( $post->ID, \WC_Facebookcommerce_Integration::FB_RICH_TEXT_DESCRIPTION, true );
 		$price        = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_PRICE, true );
 		$image_source = get_post_meta( $post->ID, Products::PRODUCT_IMAGE_SOURCE_META_KEY, true );

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1231,8 +1231,7 @@ class Admin {
 						'teeny'        => true,
 						'quicktags'    => true,
 						'tinymce'      => array(
-							'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen,wp_adv',
-							'toolbar2' => 'strikethrough,hr,forecolor,pastetext,removeformat,charmap,outdent,indent,undo,redo,wp_help',
+							'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen',
 							'entity_encoding' => 'named',
 							'verify_html' => false,
 							'preserve_newlines' => true,
@@ -1409,8 +1408,7 @@ class Admin {
 				'teeny'        => true,
 				'quicktags'    => true,
 				'tinymce'      => array(
-					'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen,wp_adv',
-					'toolbar2' => 'strikethrough,hr,forecolor,pastetext,removeformat,charmap,outdent,indent,undo,redo,wp_help',
+					'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen',
 					'entity_encoding' => 'named',
 					'verify_html' => false,
 					'preserve_newlines' => true,

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1182,6 +1182,7 @@ class Admin {
 		$product 	  = wc_get_product( $post );
 
 		$description  = get_post_meta( $post->ID, \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, true );
+		$rich_text_description  = get_post_meta( $post->ID, \WC_Facebookcommerce_Integration::FB_RICH_TEXT_DESCRIPTION, true );
 		$price        = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_PRICE, true );
 		$image_source = get_post_meta( $post->ID, Products::PRODUCT_IMAGE_SOURCE_META_KEY, true );
 		$image        = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_IMAGE, true );
@@ -1220,7 +1221,7 @@ class Admin {
 					 esc_html__( 'Facebook Description', 'facebook-for-woocommerce' ) . 
 					 '</label>';
 				wp_editor(
-					$description,
+					$rich_text_description,
 					\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
 					array(
 						'id'      => 'wc_facebook_sync_mode',
@@ -1228,10 +1229,15 @@ class Admin {
 						'textarea_rows' => 10,
 						'media_buttons' => true,
 						'teeny'        => true,
-						'quicktags'    => false,
+						'quicktags'    => true,
 						'tinymce'      => array(
 							'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen,wp_adv',
-							'toolbar2' => 'strikethrough,hr,forecolor,pastetext,removeformat,charmap,outdent,indent,undo,redo,wp_help'
+							'toolbar2' => 'strikethrough,hr,forecolor,pastetext,removeformat,charmap,outdent,indent,undo,redo,wp_help',
+							'entity_encoding' => 'named',
+							'verify_html' => false,
+							'preserve_newlines' => true,
+							'entities' => '160,nbsp,38,amp,60,lt,62,gt',
+							'cleanup' => false,
 						),
 					)
 				);
@@ -1359,6 +1365,7 @@ class Admin {
 		$is_visible   = ( $visibility = $this->get_product_variation_meta( $variation, Products::VISIBILITY_META_KEY, $parent ) ) ? wc_string_to_bool( $visibility ) : true;
 
 		$description  = $this->get_product_variation_meta( $variation, \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $parent );
+		$rich_text_description  = $this->get_product_variation_meta( $variation, \WC_Facebookcommerce_Integration::FB_RICH_TEXT_DESCRIPTION, $parent );
 		$price        = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_PRICE, $parent );
 		$image_url    = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_IMAGE, $parent );
 		$image_source = $variation->get_meta( Products::PRODUCT_IMAGE_SOURCE_META_KEY );
@@ -1401,12 +1408,17 @@ class Admin {
 				'textarea_rows' => 10,
 				'media_buttons' => true,
 				'teeny'        => true,
-				'quicktags'    => false,
+				'quicktags'    => true,
 				'tinymce'      => array(
 					'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen,wp_adv',
-					'toolbar2' => 'strikethrough,hr,forecolor,pastetext,removeformat,charmap,outdent,indent,undo,redo,wp_help'
+					'toolbar2' => 'strikethrough,hr,forecolor,pastetext,removeformat,charmap,outdent,indent,undo,redo,wp_help',
+					'entity_encoding' => 'named',
+					'verify_html' => false,
+					'preserve_newlines' => true,
+					'entities' => '160,nbsp,38,amp,60,lt,62,gt',
+					'cleanup' => false,
 				),
-				)
+			)
 		);
 		echo '</div>';
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1230,7 +1230,7 @@ class Admin {
 						'teeny'        => true,
 						'quicktags'    => false,
 						'tinymce'      => array(
-							'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen',
+							'toolbar1' => 'bold,italic,bullist,spellchecker,fullscreen',
 						),
 					)
 				);
@@ -1387,26 +1387,6 @@ class Admin {
 			)
 		);
 
-		echo '<div class="wp-editor-wrap">';
-		echo '<label for="' . esc_attr(\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION) . '">' . 
-			 esc_html__( 'Facebook Description', 'facebook-for-woocommerce' ) . 
-			 '</label>';
-		wp_editor(
-			$rich_text_description,
-			\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
-			array(
-				'textarea_name' => \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
-				'textarea_rows' => 10,
-				'media_buttons' => true,
-				'teeny'        => true,
-				'quicktags'    => false,
-				'tinymce'      => array(
-					'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen',
-				),
-			)
-		);
-		echo '</div>';
-
 		woocommerce_wp_radio(
 			array(
 				'id'            => "variable_fb_product_image_source$index",
@@ -1516,6 +1496,9 @@ class Admin {
 			Products::set_product_visibility( $variation, self::SYNC_MODE_SYNC_AND_HIDE !== $sync_mode );
 			$posted_param = 'variable_' . \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION;
 			$description  = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_text_field( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
+			$posted_param = 'variable_' . \WC_Facebookcommerce_Integration::FB_RICH_TEXT_DESCRIPTION;
+			// $rich_text_description  = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_text_field( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
+			$rich_text_description  = 'Nene';
 			$posted_param = 'variable_' . \WC_Facebook_Product::FB_MPN;
 			$fb_mpn  = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_text_field( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
 			$posted_param = 'variable_fb_product_image_source';
@@ -1525,6 +1508,7 @@ class Admin {
 			$posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_PRICE;
 			$price        = isset( $_POST[ $posted_param ][ $index ] ) ? wc_format_decimal( wc_clean( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) ) : '';
 			$variation->update_meta_data( \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $description );
+			$variation->update_meta_data( 'rich_text_description', $rich_text_description );
 			$variation->update_meta_data( Products::PRODUCT_IMAGE_SOURCE_META_KEY, $image_source );
 			$variation->update_meta_data( \WC_Facebook_Product::FB_MPN, $fb_mpn );
 			$variation->update_meta_data( \WC_Facebook_Product::FB_PRODUCT_IMAGE, $image_url );

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1395,7 +1395,6 @@ class Admin {
 			)
 		);
 
-		// $editor_id = sprintf( 'variable_%s%s', \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $index );
 		echo '<div class="wp-editor-wrap">';
 		echo '<label for="' . esc_attr(\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION) . '">' . 
 			 esc_html__( 'Facebook Description', 'facebook-for-woocommerce' ) . 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1356,8 +1356,7 @@ class Admin {
 
 		$sync_enabled = 'no' !== $this->get_product_variation_meta( $variation, Products::SYNC_ENABLED_META_KEY, $parent );
 		$is_visible   = ( $visibility = $this->get_product_variation_meta( $variation, Products::VISIBILITY_META_KEY, $parent ) ) ? wc_string_to_bool( $visibility ) : true;
-
-		$rich_text_description  = $this->get_product_variation_meta( $variation, \WC_Facebookcommerce_Integration::FB_RICH_TEXT_DESCRIPTION, $parent );
+		$description  = $this->get_product_variation_meta( $variation, \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $parent );		
 		$price        = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_PRICE, $parent );
 		$image_url    = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_IMAGE, $parent );
 		$image_source = $variation->get_meta( Products::PRODUCT_IMAGE_SOURCE_META_KEY );
@@ -1383,6 +1382,21 @@ class Admin {
 				'desc_tip'    => true,
 				'description' => __( 'Choose whether to sync this product to Facebook and, if synced, whether it should be visible in the catalog.', 'facebook-for-woocommerce' ),
 				'class'         => 'js-variable-fb-sync-toggle',
+				'wrapper_class' => 'form-row form-row-full',
+			)
+		);
+
+		woocommerce_wp_textarea_input(
+			array(
+				'id'            => sprintf( 'variable_%s%s', \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $index ),
+				'name'          => sprintf( "variable_%s[$index]", \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION ),
+				'label'         => __( 'Facebook Description', 'facebook-for-woocommerce' ),
+				'desc_tip'      => true,
+				'description'   => __( 'Custom (plain-text only) description for product on Facebook. If blank, product description will be used. If product description is blank, shortname will be used.', 'facebook-for-woocommerce' ),
+				'cols'          => 40,
+				'rows'          => 5,
+				'value'         => $description,
+				'class'         => 'enable-if-sync-enabled',
 				'wrapper_class' => 'form-row form-row-full',
 			)
 		);
@@ -1496,7 +1510,6 @@ class Admin {
 			Products::set_product_visibility( $variation, self::SYNC_MODE_SYNC_AND_HIDE !== $sync_mode );
 			$posted_param = 'variable_' . \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION;
 			$description  = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_text_field( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
-			$posted_param = 'variable_' . \WC_Facebookcommerce_Integration::FB_RICH_TEXT_DESCRIPTION;
 			$posted_param = 'variable_' . \WC_Facebook_Product::FB_MPN;
 			$fb_mpn  = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_text_field( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
 			$posted_param = 'variable_fb_product_image_source';
@@ -1506,6 +1519,7 @@ class Admin {
 			$posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_PRICE;
 			$price        = isset( $_POST[ $posted_param ][ $index ] ) ? wc_format_decimal( wc_clean( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) ) : '';
 			$variation->update_meta_data( \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $description );
+			$variation->update_meta_data( \WC_Facebookcommerce_Integration::FB_RICH_TEXT_DESCRIPTION, $description );
 			$variation->update_meta_data( Products::PRODUCT_IMAGE_SOURCE_META_KEY, $image_source );
 			$variation->update_meta_data( \WC_Facebook_Product::FB_MPN, $fb_mpn );
 			$variation->update_meta_data( \WC_Facebook_Product::FB_PRODUCT_IMAGE, $image_url );

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1215,18 +1215,27 @@ class Admin {
 					)
 				);
 
-				woocommerce_wp_textarea_input(
+				echo '<div class="wp-editor-wrap">';
+				echo '<label for="' . esc_attr(\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION) . '">' . 
+					 esc_html__( 'Facebook Description', 'facebook-for-woocommerce' ) . 
+					 '</label>';
+				wp_editor(
+					$description,
+					\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
 					array(
-						'id'          => \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
-						'label'       => __( 'Facebook Description', 'facebook-for-woocommerce' ),
-						'desc_tip'    => true,
-						'description' => __( 'Custom (plain-text only) description for product on Facebook. If blank, product description will be used. If product description is blank, shortname will be used.', 'facebook-for-woocommerce' ),
-						'cols'        => 40,
-						'rows'        => 20,
-						'value'       => $description,
-						'class'       => 'short enable-if-sync-enabled',
+						'textarea_name' => \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
+						'textarea_rows' => 10,
+						'media_buttons' => false,
+						'teeny'        => true,
+						'quicktags'    => false,
+						'tinymce'      => array(
+							'toolbar1' => 'bold,italic,underline,bullist,numlist,link,unlink',
+							'toolbar2' => '',
+						),
+						'editor_css'   => '<style>.wp-editor-area{height:200px !important;}</style>',
 					)
 				);
+				echo '</div>';
 
 				woocommerce_wp_radio(
 					array(
@@ -1379,20 +1388,28 @@ class Admin {
 			)
 		);
 
-		woocommerce_wp_textarea_input(
+		// $editor_id = sprintf( 'variable_%s%s', \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $index );
+		echo '<div class="wp-editor-wrap">';
+		echo '<label for="' . esc_attr(\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION) . '">' . 
+			 esc_html__( 'Facebook Description', 'facebook-for-woocommerce' ) . 
+			 '</label>';
+		wp_editor(
+			$description,
+			\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
 			array(
-				'id'            => sprintf( 'variable_%s%s', \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $index ),
-				'name'          => sprintf( "variable_%s[$index]", \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION ),
-				'label'         => __( 'Facebook Description', 'facebook-for-woocommerce' ),
-				'desc_tip'      => true,
-				'description'   => __( 'Custom (plain-text only) description for product on Facebook. If blank, product description will be used. If product description is blank, shortname will be used.', 'facebook-for-woocommerce' ),
-				'cols'          => 40,
-				'rows'          => 5,
-				'value'         => $description,
-				'class'         => 'enable-if-sync-enabled',
-				'wrapper_class' => 'form-row form-row-full',
+				'textarea_name' => \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
+				'textarea_rows' => 10,
+				'media_buttons' => false,
+				'teeny'        => true,
+				'quicktags'    => false,
+				'tinymce'      => array(
+					'toolbar1' => 'bold,italic,underline,bullist,numlist,link,unlink',
+					'toolbar2' => '',
+				),
+				'editor_css'   => '<style>.wp-editor-area{height:200px !important;}</style>',
 			)
 		);
+		echo '</div>';
 
 		woocommerce_wp_radio(
 			array(

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1223,16 +1223,16 @@ class Admin {
 					$description,
 					\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
 					array(
+						'id'      => 'wc_facebook_sync_mode',
 						'textarea_name' => \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
 						'textarea_rows' => 10,
-						'media_buttons' => false,
+						'media_buttons' => true,
 						'teeny'        => true,
 						'quicktags'    => false,
 						'tinymce'      => array(
-							'toolbar1' => 'bold,italic,underline,bullist,numlist,link,unlink',
-							'toolbar2' => '',
+							'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen,wp_adv',
+							'toolbar2' => 'strikethrough,hr,forecolor,pastetext,removeformat,charmap,outdent,indent,undo,redo,wp_help'
 						),
-						'editor_css'   => '<style>.wp-editor-area{height:200px !important;}</style>',
 					)
 				);
 				echo '</div>';
@@ -1399,15 +1399,14 @@ class Admin {
 			array(
 				'textarea_name' => \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
 				'textarea_rows' => 10,
-				'media_buttons' => false,
+				'media_buttons' => true,
 				'teeny'        => true,
 				'quicktags'    => false,
 				'tinymce'      => array(
-					'toolbar1' => 'bold,italic,underline,bullist,numlist,link,unlink',
-					'toolbar2' => '',
+					'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen,wp_adv',
+					'toolbar2' => 'strikethrough,hr,forecolor,pastetext,removeformat,charmap,outdent,indent,undo,redo,wp_help'
 				),
-				'editor_css'   => '<style>.wp-editor-area{height:200px !important;}</style>',
-			)
+				)
 		);
 		echo '</div>';
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1229,14 +1229,9 @@ class Admin {
 						'textarea_rows' => 10,
 						'media_buttons' => true,
 						'teeny'        => true,
-						'quicktags'    => true,
+						'quicktags'    => false,
 						'tinymce'      => array(
 							'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen',
-							'entity_encoding' => 'named',
-							'verify_html' => false,
-							'preserve_newlines' => true,
-							'entities' => '160,nbsp,38,amp,60,lt,62,gt',
-							'cleanup' => false,
 						),
 					)
 				);
@@ -1363,7 +1358,6 @@ class Admin {
 		$sync_enabled = 'no' !== $this->get_product_variation_meta( $variation, Products::SYNC_ENABLED_META_KEY, $parent );
 		$is_visible   = ( $visibility = $this->get_product_variation_meta( $variation, Products::VISIBILITY_META_KEY, $parent ) ) ? wc_string_to_bool( $visibility ) : true;
 
-		$description  = $this->get_product_variation_meta( $variation, \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $parent );
 		$rich_text_description  = $this->get_product_variation_meta( $variation, \WC_Facebookcommerce_Integration::FB_RICH_TEXT_DESCRIPTION, $parent );
 		$price        = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_PRICE, $parent );
 		$image_url    = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_IMAGE, $parent );
@@ -1399,21 +1393,16 @@ class Admin {
 			 esc_html__( 'Facebook Description', 'facebook-for-woocommerce' ) . 
 			 '</label>';
 		wp_editor(
-			$description,
+			$rich_text_description,
 			\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
 			array(
 				'textarea_name' => \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
 				'textarea_rows' => 10,
 				'media_buttons' => true,
 				'teeny'        => true,
-				'quicktags'    => true,
+				'quicktags'    => false,
 				'tinymce'      => array(
 					'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen',
-					'entity_encoding' => 'named',
-					'verify_html' => false,
-					'preserve_newlines' => true,
-					'entities' => '160,nbsp,38,amp,60,lt,62,gt',
-					'cleanup' => false,
 				),
 			)
 		);

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1497,8 +1497,6 @@ class Admin {
 			$posted_param = 'variable_' . \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION;
 			$description  = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_text_field( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
 			$posted_param = 'variable_' . \WC_Facebookcommerce_Integration::FB_RICH_TEXT_DESCRIPTION;
-			// $rich_text_description  = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_text_field( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
-			$rich_text_description  = 'Nene';
 			$posted_param = 'variable_' . \WC_Facebook_Product::FB_MPN;
 			$fb_mpn  = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_text_field( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
 			$posted_param = 'variable_fb_product_image_source';
@@ -1508,7 +1506,6 @@ class Admin {
 			$posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_PRICE;
 			$price        = isset( $_POST[ $posted_param ][ $index ] ) ? wc_format_decimal( wc_clean( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) ) : '';
 			$variation->update_meta_data( \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $description );
-			$variation->update_meta_data( 'rich_text_description', $rich_text_description );
 			$variation->update_meta_data( Products::PRODUCT_IMAGE_SOURCE_META_KEY, $image_source );
 			$variation->update_meta_data( \WC_Facebook_Product::FB_MPN, $fb_mpn );
 			$variation->update_meta_data( \WC_Facebook_Product::FB_PRODUCT_IMAGE, $image_url );

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -47,7 +47,6 @@ class WC_Facebook_Product {
 	const MAX_TIME   = 'T23:59+00:00';
 	const MIN_TIME   = 'T00:00+00:00';
 
-	public static $rich_text_description_source = WC_Facebookcommerce_Utils::WC_DESCRIPTION;
 	static $use_checkout_url                    = array(
 		'simple'    => 1,
 		'variable'  => 1,
@@ -69,11 +68,6 @@ class WC_Facebook_Product {
 	 */
 	private $fb_description;
 
-
-	/**
-	 * @var string Facebook Rich Text Description.
-	 */
-	private $fb_rich_text_description;
 
 	/**
 	 * @var array Gallery URLs.
@@ -533,9 +527,9 @@ class WC_Facebook_Product {
 	 * Get the rich text description for a product.
 	 *
 	 * This function retrieves the rich text product description based on the following logic:
-	 * 1. Check if the facebook rich text description is set and not empty.
+	 * 1. Check if the Facebook rich text description is set and not empty.
 	 * 2. If the rich text description is available, use it as the preferred description.
-	 * 3. Otherwise, fall back to the plain text description made available by Woocommerce.
+	 * 3. Otherwise, fall back to the plain text description made available by WooCommerce.
 	 *
 	 * @return string The rich text description for the product.
 	 */
@@ -551,16 +545,12 @@ class WC_Facebook_Product {
 
 		// Try to get rich text description from post meta if description has been set
 		if ( empty( $rich_text_description ) ) {
-			$temp_rich_text_description = get_post_meta(
+			$rich_text_description = get_post_meta(
 				$this->id,
 				self::FB_RICH_TEXT_DESCRIPTION,
 				true
 			);
 
-			if ( $temp_rich_text_description ) {
-				self::$rich_text_description_source = WC_Facebookcommerce_Utils::FB_DESCRIPTION;
-				$rich_text_description              = $temp_rich_text_description;
-			}
 		}
 
 		// For variable products, we want to use the rich text description of the variant.
@@ -600,7 +590,7 @@ class WC_Facebook_Product {
 	 */
 	public function add_sale_price( $product_data, $for_items_batch = false ) {
 
-		$sale_price                = $this->woo_product->get_sale_price();
+		$sale_price = $this->woo_product->get_sale_price();
 		$sale_price_effective_date = '';
 		$sale_start = '';
 		$sale_end = '';
@@ -619,7 +609,7 @@ class WC_Facebook_Product {
 				( $sale_start == self::MIN_DATE_1 . self::MIN_TIME && $sale_end == self::MAX_DATE . self::MAX_TIME )
 				? ''
 				: $sale_start . '/' . $sale_end;
-				$sale_price                =
+				$sale_price =
 				intval( round( $this->get_price_plus_tax( $sale_price ) * 100 ) );
 
 			// Set Sale start and end as empty if set to default values
@@ -812,7 +802,7 @@ class WC_Facebook_Product {
 		WC_Facebookcommerce_Utils::get_product_categories( $id );
 
 		// Get brand attribute.
-		$brand          = get_post_meta( $id, Products::ENHANCED_CATALOG_ATTRIBUTES_META_KEY_PREFIX . 'brand', true );
+		$brand = get_post_meta( $id, Products::ENHANCED_CATALOG_ATTRIBUTES_META_KEY_PREFIX . 'brand', true );
 		$brand_taxonomy = get_the_term_list( $id, 'product_brand', '', ', ' );
 
 		if ( $brand ) {
@@ -823,15 +813,14 @@ class WC_Facebook_Product {
 			$brand = wp_strip_all_tags( WC_Facebookcommerce_Utils::get_store_name() );
 		}
 
-		$rich_text_description = $this->get_rich_text_description();
 		$custom_fields = $this->get_facebook_specific_fields();
 
 		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
-			$product_data   = array_merge(
+			$product_data   = array(
 				array(
 					'title'                 => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
 					'description'           => $this->get_fb_description(),
-					'rich_text_description' => $rich_text_description,
+					'rich_text_description' => $this->get_rich_text_description(),
 					'image_link'            => $image_urls[0],
 					'additional_image_link' => $this->get_additional_image_urls( $image_urls ),
 					'link'                  => $product_url,
@@ -842,7 +831,7 @@ class WC_Facebook_Product {
 					'price'                 => $this->get_fb_price( true ),
 					'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
 					'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
-				'custom_fields'			=> $custom_fields,
+					'custom_fields'			=> $custom_fields,
 				),
 			);
 			$product_data   = $this->add_sale_price( $product_data, true );
@@ -851,14 +840,14 @@ class WC_Facebook_Product {
 				$product_data['video'] = $video_urls;
 			}
 		} else {
-			$product_data = array_merge(
+			$product_data = array(
 				array(
 					'name'                  => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
 					'description'           => $this->get_fb_description(),
 					'image_url'             => $image_urls[0],
 					'additional_image_urls' => $this->get_additional_image_urls( $image_urls ),
 					'url'                   => $product_url,
-					'rich_text_description' => $rich_text_description,
+					'rich_text_description' => $this->get_rich_text_description(),
 					/**
 					 * 'category' is a required field for creating a ProductItem object when posting to /{product_catalog_id}/products.
 					 * This field should have the Google product category for the item. Google product category is not a required field
@@ -1256,4 +1245,3 @@ class WC_Facebook_Product {
 	}
 
 }
-

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -353,13 +353,17 @@ class WC_Facebook_Product {
 	}
 
 	public function set_description( $description ) {
-		$description          = stripslashes(
-			WC_Facebookcommerce_Utils::clean_string( $description )
-		);
 		$rich_text_description          = stripslashes(
 			WC_Facebookcommerce_Utils::clean_string( $description, false )
 		);
-		$this->fb_description = $description;
+
+		$description          = stripslashes(
+			WC_Facebookcommerce_Utils::clean_string( $description )
+		);
+		
+		error_log('FB Product Description SET value: ' . print_r($description, true));
+
+		$this->fb_description = $rich_text_description;
 		$this->fb_rich_text_description = $rich_text_description;
 
 		update_post_meta(
@@ -570,7 +574,6 @@ class WC_Facebook_Product {
 			// Try to get description from post meta if fb description has been set
 			$temp_rich_text_description = get_post_meta(
 				$this->id,
-				self::FB_RICH_TEXT_DESCRIPTION,
 				self::FB_RICH_TEXT_DESCRIPTION,
 				true
 			);
@@ -849,6 +852,7 @@ class WC_Facebook_Product {
 				array(
 					'title'                 => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
 					'description'           => $this->get_fb_description(),
+					'rich_text_description' => $rich_text_description,
 					'image_link'            => $image_urls[0],
 					'additional_image_link' => $this->get_additional_image_urls( $image_urls ),
 					'link'                  => $product_url,
@@ -861,7 +865,7 @@ class WC_Facebook_Product {
 					'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
 				'custom_fields'			=> $custom_fields,
 				),
-				self::$rich_text_description_source === WC_Facebookcommerce_Utils::WC_DESCRIPTION ? array( 'rich_text_description' => $rich_text_description ) : array()
+				// self::$rich_text_description_source === WC_Facebookcommerce_Utils::WC_DESCRIPTION ? array( 'rich_text_description' => $rich_text_description ) : array()
 			);
 			$product_data   = $this->add_sale_price( $product_data, true );
 			$gpc_field_name = 'google_product_category';
@@ -876,6 +880,7 @@ class WC_Facebook_Product {
 					'image_url'             => $image_urls[0],
 					'additional_image_urls' => $this->get_additional_image_urls( $image_urls ),
 					'url'                   => $product_url,
+					'rich_text_description' => $rich_text_description,
 					/**
 					 * 'category' is a required field for creating a ProductItem object when posting to /{product_catalog_id}/products.
 					 * This field should have the Google product category for the item. Google product category is not a required field
@@ -897,7 +902,7 @@ class WC_Facebook_Product {
 					'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
 				'custom_fields'			=> $custom_fields
 				),
-				self::$rich_text_description_source === WC_Facebookcommerce_Utils::WC_DESCRIPTION ? array( 'rich_text_description' => $rich_text_description ) : array()
+				// self::$rich_text_description_source === WC_Facebookcommerce_Utils::WC_DESCRIPTION ? array( 'rich_text_description' => $rich_text_description ) : array()
 			);
 
 			if ( self::PRODUCT_PREP_TYPE_NORMAL !== $type_to_prepare_for && ! empty( $video_urls ) ) {

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -30,12 +30,12 @@ class WC_Facebook_Product {
 
 	// Should match facebook-commerce.php while we migrate that code over
 	// to this object.
-	const FB_PRODUCT_DESCRIPTION = 'fb_product_description';
-	const FB_PRODUCT_PRICE       = 'fb_product_price';
-	const FB_PRODUCT_IMAGE       = 'fb_product_image';
-	const FB_VARIANT_IMAGE       = 'fb_image';
-	const FB_VISIBILITY          = 'fb_visibility';
-	const FB_REMOVE_FROM_SYNC    = 'fb_remove_from_sync';
+	const FB_PRODUCT_DESCRIPTION   = 'fb_product_description';
+	const FB_PRODUCT_PRICE         = 'fb_product_price';
+	const FB_PRODUCT_IMAGE         = 'fb_product_image';
+	const FB_VARIANT_IMAGE         = 'fb_image';
+	const FB_VISIBILITY            = 'fb_visibility';
+	const FB_REMOVE_FROM_SYNC      = 'fb_remove_from_sync';
 	const FB_RICH_TEXT_DESCRIPTION = 'fb_rich_text_description';
 	const FB_BRAND               = 'fb_brand';
 	const FB_VARIABLE_BRAND      = 'fb_variable_brand';
@@ -47,8 +47,7 @@ class WC_Facebook_Product {
 	const MAX_TIME   = 'T23:59+00:00';
 	const MIN_TIME   = 'T00:00+00:00';
 
-    public static $rich_text_description_source = WC_Facebookcommerce_Utils::WOO_DESCRIPTION;
-	
+	public static $rich_text_description_source = WC_Facebookcommerce_Utils::WC_DESCRIPTION;
 
 	static $use_checkout_url = array(
 		'simple'    => 1,
@@ -113,8 +112,8 @@ class WC_Facebook_Product {
 			$this->id          = $wpid->get_id();
 			$this->woo_product = $wpid;
 		} else {
-			$this->id                     = $wpid;
-			$this->woo_product            = wc_get_product( $wpid );
+			$this->id          = $wpid;
+			$this->woo_product = wc_get_product( $wpid );
 		}
 
 		$this->fb_description         = '';
@@ -254,7 +253,7 @@ class WC_Facebook_Product {
 		 * @param string $size The image size. e.g. 'full', 'medium', 'thumbnail'.
 		 */
 		$image_size               = apply_filters( 'facebook_for_woocommerce_fb_product_image_size', 'full' );
-		$product_image_url        = wp_get_attachment_image_url( $this->woo_product->get_image_id(), $image_size ); ;
+		$product_image_url        = wp_get_attachment_image_url( $this->woo_product->get_image_id(), $image_size );
 		$parent_product_image_url = null;
 		$custom_image_url         = $this->woo_product->get_meta( self::FB_PRODUCT_IMAGE );
 
@@ -320,7 +319,7 @@ class WC_Facebook_Product {
 					)
 				);
 			}
-        }
+		}
 
 		return $video_urls;
 	}
@@ -543,19 +542,30 @@ class WC_Facebook_Product {
 		return apply_filters( 'facebook_for_woocommerce_fb_product_description', $description, $this->id );
 	}
 
+	/**
+	 * Get the rich text description for a product.
+	 *
+	 * This function determines the preferred product description based on the following logic:
+	 * 1. Check if the rich text description is available and not empty.
+	 * 2. If the rich text description is available, use it as the preferred description.
+	 * 3. Otherwise, fall back to the plain text description.
+	 *
+	 * @return string The rich text description for the product.
+	 */
 	public function get_rich_text_description() {
 		$rich_text_description = '';
 
+			// Check if the fb description is set as that takes preference.
 		if ( $this->fb_description ) {
-			$rich_text_description = $this->fb_description;
+				$rich_text_description = $this->fb_description;
 		}
 
+			// If the rich text description is available, use it as the preferred description.
 		if ( $this->rich_text_description ) {
-			$rich_text_description = $this->rich_text_description;
+				$rich_text_description = $this->rich_text_description;
 		}
-		
-		
 
+			// If no description is found from meta or variation, get from post
 		if ( empty( $rich_text_description ) ) {
 			// Try to get description from post meta if fb description has been set
 			$temp_rich_text_description = get_post_meta(
@@ -576,41 +586,39 @@ class WC_Facebook_Product {
 		if (empty($rich_text_description) && WC_Facebookcommerce_Utils::is_variation_type($this->woo_product->get_type())) {
 			$rich_text_description = WC_Facebookcommerce_Utils::clean_string($this->woo_product->get_description(), false);
 
-			// If the variant's rich text description is still empty, use the main product's rich text description as a fallback.
-			if (empty($rich_text_description) && $this->main_description) {
-				$rich_text_description = $this->rich_text_description;
+				// If the variant's rich text description is still empty, use the main product's rich text description as a fallback.
+			if ( empty( $rich_text_description ) && $this->main_description ) {
+					$rich_text_description = $this->rich_text_description;
 			}
 		}
 
-		// If no description is found from meta or variation, get from post
+			// If no description is found from meta or variation, get from post
 		if ( empty( $rich_text_description ) ) {
-			$post         = $this->get_post_data();
-			$post_content = WC_Facebookcommerce_Utils::clean_string( $post->post_content, false );
-			$post_excerpt = WC_Facebookcommerce_Utils::clean_string( $post->post_excerpt, false );
+				$post         = $this->get_post_data();
+				$post_content = WC_Facebookcommerce_Utils::clean_string( $post->post_content, false );
+				$post_excerpt = WC_Facebookcommerce_Utils::clean_string( $post->post_excerpt, false );
 
-			
 			if ( ! empty( $post_content ) ) {
-				$rich_text_description = $post_content;
+					$rich_text_description = $post_content;
 			}
 
 			if ( $this->sync_short_description || ( empty( $rich_text_description ) && ! empty( $post_excerpt ) ) ) {
-				$rich_text_description = $post_excerpt;
+					$rich_text_description = $post_excerpt;
 			}
-
 		}
-		
-		return apply_filters( 'facebook_for_woocommerce_fb_rich_text_description', $rich_text_description, $this->id );
+
+			return apply_filters( 'facebook_for_woocommerce_fb_rich_text_description', $rich_text_description, $this->id );
 	}
 
 	/**
 	 * @param array $product_data
-	 * @param bool $for_items_batch
+	 * @param bool  $for_items_batch
 	 *
 	 * @return array
 	 */
 	public function add_sale_price( $product_data, $for_items_batch = false ) {
 
-		$sale_price = $this->woo_product->get_sale_price();
+		$sale_price                = $this->woo_product->get_sale_price();
 		$sale_price_effective_date = '';
 		$sale_start = '';
 		$sale_end = '';
@@ -629,7 +637,7 @@ class WC_Facebook_Product {
 				( $sale_start == self::MIN_DATE_1 . self::MIN_TIME && $sale_end == self::MAX_DATE . self::MAX_TIME )
 				? ''
 				: $sale_start . '/' . $sale_end;
-				$sale_price =
+				$sale_price                =
 				intval( round( $this->get_price_plus_tax( $sale_price ) * 100 ) );
 
 			// Set Sale start and end as empty if set to default values
@@ -642,7 +650,7 @@ class WC_Facebook_Product {
 		// check if sale is expired and sale time range is valid
 		if ( $for_items_batch ) {
 			$product_data['sale_price_effective_date'] = $sale_price_effective_date;
-			$product_data['sale_price']                = is_numeric( $sale_price ) ? self::format_price_for_fb_items_batch( $sale_price ) : "";
+			$product_data['sale_price']                = is_numeric( $sale_price ) ? self::format_price_for_fb_items_batch( $sale_price ) : '';
 		} else {
 			$product_data['sale_price_start_date'] = $sale_start;
 			$product_data['sale_price_end_date']   = $sale_end;
@@ -679,12 +687,12 @@ class WC_Facebook_Product {
 				'price' => $price,
 			);
 			return get_option( 'woocommerce_tax_display_shop' ) === 'incl'
-				  ? wc_get_price_including_tax( $woo_product, $args )
-				  : wc_get_price_excluding_tax( $woo_product, $args );
+					? wc_get_price_including_tax( $woo_product, $args )
+					: wc_get_price_excluding_tax( $woo_product, $args );
 		} else {
 			return get_option( 'woocommerce_tax_display_shop' ) === 'incl'
-				  ? $woo_product->get_price_including_tax( 1, $price )
-				  : $woo_product->get_price_excluding_tax( 1, $price );
+					? $woo_product->get_price_including_tax( 1, $price )
+					: $woo_product->get_price_excluding_tax( 1, $price );
 		}
 	}
 
@@ -821,29 +829,40 @@ class WC_Facebook_Product {
 		$categories =
 		WC_Facebookcommerce_Utils::get_product_categories( $id );
 
+		// Get brand attribute.
+		$brand          = get_post_meta( $id, Products::ENHANCED_CATALOG_ATTRIBUTES_META_KEY_PREFIX . 'brand', true );
+		$brand_taxonomy = get_the_term_list( $id, 'product_brand', '', ', ' );
+
+		if ( $brand ) {
+			$brand = WC_Facebookcommerce_Utils::clean_string( $brand );
+		} elseif ( ! is_wp_error( $brand_taxonomy ) && $brand_taxonomy ) {
+			$brand = WC_Facebookcommerce_Utils::clean_string( $brand_taxonomy );
+		} else {
+			$brand = wp_strip_all_tags( WC_Facebookcommerce_Utils::get_store_name() );
+		}
+
 		$rich_text_description = $this->get_rich_text_description();
 		$custom_fields = $this->get_facebook_specific_fields();
 
 		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
-			$product_data = array_merge(
-			array(
-				'title'                 => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
-				'description'           => $this->get_fb_description(),
-				'image_link'            => $image_urls[0],
-				'additional_image_link' => $this->get_additional_image_urls( $image_urls ),
-				'link'                  => $product_url,
-				'product_type'          => $categories['categories'],
-				'brand'                 => Helper::str_truncate( $this->get_fb_brand(), 100 ),
+			$product_data   = array_merge(
+				array(
+					'title'                 => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
+					'description'           => $this->get_fb_description(),
+					'image_link'            => $image_urls[0],
+					'additional_image_link' => $this->get_additional_image_urls( $image_urls ),
+					'link'                  => $product_url,
+					'product_type'          => $categories['categories'],
+					'brand'                 => Helper::str_truncate( $this->get_fb_brand(), 100 ),
 				'mpn'                 	=> Helper::str_truncate( $this->get_fb_mpn(), 100 ),
-				'retailer_id'           => $retailer_id,
-				'price'                 => $this->get_fb_price( true ),
-				'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
-				'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
+					'retailer_id'           => $retailer_id,
+					'price'                 => $this->get_fb_price( true ),
+					'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
+					'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
 				'custom_fields'			=> $custom_fields,
-				'rich_text_description' => $rich_text_description
-			),
-			// self::$rich_text_description_source === WC_Facebookcommerce_Utils::WOO_DESCRIPTION ? array('rich_text_description' => $rich_text_description) : array('rich_text_description' => $rich_text_description)
-		);
+				),
+				self::$rich_text_description_source === WC_Facebookcommerce_Utils::WC_DESCRIPTION ? array( 'rich_text_description' => $rich_text_description ) : array()
+			);
 			$product_data   = $this->add_sale_price( $product_data, true );
 			$gpc_field_name = 'google_product_category';
 			if ( ! empty( $video_urls ) ) {
@@ -852,34 +871,34 @@ class WC_Facebook_Product {
 		} else {
 			$product_data = array_merge(
 				array(
-				'name'                  => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
-				'description'           => $this->get_fb_description(),
-				'image_url'             => $image_urls[0],
-				'additional_image_urls' => $this->get_additional_image_urls( $image_urls ),
-				'url'                   => $product_url,
-				/**
-				 * 'category' is a required field for creating a ProductItem object when posting to /{product_catalog_id}/products.
-				 * This field should have the Google product category for the item. Google product category is not a required field
-				 * in the WooCommerce product editor. Hence, we are setting 'category' to Woo product categories by default and overriding
-				 * it when a Google product category is set.
-				 *
-				 * @see https://developers.facebook.com/docs/marketing-api/reference/product-catalog/products/#parameters-2
-				 * @see https://github.com/woocommerce/facebook-for-woocommerce/pull/2575
-				 * @see https://github.com/woocommerce/facebook-for-woocommerce/issues/2593
-				 */
-				'category'              => $categories['categories'],
-				'product_type'          => $categories['categories'],
-				'brand'                 => Helper::str_truncate( $this->get_fb_brand(), 100 ),
+					'name'                  => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
+					'description'           => $this->get_fb_description(),
+					'image_url'             => $image_urls[0],
+					'additional_image_urls' => $this->get_additional_image_urls( $image_urls ),
+					'url'                   => $product_url,
+					/**
+					 * 'category' is a required field for creating a ProductItem object when posting to /{product_catalog_id}/products.
+					 * This field should have the Google product category for the item. Google product category is not a required field
+					 * in the WooCommerce product editor. Hence, we are setting 'category' to Woo product categories by default and overriding
+					 * it when a Google product category is set.
+					 *
+					 * @see https://developers.facebook.com/docs/marketing-api/reference/product-catalog/products/#parameters-2
+					 * @see https://github.com/woocommerce/facebook-for-woocommerce/pull/2575
+					 * @see https://github.com/woocommerce/facebook-for-woocommerce/issues/2593
+					 */
+					'category'              => $categories['categories'],
+					'product_type'          => $categories['categories'],
+					'brand'                 => Helper::str_truncate( $this->get_fb_brand(), 100 ),
 				'mpn'                 	=> Helper::str_truncate( $this->get_fb_mpn(), 100 ),
-				'retailer_id'           => $retailer_id,
-				'price'                 => $this->get_fb_price(),
-				'currency'              => get_woocommerce_currency(),
-				'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
-				'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
+					'retailer_id'           => $retailer_id,
+					'price'                 => $this->get_fb_price(),
+					'currency'              => get_woocommerce_currency(),
+					'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
+					'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
 				'custom_fields'			=> $custom_fields
-			),
-			self::$rich_text_description_source === WC_Facebookcommerce_Utils::WOO_DESCRIPTION ? array('rich_text_description' => $rich_text_description) : array()
-		);
+				),
+				self::$rich_text_description_source === WC_Facebookcommerce_Utils::WC_DESCRIPTION ? array( 'rich_text_description' => $rich_text_description ) : array()
+			);
 
 			if ( self::PRODUCT_PREP_TYPE_NORMAL !== $type_to_prepare_for && ! empty( $video_urls ) ) {
 				$product_data['video'] = $video_urls;
@@ -932,9 +951,9 @@ class WC_Facebook_Product {
 			// No Visibility Option for Variations
 			// get_virtual() returns true for "unassembled bundles", so we exclude
 			// bundles from this check.
-			if ( true === $this->get_virtual() && 'bundle' !== $this->get_type() ) {
-				$product_data['visibility'] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
-			}
+		if ( true === $this->get_virtual() && 'bundle' !== $this->get_type() ) {
+			$product_data['visibility'] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
+		}
 
 		if ( self::PRODUCT_PREP_TYPE_FEED !== $type_to_prepare_for ) {
 			$this->prepare_variants_for_item( $product_data );
@@ -946,11 +965,11 @@ class WC_Facebook_Product {
 		}
 
 		/**
-		   * Filters the generated product data.
-		   *
-		   * @param int   $id           Woocommerce product id
-		   * @param array $product_data An array of product data
-		   */
+			* Filters the generated product data.
+			*
+			* @param int   $id           Woocommerce product id
+			* @param array $product_data An array of product data
+			*/
 		return apply_filters(
 			'facebook_for_woocommerce_integration_prepare_product',
 			$product_data,
@@ -968,7 +987,7 @@ class WC_Facebook_Product {
 	 * @return array
 	 */
 	private function apply_enhanced_catalog_fields_from_attributes( $product_data, $google_category_id ) {
-		$category_handler   = facebook_for_woocommerce()->get_facebook_category_handler();
+		$category_handler = facebook_for_woocommerce()->get_facebook_category_handler();
 		if ( empty( $google_category_id ) || ! $category_handler->is_category( $google_category_id ) ) {
 			return $product_data;
 		}
@@ -1008,7 +1027,7 @@ class WC_Facebook_Product {
 	public function get_matched_attributes_for_product( $product, $all_attributes ) {
 		$matched_attributes = array();
 		$sanitized_keys     = array_map(
-			function( $key ) {
+			function ( $key ) {
 					return \WC_Facebookcommerce_Utils::sanitize_variant_name( $key, false );
 			},
 			array_keys( $product->get_attributes() )
@@ -1016,11 +1035,8 @@ class WC_Facebook_Product {
 
 		$matched_attributes = array_filter(
 			$all_attributes,
-			function( $attribute ) use ( $sanitized_keys ) {
-				if ( is_array( $attribute ) && isset( $attribute['key'] ) ) {
-					return in_array( $attribute['key'], $sanitized_keys );
-				}
-				return false; // Return false if $attribute is not valid
+			function ( $attribute ) use ( $sanitized_keys ) {
+				return in_array( $attribute['key'], $sanitized_keys );
 			}
 		);
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -36,6 +36,7 @@ class WC_Facebook_Product {
 	const FB_VARIANT_IMAGE       = 'fb_image';
 	const FB_VISIBILITY          = 'fb_visibility';
 	const FB_REMOVE_FROM_SYNC    = 'fb_remove_from_sync';
+	const FB_RICH_TEXT_DESCRIPTION = 'fb_rich_text_description';
 	const FB_BRAND               = 'fb_brand';
 	const FB_VARIABLE_BRAND      = 'fb_variable_brand';
 	const FB_MPN              	 = 'fb_mpn';
@@ -45,6 +46,9 @@ class WC_Facebook_Product {
 	const MAX_DATE   = '2038-01-17';
 	const MAX_TIME   = 'T23:59+00:00';
 	const MIN_TIME   = 'T00:00+00:00';
+
+    public static $rich_text_description_source = WC_Facebookcommerce_Utils::WOO_DESCRIPTION;
+	
 
 	static $use_checkout_url = array(
 		'simple'    => 1,
@@ -92,6 +96,11 @@ class WC_Facebook_Product {
 	 */
 	public $fb_visibility;
 
+	/**
+	 * @var string Product rich text description.
+	 */
+	public $rich_text_description;
+
 	public function __construct( $wpid, $parent_product = null ) {
 
 		if ( $wpid instanceof WC_Product ) {
@@ -107,6 +116,7 @@ class WC_Facebook_Product {
 		$this->fb_use_parent_image    = null;
 		$this->main_description       = '';
 		$this->sync_short_description = \WC_Facebookcommerce_Integration::PRODUCT_DESCRIPTION_MODE_SHORT === facebook_for_woocommerce()->get_integration()->get_product_description_mode();
+		$this->rich_text_description  = '';
 
 		if ( $meta = get_post_meta( $this->id, self::FB_VISIBILITY, true ) ) {
 			$this->fb_visibility = wc_string_to_bool( $meta );
@@ -361,6 +371,13 @@ class WC_Facebook_Product {
 		}
 	}
 
+	public function set_rich_text_description( $rich_text_description ) {
+		$rich_text_description          = stripslashes(
+			WC_Facebookcommerce_Utils::clean_string( $rich_text_description, false )
+		);
+		$this->rich_text_description = $rich_text_description;
+	}
+
 	public function set_fb_brand( $fb_brand ) {
 		$fb_brand = stripslashes(
 			WC_Facebookcommerce_Utils::clean_string( $fb_brand )
@@ -503,6 +520,62 @@ class WC_Facebook_Product {
 		 * @param int     $id          WooCommerce Product ID.
 		 */
 		return apply_filters( 'facebook_for_woocommerce_fb_product_description', $description, $this->id );
+	}
+
+	public function get_rich_text_description() {
+		$rich_text_description = '';
+
+		if ( $this->fb_description ) {
+			$rich_text_description = $this->fb_description;
+		}
+
+		if ( $this->rich_text_description ) {
+			$rich_text_description = $this->rich_text_description;
+		}
+		
+		
+
+		if ( empty( $rich_text_description ) ) {
+			// Try to get description from post meta if fb description has been set
+			$rich_text_description = get_post_meta(
+				$this->id,
+				self::FB_PRODUCT_DESCRIPTION,
+				true
+			);
+			if ($rich_text_description){
+                self::$rich_text_description_source = WC_Facebookcommerce_Utils::FB_DESCRIPTION;
+            }
+		}
+
+		// For variable products, we want to use the rich text description of the variant.
+		// If that's not available, fall back to the main (parent) product's rich text description.
+		if (empty($rich_text_description) && WC_Facebookcommerce_Utils::is_variation_type($this->woo_product->get_type())) {
+			$rich_text_description = WC_Facebookcommerce_Utils::clean_string($this->woo_product->get_rich_text_description());
+
+			// If the variant's rich text description is still empty, use the main product's rich text description as a fallback.
+			if (empty($rich_text_description) && $this->main_description) {
+				$rich_text_description = $this->rich_text_description;
+			}
+		}
+
+		// If no description is found from meta or variation, get from post
+		if ( empty( $rich_text_description ) ) {
+			$post         = $this->get_post_data();
+			$post_content = WC_Facebookcommerce_Utils::clean_string( $post->post_content, false );
+			$post_excerpt = WC_Facebookcommerce_Utils::clean_string( $post->post_excerpt, false );
+
+			
+			if ( ! empty( $post_content ) ) {
+				$rich_text_description = $post_content;
+			}
+
+			if ( $this->sync_short_description || ( empty( $rich_text_description ) && ! empty( $post_excerpt ) ) ) {
+				$rich_text_description = $post_excerpt;
+			}
+
+		}
+		
+		return apply_filters( 'facebook_for_woocommerce_fb_rich_text_description', $rich_text_description, $this->id );
 	}
 
 	/**
@@ -724,10 +797,12 @@ class WC_Facebook_Product {
 		$categories =
 		WC_Facebookcommerce_Utils::get_product_categories( $id );
 
+		$rich_text_description = $this->get_rich_text_description();
 		$custom_fields = $this->get_facebook_specific_fields();
 
 		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
-			$product_data = array(
+			$product_data = array_merge(
+			array(
 				'title'                 => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
 				'description'           => $this->get_fb_description(),
 				'image_link'            => $image_urls[0],
@@ -741,14 +816,17 @@ class WC_Facebook_Product {
 				'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
 				'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
 				'custom_fields'			=> $custom_fields
-			);
+			),
+			self::$rich_text_description_source === WC_Facebookcommerce_Utils::WOO_DESCRIPTION ? array('rich_text_description' => $rich_text_description) : array()
+		);
 			$product_data   = $this->add_sale_price( $product_data, true );
 			$gpc_field_name = 'google_product_category';
 			if ( ! empty( $video_urls ) ) {
 				$product_data['video'] = $video_urls;
 			}
 		} else {
-			$product_data = array(
+			$product_data = array_merge(
+				array(
 				'name'                  => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
 				'description'           => $this->get_fb_description(),
 				'image_url'             => $image_urls[0],
@@ -774,7 +852,9 @@ class WC_Facebook_Product {
 				'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
 				'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
 				'custom_fields'			=> $custom_fields
-			);
+			),
+			self::$rich_text_description_source === WC_Facebookcommerce_Utils::WOO_DESCRIPTION ? array('rich_text_description' => $rich_text_description) : array()
+		);
 
 			if ( self::PRODUCT_PREP_TYPE_NORMAL !== $type_to_prepare_for && ! empty( $video_urls ) ) {
 				$product_data['video'] = $video_urls;

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -71,6 +71,12 @@ class WC_Facebook_Product {
 	 */
 	private $fb_description;
 
+
+	/**
+	 * @var string Facebook Rich Text Description.
+	 */
+	private $fb_rich_text_description;
+
 	/**
 	 * @var array Gallery URLs.
 	 */
@@ -351,11 +357,22 @@ class WC_Facebook_Product {
 		$description          = stripslashes(
 			WC_Facebookcommerce_Utils::clean_string( $description )
 		);
+		$rich_text_description          = stripslashes(
+			WC_Facebookcommerce_Utils::clean_string( $description, false )
+		);
 		$this->fb_description = $description;
+		$this->fb_rich_text_description = $rich_text_description;
+
 		update_post_meta(
 			$this->id,
 			self::FB_PRODUCT_DESCRIPTION,
 			$description
+		);
+
+		update_post_meta(
+			$this->id,
+			self::FB_RICH_TEXT_DESCRIPTION,
+			$rich_text_description
 		);
 	}
 
@@ -541,20 +558,23 @@ class WC_Facebook_Product {
 
 		if ( empty( $rich_text_description ) ) {
 			// Try to get description from post meta if fb description has been set
-			$rich_text_description = get_post_meta(
+			$temp_rich_text_description = get_post_meta(
 				$this->id,
+				self::FB_RICH_TEXT_DESCRIPTION,
 				self::FB_RICH_TEXT_DESCRIPTION,
 				true
 			);
-			if ($rich_text_description){
+
+			if ($temp_rich_text_description){
                 self::$rich_text_description_source = WC_Facebookcommerce_Utils::FB_DESCRIPTION;
+				$rich_text_description = $temp_rich_text_description;
             }
 		}
 
 		// For variable products, we want to use the rich text description of the variant.
 		// If that's not available, fall back to the main (parent) product's rich text description.
 		if (empty($rich_text_description) && WC_Facebookcommerce_Utils::is_variation_type($this->woo_product->get_type())) {
-			$rich_text_description = WC_Facebookcommerce_Utils::clean_string($this->woo_product->get_rich_text_description());
+			$rich_text_description = WC_Facebookcommerce_Utils::clean_string($this->woo_product->get_description(), false);
 
 			// If the variant's rich text description is still empty, use the main product's rich text description as a fallback.
 			if (empty($rich_text_description) && $this->main_description) {

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -372,10 +372,14 @@ class WC_Facebook_Product {
 	}
 
 	public function set_rich_text_description( $rich_text_description ) {
-		$rich_text_description          = stripslashes(
-			WC_Facebookcommerce_Utils::clean_string( $rich_text_description, false )
-		);
+		$rich_text_description          = 
+			WC_Facebookcommerce_Utils::clean_string( $rich_text_description, false );
 		$this->rich_text_description = $rich_text_description;
+		update_post_meta(
+			$this->id,
+			self::FB_RICH_TEXT_DESCRIPTION,
+			$rich_text_description
+		);
 	}
 
 	public function set_fb_brand( $fb_brand ) {
@@ -539,7 +543,7 @@ class WC_Facebook_Product {
 			// Try to get description from post meta if fb description has been set
 			$rich_text_description = get_post_meta(
 				$this->id,
-				self::FB_PRODUCT_DESCRIPTION,
+				self::FB_RICH_TEXT_DESCRIPTION,
 				true
 			);
 			if ($rich_text_description){
@@ -815,9 +819,10 @@ class WC_Facebook_Product {
 				'price'                 => $this->get_fb_price( true ),
 				'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
 				'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
-				'custom_fields'			=> $custom_fields
+				'custom_fields'			=> $custom_fields,
+				'rich_text_description' => $rich_text_description
 			),
-			self::$rich_text_description_source === WC_Facebookcommerce_Utils::WOO_DESCRIPTION ? array('rich_text_description' => $rich_text_description) : array()
+			// self::$rich_text_description_source === WC_Facebookcommerce_Utils::WOO_DESCRIPTION ? array('rich_text_description' => $rich_text_description) : array('rich_text_description' => $rich_text_description)
 		);
 			$product_data   = $this->add_sale_price( $product_data, true );
 			$gpc_field_name = 'google_product_category';

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -525,10 +525,10 @@ class WC_Facebook_Product {
 	/**
 	 * Get the rich text description for a product.
 	 *
-	 * This function retrieves the rich text product description based on the following logic:
+	 * This function retrieves the rich text product description, prioritizing Facebook
+	 * rich text descriptions over WooCommerce product descriptions.
 	 * 1. Check if the Facebook rich text description is set and not empty.
-	 * 2. If the rich text description is available, use it as the preferred description.
-	 * 3. Otherwise, fall back to the plain text description made available by WooCommerce.
+	 * 2. If the rich text description is not set or empty, use the WooCommerce RTD if available.
 	 *
 	 * @return string The rich text description for the product.
 	 */
@@ -563,7 +563,7 @@ class WC_Facebook_Product {
 			}
 		}
 
-		// If no description is found from meta or variation, get from post
+		// If no description is found from meta or variation, get from product
 		if ( empty( $rich_text_description ) ) {
 			$post         = $this->get_post_data();
 			$post_content = WC_Facebookcommerce_Utils::clean_string( $post->post_content, false );

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -817,7 +817,6 @@ class WC_Facebook_Product {
 
 		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
 			$product_data   = array(
-				array(
 					'title'                 => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
 					'description'           => $this->get_fb_description(),
 					'rich_text_description' => $this->get_rich_text_description(),
@@ -832,7 +831,6 @@ class WC_Facebook_Product {
 					'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
 					'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
 					'custom_fields'			=> $custom_fields,
-				),
 			);
 			$product_data   = $this->add_sale_price( $product_data, true );
 			$gpc_field_name = 'google_product_category';
@@ -841,7 +839,6 @@ class WC_Facebook_Product {
 			}
 		} else {
 			$product_data = array(
-				array(
 					'name'                  => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
 					'description'           => $this->get_fb_description(),
 					'image_url'             => $image_urls[0],
@@ -868,7 +865,6 @@ class WC_Facebook_Product {
 					'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
 					'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
 					'custom_fields'			=> $custom_fields
-				),
 			);
 
 			if ( self::PRODUCT_PREP_TYPE_NORMAL !== $type_to_prepare_for && ! empty( $video_urls ) ) {

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1256,3 +1256,4 @@ class WC_Facebook_Product {
 	}
 
 }
+

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -68,7 +68,6 @@ class WC_Facebook_Product {
 	 */
 	private $fb_description;
 
-
 	/**
 	 * @var array Gallery URLs.
 	 */
@@ -801,18 +800,6 @@ class WC_Facebook_Product {
 		$categories =
 		WC_Facebookcommerce_Utils::get_product_categories( $id );
 
-		// Get brand attribute.
-		$brand = get_post_meta( $id, Products::ENHANCED_CATALOG_ATTRIBUTES_META_KEY_PREFIX . 'brand', true );
-		$brand_taxonomy = get_the_term_list( $id, 'product_brand', '', ', ' );
-
-		if ( $brand ) {
-			$brand = WC_Facebookcommerce_Utils::clean_string( $brand );
-		} elseif ( ! is_wp_error( $brand_taxonomy ) && $brand_taxonomy ) {
-			$brand = WC_Facebookcommerce_Utils::clean_string( $brand_taxonomy );
-		} else {
-			$brand = wp_strip_all_tags( WC_Facebookcommerce_Utils::get_store_name() );
-		}
-
 		$custom_fields = $this->get_facebook_specific_fields();
 
 		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
@@ -825,7 +812,7 @@ class WC_Facebook_Product {
 					'link'                  => $product_url,
 					'product_type'          => $categories['categories'],
 					'brand'                 => Helper::str_truncate( $this->get_fb_brand(), 100 ),
-				'mpn'                 	=> Helper::str_truncate( $this->get_fb_mpn(), 100 ),
+					'mpn'                 	=> Helper::str_truncate( $this->get_fb_mpn(), 100 ),
 					'retailer_id'           => $retailer_id,
 					'price'                 => $this->get_fb_price( true ),
 					'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
@@ -1002,8 +989,11 @@ class WC_Facebook_Product {
 
 		$matched_attributes = array_filter(
 			$all_attributes,
-			function ( $attribute ) use ( $sanitized_keys ) {
-				return in_array( $attribute['key'], $sanitized_keys );
+			function( $attribute ) use ( $sanitized_keys ) {
+				if ( is_array( $attribute ) && isset( $attribute['key'] ) ) {
+					return in_array( $attribute['key'], $sanitized_keys );
+				}
+				return false; // Return false if $attribute is not valid
 			}
 		);
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -867,7 +867,7 @@ class WC_Facebook_Product {
 					'currency'              => get_woocommerce_currency(),
 					'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
 					'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
-				'custom_fields'			=> $custom_fields
+					'custom_fields'			=> $custom_fields
 				),
 			);
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -543,16 +543,13 @@ class WC_Facebook_Product {
 		$rich_text_description = '';
 
 		// Check if the fb description is set as that takes preference
-		if ( $this->fb_description ) {
+		if ( $this->rich_text_description ) {
+			$rich_text_description = $this->rich_text_description;
+		} elseif ( $this->fb_description ) {
 			$rich_text_description = $this->fb_description;
 		}
 
-		// If the rich text description is available, use it as the preferred description
-		if ( $this->rich_text_description ) {
-			$rich_text_description = $this->rich_text_description;
-		}
-
-		// Try to get description from post meta if fb description has been set
+		// Try to get rich text description from post meta if description has been set
 		if ( empty( $rich_text_description ) ) {
 			$temp_rich_text_description = get_post_meta(
 				$this->id,

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -47,7 +47,7 @@ class WC_Facebook_Product {
 	const MAX_TIME   = 'T23:59+00:00';
 	const MIN_TIME   = 'T00:00+00:00';
 
-	static $use_checkout_url                    = array(
+	static $use_checkout_url = array(
 		'simple'    => 1,
 		'variable'  => 1,
 		'variation' => 1,

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -34,6 +34,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		const FB_VARIANT_PATTERN = 'pattern';
 		const FB_VARIANT_GENDER  = 'gender';
 
+		const FB_DESCRIPTION = 'fb_description';
+		const WOO_DESCRIPTION = 'woo_description';
+
 		public static $ems        = null;
 		public static $store_name = null;
 
@@ -252,14 +255,14 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		 * Clean up strings for FB Graph POSTing.
 		 * This function should will:
 		 * 1. Replace newlines chars/nbsp with a real space
-		 * 2. strip_tags()
+		 * 2. strip_tags() if not explicitly stated to not
 		 * 3. trim()
 		 *
 		 * @access public
 		 * @param String string
 		 * @return string
 		 */
-		public static function clean_string( $string ) {
+		public static function clean_string( $string, $strip_html_tags = true ) {
 
 			/**
 			 * Filters whether the shortcodes should be applied for a string when syncing a product or be stripped out.
@@ -269,6 +272,10 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 			 * @param bool   $apply_shortcodes Shortcodes are applied if set to `true` and stripped out if set to `false`.
 			 * @param string $string           String to clean up.
 			 */
+
+			 if (!$string){
+				return '';
+			 }
 			$apply_shortcodes = apply_filters( 'wc_facebook_string_apply_shortcodes', false, $string );
 			if ( $apply_shortcodes ) {
 				// Apply active shortcodes
@@ -280,7 +287,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 
 			$string = str_replace( array( '&amp%3B', '&amp;' ), '&', $string );
 			$string = str_replace( array( "\r", '&nbsp;', "\t" ), ' ', $string );
-			$string = wp_strip_all_tags( $string, false ); // true == remove line breaks
+			if ($strip_html_tags){
+				$string = wp_strip_all_tags( $string, false ); // true == remove line breaks
+			}
 			return $string;
 		}
 

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -35,7 +35,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		const FB_VARIANT_GENDER  = 'gender';
 
 		const FB_DESCRIPTION = 'fb_description';
-		const WOO_DESCRIPTION = 'woo_description';
+		const WC_DESCRIPTION = 'wc_description';
 
 		public static $ems        = null;
 		public static $store_name = null;
@@ -273,7 +273,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 			 * @param string $string           String to clean up.
 			 */
 
-			 if (!$string){
+			 if (empty($string)){
 				return '';
 			 }
 			$apply_shortcodes = apply_filters( 'wc_facebook_string_apply_shortcodes', false, $string );

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -34,9 +34,6 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		const FB_VARIANT_PATTERN = 'pattern';
 		const FB_VARIANT_GENDER  = 'gender';
 
-		const FB_DESCRIPTION = 'fb_description';
-		const WC_DESCRIPTION = 'wc_description';
-
 		public static $ems        = null;
 		public static $store_name = null;
 

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -495,7 +495,6 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 
 		$_POST[ WC_Facebook_Product::FB_REMOVE_FROM_SYNC ] = $product_to_delete->get_id();
 
-		$_POST[ WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION ] = 'Facebook product description.';
 		$_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ]                   = '199';
 		$_POST['fb_product_image_source']                                 = 'Image source meta key value.';
 		$_POST[ WC_Facebook_Product::FB_PRODUCT_IMAGE ]                   = 'Facebook product image.';
@@ -524,7 +523,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 		$facebook_product_data                               = $facebook_product->prepare_product(null, \WC_Facebook_Product::PRODUCT_PREP_TYPE_ITEMS_BATCH );
 		$this->integration->product_catalog_id               = '123123123123123123';
 		/* Data coming from _POST data. */
-		$facebook_product_data['description']                = 'Facebook product description.';
+		$facebook_product_data['description']                = 'Dummy Product';
 		$facebook_product_data['price']                      = '199 USD';
 		$facebook_product_data['google_product_category']    = 1718;
 		$facebook_product_data['custom_fields']	= [
@@ -566,7 +565,6 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 		$this->assertEquals(true, $updated_product_data['custom_fields']['has_fb_image']);
 
 		// Verify the actual values are still stored in meta
-		$this->assertEquals( 'Facebook product description.', get_post_meta( $facebook_product_to_update->get_id(), WC_Facebook_Product::FB_PRODUCT_DESCRIPTION, true ) );
 		$this->assertEquals( '199', get_post_meta( $facebook_product_to_update->get_id(), WC_Facebook_Product::FB_PRODUCT_PRICE, true ) );
 		$this->assertEquals( 'http://example.orgFacebook product image.', get_post_meta( $facebook_product_to_update->get_id(), WC_Facebook_Product::FB_PRODUCT_IMAGE, true ) );
 	}
@@ -1870,7 +1868,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 		set_current_screen( 'edit-post' );
 
 		/** @var WC_Product_Simple $product */
-		$product = WC_Helper_Product::create_simple_product();
+		$product =   WC_Helper_Product::create_simple_product();
 		$product->add_meta_data( WC_Facebookcommerce_Integration::FB_PRODUCT_GROUP_ID, 'facebook-product-group-id-1' );
 		$product->add_meta_data( WC_Facebookcommerce_Integration::FB_PRODUCT_ITEM_ID, 'facebook-product-item-id-1' );
 		$product->add_meta_data( Products::VISIBILITY_META_KEY, true );

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -495,6 +495,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 
 		$_POST[ WC_Facebook_Product::FB_REMOVE_FROM_SYNC ] = $product_to_delete->get_id();
 
+		$_POST[ WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION ] = 'Facebook product description.';
 		$_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ]                   = '199';
 		$_POST['fb_product_image_source']                                 = 'Image source meta key value.';
 		$_POST[ WC_Facebook_Product::FB_PRODUCT_IMAGE ]                   = 'Facebook product image.';
@@ -523,7 +524,8 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 		$facebook_product_data                               = $facebook_product->prepare_product(null, \WC_Facebook_Product::PRODUCT_PREP_TYPE_ITEMS_BATCH );
 		$this->integration->product_catalog_id               = '123123123123123123';
 		/* Data coming from _POST data. */
-		$facebook_product_data['description']                = 'Dummy Product';
+		$facebook_product_data['description']				 = 'Facebook product description.';
+		$facebook_product_data['rich_text_description']		 = 'Facebook product description.';
 		$facebook_product_data['price']                      = '199 USD';
 		$facebook_product_data['google_product_category']    = 1718;
 		$facebook_product_data['custom_fields']	= [
@@ -560,6 +562,9 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 		$facebook_product_to_update = new WC_Facebook_Product( $product_to_update->get_id() );
 		$updated_product_data = $facebook_product_to_update->prepare_product(null, \WC_Facebook_Product::PRODUCT_PREP_TYPE_ITEMS_BATCH );
 		
+		$this->assertEquals( 'Facebook product description.', get_post_meta( $facebook_product_to_update->get_id(), WC_Facebook_Product::FB_PRODUCT_DESCRIPTION, true ) );
+		$this->assertEquals( 'Facebook product description.', get_post_meta( $facebook_product_to_update->get_id(), WC_Facebook_Product::FB_RICH_TEXT_DESCRIPTION, true ) );
+
 		$this->assertEquals(true, $updated_product_data['custom_fields']['has_fb_description']);
 		$this->assertEquals(true, $updated_product_data['custom_fields']['has_fb_price']);
 		$this->assertEquals(true, $updated_product_data['custom_fields']['has_fb_image']);

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -570,6 +570,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 		$this->assertEquals(true, $updated_product_data['custom_fields']['has_fb_image']);
 
 		// Verify the actual values are still stored in meta
+		$this->assertEquals( 'Facebook product description.', get_post_meta( $facebook_product_to_update->get_id(), WC_Facebook_Product::FB_PRODUCT_DESCRIPTION, true ) );
 		$this->assertEquals( '199', get_post_meta( $facebook_product_to_update->get_id(), WC_Facebook_Product::FB_PRODUCT_PRICE, true ) );
 		$this->assertEquals( 'http://example.orgFacebook product image.', get_post_meta( $facebook_product_to_update->get_id(), WC_Facebook_Product::FB_PRODUCT_IMAGE, true ) );
 	}

--- a/tests/Unit/fbUtilsTest.php
+++ b/tests/Unit/fbUtilsTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+
+class fbUtilsTest extends WP_UnitTestCase {
+    public function testRemoveHtmlTags() {
+        $string = '<p>Hello World!</p>';
+        $expectedOutput = 'Hello World!';
+        $actualOutput = WC_Facebookcommerce_Utils::clean_string($string, true);
+        $this->assertEquals($expectedOutput, $actualOutput);
+    } 
+
+    public function testKeepHtmlTags() {
+        $string = '<p>Hello World!</p>';
+        $expectedOutput = '<p>Hello World!</p>';
+        $actualOutput = WC_Facebookcommerce_Utils::clean_string($string, false);
+        $this->assertEquals($expectedOutput, $actualOutput);
+    }
+
+    public function testReplaceSpecialCharacters() {
+        $string = 'Hello &amp; World!';
+        $expectedOutput = 'Hello & World!';
+        $actualOutput = WC_Facebookcommerce_Utils::clean_string($string, true);
+        $this->assertEquals($expectedOutput, $actualOutput);
+    }
+
+    public function testEmptyString() {
+        $string = '';
+        $expectedOutput = '';
+        $actualOutput = WC_Facebookcommerce_Utils::clean_string($string, true);
+        $this->assertEquals($expectedOutput, $actualOutput);
+    }
+
+    public function testNullString() {
+        $string = null;
+        $expectedOutput = null;
+        $actualOutput = WC_Facebookcommerce_Utils::clean_string($string, true);
+        $this->assertEquals($expectedOutput, $actualOutput);
+    }
+}

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -605,34 +605,6 @@ class fbproductTest extends WP_UnitTestCase {
 	}	
 	
 	/**
-	 * Test html tags preservation for rich text description
-	 * @return void
-	 */
-	public function test_html_preservation_for_rich_text_description() {
-    // Create a simple product
-    $product = WC_Helper_Product::create_simple_product();
-
-    // Create a Facebook product instance
-    $facebookProduct = new \WC_Facebook_Product($product);
-
-    // Set the rich text description with HTML content
-    $htmlContent = '<html>
-        <p>Unisex cotton T-shirt with 3/4 length sleeves in royal blue. Great for everyday casual wear. Features graphic print of logo in white on upper left sleeve.</p>
-        <ul>
-            <li>100% Cotton</li>
-            <li>Relaxed Fit</li>
-        </ul>
-    </html>';
-    $facebookProduct->set_rich_text_description($htmlContent);
-
-    // Get the rich text description
-    $richTextDescription = $facebookProduct->get_rich_text_description();
-
-    // Assert that the HTML content is preserved
-    $this->assertEquals($htmlContent, $richTextDescription);
-	}
-
-	/**
 	 * Tests for get_rich_text_description() method
 	 */
 	public function test_get_rich_text_description() {

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -589,6 +589,50 @@ class fbproductTest extends WP_UnitTestCase {
         $this->assertArrayHasKey('image_link', $product_data);
     }
 
+		
+	/**
+	 * Test it gets rich text description from post meta.
+	 * @return void
+	 */
+	public function test_get_rich_text_description_from_post_meta() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$facebook_product = new \WC_Facebook_Product( $product );
+		$facebook_product->set_rich_text_description( 'rich text description' );
+		$rich_text_description = $facebook_product->get_rich_text_description();
+
+		$this->assertEquals( $rich_text_description,  'rich text description' );
+	}	
+	
+	/**
+	 * Test html tags preservation for rich text description
+	 * @return void
+	 */
+	public function test_html_preservation_for_rich_text_description() {
+    // Create a simple product
+    $product = WC_Helper_Product::create_simple_product();
+
+    // Create a Facebook product instance
+    $facebookProduct = new \WC_Facebook_Product($product);
+
+    // Set the rich text description with HTML content
+    $htmlContent = '<html>
+        <p>Unisex cotton T-shirt with 3/4 length sleeves in royal blue. Great for everyday casual wear. Features graphic print of logo in white on upper left sleeve.</p>
+        <ul>
+            <li>100% Cotton</li>
+            <li>Relaxed Fit</li>
+        </ul>
+    </html>';
+    $facebookProduct->set_rich_text_description($htmlContent);
+
+    // Get the rich text description
+    $richTextDescription = $facebookProduct->get_rich_text_description();
+
+    // Assert that the HTML content is preserved
+    $this->assertEquals($htmlContent, $richTextDescription);
+	}
+
+
 	/**
 	 * Test Brand is added for simple product 
 	 * @return void

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -632,6 +632,174 @@ class fbproductTest extends WP_UnitTestCase {
     $this->assertEquals($htmlContent, $richTextDescription);
 	}
 
+	/**
+	 * Tests for get_rich_text_description() method
+	 */
+	public function test_get_rich_text_description() {
+		// Test 1: Gets rich text description from fb_description if set
+		$product = WC_Helper_Product::create_simple_product();
+		$facebook_product = new \WC_Facebook_Product($product);
+		$facebook_product->set_description('fb description test');
+		
+		$description = $facebook_product->get_rich_text_description();
+		$this->assertEquals('fb description test', $description);
+
+		// Test 2: Gets rich text description from rich_text_description if set
+		$facebook_product->set_rich_text_description('<p>rich text description test</p>');
+		$description = $facebook_product->get_rich_text_description();
+		$this->assertEquals('<p>rich text description test</p>', $description);
+
+		// Test 3: Gets rich text description from post meta
+		update_post_meta($product->get_id(), \WC_Facebook_Product::FB_RICH_TEXT_DESCRIPTION, '<p>meta description test</p>');
+		$new_facebook_product = new \WC_Facebook_Product($product); // Create new instance to clear cached values
+		$description = $new_facebook_product->get_rich_text_description();
+		$this->assertEquals('<p>meta description test</p>', $description);
+
+		// Test 4: For variations, gets description from variation first
+		$variable_product = WC_Helper_Product::create_variation_product();
+		$variation = wc_get_product($variable_product->get_children()[0]);
+		$variation->set_description('<p>variation description</p>');
+		$variation->save();
+		
+		$parent_fb_product = new \WC_Facebook_Product($variable_product);
+		$facebook_product = new \WC_Facebook_Product($variation, $parent_fb_product);
+		$description = $facebook_product->get_rich_text_description();
+		$this->assertEquals('<p>variation description</p>', $description);
+
+		// Test 5: Falls back to post content if no other description is set
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_description('<p>product content description</p>');
+		$product->save();
+		
+		$facebook_product = new \WC_Facebook_Product($product);
+		$description = $facebook_product->get_rich_text_description();
+		$this->assertEquals('<p>product content description</p>', $description);
+
+		// Test 6: Falls back to post excerpt if content is empty and sync_short_description is true
+		add_option(
+			WC_Facebookcommerce_Integration::SETTING_PRODUCT_DESCRIPTION_MODE,
+			WC_Facebookcommerce_Integration::PRODUCT_DESCRIPTION_MODE_SHORT
+		);
+		
+		$product->set_description('');
+		$product->set_short_description('<p>short description test</p>');
+		$product->save();
+		
+		$facebook_product = new \WC_Facebook_Product($product);
+		$description = $facebook_product->get_rich_text_description();
+		$this->assertEquals('<p>short description test</p>', $description);
+
+		// Test 7: Applies filters
+		add_filter('facebook_for_woocommerce_fb_rich_text_description', function($description) {
+			return '<p>filtered description</p>';
+		});
+		
+		$description = $facebook_product->get_rich_text_description();
+		$this->assertEquals('<p>filtered description</p>', $description);
+		
+		// Cleanup
+		remove_all_filters('facebook_for_woocommerce_fb_rich_text_description');
+		delete_option(WC_Facebookcommerce_Integration::SETTING_PRODUCT_DESCRIPTION_MODE);
+	}
+
+	/**
+	 * Test HTML preservation in rich text description
+	 */
+	public function test_rich_text_description_html_preservation() {
+		$product = WC_Helper_Product::create_simple_product();
+		$facebook_product = new \WC_Facebook_Product($product);
+
+		$html_content = '
+			<div class="product-description">
+				<h2>Product Features</h2>
+				<p>This is a <strong>premium</strong> product with:</p>
+				<ul>
+					<li>Feature 1</li>
+					<li>Feature 2</li>
+				</ul>
+				<table>
+					<tr>
+						<th>Size</th>
+						<th>Color</th>
+					</tr>
+					<tr>
+						<td>Large</td>
+						<td>Blue</td>
+					</tr>
+				</table>
+			</div>
+		';
+
+		$facebook_product->set_rich_text_description($html_content);
+		$description = $facebook_product->get_rich_text_description();
+		
+		// Test HTML structure is preserved
+		$this->assertStringContainsString('<div class="product-description">', $description);
+		$this->assertStringContainsString('<h2>', $description);
+		$this->assertStringContainsString('<strong>', $description);
+		$this->assertStringContainsString('<ul>', $description);
+		$this->assertStringContainsString('<li>', $description);
+		$this->assertStringContainsString('<table>', $description);
+		$this->assertStringContainsString('<tr>', $description);
+		$this->assertStringContainsString('<th>', $description);
+		$this->assertStringContainsString('<td>', $description);
+	}
+
+	/**
+	 * Test empty rich text description fallback behavior
+	 */
+	public function test_empty_rich_text_description_fallback() {
+		$product = WC_Helper_Product::create_simple_product();
+		$facebook_product = new \WC_Facebook_Product($product);
+		
+		// Ensure rich_text_description is empty
+		$facebook_product->set_rich_text_description('');
+		
+		// Test fallback to post meta
+		update_post_meta($product->get_id(), \WC_Facebook_Product::FB_RICH_TEXT_DESCRIPTION, '<p>fallback description</p>');
+		$description = $facebook_product->get_rich_text_description();
+		$this->assertEquals('<p>fallback description</p>', $description);
+		
+		// Test behavior when both rich_text_description and post meta are empty
+		delete_post_meta($product->get_id(), \WC_Facebook_Product::FB_RICH_TEXT_DESCRIPTION);
+		$description = $facebook_product->get_rich_text_description();
+		$this->assertEquals('', $description);
+	}
+
+	/**
+	 * Test rich text description handling for variable products and variations
+	 */
+	public function test_rich_text_description_variants() {
+		// Create variable product with variation
+		$variable_product = WC_Helper_Product::create_variation_product();
+		$variation = wc_get_product($variable_product->get_children()[0]);
+		
+		// Set up parent product
+		$parent_fb_product = new \WC_Facebook_Product($variable_product);
+		
+		// Set the rich text description using post meta for the parent
+		update_post_meta($variable_product->get_id(), \WC_Facebook_Product::FB_RICH_TEXT_DESCRIPTION, '<p>parent rich text</p>');
+		
+		// Test 1: Variation inherits parent's rich text description when empty
+		$facebook_product = new \WC_Facebook_Product($variation, $parent_fb_product);
+		$description = $facebook_product->get_rich_text_description();
+		$this->assertEquals('<p>parent rich text</p>', $description);
+		
+		// Test 2: Variation uses its own rich text description when set
+		$variation_fb_product = new \WC_Facebook_Product($variation, $parent_fb_product);
+		$variation_fb_product->set_rich_text_description('<p>variation rich text</p>');
+		$description = $variation_fb_product->get_rich_text_description();
+		$this->assertEquals('<p>variation rich text</p>', $description);
+		
+		// // Test 3: Variation uses its post meta when set
+		// update_post_meta($variation->get_id(), \WC_Facebook_Product::FB_RICH_TEXT_DESCRIPTION, '<p>variation meta rich text</p>');
+		// $new_variation_product = new \WC_Facebook_Product($variation, $parent_fb_product);
+		// $description = $new_variation_product->get_rich_text_description();
+		// $this->assertEquals('<p>variation meta rich text</p>', $description);
+		
+		// Test 4: Fallback chain for variations
+		delete_post_meta($variation->get_id(), \WC_Facebook_Product::FB_RICH_TEXT_DESCRIPTION);
+	}
 
 	/**
 	 * Test Brand is added for simple product 


### PR DESCRIPTION
### Add Rich Text Description to Woo Product Sync with Meta

#### Description
This PR introduces a new feature to the Facebook WooCommerce Plugin, allowing users to add rich text descriptions to their products. With this update, we can seamlessly synchronize the rich text description field with the Facebook Commerce Manager platform.

It also adds functionality for a WYSIWYG input box for the Facebook Description field in the plugin 

#### Changes
- Updated the product sync logic to handle rich text formatting.
- Modified the API payload to include the rich text description field.
- Tested for compatibility with common formatting options (bold, italic, lists, links, etc.).

#### Benefits
- Improves the visual appeal of product descriptions on Meta.
- Ensures consistent branding and formatting across platforms.
- Enhances user engagement by presenting more structured and detailed product information.

#### Testing Instructions
1. Enable the WooCommerce to Meta product sync.
2. Create or edit a product in WooCommerce with a rich text description (e.g., headings, bold, italic, lists).
3. Sync the product and verify that the description appears correctly formatted on Meta.


#### Screenshots
<img width="1244" alt="Screenshot 2024-11-04 at 11 21 23" src="https://github.com/user-attachments/assets/eb1c1fbb-5734-4c27-b710-1e031f1a58e6">
<img width="601" alt="Screenshot 2024-11-04 at 11 22 26" src="https://github.com/user-attachments/assets/a40f84e8-3127-4b62-a87d-c172ab257a98">
<img width="753" alt="Screenshot 2024-11-04 at 11 22 41" src="https://github.com/user-attachments/assets/75063389-5a78-4ae2-a73f-c2a392427472">
<img width="740" alt="Screenshot 2024-12-24 at 18 24 52" src="https://github.com/user-attachments/assets/e011e53e-9892-4e06-ace1-bfd7e22dab22" />

---

#### Additional Notes
Please let me know if there are any edge cases or scenarios that should be tested further.
