### PR TITLE
Fix translations loading before the `init` hook

### DIFF
--- a/includes/Admin/Settings_Screens/Advertise.php
+++ b/includes/Admin/Settings_Screens/Advertise.php
@@ -31,11 +31,14 @@ class Advertise extends Abstract_Settings_Screen {
 	 * @since 2.2.0
 	 */
 	public function __construct() {
-		add_action('init', [$this, 'initHook']);
+		add_action( 'init', array( $this, 'initHook' ) );
 	}
 
+	/**
+	 * Initializes this class's settings screen properties.
+	 */
 	public function initHook(): void {
-		$this->id    = self::ID;
+		$this->id                = self::ID;
 		$this->label             = __( 'Advertise', 'facebook-for-woocommerce' );
 		$this->title             = __( 'Advertise', 'facebook-for-woocommerce' );
 		$this->documentation_url = 'https://woocommerce.com/document/facebook-for-woocommerce/#how-to-create-ads-on-facebook';

--- a/includes/Admin/Settings_Screens/Advertise.php
+++ b/includes/Admin/Settings_Screens/Advertise.php
@@ -31,6 +31,10 @@ class Advertise extends Abstract_Settings_Screen {
 	 * @since 2.2.0
 	 */
 	public function __construct() {
+		add_action('init', [$this, 'initHook']);
+	}
+
+	public function initHook(): void {
 		$this->id    = self::ID;
 		$this->label             = __( 'Advertise', 'facebook-for-woocommerce' );
 		$this->title             = __( 'Advertise', 'facebook-for-woocommerce' );

--- a/includes/Admin/Settings_Screens/Advertise.php
+++ b/includes/Admin/Settings_Screens/Advertise.php
@@ -35,7 +35,7 @@ class Advertise extends Abstract_Settings_Screen {
 	}
 
 	/**
-	 * Initializes this class's settings screen properties.
+	 * Initializes this settings page's properties.
 	 */
 	public function initHook(): void {
 		$this->id                = self::ID;

--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -30,14 +30,17 @@ class Connection extends Abstract_Settings_Screen {
 	 * Connection constructor.
 	 */
 	public function __construct() {
-
-		$this->id    = self::ID;
-		$this->label = __( 'Connection', 'facebook-for-woocommerce' );
-		$this->title = __( 'Connection', 'facebook-for-woocommerce' );
+		add_action('init', [$this, 'initHook']);
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 
 		add_action( 'admin_notices', array( $this, 'add_notices' ) );
+	}
+
+	public function initHook(): void {
+		$this->id    = self::ID;
+		$this->label = __( 'Connection', 'facebook-for-woocommerce' );
+		$this->title = __( 'Connection', 'facebook-for-woocommerce' );
 	}
 
 

--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -38,7 +38,7 @@ class Connection extends Abstract_Settings_Screen {
 	}
 
 	/**
-	 * Initializes this class's settings screen properties.
+	 * Initializes this settings page's properties.
 	 */
 	public function initHook(): void {
 		$this->id    = self::ID;

--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -30,13 +30,16 @@ class Connection extends Abstract_Settings_Screen {
 	 * Connection constructor.
 	 */
 	public function __construct() {
-		add_action('init', [$this, 'initHook']);
+		add_action( 'init', array( $this, 'initHook' ) );
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 
 		add_action( 'admin_notices', array( $this, 'add_notices' ) );
 	}
 
+	/**
+	 * Initializes this class's settings screen properties.
+	 */
 	public function initHook(): void {
 		$this->id    = self::ID;
 		$this->label = __( 'Connection', 'facebook-for-woocommerce' );

--- a/includes/Admin/Settings_Screens/Product_Sets.php
+++ b/includes/Admin/Settings_Screens/Product_Sets.php
@@ -27,9 +27,12 @@ class Product_Sets extends Abstract_Settings_Screen {
 	 * Connection constructor.
 	 */
 	public function __construct() {
-		add_action('init', [$this, 'initHook']);
+		add_action( 'init', array( $this, 'initHook' ) );
 	}
 
+	/**
+	 * Initializes this class's settings screen properties.
+	 */
 	public function initHook(): void {
 		$this->id    = self::ID;
 		$this->label = __( 'Product sets', 'facebook-for-woocommerce' );

--- a/includes/Admin/Settings_Screens/Product_Sets.php
+++ b/includes/Admin/Settings_Screens/Product_Sets.php
@@ -27,6 +27,10 @@ class Product_Sets extends Abstract_Settings_Screen {
 	 * Connection constructor.
 	 */
 	public function __construct() {
+		add_action('init', [$this, 'initHook']);
+	}
+
+	public function initHook(): void {
 		$this->id    = self::ID;
 		$this->label = __( 'Product sets', 'facebook-for-woocommerce' );
 		$this->title = __( 'Product sets', 'facebook-for-woocommerce' );

--- a/includes/Admin/Settings_Screens/Product_Sets.php
+++ b/includes/Admin/Settings_Screens/Product_Sets.php
@@ -31,7 +31,7 @@ class Product_Sets extends Abstract_Settings_Screen {
 	}
 
 	/**
-	 * Initializes this class's settings screen properties.
+	 * Initializes this settings page's properties.
 	 */
 	public function initHook(): void {
 		$this->id    = self::ID;

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -45,7 +45,7 @@ class Product_Sync extends Abstract_Settings_Screen {
 	}
 
 	/**
-	 * Initializes this class's settings screen properties.
+	 * Initializes this settings page's properties.
 	 */
 	public function initHook(): void {
 		$this->id                = self::ID;

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -38,15 +38,18 @@ class Product_Sync extends Abstract_Settings_Screen {
 	 * Connection constructor.
 	 */
 	public function __construct() {
-		$this->id                = self::ID;
-		$this->label             = __( 'Product sync', 'facebook-for-woocommerce' );
-		$this->title             = __( 'Product sync', 'facebook-for-woocommerce' );
-		$this->documentation_url = 'https://woocommerce.com/document/facebook-for-woocommerce/#product-sync-settings';
+		add_action('init', [$this, 'initHook']);
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 		add_action( 'woocommerce_admin_field_product_sync_title', array( $this, 'render_title' ) );
 		add_action( 'woocommerce_admin_field_product_sync_google_product_categories', array( $this, 'render_google_product_category_field' ) );
 	}
 
+	public function initHook(): void {
+		$this->id                = self::ID;
+		$this->label             = __( 'Product sync', 'facebook-for-woocommerce' );
+		$this->title             = __( 'Product sync', 'facebook-for-woocommerce' );
+		$this->documentation_url = 'https://woocommerce.com/document/facebook-for-woocommerce/#product-sync-settings';
+	}
 
 	/**
 	 * Enqueues the assets.

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -38,12 +38,15 @@ class Product_Sync extends Abstract_Settings_Screen {
 	 * Connection constructor.
 	 */
 	public function __construct() {
-		add_action('init', [$this, 'initHook']);
+		add_action( 'init', array( $this, 'initHook' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 		add_action( 'woocommerce_admin_field_product_sync_title', array( $this, 'render_title' ) );
 		add_action( 'woocommerce_admin_field_product_sync_google_product_categories', array( $this, 'render_google_product_category_field' ) );
 	}
 
+	/**
+	 * Initializes this class's settings screen properties.
+	 */
 	public function initHook(): void {
 		$this->id                = self::ID;
 		$this->label             = __( 'Product sync', 'facebook-for-woocommerce' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The plugin's admin page properties contained strings being translated and these were called before the `init` hook causing the following notice to be logged:

```
Notice: Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the facebook-for-woocommerce domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the init action or later. Please see Debugging in WordPress for more information. (This message was added in version 6.7.0.) in /home/public_html/wp-includes/functions.php on line 6114
```

This changeset moves the admin pages' properties into the `init` hook so we follow the proper way of handling translations.

More information about the issue: https://make.wordpress.org/core/2024/10/21/i18n-improvements-6-7/#Enhanced-support-for-only-using-PHP-translation-files.

### Screenshots:

![Screenshot 2025-02-05 at 12 15 08](https://github.com/user-attachments/assets/59c49143-0197-4343-af04-a7d49fa75213)

### Detailed test instructions:
To recreate the issue, please follow these steps:

1. Enable `WP_DEBUG` and either show the errors on page or in the debug log.
2. Switch the site to a different language, e.g. French.
3. You should see the notice at the top of the admin page (like in the screenshot above) or in the debug log.