### PR TITLE
Fixed FB Attribute Syncing Issues

### DIFF
--- a/includes/Products.php
+++ b/includes/Products.php
@@ -952,7 +952,8 @@ class Products {
 					$attr_val  = $product->get_attribute( $slug );
 				}
 
-				if ( \WC_Facebookcommerce_Utils::sanitize_variant_name( $attr_name, false ) === $key ) {
+				$sanitized_attr_name = \WC_Facebookcommerce_Utils::sanitize_attribute_name( \WC_Facebookcommerce_Utils::sanitize_variant_name( $attr_name, false ) );
+				if ( $sanitized_attr_name === $key ) {
 					$value = $attr_val;
 					break;
 				}

--- a/includes/Products/FBCategories.php
+++ b/includes/Products/FBCategories.php
@@ -64,7 +64,7 @@ class FBCategories {
 		// TODO: can perform more validations here.
 		switch ( $attribute['type'] ) {
 			case 'enum':
-				return in_array( $value, $attribute['enum_values'] );
+				return in_array( strtolower( $value ), $attribute['enum_values'] );
 			case 'boolean':
 				return in_array( $value, array( 'yes', 'no' ) );
 			default:

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -801,8 +801,7 @@ class WC_Facebook_Product {
 		}
 		$enhanced_data = array();
 
-		$category_attrs = $category_handler->get_attributes_with_fallback_to_parent_category( $google_category_id );
-		$all_attributes = $this->get_matched_attributes_for_product( $this->woo_product, $category_attrs );
+		$all_attributes = $category_handler->get_attributes_with_fallback_to_parent_category( $google_category_id );
 
 		foreach ( $all_attributes as $attribute ) {
 			$value            = Products::get_enhanced_catalog_attribute( $attribute['key'], $this->woo_product );
@@ -823,33 +822,6 @@ class WC_Facebook_Product {
 		}
 
 		return array_merge( $product_data, $enhanced_data );
-	}
-
-
-	/**
-	 * Filters list of attributes to only those available for a given product
-	 *
-	 * @param \WC_Product $product WooCommerce Product
-	 * @param array       $all_attributes List of Enhanced Catalog attributes to match
-	 * @return array
-	 */
-	public function get_matched_attributes_for_product( $product, $all_attributes ) {
-		$matched_attributes = array();
-		$sanitized_keys     = array_map(
-			function( $key ) {
-					return \WC_Facebookcommerce_Utils::sanitize_variant_name( $key, false );
-			},
-			array_keys( $product->get_attributes() )
-		);
-
-		$matched_attributes = array_filter(
-			$all_attributes,
-			function( $attribute ) use ( $sanitized_keys ) {
-				return in_array( $attribute['key'], $sanitized_keys );
-			}
-		);
-
-		return $matched_attributes;
 	}
 
 

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -635,6 +635,13 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 			return $name;
 		}
 
+		/*
+		* Sanitize attribute names inline with FB name
+		*/
+		public static function sanitize_attribute_name( $name ) {
+			return str_replace(array('-', ' '), '_', $name);
+		}
+
 		public static function validateGender( $gender ) {
 			if ( $gender && ! isset( self::$validGenderArray[ $gender ] ) ) {
 				$first_char = strtolower( substr( $gender, 0, 1 ) );

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -254,7 +254,7 @@ class fbproductTest extends WP_UnitTestCase {
 
 		$woo_variation = wc_get_product($woo_product->get_children()[0]);
 		$woo_variation->set_manage_stock('yes');
-		$woo_variation->set_stock_quantity(23);		
+		$woo_variation->set_stock_quantity(23);
 
 		$fb_parent_product = new \WC_Facebook_Product($woo_product);
 		$fb_product = new \WC_Facebook_Product( $woo_variation, $fb_parent_product );
@@ -306,13 +306,13 @@ class fbproductTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test GTIN is added for simple product 
+	 * Test GTIN is added for simple product
 	 * @return void
 	 */
 	public function test_gtin_for_simple_product_set() {
 		$woo_product = WC_Helper_Product::create_simple_product();
 		$woo_product->set_global_unique_id(9504000059446);
-		
+
 		$fb_product = new \WC_Facebook_Product( $woo_product );
 		$data = $fb_product->prepare_product();
 
@@ -359,5 +359,149 @@ class fbproductTest extends WP_UnitTestCase {
 		$data = $fb_product->prepare_product();
 
 		$this->assertEquals(isset($data['gtin']), false);
+	}
+
+	/**
+	 * Test Data Provider for product category attributes
+	 */
+	public function provide_category_data()
+	{
+		return [
+			// Only FB attributes
+			[
+				173,
+				array(
+				),
+				array(
+					"size" => "medium",
+					"gender" => "female"
+				),
+				array(
+					"size" => "medium",
+					"gender" => "female"
+				),
+			],
+			// Only Woo attributes
+			[
+				173,
+				array(
+					"size" => "medium",
+					"gender" => "female"
+				),
+				array(
+				),
+				array(
+					"size" => "medium",
+					"gender" => "female"
+				),
+			],
+			// Both Woo and FB attributes
+			[
+				173,
+				array(
+					"color" => "black",
+					"material" => "cotton"
+				),
+				array(
+					"size" => "medium",
+					"gender" => "female"
+				),
+				array(
+					"color" => "black",
+					"material" => "cotton",
+					"size" => "medium",
+					"gender" => "female"
+				),
+			],
+			// Woo attributes with space, '-' and different casing of enum attribute
+			[
+				173,
+				array(
+					"age group" => "Teen",
+					"is-costume" => "yes",
+					"Sunglasses Width" => "narrow"
+				),
+				array(
+				),
+				array(
+					"age_group" => "Teen",
+					"is_costume" => "yes",
+					"sunglasses_width" => "narrow"
+				),
+			],
+			// FB attributes overriding Woo attributes
+			[
+				173,
+				array(
+					"age_group" => "teen",
+					"size" => "medium",
+				),
+				array(
+					"age_group" => "toddler",
+					"size" => "large",
+				),
+				array(
+					"age_group" => "toddler",
+					"size" => "large",
+				),
+			],
+		];
+	}
+
+	/**
+	 * Test that attribute related fields are being set correctly while preparing product.
+	 *
+	 * @dataProvider provide_category_data
+	 * @return void
+	 */
+	public function test_enhanced_catalog_fields_from_attributes(
+		$category_id,
+		$woo_attributes,
+		$fb_attributes,
+		$expected_attributes
+	) {
+		$product          = WC_Helper_Product::create_simple_product();
+		$product->update_meta_data('_wc_facebook_google_product_category', $category_id);
+
+		// Set Woo attributes
+		$attributes = array();
+		$position = 0;
+		foreach ($woo_attributes as $key => $value) {
+			$attribute = new WC_Product_Attribute();
+			$attribute->set_id(0);
+			$attribute->set_name($key);
+			$attribute->set_options(array($value));
+			$attribute->set_position($position++);
+			$attribute->set_visible(1);
+			$attribute->set_variation(0);
+			$attributes[] = $attribute;
+		}
+		$product->set_attributes($attributes);
+
+		// Set FB sttributes
+		foreach ($fb_attributes as $key => $value) {
+			$product->update_meta_data('_wc_facebook_enhanced_catalog_attributes_'.$key, $value);
+		}
+		$product->save_meta_data();
+
+		// Prepare Product and validate assertions
+		$facebook_product = new \WC_Facebook_Product($product);
+		$product_data = $facebook_product->prepare_product(
+			$facebook_product->get_id(),
+			\WC_Facebook_Product::PRODUCT_PREP_TYPE_ITEMS_BATCH
+		);
+		$this->assertEquals($product_data['google_product_category'], $category_id);
+		foreach ($expected_attributes as $key => $value) {
+			$this->assertEquals($product_data[$key], $value);
+		}
+
+		$product_data = $facebook_product->prepare_product(
+			$facebook_product->get_id(),
+			\WC_Facebook_Product::PRODUCT_PREP_TYPE_FEED
+		);
+		$this->assertEquals($product_data['category'], 173);
+		foreach ($expected_attributes as $key => $value) {
+			$this->assertEquals($product_data[$key], $value);
+		}
 	}
 }


### PR DESCRIPTION
# Changes proposed in this Pull Request:

## Fixed FB Attribute Syncing Issues with Simple Products:
### Issue 1 - FB Attributes are not always synced
Existing Behaviour:
- FB attributes will be synced **only** when corresponding Woo product attribute has been added in 'Attributes' tab.
- Priority is given to FB attribute value over Woo product attribute value.
- If no FB attribute value provided then fallback to Woo attribute value provided in 'Attributes' tab.

Modified Behaviour:
- For Simple Products, FB attributes will be always be synced and will be given precedence over Woo attribute value provided in 'Attributes' tab.
- For Variable Products, FB attributes will be always be synced, however precedence will be given to Variation attribute values provided in Variation tab. 


### Issue 2 - Attribute value syncing broken for attributes with multiple words
Existing Behaviour:
- If Woo product attribute name doesn't contain '_' then corresponding FB attribute value will never be synced.
- Attribute names like 'Age Group' or 'age-group' never gets synced

Modified Behaviour:
- Extra characters like '-' and ' ' will be replaced by '_' for successful attribute name match, thus syncing such attributes.  

### Issue 3 - Attribute value syncing broken for enum attributes with non-lowercase values
Existing Behaviour:
- If Woo product attribute name contain camel casing for an enum FB attribute then it will never be synced.
- If enum attribute like 'Age Group' have value as 'Newborn' then it will never be synced unless its changed to 'newborn'

Modified Behaviour:
- Enum attribute values converted to lowercase while matching with allowed enum values. 

### Screenshots:

#### **Before**
Attributes Tab:
<img width="323" alt="Screenshot 2024-09-01 at 22 51 15" src="https://github.com/user-attachments/assets/3241ebed-4b1e-4296-b60e-ef8bfaa62e95">
FB Tab:
<img width="302" alt="Screenshot 2024-09-01 at 22 51 36" src="https://github.com/user-attachments/assets/d4b3390a-d70e-429e-ace3-e21694c32630">
Commerce Manager:
<img width="739" alt="Screenshot 2024-09-01 at 22 53 28" src="https://github.com/user-attachments/assets/e863e60a-e72a-445f-bde5-9ae52a5a1153">
<img width="740" alt="Screenshot 2024-09-01 at 22 53 42" src="https://github.com/user-attachments/assets/6dabe26f-9e3b-4421-b061-3bbf2b4a0b6d">
<img width="746" alt="Screenshot 2024-09-01 at 22 53 50" src="https://github.com/user-attachments/assets/9a76f956-3d0c-4745-b82e-36cd26da9447">


In the snapshots you can see that: 
- Age Group didn't get synced due to space in their name
- Gender didn't get synced due to came casing 'Male' in its value.
- Sunglass-Width didn't get synced as it has '-' in its name
- Sports Team didn't get synced as its not added in Attributes Tab
- Theme got correctly overwritten


#### **After**
Attributes Tab:
<img width="344" alt="Screenshot 2024-09-01 at 22 31 21" src="https://github.com/user-attachments/assets/3a5b2b90-5650-4efb-a9d8-0c5c933fce17">
FB Tab:
<img width="281" alt="Screenshot 2024-09-01 at 22 31 58" src="https://github.com/user-attachments/assets/7e66bac0-2cb5-4bab-8a99-2d1ffb7e3ee1">
Commerce Manager:
<img width="997" alt="Screenshot 2024-09-01 at 22 32 58" src="https://github.com/user-attachments/assets/b1fe2ab7-d8f4-4b41-b356-0e1cafd1785e">
<img width="993" alt="Screenshot 2024-09-01 at 22 33 58" src="https://github.com/user-attachments/assets/c3e2a0c4-4b7e-488e-a177-18c3d2c729b6">


In the snapshots you can see that: 
- FB attribute value for Theme overridden the Woo attribute value 
- Age Group is not provided in FB attribute so its fallback to Woo attribute value
- Age Group has 'Newborn' as attribute value still got synced.
- Age Group has space in their name and sunglasses-width has '-' in their attribute name still got synced

### Detailed test instructions:

Unit test - ./vendor/bin/phpunit --filter test_enhanced_catalog_fields_from_attributes

### Changelog entry

> Fixed FB category specific attributes syncing
