### PR TITLE
Changed from trunk to main on the prepare release github action

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -35,15 +35,15 @@ jobs:
           type: ${{ github.event.inputs.type }}
           wp-version: ${{ github.event.inputs.wp-version }}
           wc-version: ${{ github.event.inputs.wc-version }}
-          main-branch: "trunk"
+          main-branch: "main"
           post-steps: |
             ### After deploy
             1. [ ] Confirm the release deployed correctly to [WPORG](https://wordpress.org/plugins/facebook-for-woocommerce/).
                - [ ] Ensure you can download and install the latest release from WPORG and WCCOM.
                - [ ] We've had an issue where the release tag (e.g. 2.6.1) wasn't present in the svn `tags/` folder.
                - [ ] Troubleshooting processes when the release version doesn't exist in the svn `tags/` folder:
-                    1. [ ] Check the version by `Stable tag` in [https://plugins.svn.wordpress.org/facebook-for-woocommerce/trunk/readme.txt](https://plugins.svn.wordpress.org/facebook-for-woocommerce/trunk/readme.txt) to see if the new release is committed to `trunk`
-                    1. [ ] If the above version is the same as the one just released, then you can make up the missed version tag by `svn cp https://plugins.svn.wordpress.org/facebook-for-woocommerce/trunk https://plugins.svn.wordpress.org/facebook-for-woocommerce/tags/X.X.X -m "Tagging version X.X.X"`. Please note that the `X.X.X` is used as a placeholder but should be replaced with the *actual* release version (e.g., `1.5.0`).
+                    1. [ ] Check the version by `Stable tag` in [https://plugins.svn.wordpress.org/facebook-for-woocommerce/main/readme.txt](https://plugins.svn.wordpress.org/facebook-for-woocommerce/main/readme.txt) to see if the new release is committed to `main`
+                    1. [ ] If the above version is the same as the one just released, then you can make up the missed version tag by `svn cp https://plugins.svn.wordpress.org/facebook-for-woocommerce/main https://plugins.svn.wordpress.org/facebook-for-woocommerce/tags/X.X.X -m "Tagging version X.X.X"`. Please note that the `X.X.X` is used as a placeholder but should be replaced with the *actual* release version (e.g., `1.5.0`).
                     1. [ ] Wait for a while, and the zip file should be able to download from: [https://downloads.wordpress.org/plugin/facebook-for-woocommerce.x.x.x.zip](https://downloads.wordpress.org/plugin/facebook-for-woocommerce.x.x.x.zip)
             1. [ ] Close the release milestone.
             1. [ ] Publish any documentation updates relating to the release:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -42,8 +42,8 @@ jobs:
                - [ ] Ensure you can download and install the latest release from WPORG and WCCOM.
                - [ ] We've had an issue where the release tag (e.g. 2.6.1) wasn't present in the svn `tags/` folder.
                - [ ] Troubleshooting processes when the release version doesn't exist in the svn `tags/` folder:
-                    1. [ ] Check the version by `Stable tag` in [https://plugins.svn.wordpress.org/facebook-for-woocommerce/main/readme.txt](https://plugins.svn.wordpress.org/facebook-for-woocommerce/main/readme.txt) to see if the new release is committed to `main`
-                    1. [ ] If the above version is the same as the one just released, then you can make up the missed version tag by `svn cp https://plugins.svn.wordpress.org/facebook-for-woocommerce/main https://plugins.svn.wordpress.org/facebook-for-woocommerce/tags/X.X.X -m "Tagging version X.X.X"`. Please note that the `X.X.X` is used as a placeholder but should be replaced with the *actual* release version (e.g., `1.5.0`).
+                    1. [ ] Check the version by `Stable tag` in [https://plugins.svn.wordpress.org/facebook-for-woocommerce/trunk/readme.txt](https://plugins.svn.wordpress.org/facebook-for-woocommerce/trunk/readme.txt) to see if the new release is committed to `trunk`
+                    1. [ ] If the above version is the same as the one just released, then you can make up the missed version tag by `svn cp https://plugins.svn.wordpress.org/facebook-for-woocommerce/trunk https://plugins.svn.wordpress.org/facebook-for-woocommerce/tags/X.X.X -m "Tagging version X.X.X"`. Please note that the `X.X.X` is used as a placeholder but should be replaced with the *actual* release version (e.g., `1.5.0`).
                     1. [ ] Wait for a while, and the zip file should be able to download from: [https://downloads.wordpress.org/plugin/facebook-for-woocommerce.x.x.x.zip](https://downloads.wordpress.org/plugin/facebook-for-woocommerce.x.x.x.zip)
             1. [ ] Close the release milestone.
             1. [ ] Publish any documentation updates relating to the release:

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -11,7 +11,7 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 3.3.2
+ * Version: 3.3.3
  * Requires at least: 5.6
  * Requires PHP: 7.4
  * Text Domain: facebook-for-woocommerce


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Changed the prepare release workflow to use main branch instead of trunk. 

### Detailed test instructions:
Create a PR for a new release. It should try to merge to main instead of trunk, and also compare to main for readme.txt, etc.

