### PR TITLE
Update php-unit-tests.yml

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -34,6 +34,9 @@ jobs:
         wp-version: [latest]
 
     steps:
+      - name: install SVN
+        run: sudo apt-get install subversion -y
+        
       - name: Checkout repository
         uses: actions/checkout@v3
 


### PR DESCRIPTION
Install SVN before the scripts run, to meet the dependency requirement

### Changes proposed in this Pull Request:
install-wp-tests.sh script fails not being able to find svn. 
I added a step to install subversion to make sure that requirement is met.

### Detailed test instructions:
Let the unit test run steps go through on PRs and see if that fails on this error:
./bin/install-wp-tests.sh: line 128: svn: command not found

### Changelog entry
Fix - Installing dependencies before running the unit tests.