### PR TITLE
Fix: get_global_unique_id function compatibility check

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -731,13 +731,13 @@ class WC_Facebook_Product {
 			$product_data['quantity_to_sell_on_facebook'] = (int) max( 0, $this->woo_product->get_stock_quantity() );
 		} else if ( $this->woo_product->is_type( 'variation' ) ) {
 			$parent_product = wc_get_product( $this->woo_product->get_parent_id() );
-			if ( $parent_product && $parent_product->managing_stock() ) {	
+			if ( $parent_product && $parent_product->managing_stock() ) {
 				$product_data['quantity_to_sell_on_facebook'] = (int) max( 0, $parent_product->get_stock_quantity() );
 			}
 		}
 
 		// Add GTIN (Global Trade Item Number)
-		if ( Compatibility::is_wc_version_gte( '9.1.0' ) && $gtin = $this->woo_product->get_global_unique_id() ) {
+		if ( method_exists( $this->woo_product, 'get_global_unique_id' ) && $gtin = $this->woo_product->get_global_unique_id() ) {
 			$product_data['gtin'] = $gtin;
 		}
 


### PR DESCRIPTION
Summary:
Fixed a bug that arose from our reliance on the plugin version compatibility tag for the public function get_global_unique_id. This function was actually introduced in WooCommerce version 9.2, but was incorrectly tagged as being available from version 9.1 onwards.
To ensure correct functionality, we have replaced the use of Compatibility::is_wc_version_gte() with method_exists(), which checks for the availability of specific public methods rather than relying on version numbers

Differential Revision: D68424348


