### PR TITLE
Install svn in unit test file

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Prepare MySQL
         uses: woocommerce/grow/prepare-mysql@actions-v1
 
+      - name: Install svn
+        run: sudo apt-get install subversion -y
+
       - name: Install WP tests
         run: ./bin/install-wp-tests.sh wordpress_test root root localhost ${{ matrix.wp-version }}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Installs svn in `php-unit-tests.yml` file because the tests error otherwise.