### PR TITLE
[WIP] Add WordPress and WooCommerce versions to the unit tests

### DIFF
--- a/.github/workflows/php-cs-on-changes.yml
+++ b/.github/workflows/php-cs-on-changes.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        php: [7.4, 8.3]
+        php: [7.4, 8.0, 8.1, 8.2, 8.3]
     name: Code sniff (PHP ${{ matrix.php }}, WP Latest)
     permissions:
       contents: read

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -31,8 +31,8 @@ jobs:
     strategy:
       matrix:
         php: [7.4, 8.3]
-        wp-version: [latest]
-        wc-version: [latest]
+        wp-version: [5.7, 6.6, 6.7]
+        wc-version: [9.6.0, 9.7,0]
 
     steps:
       - name: Install SVN

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -31,8 +31,8 @@ jobs:
     strategy:
       matrix:
         php: [7.4, 8.3]
-        wp-version: [5.7, 6.6, 6.7]
-        wc-version: [9.6.0, 9.7,0]
+        wp-version: [latest]
+        wc-version: [latest]
 
     steps:
       - name: Install SVN

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -22,24 +22,67 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      wp-versions: ${{ steps.fetch-wp.outputs.versions }}
+      wc-versions: ${{ steps.fetch-wc.outputs.versions }}
+    steps:
+      - id: fetch-wp
+        run: |
+          # Get last two stable versions
+          VERSIONS=$(curl -s "https://api.wordpress.org/core/version-check/1.7/" | \
+            jq -r '.offers[].version' | \
+            grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | \
+            awk -F. '!seen[$1"."$2]++' | \
+            sort -V | \
+            tail -n 2 | \
+            jq -R -s -c 'split("\n")[:-1]')
+
+          VERSIONS=$(jq -nc --argjson versions "$VERSIONS" '["5.7.12"] + $versions')
+
+          echo "versions=${VERSIONS}" >> "$GITHUB_OUTPUT"
+
+      - id: fetch-wc
+        run: |
+          # Get last two stable versions
+          VERSIONS=$(curl -s "https://api.github.com/repos/woocommerce/woocommerce/releases" | \
+            jq -r '.[] | select(.prerelease == false) | .tag_name' | \
+            grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | \
+            awk -F. '!seen[$1"."$2]++' | \
+            sort -V | \
+            tail -n 2 | \
+            jq -R -s -c 'split("\n")[:-1]')
+
+          echo "versions=${VERSIONS}" >> "$GITHUB_OUTPUT"
+
   UnitTests:
+    needs: get-versions
     name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version }}, WC ${{ matrix.wc-version }}
     runs-on: ubuntu-latest
     env:
       WP_CORE_DIR: "/tmp/wordpress/src"
       WP_TESTS_DIR: "/tmp/wordpress/tests/phpunit"
+
     strategy:
       matrix:
-        php: [7.4, 8.3]
-        wp-version: [5.7, 6.6, 6.7]
-        wc-version: [9.6.0, 9.7,0]
+        php: [7.4, 8.0, 8.1, 8.2, 8.3]
+        wp-version: ${{ fromJson(needs.get-versions.outputs.wp-versions) }}
+        wc-version: ${{ fromJson(needs.get-versions.outputs.wc-versions) }}
+        exclude:
+          - wp-version: 5.7.12
+            php: 8.1
+          - wp-version: 5.7.12
+            php: 8.2
+          - wp-version: 5.7.12
+            php: 8.3
 
     steps:
       - name: Install SVN
         run: sudo apt-get install subversion -y
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare PHP
         uses: woocommerce/grow/prepare-php@actions-v1

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -39,8 +39,6 @@ jobs:
             tail -n 2 | \
             jq -R -s -c 'split("\n")[:-1]')
 
-          VERSIONS=$(jq -nc --argjson versions "$VERSIONS" '["5.7.12"] + $versions')
-
           echo "versions=${VERSIONS}" >> "$GITHUB_OUTPUT"
 
       - id: fetch-wc
@@ -69,13 +67,6 @@ jobs:
         php: [7.4, 8.0, 8.1, 8.2, 8.3]
         wp-version: ${{ fromJson(needs.get-versions.outputs.wp-versions) }}
         wc-version: ${{ fromJson(needs.get-versions.outputs.wc-versions) }}
-        exclude:
-          - wp-version: 5.7.12
-            php: 8.1
-          - wp-version: 5.7.12
-            php: 8.2
-          - wp-version: 5.7.12
-            php: 8.3
 
     steps:
       - name: Install SVN


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR adds WordPress and WooCommerce versions matrix in the unit tests so we can make sure new code works in older WordPress and WooCommerce versions too.

### Detailed test instructions:
See Github's checks running multiple WC and WP versions.

### Changelog entry
Dev - Added WordPress and WooCommerce versions to the tests
