### PR TITLE
Adding support for FB Product Level Video sync

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -57,6 +57,37 @@
 	right: 12px;
 }
 
+#woocommerce-product-data #fb_product_video_selected_thumbnails p.video-thumbnail {
+    margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+}
+
+#woocommerce-product-data #fb_product_video_selected_thumbnails p.video-thumbnail img {
+    height: 20px;
+    width: 20px;
+    margin-right: 10px;
+}
+
+#woocommerce-product-data #fb_product_video_selected_thumbnails p.video-thumbnail span {
+	margin-right: 10px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+	white-space: normal;
+	line-height: 1.2em; /* Adjust line height as needed */
+	max-height: 2.4em; /* 2 lines * line-height */
+}
+
+#woocommerce-product-data #fb_product_video_selected_thumbnails p.video-thumbnail a.remove-video {
+	color: red;
+    font-weight: 400;
+    line-height: 26px;
+    text-decoration: none;
+}
+
 #woocommerce-product-data #wc-facebook-google-product-category-fields {
 	width: 50%;
 }

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -883,6 +883,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			$woo_product->set_product_image( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PRODUCT_IMAGE ] ) ) );
 		}
 
+		if ( isset( $_POST[ WC_Facebook_Product::FB_PRODUCT_VIDEO ] ) ) {
+			$attachment_ids = sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PRODUCT_VIDEO ] ) );
+			$woo_product->set_product_video_urls( $attachment_ids );
+		}
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_BRAND ] ) ) {
 			$woo_product->set_fb_brand( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_BRAND ] ) ) );
 		}

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -24,1225 +24,1282 @@ defined( 'ABSPATH' ) or exit;
  */
 class Admin {
 
-	/** @var string the "sync and show" sync mode slug */
-	const SYNC_MODE_SYNC_AND_SHOW = 'sync_and_show';
-
-	/** @var string the "sync and show" sync mode slug */
-	const SYNC_MODE_SYNC_AND_HIDE = 'sync_and_hide';
-
-	/** @var string the "sync disabled" sync mode slug */
-	const SYNC_MODE_SYNC_DISABLED = 'sync_disabled';
-
-	/** @var Product_Categories the product category admin handler */
-	protected $product_categories;
-
-	/** @var array screens ids where to include scripts */
-	protected $screen_ids = [];
-
-	/** @var Product_Sets the product set admin handler. */
-	protected $product_sets;
-
-	/**
-	 * Admin constructor.
-	 *
-	 * @since 1.10.0
-	 */
-	public function __construct() {
-
-		$order_screen_id = class_exists( OrderUtil::class ) ? OrderUtil::get_order_admin_screen() : 'shop_order';
-
-		$this->screen_ids = [
-			'product',
-			'edit-product',
-			'woocommerce_page_wc-facebook',
-			'marketing_page_wc-facebook',
-			'edit-product_cat',
-			$order_screen_id,
-		];
-
-		// enqueue admin scripts
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-
-		$plugin = facebook_for_woocommerce();
-		// only alter the admin UI if the plugin is connected to Facebook and ready to sync products
-		if ( ! $plugin->get_connection_handler()->is_connected() || ! $plugin->get_integration()->get_product_catalog_id() ) {
-			return;
-		}
-
-		$this->product_categories = new Admin\Product_Categories();
-		$this->product_sets       = new Admin\Product_Sets();
-		// add a modal in admin product pages
-		add_action( 'admin_footer', array( $this, 'render_modal_template' ) );
-
-		// add admin notice to inform that disabled products may need to be deleted manually
-		add_action( 'admin_notices', array( $this, 'maybe_show_product_disabled_sync_notice' ) );
-
-		// add admin notice if the user is enabling sync for virtual products using the bulk action
-		add_action( 'admin_notices', array( $this, 'maybe_add_enabling_virtual_products_sync_notice' ) );
-		add_filter( 'request', array( $this, 'filter_virtual_products_affected_enabling_sync' ) );
-
-		// add admin notice to inform sync mode has been automatically set to Sync and hide for virtual products and variations
-		add_action( 'admin_notices', array( $this, 'add_handled_virtual_products_variations_notice' ) );
-
-		// add columns for displaying Facebook sync enabled/disabled and catalog visibility status
-		add_filter( 'manage_product_posts_columns', array( $this, 'add_product_list_table_columns' ) );
-		add_action( 'manage_product_posts_custom_column', array( $this, 'add_product_list_table_columns_content' ) );
-
-		// add input to filter products by Facebook sync enabled
-		add_action( 'restrict_manage_posts', array( $this, 'add_products_by_sync_enabled_input_filter' ), 40 );
-		add_filter( 'request', array( $this, 'filter_products_by_sync_enabled' ) );
-
-		// add bulk actions to manage products sync
-		add_filter( 'bulk_actions-edit-product', array( $this, 'add_products_sync_bulk_actions' ), 40 );
-		add_action( 'handle_bulk_actions-edit-product', array( $this, 'handle_products_sync_bulk_actions' ) );
-
-		// add Product data tab
-		add_filter( 'woocommerce_product_data_tabs', array( $this, 'add_product_settings_tab' ) );
-		add_action( 'woocommerce_product_data_panels', array( $this, 'add_product_settings_tab_content' ) );
-
-		// add Variation edit fields
-		add_action( 'woocommerce_product_after_variable_attributes', array( $this, 'add_product_variation_edit_fields' ), 10, 3 );
-		add_action( 'woocommerce_save_product_variation', array( $this, 'save_product_variation_edit_fields' ), 10, 2 );
-
-		// add custom taxonomy for Product Sets
-		add_filter( 'gettext', array( $this, 'change_custom_taxonomy_tip' ), 20, 2 );
-	}
-
-	/**
-	 * __get method for backward compatibility.
-	 *
-	 * @param string $key property name
-	 * @return mixed
-	 * @since 3.0.32
-	 */
-	public function __get( $key ) {
-		// Add warning for private properties.
-		if ( 'product_sets' === $key ) {
-			/* translators: %s property name. */
-			_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'The %s property is protected and should not be accessed outside its class.', 'facebook-for-woocommerce' ), esc_html( $key ) ), '3.0.32' );
-			return $this->$key;
-		}
-
-		return null;
-	}
-
-	/**
-	 * Change custom taxonomy tip text
-	 *
-	 * @since 2.3.0
-	 *
-	 * @param string $translation Text translation.
-	 * @param string $text Original text.
-	 *
-	 * @return string
-	 */
-	public function change_custom_taxonomy_tip( $translation, $text ) {
-		global $current_screen;
-		if ( isset( $current_screen->id ) && 'edit-fb_product_set' === $current_screen->id && 'The name is how it appears on your site.' === $text ) {
-			$translation = esc_html__( 'The name is how it appears on Facebook Catalog.', 'facebook-for-woocommerce' );
-		}
-		return $translation;
-	}
-
-	/**
-	 * Enqueues admin scripts.
-	 *
-	 * @internal
-	 *
-	 * @since 1.10.0
-	 */
-	public function enqueue_scripts() {
-		global $current_screen;
-
-		if ( isset( $current_screen->id ) ) {
-
-			if ( in_array( $current_screen->id, $this->screen_ids, true ) || facebook_for_woocommerce()->is_plugin_settings() ) {
-
-				// enqueue modal functions
-				wp_enqueue_script(
-					'facebook-for-woocommerce-modal',
-					facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/modal.js',
-					array( 'jquery', 'wc-backbone-modal', 'jquery-blockui' ),
-					\WC_Facebookcommerce::PLUGIN_VERSION
-				);
-
-				// enqueue google product category select
-				wp_enqueue_script(
-					'wc-facebook-google-product-category-fields',
-					facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/google-product-category-fields.js',
-					array( 'jquery' ),
-					\WC_Facebookcommerce::PLUGIN_VERSION
-				);
-
-				wp_localize_script(
-					'wc-facebook-google-product-category-fields',
-					'facebook_for_woocommerce_google_product_category',
-					array(
-						'i18n' => array(
-							'top_level_dropdown_placeholder' => __( 'Search main categories...', 'facebook-for-woocommerce' ),
-							'second_level_empty_dropdown_placeholder' => __( 'Choose a main category first', 'facebook-for-woocommerce' ),
-							'general_dropdown_placeholder'   => __( 'Choose a category', 'facebook-for-woocommerce' ),
-						),
-					)
-				);
-			}
-
-			if ( 'edit-fb_product_set' === $current_screen->id ) {
-				// enqueue WooCommerce Admin Styles because of Select2
-				wp_enqueue_style(
-					'woocommerce_admin_styles',
-					WC()->plugin_url() . '/assets/css/admin.css',
-					[],
-					\WC_Facebookcommerce::PLUGIN_VERSION
-				);
-				wp_enqueue_style(
-					'facebook-for-woocommerce-product-sets-admin',
-					facebook_for_woocommerce()->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-product-sets-admin.css',
-					[],
-					\WC_Facebookcommerce::PLUGIN_VERSION
-				);
-
-				wp_enqueue_script(
-					'facebook-for-woocommerce-product-sets',
-					facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/product-sets-admin.js',
-					[ 'jquery', 'select2' ],
-					\WC_Facebookcommerce::PLUGIN_VERSION,
-					true
-				);
-
-				wp_localize_script(
-					'facebook-for-woocommerce-product-sets',
-					'facebook_for_woocommerce_product_sets',
-					array(
-
-						'excluded_category_ids'             => facebook_for_woocommerce()->get_integration()->get_excluded_product_category_ids(),
-						'excluded_category_warning_message' => __( 'You have selected one or more categories currently excluded from the Facebook sync. Products belonging to the excluded categories will not be added to your Facebook Product Set.', 'facebook-for-woocommerce' ),
-					)
-				);
-			}
-
-			if ( 'product' === $current_screen->id || 'edit-product' === $current_screen->id ) {
-				wp_enqueue_style(
-					'facebook-for-woocommerce-products-admin',
-					facebook_for_woocommerce()->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-products-admin.css',
-					[],
-					\WC_Facebookcommerce::PLUGIN_VERSION
-				);
-				wp_enqueue_script(
-					'facebook-for-woocommerce-products-admin',
-					facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/products-admin.js',
-					[ 'jquery', 'wc-backbone-modal', 'jquery-blockui', 'facebook-for-woocommerce-modal' ],
-					\WC_Facebookcommerce::PLUGIN_VERSION
-				);
-				wp_localize_script(
-					'facebook-for-woocommerce-products-admin',
-					'facebook_for_woocommerce_products_admin',
-					[
-						'ajax_url'                                        => admin_url( 'admin-ajax.php' ),
-						'enhanced_attribute_optional_selector'            => Enhanced_Catalog_Attribute_Fields::FIELD_ENHANCED_CATALOG_ATTRIBUTE_PREFIX . Enhanced_Catalog_Attribute_Fields::OPTIONAL_SELECTOR_KEY,
-						'enhanced_attribute_page_type_edit_category'      => Enhanced_Catalog_Attribute_Fields::PAGE_TYPE_EDIT_CATEGORY,
-						'enhanced_attribute_page_type_add_category'       => Enhanced_Catalog_Attribute_Fields::PAGE_TYPE_ADD_CATEGORY,
-						'enhanced_attribute_page_type_edit_product'       => Enhanced_Catalog_Attribute_Fields::PAGE_TYPE_EDIT_PRODUCT,
-						'is_product_published'                            => $this->is_current_product_published(),
-						'is_sync_enabled_for_product'                     => $this->is_sync_enabled_for_current_product(),
-						'set_product_visibility_nonce'                    => wp_create_nonce( 'set-products-visibility' ),
-						'set_product_sync_prompt_nonce'                   => wp_create_nonce( 'set-product-sync-prompt' ),
-						'set_product_sync_bulk_action_prompt_nonce'       => wp_create_nonce( 'set-product-sync-bulk-action-prompt' ),
-						'product_not_ready_modal_message'                 => $this->get_product_not_ready_modal_message(),
-						'product_not_ready_modal_buttons'                 => $this->get_product_not_ready_modal_buttons(),
-						'product_removed_from_sync_confirm_modal_message' => $this->get_product_removed_from_sync_confirm_modal_message(),
-						'product_removed_from_sync_confirm_modal_buttons' => $this->get_product_removed_from_sync_confirm_modal_buttons(),
-						'product_removed_from_sync_field_id'              => '#' . \WC_Facebook_Product::FB_REMOVE_FROM_SYNC,
-						'i18n'                                            => [
-							'missing_google_product_category_message' => __( 'Please enter a Google product category and at least one sub-category to sell this product on Instagram.', 'facebook-for-woocommerce' ),
-						],
-					]
-				);
-			}//end if
-
-			if ( facebook_for_woocommerce()->is_plugin_settings() ) {
-				wp_enqueue_style( 'woocommerce_admin_styles' );
-				wp_enqueue_script( 'wc-enhanced-select' );
-			}
-		}//end if
-
-	}
-
-	/**
-	 * Determines whether sync is enabled for the current product.
-	 *
-	 * @since 2.0.5
-	 *
-	 * @return bool
-	 */
-	private function is_sync_enabled_for_current_product() {
-		global $post;
-		$product = wc_get_product( $post );
-		if ( ! $product instanceof \WC_Product ) {
-			return false;
-		}
-		return Products::is_sync_enabled_for_product( $product );
-	}
-
-	/**
-	 * Determines whether the current product is published.
-	 *
-	 * @since 2.6.15
-	 *
-	 * @return bool
-	 */
-	private function is_current_product_published() {
-		global $post;
-		$product = wc_get_product( $post );
-		if ( ! $product instanceof \WC_Product ) {
-			return false;
-		}
-		return 'publish' === $product->get_status();
-	}
-
-	/**
-	 * Gets the markup for the message used in the product not ready modal.
-	 *
-	 * @since 2.1.0
-	 *
-	 * @return string
-	 */
-	private function get_product_not_ready_modal_message() {
-		ob_start();
-		?>
-		<p><?php esc_html_e( 'To sell this product on Instagram, please ensure it meets the following requirements:', 'facebook-for-woocommerce' ); ?></p>
-		<ul class="ul-disc">
-			<li><?php esc_html_e( 'Has a price defined', 'facebook-for-woocommerce' ); ?></li>
-			<li>
-			<?php
-			echo esc_html(
-				sprintf(
-				/* translators: Placeholders: %1$s - <strong> opening HTML tag, %2$s - </strong> closing HTML tag */
-					__( 'Has %1$sManage Stock%2$s enabled on the %1$sInventory%2$s tab', 'facebook-for-woocommerce' ),
-					'<strong>',
-					'</strong>'
-				)
-			);
-			?>
-			</li>
-			<li>
-			<?php
-			echo esc_html(
-				sprintf(
-				/* translators: Placeholders: %1$s - <strong> opening HTML tag, %2$s - </strong> closing HTML tag */
-					__( 'Has the %1$sFacebook Sync%2$s setting set to "Sync and show" or "Sync and hide"', 'facebook-for-woocommerce' ),
-					'<strong>',
-					'</strong>'
-				)
-			);
-			?>
-			</li>
-		</ul>
-		<?php
-		return ob_get_clean();
-	}
-
-	/**
-	 * Gets the markup for the buttons used in the product not ready modal.
-	 *
-	 * @since 2.1.0
-	 *
-	 * @return string
-	 */
-	private function get_product_not_ready_modal_buttons() {
-		ob_start();
-		?>
-		<button
-			id="btn-ok"
-			class="button button-large button-primary"
-		><?php esc_html_e( 'Close', 'facebook-for-woocomerce' ); ?></button>
-		<?php
-		return ob_get_clean();
-	}
-
-	/**
-	 * Gets the markup for the message used in the product removed from sync confirm modal.
-	 *
-	 * @internal
-	 *
-	 * @since 2.3.0
-	 *
-	 * @return string
-	 */
-	private function get_product_removed_from_sync_confirm_modal_message() {
-		ob_start();
-		?>
-		<p>
-		<?php
-		printf(
-			/* translators: Placeholders: %1$s - opening <a> link tag, %2$s - closing </a> link tag */
-			esc_html__( 'You\'re removing a product from the Facebook sync that is currently listed in your %1$sFacebook catalog%2$s. Would you like to delete the product from the Facebook catalog as well?', 'facebook-for-woocommerce' ),
-			'<a href="https://www.facebook.com/products" target="_blank">',
-			'</a>'
-		);
-		?>
-			</p>
-		<?php
-		return ob_get_clean();
-	}
-
-	/**
-	 * Gets the markup for the buttons used in the product removed from sync confirm modal.
-	 *
-	 * @internal
-	 *
-	 * @since 2.3.0
-	 *
-	 * @return string
-	 */
-	private function get_product_removed_from_sync_confirm_modal_buttons() {
-		ob_start();
-		?>
-		<button
-			id="btn-ok"
-			class="button button-large button-primary"
-		><?php esc_html_e( 'Remove from sync only', 'facebook-for-woocomerce' ); ?></button>
-
-		<button
-			class="button button-large button-delete button-product-removed-from-sync-delete"
-		><?php esc_html_e( 'Remove from sync and delete', 'facebook-for-woocomerce' ); ?></button>
-
-		<button
-			class="button button-large button-product-removed-from-sync-cancel"
-		><?php esc_html_e( 'Cancel', 'facebook-for-woocomerce' ); ?></button>
-		<?php
-		return ob_get_clean();
-	}
-
-	/**
-	 * Gets the product category admin handler instance.
-	 *
-	 * @since 2.1.0
-	 *
-	 * @return Product_Categories
-	 */
-	public function get_product_categories_handler() {
-		return $this->product_categories;
-	}
-
-	/**
-	 * Adds Facebook-related columns in the products edit screen.
-	 *
-	 * @internal
-	 *
-	 * @since 1.10.0
-	 *
-	 * @param array $columns array of keys and labels
-	 * @return array
-	 */
-	public function add_product_list_table_columns( $columns ) {
-		$columns['facebook_sync'] = __( 'Facebook sync', 'facebook-for-woocommerce' );
-		return $columns;
-	}
-
-	/**
-	 * Outputs sync information for products in the edit screen.
-	 *
-	 * @internal
-	 *
-	 * @since 1.10.0
-	 *
-	 * @param string $column the current column in the posts table
-	 */
-	public function add_product_list_table_columns_content( $column ) {
-		global $post;
-
-		if ( 'facebook_sync' !== $column ) {
-			return;
-		}
-
-		$product        = wc_get_product( $post );
-		$should_sync    = false;
-		$no_sync_reason = '';
-
-		if ( $product instanceof \WC_Product ) {
-			try {
-				facebook_for_woocommerce()->get_product_sync_validator( $product )->validate();
-				$should_sync = true;
-			} catch ( \Exception $e ) {
-				$no_sync_reason = $e->getMessage();
-			}
-		}
-
-		if ( $should_sync ) {
-			if ( Products::is_product_visible( $product ) ) {
-				esc_html_e( 'Sync and show', 'facebook-for-woocommerce' );
-			} else {
-				esc_html_e( 'Sync and hide', 'facebook-for-woocommerce' );
-			}
-		} else {
-			esc_html_e( 'Do not sync', 'facebook-for-woocommerce' );
-			if ( ! empty( $no_sync_reason ) ) {
-				echo wc_help_tip( $no_sync_reason );
-			}
-		}
-	}
-
-	/**
-	 * Adds a dropdown input to let shop managers filter products by sync setting.
-	 *
-	 * @internal
-	 *
-	 * @since 1.10.0
-	 */
-	public function add_products_by_sync_enabled_input_filter() {
-		global $typenow;
-
-		if ( 'product' !== $typenow ) {
-			return;
-		}
-
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$choice = isset( $_GET['fb_sync_enabled'] ) ? (string) sanitize_text_field( wp_unslash( $_GET['fb_sync_enabled'] ) ) : '';
-		?>
-		<select name="fb_sync_enabled">
-			<option value="" <?php selected( $choice, '' ); ?>><?php esc_html_e( 'Filter by Facebook sync setting', 'facebook-for-woocommerce' ); ?></option>
-			<option value="<?php echo esc_attr( self::SYNC_MODE_SYNC_AND_SHOW ); ?>" <?php selected( $choice, self::SYNC_MODE_SYNC_AND_SHOW ); ?>><?php esc_html_e( 'Sync and show', 'facebook-for-woocommerce' ); ?></option>
-			<option value="<?php echo esc_attr( self::SYNC_MODE_SYNC_AND_HIDE ); ?>" <?php selected( $choice, self::SYNC_MODE_SYNC_AND_HIDE ); ?>><?php esc_html_e( 'Sync and hide', 'facebook-for-woocommerce' ); ?></option>
-			<option value="<?php echo esc_attr( self::SYNC_MODE_SYNC_DISABLED ); ?>" <?php selected( $choice, self::SYNC_MODE_SYNC_DISABLED ); ?>><?php esc_html_e( 'Do not sync', 'facebook-for-woocommerce' ); ?></option>
-		</select>
-		<?php
-	}
-
-	/**
-	 * Filters products by Facebook sync setting.
-	 *
-	 * @internal
-	 *
-	 * @since 1.10.0
-	 *
-	 * @param array $query_vars product query vars for the edit screen
-	 * @return array
-	 */
-	public function filter_products_by_sync_enabled( $query_vars ) {
-		$valid_values = array(
-			self::SYNC_MODE_SYNC_AND_SHOW,
-			self::SYNC_MODE_SYNC_AND_HIDE,
-			self::SYNC_MODE_SYNC_DISABLED,
-		);
-
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_REQUEST['fb_sync_enabled'] ) && in_array( $_REQUEST['fb_sync_enabled'], $valid_values, true ) ) {
-			// store original meta query
-			$original_meta_query = ! empty( $query_vars['meta_query'] ) ? $query_vars['meta_query'] : [];
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$filter_value = wc_clean( wp_unslash( $_REQUEST['fb_sync_enabled'] ) );
-			// by default use an "AND" clause if multiple conditions exist for a meta query
-			if ( ! empty( $query_vars['meta_query'] ) ) {
-				$query_vars['meta_query']['relation'] = 'AND';
-			} else {
-				$query_vars['meta_query'] = [];
-			}
-
-			if ( self::SYNC_MODE_SYNC_AND_SHOW === $filter_value ) {
-				// when checking for products with sync enabled we need to check both "yes" and meta not set, this requires adding an "OR" clause
-				$query_vars = $this->add_query_vars_to_find_products_with_sync_enabled( $query_vars );
-				// only get visible products (both "yes" and meta not set)
-				$query_vars = $this->add_query_vars_to_find_visible_products( $query_vars );
-				// since we record enabled status and visibility on child variations, we need to query variable products found for their children to exclude them from query results
-				$exclude_products = [];
-				$found_ids        = get_posts( array_merge( $query_vars, array( 'fields' => 'ids' ) ) );
-				$found_products   = empty( $found_ids ) ? [] : wc_get_products(
-					array(
-						'limit'   => -1,
-						'type'    => 'variable',
-						'include' => $found_ids,
-					)
-				);
-				/** @var \WC_Product[] $found_products */
-				foreach ( $found_products as $product ) {
-					if ( ! Products::is_sync_enabled_for_product( $product )
-						 || ! Products::is_product_visible( $product ) ) {
-						$exclude_products[] = $product->get_id();
-					}
-				}
-
-				if ( ! empty( $exclude_products ) ) {
-					if ( ! empty( $query_vars['post__not_in'] ) ) {
-						$query_vars['post__not_in'] = array_merge( $query_vars['post__not_in'], $exclude_products );
-					} else {
-						$query_vars['post__not_in'] = $exclude_products;
-					}
-				}
-			} elseif ( self::SYNC_MODE_SYNC_AND_HIDE === $filter_value ) {
-				// when checking for products with sync enabled we need to check both "yes" and meta not set, this requires adding an "OR" clause
-				$query_vars = $this->add_query_vars_to_find_products_with_sync_enabled( $query_vars );
-				// only get hidden products
-				$query_vars = $this->add_query_vars_to_find_hidden_products( $query_vars );
-				// since we record enabled status and visibility on child variations, we need to query variable products found for their children to exclude them from query results
-				$exclude_products = [];
-				$found_ids        = get_posts( array_merge( $query_vars, array( 'fields' => 'ids' ) ) );
-				$found_products   = empty( $found_ids ) ? [] : wc_get_products(
-					array(
-						'limit'   => -1,
-						'type'    => 'variable',
-						'include' => $found_ids,
-					)
-				);
-				/** @var \WC_Product[] $found_products */
-				foreach ( $found_products as $product ) {
-					if ( ! Products::is_sync_enabled_for_product( $product )
-						 || Products::is_product_visible( $product ) ) {
-						$exclude_products[] = $product->get_id();
-					}
-				}
-
-				if ( ! empty( $exclude_products ) ) {
-					if ( ! empty( $query_vars['post__not_in'] ) ) {
-						$query_vars['post__not_in'] = array_merge( $query_vars['post__not_in'], $exclude_products );
-					} else {
-						$query_vars['post__not_in'] = $exclude_products;
-					}
-				}
-
-				// for the same reason, we also need to include variable products with hidden children
-				$include_products  = [];
-				$hidden_variations = get_posts(
-					array(
-						'limit'      => -1,
-						'post_type'  => 'product_variation',
-						'meta_query' => array(
-							'key'   => Products::VISIBILITY_META_KEY,
-							'value' => 'no',
-						),
-					)
-				);
-
-				/** @var \WP_Post[] $hidden_variations */
-				foreach ( $hidden_variations as $variation_post ) {
-					$variable_product = wc_get_product( $variation_post->post_parent );
-					// we need this check because we only want products with ALL variations hidden
-					if ( $variable_product instanceof \WC_Product && Products::is_sync_enabled_for_product( $variable_product )
-						 && ! Products::is_product_visible( $variable_product ) ) {
-						$include_products[] = $variable_product->get_id();
-					}
-				}
-			} else {
-				// self::SYNC_MODE_SYNC_DISABLED
-				// products to be included in the QUERY, not in the sync
-				$include_products = [];
-				$found_ids        = [];
-				$integration             = facebook_for_woocommerce()->get_integration();
-				$excluded_categories_ids = $integration ? $integration->get_excluded_product_category_ids() : [];
-				$excluded_tags_ids       = $integration ? $integration->get_excluded_product_tag_ids() : [];
-				// get the product IDs from all products in excluded taxonomies
-				if ( $excluded_categories_ids || $excluded_tags_ids ) {
-					$tax_query_vars   = $this->maybe_add_tax_query_for_excluded_taxonomies( $query_vars, true );
-					$include_products = array_merge( $include_products, get_posts( array_merge( $tax_query_vars, array( 'fields' => 'ids' ) ) ) );
-				}
-				$excluded_products = get_posts(
-					array(
-						'fields'     => 'ids',
-						'limit'      => -1,
-						'post_type'  => 'product',
-						'meta_query' => array(
-							array(
-								'key'   => Products::SYNC_ENABLED_META_KEY,
-								'value' => 'no',
-							),
-						),
-					)
-				);
-				$include_products = array_unique( array_merge( $include_products, $excluded_products ) );
-				// since we record enabled status and visibility on child variations,
-				// we need to include variable products with excluded children
-				$excluded_variations = get_posts(
-					array(
-						'limit'      => -1,
-						'post_type'  => 'product_variation',
-						'meta_query' => array(
-							array(
-								'key'   => Products::SYNC_ENABLED_META_KEY,
-								'value' => 'no',
-							),
-						),
-					)
-				);
-				/** @var \WP_Post[] $excluded_variations */
-				foreach ( $excluded_variations as $variation_post ) {
-					$variable_product = wc_get_product( $variation_post->post_parent );
-					// we need this check because we only want products with ALL variations excluded
-					if ( ! Products::is_sync_enabled_for_product( $variable_product ) ) {
-						$include_products[] = $variable_product->get_id();
-					}
-				}
-			}//end if
-
-			if ( ! empty( $include_products ) ) {
-				// we are going to query by ID, so we want to include all the IDs from before
-				$include_products = array_unique( array_merge( $found_ids, $include_products ) );
-				if ( ! empty( $query_vars['post__in'] ) ) {
-					$query_vars['post__in'] = array_merge( $query_vars['post__in'], $include_products );
-				} else {
-					$query_vars['post__in'] = $include_products;
-				}
-
-				// remove sync enabled and visibility meta queries
-				if ( ! empty( $original_meta_query ) ) {
-					$query_vars['meta_query'] = $original_meta_query;
-				} else {
-					unset( $query_vars['meta_query'] );
-				}
-			}
-		}//end if
-
-		if ( isset( $query_vars['meta_query'] ) && empty( $query_vars['meta_query'] ) ) {
-			unset( $query_vars['meta_query'] );
-		}
-
-		return $query_vars;
-	}
-
-
-	/**
-	 * Adds query vars to limit the results to products that have sync enabled.
-	 *
-	 * @since 1.10.0
-	 *
-	 * @param array $query_vars
-	 * @return array
-	 */
-	private function add_query_vars_to_find_products_with_sync_enabled( array $query_vars ) {
-		$meta_query = array(
-			'relation' => 'OR',
-			array(
-				'key'   => Products::SYNC_ENABLED_META_KEY,
-				'value' => 'yes',
-			),
-			array(
-				'key'     => Products::SYNC_ENABLED_META_KEY,
-				'compare' => 'NOT EXISTS',
-			),
-		);
-
-		if ( empty( $query_vars['meta_query'] ) ) {
-			$query_vars['meta_query'] = $meta_query;
-		} elseif ( is_array( $query_vars['meta_query'] ) ) {
-			$original_meta_query      = $query_vars['meta_query'];
-			$query_vars['meta_query'] = array(
-				'relation' => 'AND',
-				$original_meta_query,
-				$meta_query,
-			);
-		}
-
-		// check whether the product belongs to an excluded product category or tag
-		$query_vars = $this->maybe_add_tax_query_for_excluded_taxonomies( $query_vars );
-		return $query_vars;
-	}
-
-
-	/**
-	 * Adds a tax query to filter in/out products in excluded product categories and product tags.
-	 *
-	 * @since 1.10.0
-	 *
-	 * @param array $query_vars product query vars for the edit screen
-	 * @param bool  $in whether we want to return products in excluded categories and tags or not
-	 * @return array
-	 */
-	private function maybe_add_tax_query_for_excluded_taxonomies( $query_vars, $in = false ) {
-		$integration = facebook_for_woocommerce()->get_integration();
-		if ( $integration ) {
-			$tax_query               = [];
-			$excluded_categories_ids = $integration->get_excluded_product_category_ids();
-			if ( $excluded_categories_ids ) {
-				$tax_query[] = array(
-					'taxonomy' => 'product_cat',
-					'terms'    => $excluded_categories_ids,
-					'field'    => 'term_id',
-					'operator' => $in ? 'IN' : 'NOT IN',
-				);
-			}
-			$excluded_tags_ids = $integration->get_excluded_product_tag_ids();
-			if ( $excluded_tags_ids ) {
-				$tax_query[] = array(
-					'taxonomy' => 'product_tag',
-					'terms'    => $excluded_tags_ids,
-					'field'    => 'term_id',
-					'operator' => $in ? 'IN' : 'NOT IN',
-				);
-			}
-
-			if ( count( $tax_query ) > 1 ) {
-				$tax_query['relation'] = $in ? 'OR' : 'AND';
-			}
-
-			if ( $tax_query && empty( $query_vars['tax_query'] ) ) {
-				$query_vars['tax_query'] = $tax_query;
-			} elseif ( $tax_query && is_array( $query_vars ) ) {
-				$query_vars['tax_query'][] = $tax_query;
-			}
-		}//end if
-
-		return $query_vars;
-	}
-
-
-	/**
-	 * Adds query vars to limit the results to visible products.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param array $query_vars
-	 * @return array
-	 */
-	private function add_query_vars_to_find_visible_products( array $query_vars ) {
-		$visibility_meta_query = array(
-			'relation' => 'OR',
-			array(
-				'key'   => Products::VISIBILITY_META_KEY,
-				'value' => 'yes',
-			),
-			array(
-				'key'     => Products::VISIBILITY_META_KEY,
-				'compare' => 'NOT EXISTS',
-			),
-		);
-
-		if ( empty( $query_vars['meta_query'] ) ) {
-			$query_vars['meta_query'] = $visibility_meta_query;
-		} elseif ( is_array( $query_vars['meta_query'] ) ) {
-			$enabled_meta_query       = $query_vars['meta_query'];
-			$query_vars['meta_query'] = array(
-				'relation' => 'AND',
-				$enabled_meta_query,
-				$visibility_meta_query,
-			);
-		}
-
-		return $query_vars;
-	}
-
-
-	/**
-	 * Adds query vars to limit the results to hidden products.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param array $query_vars
-	 * @return array
-	 */
-	private function add_query_vars_to_find_hidden_products( array $query_vars ) {
-		$visibility_meta_query = array(
-			'key'   => Products::VISIBILITY_META_KEY,
-			'value' => 'no',
-		);
-
-		if ( empty( $query_vars['meta_query'] ) ) {
-			$query_vars['meta_query'] = $visibility_meta_query;
-		} elseif ( is_array( $query_vars['meta_query'] ) ) {
-			$enabled_meta_query       = $query_vars['meta_query'];
-			$query_vars['meta_query'] = array(
-				'relation' => 'AND',
-				$enabled_meta_query,
-				$visibility_meta_query,
-			);
-		}
-
-		return $query_vars;
-	}
-
-
-	/**
-	 * Adds bulk actions in the products edit screen.
-	 *
-	 * @internal
-	 *
-	 * @since 1.10.0
-	 *
-	 * @param array $bulk_actions array of bulk action keys and labels
-	 * @return array
-	 */
-	public function add_products_sync_bulk_actions( $bulk_actions ) {
-		$bulk_actions['facebook_include'] = __( 'Include in Facebook sync', 'facebook-for-woocommerce' );
-		$bulk_actions['facebook_exclude'] = __( 'Exclude from Facebook sync', 'facebook-for-woocommerce' );
-		return $bulk_actions;
-	}
-
-
-	/**
-	 * Handles a Facebook product sync bulk action.
-	 *
-	 * @internal
-	 *
-	 * @since 1.10.0
-	 *
-	 * @param string $redirect admin URL used by WordPress to redirect after performing the bulk action
-	 * @return string
-	 */
-	public function handle_products_sync_bulk_actions( $redirect ) {
-
-		// primary dropdown at the top of the list table
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$action = isset( $_REQUEST['action'] ) && -1 !== (int) $_REQUEST['action'] ? sanitize_text_field( wp_unslash( $_REQUEST['action'] ) ) : null;
-
-		// secondary dropdown at the bottom of the list table
-		if ( ! $action ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$action = isset( $_REQUEST['action2'] ) && -1 !== (int) $_REQUEST['action2'] ? sanitize_text_field( wp_unslash( $_REQUEST['action2'] ) ) : null;
-		}
-
-		if ( $action && in_array( $action, array( 'facebook_include', 'facebook_exclude' ), true ) ) {
-			$products = [];
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$product_ids = isset( $_REQUEST['post'] ) && is_array( $_REQUEST['post'] ) ? array_map( 'absint', $_REQUEST['post'] ) : [];
-			if ( ! empty( $product_ids ) ) {
-				/** @var \WC_Product[] $enabling_sync_virtual_products virtual products that are being included */
-				$enabling_sync_virtual_products = [];
-				/** @var \WC_Product_Variation[] $enabling_sync_virtual_variations virtual variations that are being included */
-				$enabling_sync_virtual_variations = [];
-				foreach ( $product_ids as $product_id ) {
-					if ( $product = wc_get_product( $product_id ) ) {
-						$products[] = $product;
-						if ( 'facebook_include' === $action ) {
-							if ( $product->is_virtual() && ! Products::is_sync_enabled_for_product( $product ) ) {
-								$enabling_sync_virtual_products[ $product->get_id() ] = $product;
-							} else {
-								if ( $product->is_type( 'variable' ) ) {
-									// collect the virtual variations
-									foreach ( $product->get_children() as $variation_id ) {
-										$variation = wc_get_product( $variation_id );
-										if ( $variation && $variation->is_virtual() && ! Products::is_sync_enabled_for_product( $variation ) ) {
-											$enabling_sync_virtual_products[ $product->get_id() ]     = $product;
-											$enabling_sync_virtual_variations[ $variation->get_id() ] = $variation;
-										}
-									}
-								}
-							}//end if
-						}//end if
-					}//end if
-				}//end foreach
-
-				if ( ! empty( $enabling_sync_virtual_products ) || ! empty( $enabling_sync_virtual_variations ) ) {
-					// display notice if enabling sync for virtual products or variations
-					set_transient( 'wc_' . facebook_for_woocommerce()->get_id() . '_enabling_virtual_products_sync_show_notice_' . get_current_user_id(), true, 15 * MINUTE_IN_SECONDS );
-					set_transient( 'wc_' . facebook_for_woocommerce()->get_id() . '_enabling_virtual_products_sync_affected_products_' . get_current_user_id(), array_keys( $enabling_sync_virtual_products ), 15 * MINUTE_IN_SECONDS );
-
-					// set visibility for virtual products
-					foreach ( $enabling_sync_virtual_products as $product ) {
-
-						// do not set visibility for variable products
-						if ( ! $product->is_type( 'variable' ) ) {
-							Products::set_product_visibility( $product, false );
-						}
-					}
-
-					// set visibility for virtual variations
-					foreach ( $enabling_sync_virtual_variations as $variation ) {
-
-						Products::set_product_visibility( $variation, false );
-					}
-				}//end if
-
-				if ( 'facebook_include' === $action ) {
-
-					Products::enable_sync_for_products( $products );
-
-					$this->resync_products( $products );
-
-				} elseif ( 'facebook_exclude' === $action ) {
-
-					Products::disable_sync_for_products( $products );
-
-					self::add_product_disabled_sync_notice( count( $products ) );
-				}
-			}//end if
-		}//end if
-
-		return $redirect;
-	}
-
-
-	/**
-	 * Re-syncs the given products.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param \WC_Product $products
-	 */
-	private function resync_products( array $products ) {
-
-		$integration = facebook_for_woocommerce()->get_integration();
-
-		// re-sync each product
-		foreach ( $products as $product ) {
-
-			if ( $product->is_type( 'variable' ) ) {
-
-				// create product group and schedule product variations to be synced in the background
-				$integration->on_product_publish( $product->get_id() );
-
-			} elseif ( $integration->product_should_be_synced( $product ) ) {
-
-				// schedule simple products to be updated or deleted from the catalog in the background
-				if ( Products::product_should_be_deleted( $product ) ) {
-					facebook_for_woocommerce()->get_products_sync_handler()->delete_products( array( $product->get_id() ) );
-				} else {
-					facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_products( array( $product->get_id() ) );
-				}
-			}
-		}
-	}
-
-
-	/**
-	 * Adds a transient so an informational notice is displayed on the next page load.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param int $count number of products
-	 */
-	public static function add_product_disabled_sync_notice( $count = 1 ) {
-
-		if ( ! facebook_for_woocommerce()->get_admin_notice_handler()->is_notice_dismissed( 'wc-' . facebook_for_woocommerce()->get_id_dasherized() . '-product-disabled-sync' ) ) {
-			set_transient( 'wc_' . facebook_for_woocommerce()->get_id() . '_show_product_disabled_sync_notice_' . get_current_user_id(), $count, MINUTE_IN_SECONDS );
-		}
-	}
-
-
-	/**
-	 * Adds a message for after a product or set of products get excluded from sync.
-	 *
-	 * @since 2.0.0
-	 */
-	public function maybe_show_product_disabled_sync_notice() {
-
-		$transient_name = 'wc_' . facebook_for_woocommerce()->get_id() . '_show_product_disabled_sync_notice_' . get_current_user_id();
-		$message_id     = 'wc-' . facebook_for_woocommerce()->get_id_dasherized() . '-product-disabled-sync';
-
-		if ( ( $count = get_transient( $transient_name ) ) && ( Helper::is_current_screen( 'edit-product' ) || Helper::is_current_screen( 'product' ) ) ) {
-
-			$message = sprintf(
-				/* translators: Placeholders: %1$s - <strong> tag, %2$s - </strong> tag, %3$s - <a> tag, %4$s - <a> tag */
-				_n( '%1$sHeads up!%2$s If this product was previously visible in Facebook, you may need to delete it from the %3$sFacebook catalog%4$s to completely hide it from customer view.', '%1$sHeads up!%2$s If these products were previously visible in Facebook, you may need to delete them from the %3$sFacebook catalog%4$s to completely hide them from customer view.', $count, 'facebook-for-woocommerce' ),
-				'<strong>',
-				'</strong>',
-				'<a href="https://facebook.com/products" target="_blank">',
-				'</a>'
-			);
-
-			$message .= '<a class="button js-wc-plugin-framework-notice-dismiss">' . esc_html__( "Don't show this notice again", 'facebook-for-woocommerce' ) . '</a>';
-
-			facebook_for_woocommerce()->get_admin_notice_handler()->add_admin_notice(
-				$message,
-				$message_id,
-				array(
-					'dismissible' => false,
-					// we add our own dismiss button
-														'notice_class' => 'notice-info',
-				)
-			);
-
-			delete_transient( $transient_name );
-		}//end if
-	}
-
-
-	/**
-	 * Prints a notice on products page to inform users that the virtual products selected for the Include bulk action will have sync enabled, but will be hidden.
-	 *
-	 * @internal
-	 *
-	 * @since 1.11.3-dev.2
-	 */
-	public function maybe_add_enabling_virtual_products_sync_notice() {
-
-		$show_notice_transient_name       = 'wc_' . facebook_for_woocommerce()->get_id() . '_enabling_virtual_products_sync_show_notice_' . get_current_user_id();
-		$affected_products_transient_name = 'wc_' . facebook_for_woocommerce()->get_id() . '_enabling_virtual_products_sync_affected_products_' . get_current_user_id();
-
-		if ( Helper::is_current_screen( 'edit-product' ) && get_transient( $show_notice_transient_name ) && ( $affected_products = get_transient( $affected_products_transient_name ) ) ) {
-
-			$message = sprintf(
-				esc_html(
-				/* translators: Placeholders: %1$s - number of affected products, %2$s opening HTML <a> tag, %3$s - closing HTML </a> tag, %4$s - opening HTML <a> tag, %5$s - closing HTML </a> tag */
-					_n(
-						'%2$s%1$s product%3$s or some of its variations could not be updated to show in the Facebook catalog — %4$sFacebook Commerce Policies%5$s prohibit selling some product types (like virtual products). You may still advertise Virtual products on Facebook.',
-						'%2$s%1$s products%3$s or some of their variations could not be updated to show in the Facebook catalog — %4$sFacebook Commerce Policies%5$s prohibit selling some product types (like virtual products). You may still advertise Virtual products on Facebook.',
-						count( $affected_products ),
-						'facebook-for-woocommerce'
-					)
-				),
-				count( $affected_products ),
-				'<a href="' . esc_url( add_query_arg( array( 'facebook_show_affected_products' => 1 ) ) ) . '">',
-				'</a>',
-				'<a href="https://www.facebook.com/policies/commerce/prohibited_content/subscriptions_and_digital_products" target="_blank">',
-				'</a>'
-			);
-
-			facebook_for_woocommerce()->get_admin_notice_handler()->add_admin_notice(
-				$message,
-				'wc-' . facebook_for_woocommerce()->get_id_dasherized() . '-enabling-virtual-products-sync',
-				array(
-					'dismissible'  => false,
-					'notice_class' => 'notice-info',
-				)
-			);
-
-			delete_transient( $show_notice_transient_name );
-		}//end if
-	}
-
-
-	/**
-	 * Tweaks the query to show a filtered view with the affected products.
-	 *
-	 * @internal
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param array $query_vars product query vars for the edit screen
-	 * @return array
-	 */
-	public function filter_virtual_products_affected_enabling_sync( $query_vars ) {
-
-		$transient_name = 'wc_' . facebook_for_woocommerce()->get_id() . '_enabling_virtual_products_sync_affected_products_' . get_current_user_id();
-
-		if ( isset( $_GET['facebook_show_affected_products'] ) && Helper::is_current_screen( 'edit-product' ) && $affected_products = get_transient( $transient_name ) ) {
-
-			$query_vars['post__in'] = $affected_products;
-		}
-
-		return $query_vars;
-	}
-
-
-	/**
-	 * Prints a notice to inform sync mode has been automatically set to Sync and hide for virtual products and variations.
-	 *
-	 * @internal
-	 *
-	 * @since 2.0.0
-	 */
-	public function add_handled_virtual_products_variations_notice() {
-
-		if ( 'yes' === get_option( 'wc_facebook_background_handle_virtual_products_variations_complete', 'no' ) &&
-			 'yes' !== get_option( 'wc_facebook_background_handle_virtual_products_variations_skipped', 'no' ) ) {
-
-			facebook_for_woocommerce()->get_admin_notice_handler()->add_admin_notice(
-				sprintf(
-					/* translators: Placeholders: %1$s - opening HTML <strong> tag, %2$s - closing HTML </strong> tag, %3$s - opening HTML <a> tag, %4$s - closing HTML </a> tag */
-					esc_html__( '%1$sHeads up!%2$s Facebook\'s %3$sCommerce Policies%4$s do not support selling virtual products, so we have hidden your synced Virtual products in your Facebook catalog. You may still advertise Virtual products on Facebook.', 'facebook-for-woocommerce' ),
-					'<strong>',
-					'</strong>',
-					'<a href="https://www.facebook.com/policies/commerce/prohibited_content/subscriptions_and_digital_products" target="_blank">',
-					'</a>'
-				),
-				'wc-' . facebook_for_woocommerce()->get_id_dasherized() . '-updated-virtual-products-sync',
-				array(
-					'notice_class'            => 'notice-info',
-					'always_show_on_settings' => false,
-				)
-			);
-		}
-	}
-
-
-	/**
-	 * Adds a new tab to the Product edit page.
-	 *
-	 * @internal
-	 *
-	 * @since 1.10.0
-	 *
-	 * @param array $tabs product tabs
-	 * @return array
-	 */
-	public function add_product_settings_tab( $tabs ) {
-
-		$tabs['fb_commerce_tab'] = array(
-			'label'  => __( 'Facebook', 'facebook-for-woocommerce' ),
-			'target' => 'facebook_options',
-			'class'  => array( 'show_if_simple', 'show_if_variable', 'show_if_external' ),
-		);
-
-		return $tabs;
-	}
-
-
-	/**
-	 * Adds content to the new Facebook tab on the Product edit page.
-	 *
-	 * @internal
-	 *
-	 * @since 1.10.0
-	 */
-	public function add_product_settings_tab_content() {
-		global $post;
-
-
-		// all products have sync enabled unless explicitly disabled
-		$sync_enabled = 'no' !== get_post_meta( $post->ID, Products::SYNC_ENABLED_META_KEY, true );
-		$is_visible   = ( $visibility = get_post_meta( $post->ID, Products::VISIBILITY_META_KEY, true ) ) ? wc_string_to_bool( $visibility ) : true;
-		$product 	  = wc_get_product( $post );
-
-		$description  = get_post_meta( $post->ID, \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, true );
-		$price        = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_PRICE, true );
-		$image_source = get_post_meta( $post->ID, Products::PRODUCT_IMAGE_SOURCE_META_KEY, true );
-		$image        = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_IMAGE, true );
+    /** @var string the "sync and show" sync mode slug */
+    const SYNC_MODE_SYNC_AND_SHOW = 'sync_and_show';
+
+    /** @var string the "sync and show" sync mode slug */
+    const SYNC_MODE_SYNC_AND_HIDE = 'sync_and_hide';
+
+    /** @var string the "sync disabled" sync mode slug */
+    const SYNC_MODE_SYNC_DISABLED = 'sync_disabled';
+
+    /** @var Product_Categories the product category admin handler */
+    protected $product_categories;
+
+    /** @var array screens ids where to include scripts */
+    protected $screen_ids = [];
+
+    /** @var Product_Sets the product set admin handler. */
+    protected $product_sets;
+
+    /**
+     * Admin constructor.
+     *
+     * @since 1.10.0
+     */
+    public function __construct() {
+
+        $order_screen_id = class_exists( OrderUtil::class ) ? OrderUtil::get_order_admin_screen() : 'shop_order';
+
+        $this->screen_ids = [
+            'product',
+            'edit-product',
+            'woocommerce_page_wc-facebook',
+            'marketing_page_wc-facebook',
+            'edit-product_cat',
+            $order_screen_id,
+        ];
+
+        // enqueue admin scripts
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+
+        $plugin = facebook_for_woocommerce();
+        // only alter the admin UI if the plugin is connected to Facebook and ready to sync products
+        if ( ! $plugin->get_connection_handler()->is_connected() || ! $plugin->get_integration()->get_product_catalog_id() ) {
+            return;
+        }
+
+        $this->product_categories = new Admin\Product_Categories();
+        $this->product_sets       = new Admin\Product_Sets();
+        // add a modal in admin product pages
+        add_action( 'admin_footer', array( $this, 'render_modal_template' ) );
+
+        // add admin notice to inform that disabled products may need to be deleted manually
+        add_action( 'admin_notices', array( $this, 'maybe_show_product_disabled_sync_notice' ) );
+
+        // add admin notice if the user is enabling sync for virtual products using the bulk action
+        add_action( 'admin_notices', array( $this, 'maybe_add_enabling_virtual_products_sync_notice' ) );
+        add_filter( 'request', array( $this, 'filter_virtual_products_affected_enabling_sync' ) );
+
+        // add admin notice to inform sync mode has been automatically set to Sync and hide for virtual products and variations
+        add_action( 'admin_notices', array( $this, 'add_handled_virtual_products_variations_notice' ) );
+
+        // add columns for displaying Facebook sync enabled/disabled and catalog visibility status
+        add_filter( 'manage_product_posts_columns', array( $this, 'add_product_list_table_columns' ) );
+        add_action( 'manage_product_posts_custom_column', array( $this, 'add_product_list_table_columns_content' ) );
+
+        // add input to filter products by Facebook sync enabled
+        add_action( 'restrict_manage_posts', array( $this, 'add_products_by_sync_enabled_input_filter' ), 40 );
+        add_filter( 'request', array( $this, 'filter_products_by_sync_enabled' ) );
+
+        // add bulk actions to manage products sync
+        add_filter( 'bulk_actions-edit-product', array( $this, 'add_products_sync_bulk_actions' ), 40 );
+        add_action( 'handle_bulk_actions-edit-product', array( $this, 'handle_products_sync_bulk_actions' ) );
+
+        // add Product data tab
+        add_filter( 'woocommerce_product_data_tabs', array( $this, 'add_product_settings_tab' ) );
+        add_action( 'woocommerce_product_data_panels', array( $this, 'add_product_settings_tab_content' ) );
+
+        // add Variation edit fields
+        add_action( 'woocommerce_product_after_variable_attributes', array( $this, 'add_product_variation_edit_fields' ), 10, 3 );
+        add_action( 'woocommerce_save_product_variation', array( $this, 'save_product_variation_edit_fields' ), 10, 2 );
+
+        // add custom taxonomy for Product Sets
+        add_filter( 'gettext', array( $this, 'change_custom_taxonomy_tip' ), 20, 2 );
+    }
+
+    /**
+     * __get method for backward compatibility.
+     *
+     * @param string $key property name
+     * @return mixed
+     * @since 3.0.32
+     */
+    public function __get( $key ) {
+        // Add warning for private properties.
+        if ( 'product_sets' === $key ) {
+            /* translators: %s property name. */
+            _doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'The %s property is protected and should not be accessed outside its class.', 'facebook-for-woocommerce' ), esc_html( $key ) ), '3.0.32' );
+            return $this->$key;
+        }
+
+        return null;
+    }
+
+    /**
+     * Change custom taxonomy tip text
+     *
+     * @since 2.3.0
+     *
+     * @param string $translation Text translation.
+     * @param string $text Original text.
+     *
+     * @return string
+     */
+    public function change_custom_taxonomy_tip( $translation, $text ) {
+        global $current_screen;
+        if ( isset( $current_screen->id ) && 'edit-fb_product_set' === $current_screen->id && 'The name is how it appears on your site.' === $text ) {
+            $translation = esc_html__( 'The name is how it appears on Facebook Catalog.', 'facebook-for-woocommerce' );
+        }
+        return $translation;
+    }
+
+    /**
+     * Enqueues admin scripts.
+     *
+     * @internal
+     *
+     * @since 1.10.0
+     */
+    public function enqueue_scripts() {
+        global $current_screen;
+
+        if ( isset( $current_screen->id ) ) {
+
+            if ( in_array( $current_screen->id, $this->screen_ids, true ) || facebook_for_woocommerce()->is_plugin_settings() ) {
+
+                // enqueue modal functions
+                wp_enqueue_script(
+                    'facebook-for-woocommerce-modal',
+                    facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/modal.js',
+                    array( 'jquery', 'wc-backbone-modal', 'jquery-blockui' ),
+                    \WC_Facebookcommerce::PLUGIN_VERSION
+                );
+
+                // enqueue google product category select
+                wp_enqueue_script(
+                    'wc-facebook-google-product-category-fields',
+                    facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/google-product-category-fields.js',
+                    array( 'jquery' ),
+                    \WC_Facebookcommerce::PLUGIN_VERSION
+                );
+
+                wp_localize_script(
+                    'wc-facebook-google-product-category-fields',
+                    'facebook_for_woocommerce_google_product_category',
+                    array(
+                        'i18n' => array(
+                            'top_level_dropdown_placeholder' => __( 'Search main categories...', 'facebook-for-woocommerce' ),
+                            'second_level_empty_dropdown_placeholder' => __( 'Choose a main category first', 'facebook-for-woocommerce' ),
+                            'general_dropdown_placeholder'   => __( 'Choose a category', 'facebook-for-woocommerce' ),
+                        ),
+                    )
+                );
+            }
+
+            if ( 'edit-fb_product_set' === $current_screen->id ) {
+                // enqueue WooCommerce Admin Styles because of Select2
+                wp_enqueue_style(
+                    'woocommerce_admin_styles',
+                    WC()->plugin_url() . '/assets/css/admin.css',
+                    [],
+                    \WC_Facebookcommerce::PLUGIN_VERSION
+                );
+                wp_enqueue_style(
+                    'facebook-for-woocommerce-product-sets-admin',
+                    facebook_for_woocommerce()->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-product-sets-admin.css',
+                    [],
+                    \WC_Facebookcommerce::PLUGIN_VERSION
+                );
+
+                wp_enqueue_script(
+                    'facebook-for-woocommerce-product-sets',
+                    facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/product-sets-admin.js',
+                    [ 'jquery', 'select2' ],
+                    \WC_Facebookcommerce::PLUGIN_VERSION,
+                    true
+                );
+
+                wp_localize_script(
+                    'facebook-for-woocommerce-product-sets',
+                    'facebook_for_woocommerce_product_sets',
+                    array(
+
+                        'excluded_category_ids'             => facebook_for_woocommerce()->get_integration()->get_excluded_product_category_ids(),
+                        'excluded_category_warning_message' => __( 'You have selected one or more categories currently excluded from the Facebook sync. Products belonging to the excluded categories will not be added to your Facebook Product Set.', 'facebook-for-woocommerce' ),
+                    )
+                );
+            }
+
+            if ( 'product' === $current_screen->id || 'edit-product' === $current_screen->id ) {
+                wp_enqueue_style(
+                    'facebook-for-woocommerce-products-admin',
+                    facebook_for_woocommerce()->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-products-admin.css',
+                    [],
+                    \WC_Facebookcommerce::PLUGIN_VERSION
+                );
+                wp_enqueue_script(
+                    'facebook-for-woocommerce-products-admin',
+                    facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/products-admin.js',
+                    [ 'jquery', 'wc-backbone-modal', 'jquery-blockui', 'facebook-for-woocommerce-modal' ],
+                    \WC_Facebookcommerce::PLUGIN_VERSION
+                );
+                wp_localize_script(
+                    'facebook-for-woocommerce-products-admin',
+                    'facebook_for_woocommerce_products_admin',
+                    [
+                        'ajax_url'                                        => admin_url( 'admin-ajax.php' ),
+                        'enhanced_attribute_optional_selector'            => Enhanced_Catalog_Attribute_Fields::FIELD_ENHANCED_CATALOG_ATTRIBUTE_PREFIX . Enhanced_Catalog_Attribute_Fields::OPTIONAL_SELECTOR_KEY,
+                        'enhanced_attribute_page_type_edit_category'      => Enhanced_Catalog_Attribute_Fields::PAGE_TYPE_EDIT_CATEGORY,
+                        'enhanced_attribute_page_type_add_category'       => Enhanced_Catalog_Attribute_Fields::PAGE_TYPE_ADD_CATEGORY,
+                        'enhanced_attribute_page_type_edit_product'       => Enhanced_Catalog_Attribute_Fields::PAGE_TYPE_EDIT_PRODUCT,
+                        'is_product_published'                            => $this->is_current_product_published(),
+                        'is_sync_enabled_for_product'                     => $this->is_sync_enabled_for_current_product(),
+                        'set_product_visibility_nonce'                    => wp_create_nonce( 'set-products-visibility' ),
+                        'set_product_sync_prompt_nonce'                   => wp_create_nonce( 'set-product-sync-prompt' ),
+                        'set_product_sync_bulk_action_prompt_nonce'       => wp_create_nonce( 'set-product-sync-bulk-action-prompt' ),
+                        'product_not_ready_modal_message'                 => $this->get_product_not_ready_modal_message(),
+                        'product_not_ready_modal_buttons'                 => $this->get_product_not_ready_modal_buttons(),
+                        'product_removed_from_sync_confirm_modal_message' => $this->get_product_removed_from_sync_confirm_modal_message(),
+                        'product_removed_from_sync_confirm_modal_buttons' => $this->get_product_removed_from_sync_confirm_modal_buttons(),
+                        'product_removed_from_sync_field_id'              => '#' . \WC_Facebook_Product::FB_REMOVE_FROM_SYNC,
+                        'i18n'                                            => [
+                            'missing_google_product_category_message' => __( 'Please enter a Google product category and at least one sub-category to sell this product on Instagram.', 'facebook-for-woocommerce' ),
+                        ],
+                    ]
+                );
+            }//end if
+
+            if ( facebook_for_woocommerce()->is_plugin_settings() ) {
+                wp_enqueue_style( 'woocommerce_admin_styles' );
+                wp_enqueue_script( 'wc-enhanced-select' );
+            }
+        }//end if
+
+    }
+
+    /**
+     * Determines whether sync is enabled for the current product.
+     *
+     * @since 2.0.5
+     *
+     * @return bool
+     */
+    private function is_sync_enabled_for_current_product() {
+        global $post;
+        $product = wc_get_product( $post );
+        if ( ! $product instanceof \WC_Product ) {
+            return false;
+        }
+        return Products::is_sync_enabled_for_product( $product );
+    }
+
+    /**
+     * Determines whether the current product is published.
+     *
+     * @since 2.6.15
+     *
+     * @return bool
+     */
+    private function is_current_product_published() {
+        global $post;
+        $product = wc_get_product( $post );
+        if ( ! $product instanceof \WC_Product ) {
+            return false;
+        }
+        return 'publish' === $product->get_status();
+    }
+
+    /**
+     * Gets the markup for the message used in the product not ready modal.
+     *
+     * @since 2.1.0
+     *
+     * @return string
+     */
+    private function get_product_not_ready_modal_message() {
+        ob_start();
+        ?>
+        <p><?php esc_html_e( 'To sell this product on Instagram, please ensure it meets the following requirements:', 'facebook-for-woocommerce' ); ?></p>
+        <ul class="ul-disc">
+            <li><?php esc_html_e( 'Has a price defined', 'facebook-for-woocommerce' ); ?></li>
+            <li>
+            <?php
+            echo esc_html(
+                sprintf(
+                /* translators: Placeholders: %1$s - <strong> opening HTML tag, %2$s - </strong> closing HTML tag */
+                    __( 'Has %1$sManage Stock%2$s enabled on the %1$sInventory%2$s tab', 'facebook-for-woocommerce' ),
+                    '<strong>',
+                    '</strong>'
+                )
+            );
+            ?>
+            </li>
+            <li>
+            <?php
+            echo esc_html(
+                sprintf(
+                /* translators: Placeholders: %1$s - <strong> opening HTML tag, %2$s - </strong> closing HTML tag */
+                    __( 'Has the %1$sFacebook Sync%2$s setting set to "Sync and show" or "Sync and hide"', 'facebook-for-woocommerce' ),
+                    '<strong>',
+                    '</strong>'
+                )
+            );
+            ?>
+            </li>
+        </ul>
+        <?php
+        return ob_get_clean();
+    }
+
+    /**
+     * Gets the markup for the buttons used in the product not ready modal.
+     *
+     * @since 2.1.0
+     *
+     * @return string
+     */
+    private function get_product_not_ready_modal_buttons() {
+        ob_start();
+        ?>
+        <button
+            id="btn-ok"
+            class="button button-large button-primary"
+        ><?php esc_html_e( 'Close', 'facebook-for-woocomerce' ); ?></button>
+        <?php
+        return ob_get_clean();
+    }
+
+    /**
+     * Gets the markup for the message used in the product removed from sync confirm modal.
+     *
+     * @internal
+     *
+     * @since 2.3.0
+     *
+     * @return string
+     */
+    private function get_product_removed_from_sync_confirm_modal_message() {
+        ob_start();
+        ?>
+        <p>
+        <?php
+        printf(
+            /* translators: Placeholders: %1$s - opening <a> link tag, %2$s - closing </a> link tag */
+            esc_html__( 'You\'re removing a product from the Facebook sync that is currently listed in your %1$sFacebook catalog%2$s. Would you like to delete the product from the Facebook catalog as well?', 'facebook-for-woocommerce' ),
+            '<a href="https://www.facebook.com/products" target="_blank">',
+            '</a>'
+        );
+        ?>
+            </p>
+        <?php
+        return ob_get_clean();
+    }
+
+    /**
+     * Gets the markup for the buttons used in the product removed from sync confirm modal.
+     *
+     * @internal
+     *
+     * @since 2.3.0
+     *
+     * @return string
+     */
+    private function get_product_removed_from_sync_confirm_modal_buttons() {
+        ob_start();
+        ?>
+        <button
+            id="btn-ok"
+            class="button button-large button-primary"
+        ><?php esc_html_e( 'Remove from sync only', 'facebook-for-woocomerce' ); ?></button>
+
+        <button
+            class="button button-large button-delete button-product-removed-from-sync-delete"
+        ><?php esc_html_e( 'Remove from sync and delete', 'facebook-for-woocomerce' ); ?></button>
+
+        <button
+            class="button button-large button-product-removed-from-sync-cancel"
+        ><?php esc_html_e( 'Cancel', 'facebook-for-woocomerce' ); ?></button>
+        <?php
+        return ob_get_clean();
+    }
+
+    /**
+     * Gets the product category admin handler instance.
+     *
+     * @since 2.1.0
+     *
+     * @return Product_Categories
+     */
+    public function get_product_categories_handler() {
+        return $this->product_categories;
+    }
+
+    /**
+     * Adds Facebook-related columns in the products edit screen.
+     *
+     * @internal
+     *
+     * @since 1.10.0
+     *
+     * @param array $columns array of keys and labels
+     * @return array
+     */
+    public function add_product_list_table_columns( $columns ) {
+        $columns['facebook_sync'] = __( 'Facebook sync', 'facebook-for-woocommerce' );
+        return $columns;
+    }
+
+    /**
+     * Outputs sync information for products in the edit screen.
+     *
+     * @internal
+     *
+     * @since 1.10.0
+     *
+     * @param string $column the current column in the posts table
+     */
+    public function add_product_list_table_columns_content( $column ) {
+        global $post;
+
+        if ( 'facebook_sync' !== $column ) {
+            return;
+        }
+
+        $product        = wc_get_product( $post );
+        $should_sync    = false;
+        $no_sync_reason = '';
+
+        if ( $product instanceof \WC_Product ) {
+            try {
+                facebook_for_woocommerce()->get_product_sync_validator( $product )->validate();
+                $should_sync = true;
+            } catch ( \Exception $e ) {
+                $no_sync_reason = $e->getMessage();
+            }
+        }
+
+        if ( $should_sync ) {
+            if ( Products::is_product_visible( $product ) ) {
+                esc_html_e( 'Sync and show', 'facebook-for-woocommerce' );
+            } else {
+                esc_html_e( 'Sync and hide', 'facebook-for-woocommerce' );
+            }
+        } else {
+            esc_html_e( 'Do not sync', 'facebook-for-woocommerce' );
+            if ( ! empty( $no_sync_reason ) ) {
+                echo wc_help_tip( $no_sync_reason );
+            }
+        }
+    }
+
+    /**
+     * Adds a dropdown input to let shop managers filter products by sync setting.
+     *
+     * @internal
+     *
+     * @since 1.10.0
+     */
+    public function add_products_by_sync_enabled_input_filter() {
+        global $typenow;
+
+        if ( 'product' !== $typenow ) {
+            return;
+        }
+
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $choice = isset( $_GET['fb_sync_enabled'] ) ? (string) sanitize_text_field( wp_unslash( $_GET['fb_sync_enabled'] ) ) : '';
+        ?>
+        <select name="fb_sync_enabled">
+            <option value="" <?php selected( $choice, '' ); ?>><?php esc_html_e( 'Filter by Facebook sync setting', 'facebook-for-woocommerce' ); ?></option>
+            <option value="<?php echo esc_attr( self::SYNC_MODE_SYNC_AND_SHOW ); ?>" <?php selected( $choice, self::SYNC_MODE_SYNC_AND_SHOW ); ?>><?php esc_html_e( 'Sync and show', 'facebook-for-woocommerce' ); ?></option>
+            <option value="<?php echo esc_attr( self::SYNC_MODE_SYNC_AND_HIDE ); ?>" <?php selected( $choice, self::SYNC_MODE_SYNC_AND_HIDE ); ?>><?php esc_html_e( 'Sync and hide', 'facebook-for-woocommerce' ); ?></option>
+            <option value="<?php echo esc_attr( self::SYNC_MODE_SYNC_DISABLED ); ?>" <?php selected( $choice, self::SYNC_MODE_SYNC_DISABLED ); ?>><?php esc_html_e( 'Do not sync', 'facebook-for-woocommerce' ); ?></option>
+        </select>
+        <?php
+    }
+
+    /**
+     * Filters products by Facebook sync setting.
+     *
+     * @internal
+     *
+     * @since 1.10.0
+     *
+     * @param array $query_vars product query vars for the edit screen
+     * @return array
+     */
+    public function filter_products_by_sync_enabled( $query_vars ) {
+        $valid_values = array(
+            self::SYNC_MODE_SYNC_AND_SHOW,
+            self::SYNC_MODE_SYNC_AND_HIDE,
+            self::SYNC_MODE_SYNC_DISABLED,
+        );
+
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        if ( isset( $_REQUEST['fb_sync_enabled'] ) && in_array( $_REQUEST['fb_sync_enabled'], $valid_values, true ) ) {
+            // store original meta query
+            $original_meta_query = ! empty( $query_vars['meta_query'] ) ? $query_vars['meta_query'] : [];
+            // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $filter_value = wc_clean( wp_unslash( $_REQUEST['fb_sync_enabled'] ) );
+            // by default use an "AND" clause if multiple conditions exist for a meta query
+            if ( ! empty( $query_vars['meta_query'] ) ) {
+                $query_vars['meta_query']['relation'] = 'AND';
+            } else {
+                $query_vars['meta_query'] = [];
+            }
+
+            if ( self::SYNC_MODE_SYNC_AND_SHOW === $filter_value ) {
+                // when checking for products with sync enabled we need to check both "yes" and meta not set, this requires adding an "OR" clause
+                $query_vars = $this->add_query_vars_to_find_products_with_sync_enabled( $query_vars );
+                // only get visible products (both "yes" and meta not set)
+                $query_vars = $this->add_query_vars_to_find_visible_products( $query_vars );
+                // since we record enabled status and visibility on child variations, we need to query variable products found for their children to exclude them from query results
+                $exclude_products = [];
+                $found_ids        = get_posts( array_merge( $query_vars, array( 'fields' => 'ids' ) ) );
+                $found_products   = empty( $found_ids ) ? [] : wc_get_products(
+                    array(
+                        'limit'   => -1,
+                        'type'    => 'variable',
+                        'include' => $found_ids,
+                    )
+                );
+                /** @var \WC_Product[] $found_products */
+                foreach ( $found_products as $product ) {
+                    if ( ! Products::is_sync_enabled_for_product( $product )
+                         || ! Products::is_product_visible( $product ) ) {
+                        $exclude_products[] = $product->get_id();
+                    }
+                }
+
+                if ( ! empty( $exclude_products ) ) {
+                    if ( ! empty( $query_vars['post__not_in'] ) ) {
+                        $query_vars['post__not_in'] = array_merge( $query_vars['post__not_in'], $exclude_products );
+                    } else {
+                        $query_vars['post__not_in'] = $exclude_products;
+                    }
+                }
+            } elseif ( self::SYNC_MODE_SYNC_AND_HIDE === $filter_value ) {
+                // when checking for products with sync enabled we need to check both "yes" and meta not set, this requires adding an "OR" clause
+                $query_vars = $this->add_query_vars_to_find_products_with_sync_enabled( $query_vars );
+                // only get hidden products
+                $query_vars = $this->add_query_vars_to_find_hidden_products( $query_vars );
+                // since we record enabled status and visibility on child variations, we need to query variable products found for their children to exclude them from query results
+                $exclude_products = [];
+                $found_ids        = get_posts( array_merge( $query_vars, array( 'fields' => 'ids' ) ) );
+                $found_products   = empty( $found_ids ) ? [] : wc_get_products(
+                    array(
+                        'limit'   => -1,
+                        'type'    => 'variable',
+                        'include' => $found_ids,
+                    )
+                );
+                /** @var \WC_Product[] $found_products */
+                foreach ( $found_products as $product ) {
+                    if ( ! Products::is_sync_enabled_for_product( $product )
+                         || Products::is_product_visible( $product ) ) {
+                        $exclude_products[] = $product->get_id();
+                    }
+                }
+
+                if ( ! empty( $exclude_products ) ) {
+                    if ( ! empty( $query_vars['post__not_in'] ) ) {
+                        $query_vars['post__not_in'] = array_merge( $query_vars['post__not_in'], $exclude_products );
+                    } else {
+                        $query_vars['post__not_in'] = $exclude_products;
+                    }
+                }
+
+                // for the same reason, we also need to include variable products with hidden children
+                $include_products  = [];
+                $hidden_variations = get_posts(
+                    array(
+                        'limit'      => -1,
+                        'post_type'  => 'product_variation',
+                        'meta_query' => array(
+                            'key'   => Products::VISIBILITY_META_KEY,
+                            'value' => 'no',
+                        ),
+                    )
+                );
+
+                /** @var \WP_Post[] $hidden_variations */
+                foreach ( $hidden_variations as $variation_post ) {
+                    $variable_product = wc_get_product( $variation_post->post_parent );
+                    // we need this check because we only want products with ALL variations hidden
+                    if ( $variable_product instanceof \WC_Product && Products::is_sync_enabled_for_product( $variable_product )
+                         && ! Products::is_product_visible( $variable_product ) ) {
+                        $include_products[] = $variable_product->get_id();
+                    }
+                }
+            } else {
+                // self::SYNC_MODE_SYNC_DISABLED
+                // products to be included in the QUERY, not in the sync
+                $include_products = [];
+                $found_ids        = [];
+                $integration             = facebook_for_woocommerce()->get_integration();
+                $excluded_categories_ids = $integration ? $integration->get_excluded_product_category_ids() : [];
+                $excluded_tags_ids       = $integration ? $integration->get_excluded_product_tag_ids() : [];
+                // get the product IDs from all products in excluded taxonomies
+                if ( $excluded_categories_ids || $excluded_tags_ids ) {
+                    $tax_query_vars   = $this->maybe_add_tax_query_for_excluded_taxonomies( $query_vars, true );
+                    $include_products = array_merge( $include_products, get_posts( array_merge( $tax_query_vars, array( 'fields' => 'ids' ) ) ) );
+                }
+                $excluded_products = get_posts(
+                    array(
+                        'fields'     => 'ids',
+                        'limit'      => -1,
+                        'post_type'  => 'product',
+                        'meta_query' => array(
+                            array(
+                                'key'   => Products::SYNC_ENABLED_META_KEY,
+                                'value' => 'no',
+                            ),
+                        ),
+                    )
+                );
+                $include_products = array_unique( array_merge( $include_products, $excluded_products ) );
+                // since we record enabled status and visibility on child variations,
+                // we need to include variable products with excluded children
+                $excluded_variations = get_posts(
+                    array(
+                        'limit'      => -1,
+                        'post_type'  => 'product_variation',
+                        'meta_query' => array(
+                            array(
+                                'key'   => Products::SYNC_ENABLED_META_KEY,
+                                'value' => 'no',
+                            ),
+                        ),
+                    )
+                );
+                /** @var \WP_Post[] $excluded_variations */
+                foreach ( $excluded_variations as $variation_post ) {
+                    $variable_product = wc_get_product( $variation_post->post_parent );
+                    // we need this check because we only want products with ALL variations excluded
+                    if ( ! Products::is_sync_enabled_for_product( $variable_product ) ) {
+                        $include_products[] = $variable_product->get_id();
+                    }
+                }
+            }//end if
+
+            if ( ! empty( $include_products ) ) {
+                // we are going to query by ID, so we want to include all the IDs from before
+                $include_products = array_unique( array_merge( $found_ids, $include_products ) );
+                if ( ! empty( $query_vars['post__in'] ) ) {
+                    $query_vars['post__in'] = array_merge( $query_vars['post__in'], $include_products );
+                } else {
+                    $query_vars['post__in'] = $include_products;
+                }
+
+                // remove sync enabled and visibility meta queries
+                if ( ! empty( $original_meta_query ) ) {
+                    $query_vars['meta_query'] = $original_meta_query;
+                } else {
+                    unset( $query_vars['meta_query'] );
+                }
+            }
+        }//end if
+
+        if ( isset( $query_vars['meta_query'] ) && empty( $query_vars['meta_query'] ) ) {
+            unset( $query_vars['meta_query'] );
+        }
+
+        return $query_vars;
+    }
+
+
+    /**
+     * Adds query vars to limit the results to products that have sync enabled.
+     *
+     * @since 1.10.0
+     *
+     * @param array $query_vars
+     * @return array
+     */
+    private function add_query_vars_to_find_products_with_sync_enabled( array $query_vars ) {
+        $meta_query = array(
+            'relation' => 'OR',
+            array(
+                'key'   => Products::SYNC_ENABLED_META_KEY,
+                'value' => 'yes',
+            ),
+            array(
+                'key'     => Products::SYNC_ENABLED_META_KEY,
+                'compare' => 'NOT EXISTS',
+            ),
+        );
+
+        if ( empty( $query_vars['meta_query'] ) ) {
+            $query_vars['meta_query'] = $meta_query;
+        } elseif ( is_array( $query_vars['meta_query'] ) ) {
+            $original_meta_query      = $query_vars['meta_query'];
+            $query_vars['meta_query'] = array(
+                'relation' => 'AND',
+                $original_meta_query,
+                $meta_query,
+            );
+        }
+
+        // check whether the product belongs to an excluded product category or tag
+        $query_vars = $this->maybe_add_tax_query_for_excluded_taxonomies( $query_vars );
+        return $query_vars;
+    }
+
+
+    /**
+     * Adds a tax query to filter in/out products in excluded product categories and product tags.
+     *
+     * @since 1.10.0
+     *
+     * @param array $query_vars product query vars for the edit screen
+     * @param bool  $in whether we want to return products in excluded categories and tags or not
+     * @return array
+     */
+    private function maybe_add_tax_query_for_excluded_taxonomies( $query_vars, $in = false ) {
+        $integration = facebook_for_woocommerce()->get_integration();
+        if ( $integration ) {
+            $tax_query               = [];
+            $excluded_categories_ids = $integration->get_excluded_product_category_ids();
+            if ( $excluded_categories_ids ) {
+                $tax_query[] = array(
+                    'taxonomy' => 'product_cat',
+                    'terms'    => $excluded_categories_ids,
+                    'field'    => 'term_id',
+                    'operator' => $in ? 'IN' : 'NOT IN',
+                );
+            }
+            $excluded_tags_ids = $integration->get_excluded_product_tag_ids();
+            if ( $excluded_tags_ids ) {
+                $tax_query[] = array(
+                    'taxonomy' => 'product_tag',
+                    'terms'    => $excluded_tags_ids,
+                    'field'    => 'term_id',
+                    'operator' => $in ? 'IN' : 'NOT IN',
+                );
+            }
+
+            if ( count( $tax_query ) > 1 ) {
+                $tax_query['relation'] = $in ? 'OR' : 'AND';
+            }
+
+            if ( $tax_query && empty( $query_vars['tax_query'] ) ) {
+                $query_vars['tax_query'] = $tax_query;
+            } elseif ( $tax_query && is_array( $query_vars ) ) {
+                $query_vars['tax_query'][] = $tax_query;
+            }
+        }//end if
+
+        return $query_vars;
+    }
+
+
+    /**
+     * Adds query vars to limit the results to visible products.
+     *
+     * @since 2.0.0
+     *
+     * @param array $query_vars
+     * @return array
+     */
+    private function add_query_vars_to_find_visible_products( array $query_vars ) {
+        $visibility_meta_query = array(
+            'relation' => 'OR',
+            array(
+                'key'   => Products::VISIBILITY_META_KEY,
+                'value' => 'yes',
+            ),
+            array(
+                'key'     => Products::VISIBILITY_META_KEY,
+                'compare' => 'NOT EXISTS',
+            ),
+        );
+
+        if ( empty( $query_vars['meta_query'] ) ) {
+            $query_vars['meta_query'] = $visibility_meta_query;
+        } elseif ( is_array( $query_vars['meta_query'] ) ) {
+            $enabled_meta_query       = $query_vars['meta_query'];
+            $query_vars['meta_query'] = array(
+                'relation' => 'AND',
+                $enabled_meta_query,
+                $visibility_meta_query,
+            );
+        }
+
+        return $query_vars;
+    }
+
+
+    /**
+     * Adds query vars to limit the results to hidden products.
+     *
+     * @since 2.0.0
+     *
+     * @param array $query_vars
+     * @return array
+     */
+    private function add_query_vars_to_find_hidden_products( array $query_vars ) {
+        $visibility_meta_query = array(
+            'key'   => Products::VISIBILITY_META_KEY,
+            'value' => 'no',
+        );
+
+        if ( empty( $query_vars['meta_query'] ) ) {
+            $query_vars['meta_query'] = $visibility_meta_query;
+        } elseif ( is_array( $query_vars['meta_query'] ) ) {
+            $enabled_meta_query       = $query_vars['meta_query'];
+            $query_vars['meta_query'] = array(
+                'relation' => 'AND',
+                $enabled_meta_query,
+                $visibility_meta_query,
+            );
+        }
+
+        return $query_vars;
+    }
+
+
+    /**
+     * Adds bulk actions in the products edit screen.
+     *
+     * @internal
+     *
+     * @since 1.10.0
+     *
+     * @param array $bulk_actions array of bulk action keys and labels
+     * @return array
+     */
+    public function add_products_sync_bulk_actions( $bulk_actions ) {
+        $bulk_actions['facebook_include'] = __( 'Include in Facebook sync', 'facebook-for-woocommerce' );
+        $bulk_actions['facebook_exclude'] = __( 'Exclude from Facebook sync', 'facebook-for-woocommerce' );
+        return $bulk_actions;
+    }
+
+
+    /**
+     * Handles a Facebook product sync bulk action.
+     *
+     * @internal
+     *
+     * @since 1.10.0
+     *
+     * @param string $redirect admin URL used by WordPress to redirect after performing the bulk action
+     * @return string
+     */
+    public function handle_products_sync_bulk_actions( $redirect ) {
+
+        // primary dropdown at the top of the list table
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $action = isset( $_REQUEST['action'] ) && -1 !== (int) $_REQUEST['action'] ? sanitize_text_field( wp_unslash( $_REQUEST['action'] ) ) : null;
+
+        // secondary dropdown at the bottom of the list table
+        if ( ! $action ) {
+            // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $action = isset( $_REQUEST['action2'] ) && -1 !== (int) $_REQUEST['action2'] ? sanitize_text_field( wp_unslash( $_REQUEST['action2'] ) ) : null;
+        }
+
+        if ( $action && in_array( $action, array( 'facebook_include', 'facebook_exclude' ), true ) ) {
+            $products = [];
+            // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $product_ids = isset( $_REQUEST['post'] ) && is_array( $_REQUEST['post'] ) ? array_map( 'absint', $_REQUEST['post'] ) : [];
+            if ( ! empty( $product_ids ) ) {
+                /** @var \WC_Product[] $enabling_sync_virtual_products virtual products that are being included */
+                $enabling_sync_virtual_products = [];
+                /** @var \WC_Product_Variation[] $enabling_sync_virtual_variations virtual variations that are being included */
+                $enabling_sync_virtual_variations = [];
+                foreach ( $product_ids as $product_id ) {
+                    if ( $product = wc_get_product( $product_id ) ) {
+                        $products[] = $product;
+                        if ( 'facebook_include' === $action ) {
+                            if ( $product->is_virtual() && ! Products::is_sync_enabled_for_product( $product ) ) {
+                                $enabling_sync_virtual_products[ $product->get_id() ] = $product;
+                            } else {
+                                if ( $product->is_type( 'variable' ) ) {
+                                    // collect the virtual variations
+                                    foreach ( $product->get_children() as $variation_id ) {
+                                        $variation = wc_get_product( $variation_id );
+                                        if ( $variation && $variation->is_virtual() && ! Products::is_sync_enabled_for_product( $variation ) ) {
+                                            $enabling_sync_virtual_products[ $product->get_id() ]     = $product;
+                                            $enabling_sync_virtual_variations[ $variation->get_id() ] = $variation;
+                                        }
+                                    }
+                                }
+                            }//end if
+                        }//end if
+                    }//end if
+                }//end foreach
+
+                if ( ! empty( $enabling_sync_virtual_products ) || ! empty( $enabling_sync_virtual_variations ) ) {
+                    // display notice if enabling sync for virtual products or variations
+                    set_transient( 'wc_' . facebook_for_woocommerce()->get_id() . '_enabling_virtual_products_sync_show_notice_' . get_current_user_id(), true, 15 * MINUTE_IN_SECONDS );
+                    set_transient( 'wc_' . facebook_for_woocommerce()->get_id() . '_enabling_virtual_products_sync_affected_products_' . get_current_user_id(), array_keys( $enabling_sync_virtual_products ), 15 * MINUTE_IN_SECONDS );
+
+                    // set visibility for virtual products
+                    foreach ( $enabling_sync_virtual_products as $product ) {
+
+                        // do not set visibility for variable products
+                        if ( ! $product->is_type( 'variable' ) ) {
+                            Products::set_product_visibility( $product, false );
+                        }
+                    }
+
+                    // set visibility for virtual variations
+                    foreach ( $enabling_sync_virtual_variations as $variation ) {
+
+                        Products::set_product_visibility( $variation, false );
+                    }
+                }//end if
+
+                if ( 'facebook_include' === $action ) {
+
+                    Products::enable_sync_for_products( $products );
+
+                    $this->resync_products( $products );
+
+                } elseif ( 'facebook_exclude' === $action ) {
+
+                    Products::disable_sync_for_products( $products );
+
+                    self::add_product_disabled_sync_notice( count( $products ) );
+                }
+            }//end if
+        }//end if
+
+        return $redirect;
+    }
+
+
+    /**
+     * Re-syncs the given products.
+     *
+     * @since 2.0.0
+     *
+     * @param \WC_Product $products
+     */
+    private function resync_products( array $products ) {
+
+        $integration = facebook_for_woocommerce()->get_integration();
+
+        // re-sync each product
+        foreach ( $products as $product ) {
+
+            if ( $product->is_type( 'variable' ) ) {
+
+                // create product group and schedule product variations to be synced in the background
+                $integration->on_product_publish( $product->get_id() );
+
+            } elseif ( $integration->product_should_be_synced( $product ) ) {
+
+                // schedule simple products to be updated or deleted from the catalog in the background
+                if ( Products::product_should_be_deleted( $product ) ) {
+                    facebook_for_woocommerce()->get_products_sync_handler()->delete_products( array( $product->get_id() ) );
+                } else {
+                    facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_products( array( $product->get_id() ) );
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Adds a transient so an informational notice is displayed on the next page load.
+     *
+     * @since 2.0.0
+     *
+     * @param int $count number of products
+     */
+    public static function add_product_disabled_sync_notice( $count = 1 ) {
+
+        if ( ! facebook_for_woocommerce()->get_admin_notice_handler()->is_notice_dismissed( 'wc-' . facebook_for_woocommerce()->get_id_dasherized() . '-product-disabled-sync' ) ) {
+            set_transient( 'wc_' . facebook_for_woocommerce()->get_id() . '_show_product_disabled_sync_notice_' . get_current_user_id(), $count, MINUTE_IN_SECONDS );
+        }
+    }
+
+
+    /**
+     * Adds a message for after a product or set of products get excluded from sync.
+     *
+     * @since 2.0.0
+     */
+    public function maybe_show_product_disabled_sync_notice() {
+
+        $transient_name = 'wc_' . facebook_for_woocommerce()->get_id() . '_show_product_disabled_sync_notice_' . get_current_user_id();
+        $message_id     = 'wc-' . facebook_for_woocommerce()->get_id_dasherized() . '-product-disabled-sync';
+
+        if ( ( $count = get_transient( $transient_name ) ) && ( Helper::is_current_screen( 'edit-product' ) || Helper::is_current_screen( 'product' ) ) ) {
+
+            $message = sprintf(
+                /* translators: Placeholders: %1$s - <strong> tag, %2$s - </strong> tag, %3$s - <a> tag, %4$s - <a> tag */
+                _n( '%1$sHeads up!%2$s If this product was previously visible in Facebook, you may need to delete it from the %3$sFacebook catalog%4$s to completely hide it from customer view.', '%1$sHeads up!%2$s If these products were previously visible in Facebook, you may need to delete them from the %3$sFacebook catalog%4$s to completely hide them from customer view.', $count, 'facebook-for-woocommerce' ),
+                '<strong>',
+                '</strong>',
+                '<a href="https://facebook.com/products" target="_blank">',
+                '</a>'
+            );
+
+            $message .= '<a class="button js-wc-plugin-framework-notice-dismiss">' . esc_html__( "Don't show this notice again", 'facebook-for-woocommerce' ) . '</a>';
+
+            facebook_for_woocommerce()->get_admin_notice_handler()->add_admin_notice(
+                $message,
+                $message_id,
+                array(
+                    'dismissible' => false,
+                    // we add our own dismiss button
+                                                        'notice_class' => 'notice-info',
+                )
+            );
+
+            delete_transient( $transient_name );
+        }//end if
+    }
+
+
+    /**
+     * Prints a notice on products page to inform users that the virtual products selected for the Include bulk action will have sync enabled, but will be hidden.
+     *
+     * @internal
+     *
+     * @since 1.11.3-dev.2
+     */
+    public function maybe_add_enabling_virtual_products_sync_notice() {
+
+        $show_notice_transient_name       = 'wc_' . facebook_for_woocommerce()->get_id() . '_enabling_virtual_products_sync_show_notice_' . get_current_user_id();
+        $affected_products_transient_name = 'wc_' . facebook_for_woocommerce()->get_id() . '_enabling_virtual_products_sync_affected_products_' . get_current_user_id();
+
+        if ( Helper::is_current_screen( 'edit-product' ) && get_transient( $show_notice_transient_name ) && ( $affected_products = get_transient( $affected_products_transient_name ) ) ) {
+
+            $message = sprintf(
+                esc_html(
+                /* translators: Placeholders: %1$s - number of affected products, %2$s opening HTML <a> tag, %3$s - closing HTML </a> tag, %4$s - opening HTML <a> tag, %5$s - closing HTML </a> tag */
+                    _n(
+                        '%2$s%1$s product%3$s or some of its variations could not be updated to show in the Facebook catalog — %4$sFacebook Commerce Policies%5$s prohibit selling some product types (like virtual products). You may still advertise Virtual products on Facebook.',
+                        '%2$s%1$s products%3$s or some of their variations could not be updated to show in the Facebook catalog — %4$sFacebook Commerce Policies%5$s prohibit selling some product types (like virtual products). You may still advertise Virtual products on Facebook.',
+                        count( $affected_products ),
+                        'facebook-for-woocommerce'
+                    )
+                ),
+                count( $affected_products ),
+                '<a href="' . esc_url( add_query_arg( array( 'facebook_show_affected_products' => 1 ) ) ) . '">',
+                '</a>',
+                '<a href="https://www.facebook.com/policies/commerce/prohibited_content/subscriptions_and_digital_products" target="_blank">',
+                '</a>'
+            );
+
+            facebook_for_woocommerce()->get_admin_notice_handler()->add_admin_notice(
+                $message,
+                'wc-' . facebook_for_woocommerce()->get_id_dasherized() . '-enabling-virtual-products-sync',
+                array(
+                    'dismissible'  => false,
+                    'notice_class' => 'notice-info',
+                )
+            );
+
+            delete_transient( $show_notice_transient_name );
+        }//end if
+    }
+
+
+    /**
+     * Tweaks the query to show a filtered view with the affected products.
+     *
+     * @internal
+     *
+     * @since 2.0.0
+     *
+     * @param array $query_vars product query vars for the edit screen
+     * @return array
+     */
+    public function filter_virtual_products_affected_enabling_sync( $query_vars ) {
+
+        $transient_name = 'wc_' . facebook_for_woocommerce()->get_id() . '_enabling_virtual_products_sync_affected_products_' . get_current_user_id();
+
+        if ( isset( $_GET['facebook_show_affected_products'] ) && Helper::is_current_screen( 'edit-product' ) && $affected_products = get_transient( $transient_name ) ) {
+
+            $query_vars['post__in'] = $affected_products;
+        }
+
+        return $query_vars;
+    }
+
+
+    /**
+     * Prints a notice to inform sync mode has been automatically set to Sync and hide for virtual products and variations.
+     *
+     * @internal
+     *
+     * @since 2.0.0
+     */
+    public function add_handled_virtual_products_variations_notice() {
+
+        if ( 'yes' === get_option( 'wc_facebook_background_handle_virtual_products_variations_complete', 'no' ) &&
+             'yes' !== get_option( 'wc_facebook_background_handle_virtual_products_variations_skipped', 'no' ) ) {
+
+            facebook_for_woocommerce()->get_admin_notice_handler()->add_admin_notice(
+                sprintf(
+                    /* translators: Placeholders: %1$s - opening HTML <strong> tag, %2$s - closing HTML </strong> tag, %3$s - opening HTML <a> tag, %4$s - closing HTML </a> tag */
+                    esc_html__( '%1$sHeads up!%2$s Facebook\'s %3$sCommerce Policies%4$s do not support selling virtual products, so we have hidden your synced Virtual products in your Facebook catalog. You may still advertise Virtual products on Facebook.', 'facebook-for-woocommerce' ),
+                    '<strong>',
+                    '</strong>',
+                    '<a href="https://www.facebook.com/policies/commerce/prohibited_content/subscriptions_and_digital_products" target="_blank">',
+                    '</a>'
+                ),
+                'wc-' . facebook_for_woocommerce()->get_id_dasherized() . '-updated-virtual-products-sync',
+                array(
+                    'notice_class'            => 'notice-info',
+                    'always_show_on_settings' => false,
+                )
+            );
+        }
+    }
+
+
+    /**
+     * Adds a new tab to the Product edit page.
+     *
+     * @internal
+     *
+     * @since 1.10.0
+     *
+     * @param array $tabs product tabs
+     * @return array
+     */
+    public function add_product_settings_tab( $tabs ) {
+
+        $tabs['fb_commerce_tab'] = array(
+            'label'  => __( 'Facebook', 'facebook-for-woocommerce' ),
+            'target' => 'facebook_options',
+            'class'  => array( 'show_if_simple', 'show_if_variable', 'show_if_external' ),
+        );
+
+        return $tabs;
+    }
+
+
+    /**
+     * Outputs the form field for Facebook Product Videos with a description tip.
+     *
+     * @param array $video_urls Array of video URLs.
+     */
+    private function render_facebook_product_video_field( $video_urls ) {
+        $attachment_ids = [];
+
+        // Output the form field for Facebook Product Videos with a description tip
+        ?>
+        <p class="form-field fb_product_video_field">
+            <label for="fb_product_video"><?php esc_html_e( 'Facebook Product Video', 'facebook-for-woocommerce' ); ?></label>
+            <button type="button" class="button" id="open_media_library" name="fb_product_video"><?php esc_html_e( 'Choose', 'facebook-for-woocommerce' ); ?></button>
+            <span class="woocommerce-help-tip" data-tip="<?php esc_attr_e( 'Choose the product video that should be synced to the Facebook catalog and displayed for this product.', 'facebook-for-woocommerce' ); ?>" tabindex="0"></span>
+        </p>
+        <div id="fb_product_video_selected_thumbnails">
+        <?php
+
+        if ( ! empty( $video_urls ) ) {
+            foreach ( $video_urls as $video_url ) {
+                $attachment_id = attachment_url_to_postid( $video_url );
+                if ( $attachment_id ) {
+                    $attachment_ids[] = $attachment_id;
+                    // Get the video thumbnail URL
+                    $thumbnail_url = wp_get_attachment_image_url( $attachment_id, 'thumbnail' );
+                    if ( ! $thumbnail_url ) {
+                        // Fallback to a default icon if no thumbnail is available
+                        $thumbnail_url = esc_url( wp_mime_type_icon( 'video' ) );
+                    }
+                    // Escape URLs and attributes
+                    $video_url_escaped = esc_url( $video_url );
+                    $attachment_id_escaped = esc_attr( $attachment_id );
+                    ?>
+                    <p class="form-field video-thumbnail">
+                        <img src="<?php echo esc_url( $thumbnail_url ); ?>">
+                        <span data-attachment-id="<?php echo $attachment_id_escaped; ?>"><?php echo $video_url_escaped; ?></span>
+                        <a href="#" class="remove-video" data-attachment-id="<?php echo $attachment_id_escaped; ?>"><?php esc_html_e( 'Remove', 'facebook-for-woocommerce' ); ?></a>
+                    </p>
+                    <?php
+                }
+            }
+        }
+        ?>
+        </div>
+
+        <?php
+        // hidden input to store attachment IDs
+        woocommerce_wp_hidden_input(
+            [
+                'id'   => \WC_Facebook_Product::FB_PRODUCT_VIDEO,
+                'name' => \WC_Facebook_Product::FB_PRODUCT_VIDEO,
+                'value' => esc_attr( implode( ',', $attachment_ids ) ), // Store attachment IDs
+            ]
+        );
+    }
+
+
+    /**
+     * Adds content to the new Facebook tab on the Product edit page.
+     *
+     * @internal
+     *
+     * @since 1.10.0
+     */
+    public function add_product_settings_tab_content() {
+        global $post;
+
+
+        // all products have sync enabled unless explicitly disabled
+        $sync_enabled = 'no' !== get_post_meta( $post->ID, Products::SYNC_ENABLED_META_KEY, true );
+        $is_visible   = ( $visibility = get_post_meta( $post->ID, Products::VISIBILITY_META_KEY, true ) ) ? wc_string_to_bool( $visibility ) : true;
+        $product      = wc_get_product( $post );
+        $description  = get_post_meta( $post->ID, \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, true );
+        $price        = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_PRICE, true );
+        $image_source = get_post_meta( $post->ID, Products::PRODUCT_IMAGE_SOURCE_META_KEY, true );
+        $image        = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_IMAGE, true );
+		$video_urls   = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_VIDEO, true );
 		$fb_brand     = get_post_meta( $post->ID, \WC_Facebook_Product::FB_BRAND, true ) ? get_post_meta( $post->ID, \WC_Facebook_Product::FB_BRAND, true ) : get_post_meta( $post->ID, '_wc_facebook_enhanced_catalog_attributes_brand', true );
 		$fb_mpn       = get_post_meta( $post->ID, \WC_Facebook_Product::FB_MPN, true );
 
-		if ( $sync_enabled ) {
-			$sync_mode = $is_visible ? self::SYNC_MODE_SYNC_AND_SHOW : self::SYNC_MODE_SYNC_AND_HIDE;
-		} else {
-			$sync_mode = self::SYNC_MODE_SYNC_DISABLED;
-		}
+        if ( $sync_enabled ) {
+            $sync_mode = $is_visible ? self::SYNC_MODE_SYNC_AND_SHOW : self::SYNC_MODE_SYNC_AND_HIDE;
+        } else {
+            $sync_mode = self::SYNC_MODE_SYNC_DISABLED;
+        }
 
-		// 'id' attribute needs to match the 'target' parameter set above
-		?>
-		<div id='facebook_options' class='panel woocommerce_options_panel'>
-			<div class='options_group hide_if_variable'>
-				<?php
+        // 'id' attribute needs to match the 'target' parameter set above
+        ?>
+        <div id='facebook_options' class='panel woocommerce_options_panel'>
+            <div class='options_group hide_if_variable'>
+                <?php
 
-				woocommerce_wp_select(
-					array(
-						'id'      => 'wc_facebook_sync_mode',
-						'label'   => __( 'Facebook Sync', 'facebook-for-woocommerce' ),
-						'options' => array(
-							self::SYNC_MODE_SYNC_AND_SHOW => __( 'Sync and show in catalog', 'facebook-for-woocommerce' ),
-							self::SYNC_MODE_SYNC_AND_HIDE => __( 'Sync and hide in catalog', 'facebook-for-woocommerce' ),
-							self::SYNC_MODE_SYNC_DISABLED => __( 'Do not sync', 'facebook-for-woocommerce' ),
-						),
-						'value'       => $sync_mode,
-						'desc_tip'    => true,
-						'description' => __( 'Choose whether to sync this product to Facebook and, if synced, whether it should be visible in the catalog.', 'facebook-for-woocommerce' ),
-					)
-				);
+                woocommerce_wp_select(
+                    array(
+                        'id'      => 'wc_facebook_sync_mode',
+                        'label'   => __( 'Facebook Sync', 'facebook-for-woocommerce' ),
+                        'options' => array(
+                            self::SYNC_MODE_SYNC_AND_SHOW => __( 'Sync and show in catalog', 'facebook-for-woocommerce' ),
+                            self::SYNC_MODE_SYNC_AND_HIDE => __( 'Sync and hide in catalog', 'facebook-for-woocommerce' ),
+                            self::SYNC_MODE_SYNC_DISABLED => __( 'Do not sync', 'facebook-for-woocommerce' ),
+                        ),
+                        'value'       => $sync_mode,
+                        'desc_tip'    => true,
+                        'description' => __( 'Choose whether to sync this product to Facebook and, if synced, whether it should be visible in the catalog.', 'facebook-for-woocommerce' ),
+                    )
+                );
 
-				woocommerce_wp_textarea_input(
-					array(
-						'id'          => \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
-						'label'       => __( 'Facebook Description', 'facebook-for-woocommerce' ),
-						'desc_tip'    => true,
-						'description' => __( 'Custom (plain-text only) description for product on Facebook. If blank, product description will be used. If product description is blank, shortname will be used.', 'facebook-for-woocommerce' ),
-						'cols'        => 40,
-						'rows'        => 20,
-						'value'       => $description,
-						'class'       => 'short enable-if-sync-enabled',
-					)
-				);
+                woocommerce_wp_textarea_input(
+                    array(
+                        'id'          => \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
+                        'label'       => __( 'Facebook Description', 'facebook-for-woocommerce' ),
+                        'desc_tip'    => true,
+                        'description' => __( 'Custom (plain-text only) description for product on Facebook. If blank, product description will be used. If product description is blank, shortname will be used.', 'facebook-for-woocommerce' ),
+                        'cols'        => 40,
+                        'rows'        => 20,
+                        'value'       => $description,
+                        'class'       => 'short enable-if-sync-enabled',
+                    )
+                );
 
-				woocommerce_wp_radio(
-					array(
-						'id'            => 'fb_product_image_source',
-						'label'         => __( 'Facebook Product Image', 'facebook-for-woocommerce' ),
-						'desc_tip'      => true,
-						'description'   => __( 'Choose the product image that should be synced to the Facebook catalog and displayed for this product.', 'facebook-for-woocommerce' ),
-						'options'       => array(
-							Products::PRODUCT_IMAGE_SOURCE_PRODUCT => __( 'Use WooCommerce image', 'facebook-for-woocommerce' ),
-							Products::PRODUCT_IMAGE_SOURCE_CUSTOM  => __( 'Use custom image', 'facebook-for-woocommerce' ),
-						),
-						'value'         => $image_source ?: Products::PRODUCT_IMAGE_SOURCE_PRODUCT,
-						'class'         => 'short enable-if-sync-enabled js-fb-product-image-source',
-						'wrapper_class' => 'fb-product-image-source-field',
-					)
-				);
+                woocommerce_wp_radio(
+                    array(
+                        'id'            => 'fb_product_image_source',
+                        'label'         => __( 'Facebook Product Image', 'facebook-for-woocommerce' ),
+                        'desc_tip'      => true,
+                        'description'   => __( 'Choose the product image that should be synced to the Facebook catalog and displayed for this product.', 'facebook-for-woocommerce' ),
+                        'options'       => array(
+                            Products::PRODUCT_IMAGE_SOURCE_PRODUCT => __( 'Use WooCommerce image', 'facebook-for-woocommerce' ),
+                            Products::PRODUCT_IMAGE_SOURCE_CUSTOM  => __( 'Use custom image', 'facebook-for-woocommerce' ),
+                        ),
+                        'value'         => $image_source ?: Products::PRODUCT_IMAGE_SOURCE_PRODUCT,
+                        'class'         => 'short enable-if-sync-enabled js-fb-product-image-source',
+                        'wrapper_class' => 'fb-product-image-source-field',
+                    )
+                );
 
 				woocommerce_wp_text_input(
 					array(
@@ -1254,6 +1311,8 @@ class Admin {
 						'description'   => __( 'Please enter an absolute URL (e.g. https://domain.com/image.jpg).', 'facebook-for-woocommerce' ),
 					)
 				);
+
+                $this->render_facebook_product_video_field( $video_urls );
 
 				woocommerce_wp_text_input(
 					array(
@@ -1290,14 +1349,14 @@ class Admin {
 					)
 				);
 
-				woocommerce_wp_hidden_input(
-					array(
-						'id'    => \WC_Facebook_Product::FB_REMOVE_FROM_SYNC,
-						'value' => '',
-					)
-				);
-				?>
-			</div>
+                woocommerce_wp_hidden_input(
+                    array(
+                        'id'    => \WC_Facebook_Product::FB_REMOVE_FROM_SYNC,
+                        'value' => '',
+                    )
+                );
+                ?>
+            </div>
 			
 			<div class='options_group show_if_variable'>
 				<?php
@@ -1313,134 +1372,134 @@ class Admin {
 			</div>
 
 			
-			<div class='wc-facebook-commerce-options-group options_group'>
-				<?php \WooCommerce\Facebook\Admin\Products::render_google_product_category_fields_and_enhanced_attributes( $product ); ?>
-			</div>
-		</div>
-		<?php
-	}
+            <div class='wc-facebook-commerce-options-group options_group'>
+                <?php \WooCommerce\Facebook\Admin\Products::render_google_product_category_fields_and_enhanced_attributes( $product ); ?>
+            </div>
+        </div>
+        <?php
+    }
 
 
-	/**
-	 * Outputs the Facebook settings fields for a single variation.
-	 *
-	 * @internal
-	 *
-	 * @since 1.10.0
-	 *
-	 * @param int      $index the index of the current variation
-	 * @param array    $variation_data unused
-	 * @param \WC_Post $post the post type for the current variation
-	 */
-	public function add_product_variation_edit_fields( $index, $variation_data, $post ) {
+    /**
+     * Outputs the Facebook settings fields for a single variation.
+     *
+     * @internal
+     *
+     * @since 1.10.0
+     *
+     * @param int      $index the index of the current variation
+     * @param array    $variation_data unused
+     * @param \WC_Post $post the post type for the current variation
+     */
+    public function add_product_variation_edit_fields( $index, $variation_data, $post ) {
 
-		$variation = wc_get_product( $post );
+        $variation = wc_get_product( $post );
 
-		if ( ! $variation instanceof \WC_Product_Variation ) {
-			return;
-		}
+        if ( ! $variation instanceof \WC_Product_Variation ) {
+            return;
+        }
 
-		$parent = wc_get_product( $variation->get_parent_id() );
+        $parent = wc_get_product( $variation->get_parent_id() );
 
-		if ( ! $parent instanceof \WC_Product ) {
-			return;
-		}
+        if ( ! $parent instanceof \WC_Product ) {
+            return;
+        }
 
-		$sync_enabled = 'no' !== $this->get_product_variation_meta( $variation, Products::SYNC_ENABLED_META_KEY, $parent );
-		$is_visible   = ( $visibility = $this->get_product_variation_meta( $variation, Products::VISIBILITY_META_KEY, $parent ) ) ? wc_string_to_bool( $visibility ) : true;
+        $sync_enabled = 'no' !== $this->get_product_variation_meta( $variation, Products::SYNC_ENABLED_META_KEY, $parent );
+        $is_visible   = ( $visibility = $this->get_product_variation_meta( $variation, Products::VISIBILITY_META_KEY, $parent ) ) ? wc_string_to_bool( $visibility ) : true;
 
-		$description  = $this->get_product_variation_meta( $variation, \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $parent );
-		$price        = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_PRICE, $parent );
-		$image_url    = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_IMAGE, $parent );
-		$image_source = $variation->get_meta( Products::PRODUCT_IMAGE_SOURCE_META_KEY );
+        $description  = $this->get_product_variation_meta( $variation, \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $parent );
+        $price        = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_PRICE, $parent );
+        $image_url    = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_IMAGE, $parent );
+        $image_source = $variation->get_meta( Products::PRODUCT_IMAGE_SOURCE_META_KEY );
 		$fb_mpn    	  = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_MPN, $parent );
 
-		if ( $sync_enabled ) {
-			$sync_mode = $is_visible ? self::SYNC_MODE_SYNC_AND_SHOW : self::SYNC_MODE_SYNC_AND_HIDE;
-		} else {
-			$sync_mode = self::SYNC_MODE_SYNC_DISABLED;
-		}
+        if ( $sync_enabled ) {
+            $sync_mode = $is_visible ? self::SYNC_MODE_SYNC_AND_SHOW : self::SYNC_MODE_SYNC_AND_HIDE;
+        } else {
+            $sync_mode = self::SYNC_MODE_SYNC_DISABLED;
+        }
 
-		woocommerce_wp_select(
-			array(
-				'id'            => "variable_facebook_sync_mode$index",
-				'name'          => "variable_facebook_sync_mode[$index]",
-				'label'         => __( 'Facebook Sync', 'facebook-for-woocommerce' ),
-				'options'       => array(
-					self::SYNC_MODE_SYNC_AND_SHOW => __( 'Sync and show in catalog', 'facebook-for-woocommerce' ),
-					self::SYNC_MODE_SYNC_AND_HIDE => __( 'Sync and hide in catalog', 'facebook-for-woocommerce' ),
-					self::SYNC_MODE_SYNC_DISABLED => __( 'Do not sync', 'facebook-for-woocommerce' ),
-				),
-				'value'         => $sync_mode,
-				'desc_tip'    => true,
-				'description' => __( 'Choose whether to sync this product to Facebook and, if synced, whether it should be visible in the catalog.', 'facebook-for-woocommerce' ),
-				'class'         => 'js-variable-fb-sync-toggle',
-				'wrapper_class' => 'form-row form-row-full',
-			)
-		);
+        woocommerce_wp_select(
+            array(
+                'id'            => "variable_facebook_sync_mode$index",
+                'name'          => "variable_facebook_sync_mode[$index]",
+                'label'         => __( 'Facebook Sync', 'facebook-for-woocommerce' ),
+                'options'       => array(
+                    self::SYNC_MODE_SYNC_AND_SHOW => __( 'Sync and show in catalog', 'facebook-for-woocommerce' ),
+                    self::SYNC_MODE_SYNC_AND_HIDE => __( 'Sync and hide in catalog', 'facebook-for-woocommerce' ),
+                    self::SYNC_MODE_SYNC_DISABLED => __( 'Do not sync', 'facebook-for-woocommerce' ),
+                ),
+                'value'         => $sync_mode,
+                'desc_tip'    => true,
+                'description' => __( 'Choose whether to sync this product to Facebook and, if synced, whether it should be visible in the catalog.', 'facebook-for-woocommerce' ),
+                'class'         => 'js-variable-fb-sync-toggle',
+                'wrapper_class' => 'form-row form-row-full',
+            )
+        );
 
-		woocommerce_wp_textarea_input(
-			array(
-				'id'            => sprintf( 'variable_%s%s', \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $index ),
-				'name'          => sprintf( "variable_%s[$index]", \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION ),
-				'label'         => __( 'Facebook Description', 'facebook-for-woocommerce' ),
-				'desc_tip'      => true,
-				'description'   => __( 'Custom (plain-text only) description for product on Facebook. If blank, product description will be used. If product description is blank, shortname will be used.', 'facebook-for-woocommerce' ),
-				'cols'          => 40,
-				'rows'          => 5,
-				'value'         => $description,
-				'class'         => 'enable-if-sync-enabled',
-				'wrapper_class' => 'form-row form-row-full',
-			)
-		);
+        woocommerce_wp_textarea_input(
+            array(
+                'id'            => sprintf( 'variable_%s%s', \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $index ),
+                'name'          => sprintf( "variable_%s[$index]", \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION ),
+                'label'         => __( 'Facebook Description', 'facebook-for-woocommerce' ),
+                'desc_tip'      => true,
+                'description'   => __( 'Custom (plain-text only) description for product on Facebook. If blank, product description will be used. If product description is blank, shortname will be used.', 'facebook-for-woocommerce' ),
+                'cols'          => 40,
+                'rows'          => 5,
+                'value'         => $description,
+                'class'         => 'enable-if-sync-enabled',
+                'wrapper_class' => 'form-row form-row-full',
+            )
+        );
 
-		woocommerce_wp_radio(
-			array(
-				'id'            => "variable_fb_product_image_source$index",
-				'name'          => "variable_fb_product_image_source[$index]",
-				'label'         => __( 'Facebook Product Image', 'facebook-for-woocommerce' ),
-				'desc_tip'      => true,
-				'description'   => __( 'Choose the product image that should be synced to the Facebook catalog and displayed for this product.', 'facebook-for-woocommerce' ),
-				'options'       => array(
-					Products::PRODUCT_IMAGE_SOURCE_PRODUCT        => __( 'Use variation image', 'facebook-for-woocommerce' ),
-					Products::PRODUCT_IMAGE_SOURCE_PARENT_PRODUCT => __( 'Use parent image', 'facebook-for-woocommerce' ),
-					Products::PRODUCT_IMAGE_SOURCE_CUSTOM         => __( 'Use custom image', 'facebook-for-woocommerce' ),
-				),
-				'value'         => $image_source ?: Products::PRODUCT_IMAGE_SOURCE_PRODUCT,
-				'class'         => 'enable-if-sync-enabled js-fb-product-image-source',
-				'wrapper_class' => 'fb-product-image-source-field',
-			)
-		);
+        woocommerce_wp_radio(
+            array(
+                'id'            => "variable_fb_product_image_source$index",
+                'name'          => "variable_fb_product_image_source[$index]",
+                'label'         => __( 'Facebook Product Image', 'facebook-for-woocommerce' ),
+                'desc_tip'      => true,
+                'description'   => __( 'Choose the product image that should be synced to the Facebook catalog and displayed for this product.', 'facebook-for-woocommerce' ),
+                'options'       => array(
+                    Products::PRODUCT_IMAGE_SOURCE_PRODUCT        => __( 'Use variation image', 'facebook-for-woocommerce' ),
+                    Products::PRODUCT_IMAGE_SOURCE_PARENT_PRODUCT => __( 'Use parent image', 'facebook-for-woocommerce' ),
+                    Products::PRODUCT_IMAGE_SOURCE_CUSTOM         => __( 'Use custom image', 'facebook-for-woocommerce' ),
+                ),
+                'value'         => $image_source ?: Products::PRODUCT_IMAGE_SOURCE_PRODUCT,
+                'class'         => 'enable-if-sync-enabled js-fb-product-image-source',
+                'wrapper_class' => 'fb-product-image-source-field',
+            )
+        );
 
-		woocommerce_wp_text_input(
-			array(
-				'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_PRODUCT_IMAGE, $index ),
-				'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_PRODUCT_IMAGE ),
-				'label'         => __( 'Custom Image URL', 'facebook-for-woocommerce' ),
-				'value'         => $image_url,
-				'class'         => sprintf( 'enable-if-sync-enabled product-image-source-field show-if-product-image-source-%s', Products::PRODUCT_IMAGE_SOURCE_CUSTOM ),
-				'wrapper_class' => 'form-row form-row-full',
-				'desc_tip'      => true,
-				'description'   => __( 'Please enter an absolute URL (e.g. https://domain.com/image.jpg).', 'facebook-for-woocommerce' ),
-			)
-		);
+        woocommerce_wp_text_input(
+            array(
+                'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_PRODUCT_IMAGE, $index ),
+                'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_PRODUCT_IMAGE ),
+                'label'         => __( 'Custom Image URL', 'facebook-for-woocommerce' ),
+                'value'         => $image_url,
+                'class'         => sprintf( 'enable-if-sync-enabled product-image-source-field show-if-product-image-source-%s', Products::PRODUCT_IMAGE_SOURCE_CUSTOM ),
+                'wrapper_class' => 'form-row form-row-full',
+                'desc_tip'      => true,
+                'description'   => __( 'Please enter an absolute URL (e.g. https://domain.com/image.jpg).', 'facebook-for-woocommerce' ),
+            )
+        );
 
-		woocommerce_wp_text_input(
-			array(
-				'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_PRODUCT_PRICE, $index ),
-				'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_PRODUCT_PRICE ),
-				'label'         => sprintf(
-				 /* translators: Placeholders %1$s - WC currency symbol */
-					__( 'Facebook Price (%1$s)', 'facebook-for-woocommerce' ),
-					get_woocommerce_currency_symbol()
-				),
-				'desc_tip'      => true,
-				'description'   => __( 'Custom price for product on Facebook. Please enter in monetary decimal (.) format without thousand separators and currency symbols. If blank, product price will be used.', 'facebook-for-woocommerce' ),
-				'value'         => wc_format_decimal( $price ),
-				'class'         => 'enable-if-sync-enabled',
-				'wrapper_class' => 'form-row form-full',
-			)
-		);
+        woocommerce_wp_text_input(
+            array(
+                'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_PRODUCT_PRICE, $index ),
+                'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_PRODUCT_PRICE ),
+                'label'         => sprintf(
+                 /* translators: Placeholders %1$s - WC currency symbol */
+                    __( 'Facebook Price (%1$s)', 'facebook-for-woocommerce' ),
+                    get_woocommerce_currency_symbol()
+                ),
+                'desc_tip'      => true,
+                'description'   => __( 'Custom price for product on Facebook. Please enter in monetary decimal (.) format without thousand separators and currency symbols. If blank, product price will be used.', 'facebook-for-woocommerce' ),
+                'value'         => wc_format_decimal( $price ),
+                'class'         => 'enable-if-sync-enabled',
+                'wrapper_class' => 'form-row form-full',
+            )
+        );
 
 		woocommerce_wp_text_input(
 			array(
@@ -1452,114 +1511,117 @@ class Admin {
 			)
 		);
 
-	}
+    }
 
 
-	/**
-	 * Gets the stored value for the given meta of a product variation.
-	 *
-	 * If no value is found, we try to use the value stored in the parent product.
-	 *
-	 * @since 1.10.0
-	 *
-	 * @param \WC_Product_Variation $variation the product variation
-	 * @param string                $key the name of the meta to retrieve
-	 * @param \WC_Product           $parent the parent product
-	 * @return mixed
-	 */
-	private function get_product_variation_meta( $variation, $key, $parent ) {
-		$value = $variation->get_meta( $key );
-		if ( '' === $value && $parent instanceof \WC_Product ) {
-			$value = $parent->get_meta( $key );
-		}
-		return $value;
-	}
+    /**
+     * Gets the stored value for the given meta of a product variation.
+     *
+     * If no value is found, we try to use the value stored in the parent product.
+     *
+     * @since 1.10.0
+     *
+     * @param \WC_Product_Variation $variation the product variation
+     * @param string                $key the name of the meta to retrieve
+     * @param \WC_Product           $parent the parent product
+     * @return mixed
+     */
+    private function get_product_variation_meta( $variation, $key, $parent ) {
+        $value = $variation->get_meta( $key );
+        if ( '' === $value && $parent instanceof \WC_Product ) {
+            $value = $parent->get_meta( $key );
+        }
+        return $value;
+    }
 
 
-	/**
-	 * Saves the submitted Facebook settings for each variation.
-	 *
-	 * @internal
-	 *
-	 * @since 1.10.0
-	 *
-	 * @param int $variation_id the ID of the product variation being edited
-	 * @param int $index the index of the current variation
-	 */
-	public function save_product_variation_edit_fields( $variation_id, $index ) {
-		$variation = wc_get_product( $variation_id );
-		if ( ! $variation instanceof \WC_Product_Variation ) {
-			return;
-		}
-		$sync_mode    = isset( $_POST['variable_facebook_sync_mode'][ $index ] ) ? wc_clean( wp_unslash( $_POST['variable_facebook_sync_mode'][ $index ] ) ) : self::SYNC_MODE_SYNC_DISABLED;
-		$sync_enabled = self::SYNC_MODE_SYNC_DISABLED !== $sync_mode;
-		if ( self::SYNC_MODE_SYNC_AND_SHOW === $sync_mode && $variation->is_virtual() ) {
-			// force to Sync and hide
-			$sync_mode = self::SYNC_MODE_SYNC_AND_HIDE;
-		}
-		// phpcs:disable WordPress.Security.NonceVerification.Missing
-		if ( $sync_enabled ) {
-			Products::enable_sync_for_products( array( $variation ) );
-			Products::set_product_visibility( $variation, self::SYNC_MODE_SYNC_AND_HIDE !== $sync_mode );
-			$posted_param = 'variable_' . \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION;
-			$description  = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_text_field( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
+    /**
+     * Saves the submitted Facebook settings for each variation.
+     *
+     * @internal
+     *
+     * @since 1.10.0
+     *
+     * @param int $variation_id the ID of the product variation being edited
+     * @param int $index the index of the current variation
+     */
+    public function save_product_variation_edit_fields( $variation_id, $index ) {
+        $variation = wc_get_product( $variation_id );
+        if ( ! $variation instanceof \WC_Product_Variation ) {
+            return;
+        }
+        $sync_mode    = isset( $_POST['variable_facebook_sync_mode'][ $index ] ) ? wc_clean( wp_unslash( $_POST['variable_facebook_sync_mode'][ $index ] ) ) : self::SYNC_MODE_SYNC_DISABLED;
+        $sync_enabled = self::SYNC_MODE_SYNC_DISABLED !== $sync_mode;
+        if ( self::SYNC_MODE_SYNC_AND_SHOW === $sync_mode && $variation->is_virtual() ) {
+            // force to Sync and hide
+            $sync_mode = self::SYNC_MODE_SYNC_AND_HIDE;
+        }
+        // phpcs:disable WordPress.Security.NonceVerification.Missing
+        if ( $sync_enabled ) {
+            Products::enable_sync_for_products( array( $variation ) );
+            Products::set_product_visibility( $variation, self::SYNC_MODE_SYNC_AND_HIDE !== $sync_mode );
+            $posted_param = 'variable_' . \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION;
+            $description  = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_text_field( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
 			$posted_param = 'variable_' . \WC_Facebook_Product::FB_MPN;
 			$fb_mpn  = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_text_field( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
-			$posted_param = 'variable_fb_product_image_source';
-			$image_source = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_key( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : '';
-			$posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_IMAGE;
-			$image_url    = isset( $_POST[ $posted_param ][ $index ] ) ? esc_url_raw( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
-			$posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_PRICE;
-			$price        = isset( $_POST[ $posted_param ][ $index ] ) ? wc_format_decimal( wc_clean( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) ) : '';
-			$variation->update_meta_data( \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $description );
-			$variation->update_meta_data( Products::PRODUCT_IMAGE_SOURCE_META_KEY, $image_source );
+            $posted_param = 'variable_fb_product_image_source';
+            $image_source = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_key( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : '';
+            $posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_IMAGE;
+            $image_url    = isset( $_POST[ $posted_param ][ $index ] ) ? esc_url_raw( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
+            $posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_VIDEO;
+            $video_urls   = isset( $_POST[ $posted_param ][ $index ] ) ? esc_url_raw( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : [];
+            $posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_PRICE;
+            $price        = isset( $_POST[ $posted_param ][ $index ] ) ? wc_format_decimal( wc_clean( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) ) : '';
+            $variation->update_meta_data( \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $description );
+            $variation->update_meta_data( Products::PRODUCT_IMAGE_SOURCE_META_KEY, $image_source );
 			$variation->update_meta_data( \WC_Facebook_Product::FB_MPN, $fb_mpn );
-			$variation->update_meta_data( \WC_Facebook_Product::FB_PRODUCT_IMAGE, $image_url );
-			$variation->update_meta_data( \WC_Facebook_Product::FB_PRODUCT_PRICE, $price );
-			$variation->save_meta_data();
-		} else {
-			Products::disable_sync_for_products( array( $variation ) );
-		}//end if
-		// phpcs:enable WordPress.Security.NonceVerification.Missing
-	}
+            $variation->update_meta_data( \WC_Facebook_Product::FB_PRODUCT_IMAGE, $image_url );
+            $variation->update_meta_data( \WC_Facebook_Product::FB_PRODUCT_VIDEO, $video_urls );
+            $variation->update_meta_data( \WC_Facebook_Product::FB_PRODUCT_PRICE, $price );
+            $variation->save_meta_data();
+        } else {
+            Products::disable_sync_for_products( array( $variation ) );
+        }//end if
+        // phpcs:enable WordPress.Security.NonceVerification.Missing
+    }
 
 
-	/**
-	 * Outputs a modal template in admin product pages.
-	 *
-	 * @internal
-	 *
-	 * @since 1.10.0
-	 */
-	public function render_modal_template() {
-		global $current_screen;
+    /**
+     * Outputs a modal template in admin product pages.
+     *
+     * @internal
+     *
+     * @since 1.10.0
+     */
+    public function render_modal_template() {
+        global $current_screen;
 
-		// bail if not on the products, product edit, or settings screen
-		if ( ! $current_screen || ! in_array( $current_screen->id, $this->screen_ids, true ) ) {
-			return;
-		}
-		?>
-		<script type="text/template" id="tmpl-facebook-for-woocommerce-modal">
-			<div class="wc-backbone-modal facebook-for-woocommerce-modal">
-				<div class="wc-backbone-modal-content">
-					<section class="wc-backbone-modal-main" role="main">
-						<header class="wc-backbone-modal-header">
-							<h1><?php esc_html_e( 'Facebook for WooCommerce', 'facebook-for-woocommerce' ); ?></h1>
-							<button class="modal-close modal-close-link dashicons dashicons-no-alt">
-								<span class="screen-reader-text"><?php esc_html_e( 'Close modal panel', 'facebook-for-woocommerce' ); ?></span>
-							</button>
-						</header>
-						<article>{{{data.message}}}</article>
-						<footer>
-							<div class="inner">{{{data.buttons}}}</div>
-						</footer>
-					</section>
-				</div>
-			</div>
-			<div class="wc-backbone-modal-backdrop modal-close"></div>
-		</script>
-		<?php
-	}
+        // bail if not on the products, product edit, or settings screen
+        if ( ! $current_screen || ! in_array( $current_screen->id, $this->screen_ids, true ) ) {
+            return;
+        }
+        ?>
+        <script type="text/template" id="tmpl-facebook-for-woocommerce-modal">
+            <div class="wc-backbone-modal facebook-for-woocommerce-modal">
+                <div class="wc-backbone-modal-content">
+                    <section class="wc-backbone-modal-main" role="main">
+                        <header class="wc-backbone-modal-header">
+                            <h1><?php esc_html_e( 'Facebook for WooCommerce', 'facebook-for-woocommerce' ); ?></h1>
+                            <button class="modal-close modal-close-link dashicons dashicons-no-alt">
+                                <span class="screen-reader-text"><?php esc_html_e( 'Close modal panel', 'facebook-for-woocommerce' ); ?></span>
+                            </button>
+                        </header>
+                        <article>{{{data.message}}}</article>
+                        <footer>
+                            <div class="inner">{{{data.buttons}}}</div>
+                        </footer>
+                    </section>
+                </div>
+            </div>
+            <div class="wc-backbone-modal-backdrop modal-close"></div>
+        </script>
+        <?php
+    }
 
 
 }

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -373,17 +373,10 @@ class WC_Facebook_Product {
         }
     }
 
-	public function set_product_video_urls( $video_urls ) {
-		 $attachment_id_array = explode(',', $video_urls);
-        // Remove any empty values
-        $attachment_id_array = array_filter($attachment_id_array);
-        // Trim each ID to remove any whitespace
-        $attachment_id_array = array_map('trim', $attachment_id_array);
-        $video_urls = array_map(function($attachment_id) {
-            return wp_get_attachment_url($attachment_id);
-        }, $attachment_id_array);
-        // Filter out any false values (in case an ID doesn't correspond to a valid attachment)
-        $video_urls = array_filter($video_urls);
+	public function set_product_video_urls( $attachment_ids ) {
+		$video_urls = array_filter(array_map(function($id) {
+            return trim(wp_get_attachment_url($id));
+        }, explode(',', $attachment_ids)));
         update_post_meta(
             $this->id,
             self::FB_PRODUCT_VIDEO,

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -21,344 +21,374 @@ defined( 'ABSPATH' ) || exit;
  * Custom FB Product proxy class
  */
 class WC_Facebook_Product {
-	// Used for the background sync
-	const PRODUCT_PREP_TYPE_ITEMS_BATCH = 'items_batch';
-	// Used for the background feed upload
-	const PRODUCT_PREP_TYPE_FEED = 'feed';
-	// Used for direct update and create calls
-	const PRODUCT_PREP_TYPE_NORMAL = 'normal';
+    // Used for the background sync
+    const PRODUCT_PREP_TYPE_ITEMS_BATCH = 'items_batch';
+    // Used for the background feed upload
+    const PRODUCT_PREP_TYPE_FEED = 'feed';
+    // Used for direct update and create calls
+    const PRODUCT_PREP_TYPE_NORMAL = 'normal';
 
-	// Should match facebook-commerce.php while we migrate that code over
-	// to this object.
-	const FB_PRODUCT_DESCRIPTION = 'fb_product_description';
-	const FB_PRODUCT_PRICE       = 'fb_product_price';
-	const FB_PRODUCT_IMAGE       = 'fb_product_image';
-	const FB_VARIANT_IMAGE       = 'fb_image';
-	const FB_VISIBILITY          = 'fb_visibility';
-	const FB_REMOVE_FROM_SYNC    = 'fb_remove_from_sync';
+    // Should match facebook-commerce.php while we migrate that code over
+    // to this object.
+    const FB_PRODUCT_DESCRIPTION = 'fb_product_description';
+    const FB_PRODUCT_PRICE       = 'fb_product_price';
+    const FB_PRODUCT_IMAGE       = 'fb_product_image';
+    const FB_PRODUCT_VIDEO       = 'fb_product_video';
+    const FB_VARIANT_IMAGE       = 'fb_image';
+    const FB_VISIBILITY          = 'fb_visibility';
+    const FB_REMOVE_FROM_SYNC    = 'fb_remove_from_sync';
 	const FB_BRAND               = 'fb_brand';
 	const FB_VARIABLE_BRAND      = 'fb_variable_brand';
 	const FB_MPN              	 = 'fb_mpn';
 
-	const MIN_DATE_1 = '1970-01-29';
-	const MIN_DATE_2 = '1970-01-30';
-	const MAX_DATE   = '2038-01-17';
-	const MAX_TIME   = 'T23:59+00:00';
-	const MIN_TIME   = 'T00:00+00:00';
+    const MIN_DATE_1 = '1970-01-29';
+    const MIN_DATE_2 = '1970-01-30';
+    const MAX_DATE   = '2038-01-17';
+    const MAX_TIME   = 'T23:59+00:00';
+    const MIN_TIME   = 'T00:00+00:00';
 
-	static $use_checkout_url = array(
-		'simple'    => 1,
-		'variable'  => 1,
-		'variation' => 1,
-	);
+    static $use_checkout_url = array(
+        'simple'    => 1,
+        'variable'  => 1,
+        'variation' => 1,
+    );
 
-	/**
-	 * @var int WC_Product ID.
-	 */
-	public $id;
+    /**
+     * @var int WC_Product ID.
+     */
+    public $id;
 
-	/**
-	 * @var WC_Product
-	 */
-	public $woo_product;
+    /**
+     * @var WC_Product
+     */
+    public $woo_product;
 
-	/**
-	 * @var string Facebook Product Description.
-	 */
-	private $fb_description;
+    /**
+     * @var string Facebook Product Description.
+     */
+    private $fb_description;
 
-	/**
-	 * @var array Gallery URLs.
-	 */
-	private $gallery_urls;
+    /**
+     * @var array Gallery URLs.
+     */
+    private $gallery_urls;
 
-	/**
-	 * @var bool Use parent image for variable products.
-	 */
-	private $fb_use_parent_image;
+    /**
+     * @var bool Use parent image for variable products.
+     */
+    private $fb_use_parent_image;
 
-	/**
-	 * @var string Product Description.
-	 */
-	private $main_description;
+    /**
+     * @var string Product Description.
+     */
+    private $main_description;
 
-	/**
-	 * @var bool  Sync short description.
-	 */
-	private $sync_short_description;
+    /**
+     * @var bool  Sync short description.
+     */
+    private $sync_short_description;
 
-	/**
-	 * @var bool Product visibility on Facebook.
-	 */
-	public $fb_visibility;
+    /**
+     * @var bool Product visibility on Facebook.
+     */
+    public $fb_visibility;
 
-	public function __construct( $wpid, $parent_product = null ) {
+    public function __construct( $wpid, $parent_product = null ) {
 
-		if ( $wpid instanceof WC_Product ) {
-			$this->id          = $wpid->get_id();
-			$this->woo_product = $wpid;
-		} else {
-			$this->id                     = $wpid;
-			$this->woo_product            = wc_get_product( $wpid );
-		}
-
-		$this->fb_description         = '';
-		$this->gallery_urls           = null;
-		$this->fb_use_parent_image    = null;
-		$this->main_description       = '';
-		$this->sync_short_description = \WC_Facebookcommerce_Integration::PRODUCT_DESCRIPTION_MODE_SHORT === facebook_for_woocommerce()->get_integration()->get_product_description_mode();
-
-		if ( $meta = get_post_meta( $this->id, self::FB_VISIBILITY, true ) ) {
-			$this->fb_visibility = wc_string_to_bool( $meta );
-		} else {
-			$this->fb_visibility = '';
-			// for products that haven't synced yet
-		}
-
-		// Variable products should use some data from the parent_product
-		// For performance reasons, that data shouldn't be regenerated every time.
-		if ( $parent_product ) {
-			$this->gallery_urls        = $parent_product->get_gallery_urls();
-			$this->fb_use_parent_image = $parent_product->get_use_parent_image();
-			$this->main_description    = $parent_product->get_fb_description();
-		}
-	}
-
-	/**
-	 * __get method for backward compatibility.
-	 *
-	 * @param string $key property name
-	 * @return mixed
-	 * @since 3.0.32
-	 */
-	public function __get( $key ) {
-		// Add warning for private properties.
-		if ( in_array( $key, array( 'fb_description', 'gallery_urls', 'fb_use_parent_image', 'main_description', 'sync_short_description' ), true ) ) {
-			/* translators: %s property name. */
-			_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'The %s property is private and should not be accessed outside its class.', 'facebook-for-woocommerce' ), esc_html( $key ) ), '3.0.32' );
-			return $this->$key;
-		}
-
-		return null;
-	}
-
-	public function exists() {
-		return ( $this->woo_product !== null && $this->woo_product !== false );
-	}
-
-	// Fall back to calling method on $woo_product
-	public function __call( $function, $args ) {
-		if ( $this->woo_product ) {
-			return call_user_func_array( array( $this->woo_product, $function ), $args );
-		} else {
-			$e         = new Exception();
-			$backtrace = var_export( $e->getTraceAsString(), true );
-			WC_Facebookcommerce_Utils::fblog(
-				"Calling $function on Null Woo Object. Trace:\n" . $backtrace,
-				array(),
-				true
-			);
-			return null;
-		}
-	}
-
-	public function get_gallery_urls() {
-		if ( $this->gallery_urls === null ) {
-			if ( is_callable( array( $this, 'get_gallery_image_ids' ) ) ) {
-				$image_ids = $this->get_gallery_image_ids();
-			} else {
-				$image_ids = $this->get_gallery_attachment_ids();
-			}
-			$gallery_urls = array();
-			foreach ( $image_ids as $image_id ) {
-				$image_url = wp_get_attachment_url( $image_id );
-				if ( ! empty( $image_url ) ) {
-					array_push(
-						$gallery_urls,
-						WC_Facebookcommerce_Utils::make_url( $image_url )
-					);
-				}
-			}
-			$this->gallery_urls = array_filter( $gallery_urls );
-		}
-
-		return $this->gallery_urls;
-	}
-
-	public function get_post_data() {
-		if ( is_callable( 'get_post' ) ) {
-			return get_post( $this->id );
-		} else {
-			return $this->get_post_data();
-		}
-	}
-
-	public function get_fb_price( $for_items_batch = false ) {
-		$product_price = Products::get_product_price( $this->woo_product );
-
-		return $for_items_batch ? self::format_price_for_fb_items_batch( $product_price ) : $product_price;
-	}
-
-	private static function format_price_for_fb_items_batch( $price ) {
-		// items_batch endpoint requires a string and a currency code
-		$formatted = ( $price / 100.0 ) . ' ' . get_woocommerce_currency();
-		return $formatted;
-	}
-
-
-	/**
-	 * Determines whether the current product is a WooCommerce Bookings product.
-	 *
-	 * TODO: add an integration that filters the Facebook price instead {WV 2020-07-22}
-	 *
-	 * @since 2.0.0
-	 *
-	 * @return bool
-	 */
-	private function is_bookable_product() {
-
-		return facebook_for_woocommerce()->is_plugin_active( 'woocommerce-bookings.php' ) && class_exists( 'WC_Product_Booking' ) && is_callable( 'is_wc_booking_product' ) && is_wc_booking_product( $this );
-	}
-
-
-	/**
-	 * Gets a list of image URLs to use for this product in Facebook sync.
-	 *
-	 * @return array
-	 */
-	public function get_all_image_urls() {
-
-		$image_urls = array();
-
-		/**
-		 * Filters the FB product image size.
-		 *
-		 * @since 3.0.34
-		 *
-		 * @param string $size The image size. e.g. 'full', 'medium', 'thumbnail'.
-		 */
-		$image_size               = apply_filters( 'facebook_for_woocommerce_fb_product_image_size', 'full' );
-		$product_image_url        = wp_get_attachment_image_url( $this->woo_product->get_image_id(), $image_size ); ;
-		$parent_product_image_url = null;
-		$custom_image_url         = $this->woo_product->get_meta( self::FB_PRODUCT_IMAGE );
-
-		if ( $this->woo_product->is_type( 'variation' ) ) {
-
-			if ( $parent_product = wc_get_product( $this->woo_product->get_parent_id() ) ) {
-
-				$parent_product_image_url = wp_get_attachment_image_url( $parent_product->get_image_id(), $image_size );
-			}
-		}
-
-		switch ( $this->woo_product->get_meta( Products::PRODUCT_IMAGE_SOURCE_META_KEY ) ) {
-
-			case Products::PRODUCT_IMAGE_SOURCE_CUSTOM:
-				$image_urls = array( $custom_image_url, $product_image_url, $parent_product_image_url );
-				break;
-
-			case Products::PRODUCT_IMAGE_SOURCE_PARENT_PRODUCT:
-				$image_urls = array( $parent_product_image_url, $product_image_url );
-				break;
-
-			case Products::PRODUCT_IMAGE_SOURCE_PRODUCT:
-			default:
-				$image_urls = array( $product_image_url, $parent_product_image_url );
-				break;
-		}
-
-		$image_urls = array_merge( $image_urls, $this->get_gallery_urls() );
-		$image_urls = array_filter( array_unique( $image_urls ) );
-
-		// Regenerate $image_url PHP array indexes after filtering.
-		// The array_filter does not touches indexes so if something gets removed we may end up with gaps.
-		// Later parts of the code expect something to exist under the 0 index.
-		$image_urls = array_values( $image_urls );
-
-		if ( empty( $image_urls ) ) {
-			$image_urls[] = wc_placeholder_img_src();
-		}
-
-		return $image_urls;
-	}
-
-	/**
-	 * Gets a list of video URLs to use for this product in Facebook sync.
-	 *
-	 * @return array
-	 */
-	public function get_all_video_urls() {
-
-		$video_urls = array();
-
-		$attached_videos = get_attached_media( 'video', $this->id );
-		if ( empty( $attached_videos ) ) {
-			return $video_urls;
-		}
-		foreach ( $attached_videos as $video ) {
-			$url = wp_get_attachment_url( $video->ID );
-			if ( $url ) {
-				array_push(
-					$video_urls,
-					array(
-						'url' => $url,
-					)
-				);
-			}
+        if ( $wpid instanceof WC_Product ) {
+            $this->id          = $wpid->get_id();
+            $this->woo_product = $wpid;
+        } else {
+            $this->id                     = $wpid;
+            $this->woo_product            = wc_get_product( $wpid );
         }
 
-		return $video_urls;
-	}
+        $this->fb_description         = '';
+        $this->gallery_urls           = null;
+        $this->fb_use_parent_image    = null;
+        $this->main_description       = '';
+        $this->sync_short_description = \WC_Facebookcommerce_Integration::PRODUCT_DESCRIPTION_MODE_SHORT === facebook_for_woocommerce()->get_integration()->get_product_description_mode();
+
+        if ( $meta = get_post_meta( $this->id, self::FB_VISIBILITY, true ) ) {
+            $this->fb_visibility = wc_string_to_bool( $meta );
+        } else {
+            $this->fb_visibility = '';
+            // for products that haven't synced yet
+        }
+
+        // Variable products should use some data from the parent_product
+        // For performance reasons, that data shouldn't be regenerated every time.
+        if ( $parent_product ) {
+            $this->gallery_urls        = $parent_product->get_gallery_urls();
+            $this->fb_use_parent_image = $parent_product->get_use_parent_image();
+            $this->main_description    = $parent_product->get_fb_description();
+        }
+    }
+
+    /**
+     * __get method for backward compatibility.
+     *
+     * @param string $key property name
+     * @return mixed
+     * @since 3.0.32
+     */
+    public function __get( $key ) {
+        // Add warning for private properties.
+        if ( in_array( $key, array( 'fb_description', 'gallery_urls', 'fb_use_parent_image', 'main_description', 'sync_short_description' ), true ) ) {
+            /* translators: %s property name. */
+            _doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'The %s property is private and should not be accessed outside its class.', 'facebook-for-woocommerce' ), esc_html( $key ) ), '3.0.32' );
+            return $this->$key;
+        }
+
+        return null;
+    }
+
+    public function exists() {
+        return ( $this->woo_product !== null && $this->woo_product !== false );
+    }
+
+    // Fall back to calling method on $woo_product
+    public function __call( $function, $args ) {
+        if ( $this->woo_product ) {
+            return call_user_func_array( array( $this->woo_product, $function ), $args );
+        } else {
+            $e         = new Exception();
+            $backtrace = var_export( $e->getTraceAsString(), true );
+            WC_Facebookcommerce_Utils::fblog(
+                "Calling $function on Null Woo Object. Trace:\n" . $backtrace,
+                array(),
+                true
+            );
+            return null;
+        }
+    }
+
+    public function get_gallery_urls() {
+        if ( $this->gallery_urls === null ) {
+            if ( is_callable( array( $this, 'get_gallery_image_ids' ) ) ) {
+                $image_ids = $this->get_gallery_image_ids();
+            } else {
+                $image_ids = $this->get_gallery_attachment_ids();
+            }
+            $gallery_urls = array();
+            foreach ( $image_ids as $image_id ) {
+                $image_url = wp_get_attachment_url( $image_id );
+                if ( ! empty( $image_url ) ) {
+                    array_push(
+                        $gallery_urls,
+                        WC_Facebookcommerce_Utils::make_url( $image_url )
+                    );
+                }
+            }
+            $this->gallery_urls = array_filter( $gallery_urls );
+        }
+
+        return $this->gallery_urls;
+    }
+
+    public function get_post_data() {
+        if ( is_callable( 'get_post' ) ) {
+            return get_post( $this->id );
+        } else {
+            return $this->get_post_data();
+        }
+    }
+
+    public function get_fb_price( $for_items_batch = false ) {
+        $product_price = Products::get_product_price( $this->woo_product );
+
+        return $for_items_batch ? self::format_price_for_fb_items_batch( $product_price ) : $product_price;
+    }
+
+    private static function format_price_for_fb_items_batch( $price ) {
+        // items_batch endpoint requires a string and a currency code
+        $formatted = ( $price / 100.0 ) . ' ' . get_woocommerce_currency();
+        return $formatted;
+    }
+
+
+    /**
+     * Determines whether the current product is a WooCommerce Bookings product.
+     *
+     * TODO: add an integration that filters the Facebook price instead {WV 2020-07-22}
+     *
+     * @since 2.0.0
+     *
+     * @return bool
+     */
+    private function is_bookable_product() {
+
+        return facebook_for_woocommerce()->is_plugin_active( 'woocommerce-bookings.php' ) && class_exists( 'WC_Product_Booking' ) && is_callable( 'is_wc_booking_product' ) && is_wc_booking_product( $this );
+    }
+
+
+    /**
+     * Gets a list of image URLs to use for this product in Facebook sync.
+     *
+     * @return array
+     */
+    public function get_all_image_urls() {
+
+        $image_urls = array();
+
+        /**
+         * Filters the FB product image size.
+         *
+         * @since 3.0.34
+         *
+         * @param string $size The image size. e.g. 'full', 'medium', 'thumbnail'.
+         */
+        $image_size               = apply_filters( 'facebook_for_woocommerce_fb_product_image_size', 'full' );
+        $product_image_url        = wp_get_attachment_image_url( $this->woo_product->get_image_id(), $image_size ); ;
+        $parent_product_image_url = null;
+        $custom_image_url         = $this->woo_product->get_meta( self::FB_PRODUCT_IMAGE );
+
+        if ( $this->woo_product->is_type( 'variation' ) ) {
+
+            if ( $parent_product = wc_get_product( $this->woo_product->get_parent_id() ) ) {
+
+                $parent_product_image_url = wp_get_attachment_image_url( $parent_product->get_image_id(), $image_size );
+            }
+        }
+
+        switch ( $this->woo_product->get_meta( Products::PRODUCT_IMAGE_SOURCE_META_KEY ) ) {
+
+            case Products::PRODUCT_IMAGE_SOURCE_CUSTOM:
+                $image_urls = array( $custom_image_url, $product_image_url, $parent_product_image_url );
+                break;
+
+            case Products::PRODUCT_IMAGE_SOURCE_PARENT_PRODUCT:
+                $image_urls = array( $parent_product_image_url, $product_image_url );
+                break;
+
+            case Products::PRODUCT_IMAGE_SOURCE_PRODUCT:
+            default:
+                $image_urls = array( $product_image_url, $parent_product_image_url );
+                break;
+        }
+
+        $image_urls = array_merge( $image_urls, $this->get_gallery_urls() );
+        $image_urls = array_filter( array_unique( $image_urls ) );
+
+        // Regenerate $image_url PHP array indexes after filtering.
+        // The array_filter does not touches indexes so if something gets removed we may end up with gaps.
+        // Later parts of the code expect something to exist under the 0 index.
+        $image_urls = array_values( $image_urls );
+
+        if ( empty( $image_urls ) ) {
+            $image_urls[] = wc_placeholder_img_src();
+        }
+
+        return $image_urls;
+    }
+
+    /**
+     * Gets a list of video URLs to use for this product in Facebook sync.
+     *
+     * @return array
+     */
+    public function get_all_video_urls() {
+
+        $video_urls = array();
+
+        $attached_videos = get_attached_media( 'video', $this->id );
+
+        $custom_video_urls = $this->woo_product->get_meta( self::FB_PRODUCT_VIDEO );
+
+        if ( empty( $attached_videos ) && empty( $custom_video_urls ) ) {
+            return $video_urls;
+        }
+
+       // Add attached video URLs to the list
+        if ( !empty( $attached_videos ) ) {
+            foreach ( $attached_videos as $video ) {
+                $url = wp_get_attachment_url( $video->ID );
+                if ( $url ) {
+                    $video_urls[] = array('url' => $url);
+                }
+            }
+        }
+        // Add custom video URLs to the list
+        if (!empty($custom_video_urls) && is_array($custom_video_urls)) {
+            foreach ($custom_video_urls as $custom_url) {
+                $custom_url = trim($custom_url);
+                if (!empty($custom_url)) {
+                    $video_urls[] = array('url' => $custom_url);
+                }
+            }
+        }
+
+        return $video_urls;
+    }
 
 
 
-	/**
-	 * Gets the list of additional image URLs for the product from the complete list of image URLs.
-	 *
-	 * It assumes the first URL will be used as the product image.
-	 * It returns 20 or less image URLs because Facebook doesn't allow more items on the additional_image_urls field.
-	 *
-	 * @since 2.0.2
-	 *
-	 * @param array $image_urls all image URLs for the product.
-	 * @return array
-	 */
-	private function get_additional_image_urls( $image_urls ) {
+    /**
+     * Gets the list of additional image URLs for the product from the complete list of image URLs.
+     *
+     * It assumes the first URL will be used as the product image.
+     * It returns 20 or less image URLs because Facebook doesn't allow more items on the additional_image_urls field.
+     *
+     * @since 2.0.2
+     *
+     * @param array $image_urls all image URLs for the product.
+     * @return array
+     */
+    private function get_additional_image_urls( $image_urls ) {
 
-		return array_slice( $image_urls, 1, 20 );
-	}
+        return array_slice( $image_urls, 1, 20 );
+    }
 
 
-	// Returns the parent image id for variable products only.
-	public function get_parent_image_id() {
-		if ( WC_Facebookcommerce_Utils::is_variation_type( $this->woo_product->get_type() ) ) {
-			$parent_data = $this->get_parent_data();
-			return $parent_data['image_id'];
-		}
-		return null;
-	}
+    // Returns the parent image id for variable products only.
+    public function get_parent_image_id() {
+        if ( WC_Facebookcommerce_Utils::is_variation_type( $this->woo_product->get_type() ) ) {
+            $parent_data = $this->get_parent_data();
+            return $parent_data['image_id'];
+        }
+        return null;
+    }
 
-	public function set_description( $description ) {
-		$description          = stripslashes(
-			WC_Facebookcommerce_Utils::clean_string( $description )
-		);
-		$this->fb_description = $description;
-		update_post_meta(
-			$this->id,
-			self::FB_PRODUCT_DESCRIPTION,
-			$description
-		);
-	}
+    public function set_description( $description ) {
+        $description          = stripslashes(
+            WC_Facebookcommerce_Utils::clean_string( $description )
+        );
+        $this->fb_description = $description;
+        update_post_meta(
+            $this->id,
+            self::FB_PRODUCT_DESCRIPTION,
+            $description
+        );
+    }
 
-	public function set_product_image( $image ) {
-		if ( $image !== null && strlen( $image ) !== 0 ) {
-			$image = WC_Facebookcommerce_Utils::clean_string( $image );
-			$image = WC_Facebookcommerce_Utils::make_url( $image );
-			update_post_meta(
-				$this->id,
-				self::FB_PRODUCT_IMAGE,
-				$image
-			);
-		}
+    public function set_product_image( $image ) {
+        if ( $image !== null && strlen( $image ) !== 0 ) {
+            $image = WC_Facebookcommerce_Utils::clean_string( $image );
+            $image = WC_Facebookcommerce_Utils::make_url( $image );
+            update_post_meta(
+                $this->id,
+                self::FB_PRODUCT_IMAGE,
+                $image
+            );
+        }
+    }
+
+	public function set_product_video_urls( $video_urls ) {
+		 $attachment_id_array = explode(',', $video_urls);
+        // Remove any empty values
+        $attachment_id_array = array_filter($attachment_id_array);
+        // Trim each ID to remove any whitespace
+        $attachment_id_array = array_map('trim', $attachment_id_array);
+        $video_urls = array_map(function($attachment_id) {
+            return wp_get_attachment_url($attachment_id);
+        }, $attachment_id_array);
+        // Filter out any false values (in case an ID doesn't correspond to a valid attachment)
+        $video_urls = array_filter($video_urls);
+        update_post_meta(
+            $this->id,
+            self::FB_PRODUCT_VIDEO,
+            $video_urls
+        );
 	}
 
 	public function set_fb_brand( $fb_brand ) {
@@ -383,38 +413,38 @@ class WC_Facebook_Product {
 		);
 	}
 
-	public function set_price( $price ) {
-		if ( is_numeric( $price ) ) {
-			update_post_meta(
-				$this->id,
-				self::FB_PRODUCT_PRICE,
-				$price
-			);
-		} else {
-			delete_post_meta(
-				$this->id,
-				self::FB_PRODUCT_PRICE
-			);
-		}
-	}
+    public function set_price( $price ) {
+        if ( is_numeric( $price ) ) {
+            update_post_meta(
+                $this->id,
+                self::FB_PRODUCT_PRICE,
+                $price
+            );
+        } else {
+            delete_post_meta(
+                $this->id,
+                self::FB_PRODUCT_PRICE
+            );
+        }
+    }
 
-	public function get_use_parent_image() {
-		if ( $this->fb_use_parent_image === null ) {
-			$variant_image_setting     =
-			get_post_meta( $this->id, self::FB_VARIANT_IMAGE, true );
-			$this->fb_use_parent_image = ( $variant_image_setting ) ? true : false;
-		}
-		return $this->fb_use_parent_image;
-	}
+    public function get_use_parent_image() {
+        if ( $this->fb_use_parent_image === null ) {
+            $variant_image_setting     =
+            get_post_meta( $this->id, self::FB_VARIANT_IMAGE, true );
+            $this->fb_use_parent_image = ( $variant_image_setting ) ? true : false;
+        }
+        return $this->fb_use_parent_image;
+    }
 
-	public function set_use_parent_image( $setting ) {
-		$this->fb_use_parent_image = ( $setting == 'yes' );
-		update_post_meta(
-			$this->id,
-			self::FB_VARIANT_IMAGE,
-			$this->fb_use_parent_image
-		);
-	}
+    public function set_use_parent_image( $setting ) {
+        $this->fb_use_parent_image = ( $setting == 'yes' );
+        update_post_meta(
+            $this->id,
+            self::FB_VARIANT_IMAGE,
+            $this->fb_use_parent_image
+        );
+    }
 
 	public function get_fb_brand() {
 		// Get brand directly from post meta
@@ -448,112 +478,112 @@ class WC_Facebook_Product {
 		return WC_Facebookcommerce_Utils::clean_string( $fb_brand );
 	}
 
-	public function get_fb_description() {
-		$description = '';
+    public function get_fb_description() {
+        $description = '';
 
-		if ( $this->fb_description ) {
-			$description = $this->fb_description;
-		}
+        if ( $this->fb_description ) {
+            $description = $this->fb_description;
+        }
 
-		if ( empty( $description ) ) {
-			// Try to get description from post meta
-			$description = get_post_meta(
-				$this->id,
-				self::FB_PRODUCT_DESCRIPTION,
-				true
-			);
-		}
+        if ( empty( $description ) ) {
+            // Try to get description from post meta
+            $description = get_post_meta(
+                $this->id,
+                self::FB_PRODUCT_DESCRIPTION,
+                true
+            );
+        }
 
-		// Check if the product type is a variation and no description is found yet
-		if ( empty( $description ) && WC_Facebookcommerce_Utils::is_variation_type( $this->woo_product->get_type() ) ) {
-			$description = WC_Facebookcommerce_Utils::clean_string( $this->woo_product->get_description() );
+        // Check if the product type is a variation and no description is found yet
+        if ( empty( $description ) && WC_Facebookcommerce_Utils::is_variation_type( $this->woo_product->get_type() ) ) {
+            $description = WC_Facebookcommerce_Utils::clean_string( $this->woo_product->get_description() );
 
-			// Fallback to main description
-			if ( empty( $description ) && $this->main_description ) {
-				$description = $this->main_description;
-			}
-		}
+            // Fallback to main description
+            if ( empty( $description ) && $this->main_description ) {
+                $description = $this->main_description;
+            }
+        }
 
-		// If no description is found from meta or variation, get from post
-		if ( empty( $description ) ) {
-			$post         = $this->get_post_data();
-			$post_content = WC_Facebookcommerce_Utils::clean_string( $post->post_content );
-			$post_excerpt = WC_Facebookcommerce_Utils::clean_string( $post->post_excerpt );
-			$post_title   = WC_Facebookcommerce_Utils::clean_string( $post->post_title );
+        // If no description is found from meta or variation, get from post
+        if ( empty( $description ) ) {
+            $post         = $this->get_post_data();
+            $post_content = WC_Facebookcommerce_Utils::clean_string( $post->post_content );
+            $post_excerpt = WC_Facebookcommerce_Utils::clean_string( $post->post_excerpt );
+            $post_title   = WC_Facebookcommerce_Utils::clean_string( $post->post_title );
 
-			// Prioritize content, then excerpt, then title
-			if ( ! empty( $post_content ) ) {
-				$description = $post_content;
-			}
+            // Prioritize content, then excerpt, then title
+            if ( ! empty( $post_content ) ) {
+                $description = $post_content;
+            }
 
-			if ( $this->sync_short_description || ( empty( $description ) && ! empty( $post_excerpt ) ) ) {
-				$description = $post_excerpt;
-			}
+            if ( $this->sync_short_description || ( empty( $description ) && ! empty( $post_excerpt ) ) ) {
+                $description = $post_excerpt;
+            }
 
-			if ( empty( $description ) ) {
-				$description = $post_title;
-			}
-		}
-		/**
-		 * Filters the FB product description.
-		 *
-		 * @since 3.2.6
-		 *
-		 * @param string  $description Facebook product description.
-		 * @param int     $id          WooCommerce Product ID.
-		 */
-		return apply_filters( 'facebook_for_woocommerce_fb_product_description', $description, $this->id );
-	}
+            if ( empty( $description ) ) {
+                $description = $post_title;
+            }
+        }
+        /**
+         * Filters the FB product description.
+         *
+         * @since 3.2.6
+         *
+         * @param string  $description Facebook product description.
+         * @param int     $id          WooCommerce Product ID.
+         */
+        return apply_filters( 'facebook_for_woocommerce_fb_product_description', $description, $this->id );
+    }
 
-	/**
-	 * @param array $product_data
-	 * @param bool $for_items_batch
-	 *
-	 * @return array
-	 */
-	public function add_sale_price( $product_data, $for_items_batch = false ) {
+    /**
+     * @param array $product_data
+     * @param bool $for_items_batch
+     *
+     * @return array
+     */
+    public function add_sale_price( $product_data, $for_items_batch = false ) {
 
-		$sale_price = $this->woo_product->get_sale_price();
-		$sale_price_effective_date = '';
-		$sale_start = '';
-		$sale_end = '';
+        $sale_price = $this->woo_product->get_sale_price();
+        $sale_price_effective_date = '';
+        $sale_start = '';
+        $sale_end = '';
 
-		// check if sale exist
-		if ( is_numeric( $sale_price ) && $sale_price > 0 ) {
-			$sale_start =
-				( $date     = $this->woo_product->get_date_on_sale_from() )
-					? date_i18n( WC_DateTime::ATOM, $date->getOffsetTimestamp() )
-					: self::MIN_DATE_1 . self::MIN_TIME;
-			$sale_end =
-				( $date   = $this->woo_product->get_date_on_sale_to() )
-					? date_i18n( WC_DateTime::ATOM, $date->getOffsetTimestamp() )
-					: self::MAX_DATE . self::MAX_TIME;
-			$sale_price_effective_date =
-				( $sale_start == self::MIN_DATE_1 . self::MIN_TIME && $sale_end == self::MAX_DATE . self::MAX_TIME )
-				? ''
-				: $sale_start . '/' . $sale_end;
-				$sale_price =
-				intval( round( $this->get_price_plus_tax( $sale_price ) * 100 ) );
+        // check if sale exist
+        if ( is_numeric( $sale_price ) && $sale_price > 0 ) {
+            $sale_start =
+                ( $date     = $this->woo_product->get_date_on_sale_from() )
+                    ? date_i18n( WC_DateTime::ATOM, $date->getOffsetTimestamp() )
+                    : self::MIN_DATE_1 . self::MIN_TIME;
+            $sale_end =
+                ( $date   = $this->woo_product->get_date_on_sale_to() )
+                    ? date_i18n( WC_DateTime::ATOM, $date->getOffsetTimestamp() )
+                    : self::MAX_DATE . self::MAX_TIME;
+            $sale_price_effective_date =
+                ( $sale_start == self::MIN_DATE_1 . self::MIN_TIME && $sale_end == self::MAX_DATE . self::MAX_TIME )
+                ? ''
+                : $sale_start . '/' . $sale_end;
+                $sale_price =
+                intval( round( $this->get_price_plus_tax( $sale_price ) * 100 ) );
 
-			// Set Sale start and end as empty if set to default values
-			if ( $sale_start == self::MIN_DATE_1 . self::MIN_TIME && $sale_end == self::MAX_DATE . self::MAX_TIME ) {
-				$sale_start = '';
-				$sale_end   = '';
-			}
-		}
+            // Set Sale start and end as empty if set to default values
+            if ( $sale_start == self::MIN_DATE_1 . self::MIN_TIME && $sale_end == self::MAX_DATE . self::MAX_TIME ) {
+                $sale_start = '';
+                $sale_end   = '';
+            }
+        }
 
-		// check if sale is expired and sale time range is valid
-		if ( $for_items_batch ) {
-			$product_data['sale_price_effective_date'] = $sale_price_effective_date;
-			$product_data['sale_price']                = is_numeric( $sale_price ) ? self::format_price_for_fb_items_batch( $sale_price ) : "";
-		} else {
-			$product_data['sale_price_start_date'] = $sale_start;
-			$product_data['sale_price_end_date']   = $sale_end;
-			$product_data['sale_price']            = is_numeric( $sale_price ) ? $sale_price : 0;
-		}
+        // check if sale is expired and sale time range is valid
+        if ( $for_items_batch ) {
+            $product_data['sale_price_effective_date'] = $sale_price_effective_date;
+            $product_data['sale_price']                = is_numeric( $sale_price ) ? self::format_price_for_fb_items_batch( $sale_price ) : "";
+        } else {
+            $product_data['sale_price_start_date'] = $sale_start;
+            $product_data['sale_price_end_date']   = $sale_end;
+            $product_data['sale_price']            = is_numeric( $sale_price ) ? $sale_price : 0;
+        }
 
-		return $product_data;
-	}
+        return $product_data;
+    }
 
 	public function get_fb_mpn() {
 		$fb_mpn = get_post_meta(
@@ -573,324 +603,324 @@ class WC_Facebook_Product {
 		return WC_Facebookcommerce_Utils::clean_string( $fb_mpn );
 	}
 
-	public function get_price_plus_tax( $price ) {
-		$woo_product = $this->woo_product;
-		// // wc_get_price_including_tax exist for Woo > 2.7
-		if ( function_exists( 'wc_get_price_including_tax' ) ) {
-			$args = array(
-				'qty'   => 1,
-				'price' => $price,
-			);
-			return get_option( 'woocommerce_tax_display_shop' ) === 'incl'
-				  ? wc_get_price_including_tax( $woo_product, $args )
-				  : wc_get_price_excluding_tax( $woo_product, $args );
-		} else {
-			return get_option( 'woocommerce_tax_display_shop' ) === 'incl'
-				  ? $woo_product->get_price_including_tax( 1, $price )
-				  : $woo_product->get_price_excluding_tax( 1, $price );
-		}
-	}
+    public function get_price_plus_tax( $price ) {
+        $woo_product = $this->woo_product;
+        // // wc_get_price_including_tax exist for Woo > 2.7
+        if ( function_exists( 'wc_get_price_including_tax' ) ) {
+            $args = array(
+                'qty'   => 1,
+                'price' => $price,
+            );
+            return get_option( 'woocommerce_tax_display_shop' ) === 'incl'
+                  ? wc_get_price_including_tax( $woo_product, $args )
+                  : wc_get_price_excluding_tax( $woo_product, $args );
+        } else {
+            return get_option( 'woocommerce_tax_display_shop' ) === 'incl'
+                  ? $woo_product->get_price_including_tax( 1, $price )
+                  : $woo_product->get_price_excluding_tax( 1, $price );
+        }
+    }
 
-	public function get_grouped_product_option_names( $key, $option_values ) {
-		// Convert all slug_names in $option_values into the visible names that
-		// advertisers have set to be the display names for a given attribute value
-		$terms = get_the_terms( $this->id, $key );
-		return ! is_array( $terms ) ? array() : array_map(
-			function ( $slug_name ) use ( $terms ) {
-				foreach ( $terms as $term ) {
-					if ( $term->slug === $slug_name ) {
-						return $term->name;
-					}
-				}
-				return $slug_name;
-			},
-			$option_values
-		);
-	}
+    public function get_grouped_product_option_names( $key, $option_values ) {
+        // Convert all slug_names in $option_values into the visible names that
+        // advertisers have set to be the display names for a given attribute value
+        $terms = get_the_terms( $this->id, $key );
+        return ! is_array( $terms ) ? array() : array_map(
+            function ( $slug_name ) use ( $terms ) {
+                foreach ( $terms as $term ) {
+                    if ( $term->slug === $slug_name ) {
+                        return $term->name;
+                    }
+                }
+                return $slug_name;
+            },
+            $option_values
+        );
+    }
 
 
-	public function update_visibility( $is_product_page, $visible_box_checked ) {
-		$visibility = get_post_meta( $this->id, self::FB_VISIBILITY, true );
-		if ( $visibility && ! $is_product_page ) {
-			// If the product was previously set to visible, keep it as visible
-			// (unless we're on the product page)
-			$this->fb_visibility = $visibility;
-		} else {
-			// If the product is not visible OR we're on the product page,
-			// then update the visibility as needed.
-			$this->fb_visibility = $visible_box_checked ? true : false;
-			update_post_meta( $this->id, self::FB_VISIBILITY, $this->fb_visibility );
-		}
-	}
+    public function update_visibility( $is_product_page, $visible_box_checked ) {
+        $visibility = get_post_meta( $this->id, self::FB_VISIBILITY, true );
+        if ( $visibility && ! $is_product_page ) {
+            // If the product was previously set to visible, keep it as visible
+            // (unless we're on the product page)
+            $this->fb_visibility = $visibility;
+        } else {
+            // If the product is not visible OR we're on the product page,
+            // then update the visibility as needed.
+            $this->fb_visibility = $visible_box_checked ? true : false;
+            update_post_meta( $this->id, self::FB_VISIBILITY, $this->fb_visibility );
+        }
+    }
 
-	// wrapper function to find item_id for default variation
-	function find_matching_product_variation() {
-		if ( is_callable( array( $this, 'get_default_attributes' ) ) ) {
-			$default_attributes = $this->get_default_attributes();
-		} else {
-			$default_attributes = $this->get_variation_default_attributes();
-		}
+    // wrapper function to find item_id for default variation
+    function find_matching_product_variation() {
+        if ( is_callable( array( $this, 'get_default_attributes' ) ) ) {
+            $default_attributes = $this->get_default_attributes();
+        } else {
+            $default_attributes = $this->get_variation_default_attributes();
+        }
 
-		if ( ! $default_attributes ) {
-			return;
-		}
-		foreach ( $default_attributes as $key => $value ) {
-			if ( strncmp( $key, 'attribute_', strlen( 'attribute_' ) ) === 0 ) {
-				continue;
-			}
-			unset( $default_attributes[ $key ] );
-			$default_attributes[ sprintf( 'attribute_%s', $key ) ] = $value;
-		}
-		if ( class_exists( 'WC_Data_Store' ) ) {
-			// for >= woo 3.0.0
-			$data_store = WC_Data_Store::load( 'product' );
-			return $data_store->find_matching_product_variation(
-				$this,
-				$default_attributes
-			);
-		} else {
-			return $this->get_matching_variation( $default_attributes );
-		}
-	}
+        if ( ! $default_attributes ) {
+            return;
+        }
+        foreach ( $default_attributes as $key => $value ) {
+            if ( strncmp( $key, 'attribute_', strlen( 'attribute_' ) ) === 0 ) {
+                continue;
+            }
+            unset( $default_attributes[ $key ] );
+            $default_attributes[ sprintf( 'attribute_%s', $key ) ] = $value;
+        }
+        if ( class_exists( 'WC_Data_Store' ) ) {
+            // for >= woo 3.0.0
+            $data_store = WC_Data_Store::load( 'product' );
+            return $data_store->find_matching_product_variation(
+                $this,
+                $default_attributes
+            );
+        } else {
+            return $this->get_matching_variation( $default_attributes );
+        }
+    }
 
-	private function build_checkout_url( $product_url ) {
-		// Use product_url for external/bundle product setting.
-		$product_type = $this->get_type();
-		if ( ! $product_type || ! isset( self::$use_checkout_url[ $product_type ] ) ) {
-				$checkout_url = $product_url;
-		} elseif ( wc_get_cart_url() ) {
-			$char = '?';
-			// Some merchant cart pages are actually a querystring
-			if ( strpos( wc_get_cart_url(), '?' ) !== false ) {
-				$char = '&';
-			}
+    private function build_checkout_url( $product_url ) {
+        // Use product_url for external/bundle product setting.
+        $product_type = $this->get_type();
+        if ( ! $product_type || ! isset( self::$use_checkout_url[ $product_type ] ) ) {
+                $checkout_url = $product_url;
+        } elseif ( wc_get_cart_url() ) {
+            $char = '?';
+            // Some merchant cart pages are actually a querystring
+            if ( strpos( wc_get_cart_url(), '?' ) !== false ) {
+                $char = '&';
+            }
 
-			$checkout_url = WC_Facebookcommerce_Utils::make_url(
-				wc_get_cart_url() . $char
-			);
+            $checkout_url = WC_Facebookcommerce_Utils::make_url(
+                wc_get_cart_url() . $char
+            );
 
-			if ( WC_Facebookcommerce_Utils::is_variation_type( $this->get_type() ) ) {
-				$query_data = array(
-					'add-to-cart'  => $this->get_parent_id(),
-					'variation_id' => $this->get_id(),
-				);
+            if ( WC_Facebookcommerce_Utils::is_variation_type( $this->get_type() ) ) {
+                $query_data = array(
+                    'add-to-cart'  => $this->get_parent_id(),
+                    'variation_id' => $this->get_id(),
+                );
 
-				$query_data = array_merge(
-					$query_data,
-					$this->get_variation_attributes()
-				);
+                $query_data = array_merge(
+                    $query_data,
+                    $this->get_variation_attributes()
+                );
 
-			} else {
-				$query_data = array(
-					'add-to-cart' => $this->get_id(),
-				);
-			}
+            } else {
+                $query_data = array(
+                    'add-to-cart' => $this->get_id(),
+                );
+            }
 
-			$checkout_url = $checkout_url . http_build_query( $query_data );
+            $checkout_url = $checkout_url . http_build_query( $query_data );
 
-		} else {
-			$checkout_url = null;
-		}//end if
-	}
+        } else {
+            $checkout_url = null;
+        }//end if
+    }
 
-	/**
-	 * Gets product data to send to Facebook.
-	 *
-	 * @param string $retailer_id the retailer ID of the product
-	 * @param string $type_to_prepare_for whether the data is going to be used in a feed upload, an items_batch update or a direct api call
-	 * @return array
-	 */
-	public function prepare_product( $retailer_id = null, $type_to_prepare_for = self::PRODUCT_PREP_TYPE_NORMAL ) {
+    /**
+     * Gets product data to send to Facebook.
+     *
+     * @param string $retailer_id the retailer ID of the product
+     * @param string $type_to_prepare_for whether the data is going to be used in a feed upload, an items_batch update or a direct api call
+     * @return array
+     */
+    public function prepare_product( $retailer_id = null, $type_to_prepare_for = self::PRODUCT_PREP_TYPE_NORMAL ) {
 
-		if ( ! $retailer_id ) {
-			$retailer_id =
-			WC_Facebookcommerce_Utils::get_fb_retailer_id( $this );
-		}
-		$image_urls = $this->get_all_image_urls();
+        if ( ! $retailer_id ) {
+            $retailer_id =
+            WC_Facebookcommerce_Utils::get_fb_retailer_id( $this );
+        }
+        $image_urls = $this->get_all_image_urls();
 
-		$video_urls = $this->get_all_video_urls();
+        $video_urls = $this->get_all_video_urls();
 
-		// Replace WordPress sanitization's ampersand with a real ampersand.
-		$product_url = str_replace(
-			'&amp%3B',
-			'&',
-			html_entity_decode( $this->get_permalink() )
-		);
+        // Replace WordPress sanitization's ampersand with a real ampersand.
+        $product_url = str_replace(
+            '&amp%3B',
+            '&',
+            html_entity_decode( $this->get_permalink() )
+        );
 
-		$id = $this->get_id();
-		if ( WC_Facebookcommerce_Utils::is_variation_type( $this->get_type() ) ) {
-			$id = $this->get_parent_id();
-		}
-		$categories =
-		WC_Facebookcommerce_Utils::get_product_categories( $id );
+        $id = $this->get_id();
+        if ( WC_Facebookcommerce_Utils::is_variation_type( $this->get_type() ) ) {
+            $id = $this->get_parent_id();
+        }
+        $categories =
+        WC_Facebookcommerce_Utils::get_product_categories( $id );
 
-		$custom_fields = $this->get_facebook_specific_fields();
+        $custom_fields = $this->get_facebook_specific_fields();
 
-		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
-			$product_data = array(
-				'title'                 => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
-				'description'           => $this->get_fb_description(),
-				'image_link'            => $image_urls[0],
-				'additional_image_link' => $this->get_additional_image_urls( $image_urls ),
-				'link'                  => $product_url,
-				'product_type'          => $categories['categories'],
-				'brand'                 => Helper::str_truncate( $this->get_fb_brand(), 100 ),
+        if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
+            $product_data = array(
+                'title'                 => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
+                'description'           => $this->get_fb_description(),
+                'image_link'            => $image_urls[0],
+                'additional_image_link' => $this->get_additional_image_urls( $image_urls ),
+                'link'                  => $product_url,
+                'product_type'          => $categories['categories'],
+                'brand'                 => Helper::str_truncate( $this->get_fb_brand(), 100 ),
 				'mpn'                 	=> Helper::str_truncate( $this->get_fb_mpn(), 100 ),
-				'retailer_id'           => $retailer_id,
-				'price'                 => $this->get_fb_price( true ),
-				'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
-				'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
+                'retailer_id'           => $retailer_id,
+                'price'                 => $this->get_fb_price( true ),
+                'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
+                'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
 				'custom_fields'			=> $custom_fields
-			);
-			$product_data   = $this->add_sale_price( $product_data, true );
-			$gpc_field_name = 'google_product_category';
-			if ( ! empty( $video_urls ) ) {
-				$product_data['video'] = $video_urls;
-			}
-		} else {
-			$product_data = array(
-				'name'                  => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
-				'description'           => $this->get_fb_description(),
-				'image_url'             => $image_urls[0],
-				'additional_image_urls' => $this->get_additional_image_urls( $image_urls ),
-				'url'                   => $product_url,
-				/**
-				 * 'category' is a required field for creating a ProductItem object when posting to /{product_catalog_id}/products.
-				 * This field should have the Google product category for the item. Google product category is not a required field
-				 * in the WooCommerce product editor. Hence, we are setting 'category' to Woo product categories by default and overriding
-				 * it when a Google product category is set.
-				 *
-				 * @see https://developers.facebook.com/docs/marketing-api/reference/product-catalog/products/#parameters-2
-				 * @see https://github.com/woocommerce/facebook-for-woocommerce/pull/2575
-				 * @see https://github.com/woocommerce/facebook-for-woocommerce/issues/2593
-				 */
-				'category'              => $categories['categories'],
-				'product_type'          => $categories['categories'],
-				'brand'                 => Helper::str_truncate( $this->get_fb_brand(), 100 ),
+            );
+            $product_data   = $this->add_sale_price( $product_data, true );
+            $gpc_field_name = 'google_product_category';
+            if ( ! empty( $video_urls ) ) {
+                $product_data['video'] = $video_urls;
+            }
+        } else {
+            $product_data = array(
+                'name'                  => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
+                'description'           => $this->get_fb_description(),
+                'image_url'             => $image_urls[0],
+                'additional_image_urls' => $this->get_additional_image_urls( $image_urls ),
+                'url'                   => $product_url,
+                /**
+                 * 'category' is a required field for creating a ProductItem object when posting to /{product_catalog_id}/products.
+                 * This field should have the Google product category for the item. Google product category is not a required field
+                 * in the WooCommerce product editor. Hence, we are setting 'category' to Woo product categories by default and overriding
+                 * it when a Google product category is set.
+                 *
+                 * @see https://developers.facebook.com/docs/marketing-api/reference/product-catalog/products/#parameters-2
+                 * @see https://github.com/woocommerce/facebook-for-woocommerce/pull/2575
+                 * @see https://github.com/woocommerce/facebook-for-woocommerce/issues/2593
+                 */
+                'category'              => $categories['categories'],
+                'product_type'          => $categories['categories'],
+                'brand'                 => Helper::str_truncate( $this->get_fb_brand(), 100 ),
 				'mpn'                 	=> Helper::str_truncate( $this->get_fb_mpn(), 100 ),
-				'retailer_id'           => $retailer_id,
-				'price'                 => $this->get_fb_price(),
-				'currency'              => get_woocommerce_currency(),
-				'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
-				'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
+                'retailer_id'           => $retailer_id,
+                'price'                 => $this->get_fb_price(),
+                'currency'              => get_woocommerce_currency(),
+                'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
+                'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
 				'custom_fields'			=> $custom_fields
-			);
+            );
 
-			if ( self::PRODUCT_PREP_TYPE_NORMAL !== $type_to_prepare_for && ! empty( $video_urls ) ) {
-				$product_data['video'] = $video_urls;
-			}
-			$product_data   = $this->add_sale_price( $product_data );
-			$gpc_field_name = 'category';
-		}//end if
+            if ( self::PRODUCT_PREP_TYPE_NORMAL !== $type_to_prepare_for && ! empty( $video_urls ) ) {
+                $product_data['video'] = $video_urls;
+            }
+            $product_data   = $this->add_sale_price( $product_data );
+            $gpc_field_name = 'category';
+        }//end if
 
-		$google_product_category = Products::get_google_product_category_id( $this->woo_product );
-		if ( $google_product_category ) {
-			$product_data[ $gpc_field_name ] = $google_product_category;
-		}
+        $google_product_category = Products::get_google_product_category_id( $this->woo_product );
+        if ( $google_product_category ) {
+            $product_data[ $gpc_field_name ] = $google_product_category;
+        }
 
-		// Currently only items batch and feed support enhanced catalog fields
-		if ( self::PRODUCT_PREP_TYPE_NORMAL !== $type_to_prepare_for && $google_product_category ) {
-			$product_data = $this->apply_enhanced_catalog_fields_from_attributes( $product_data, $google_product_category );
-		}
+        // Currently only items batch and feed support enhanced catalog fields
+        if ( self::PRODUCT_PREP_TYPE_NORMAL !== $type_to_prepare_for && $google_product_category ) {
+            $product_data = $this->apply_enhanced_catalog_fields_from_attributes( $product_data, $google_product_category );
+        }
 
-		// Add stock quantity if the product or variant is stock managed.
-		// In case if variant is not stock managed but parent is, fallback on parent value.
-		if ( $this->woo_product->managing_stock() ) {
-			$product_data['quantity_to_sell_on_facebook'] = (int) max( 0, $this->woo_product->get_stock_quantity() );
-		} else if ( $this->woo_product->is_type( 'variation' ) ) {
-			$parent_product = wc_get_product( $this->woo_product->get_parent_id() );
-			if ( $parent_product && $parent_product->managing_stock() ) {
-				$product_data['quantity_to_sell_on_facebook'] = (int) max( 0, $parent_product->get_stock_quantity() );
-			}
-		}
+        // Add stock quantity if the product or variant is stock managed.
+        // In case if variant is not stock managed but parent is, fallback on parent value.
+        if ( $this->woo_product->managing_stock() ) {
+            $product_data['quantity_to_sell_on_facebook'] = (int) max( 0, $this->woo_product->get_stock_quantity() );
+        } else if ( $this->woo_product->is_type( 'variation' ) ) {
+            $parent_product = wc_get_product( $this->woo_product->get_parent_id() );
+            if ( $parent_product && $parent_product->managing_stock() ) {
+                $product_data['quantity_to_sell_on_facebook'] = (int) max( 0, $parent_product->get_stock_quantity() );
+            }
+        }
 
-		// Add GTIN (Global Trade Item Number)
-		if ( method_exists( $this->woo_product, 'get_global_unique_id' ) && $gtin = $this->woo_product->get_global_unique_id() ) {
-			$product_data['gtin'] = $gtin;
-		}
+        // Add GTIN (Global Trade Item Number)
+        if ( method_exists( $this->woo_product, 'get_global_unique_id' ) && $gtin = $this->woo_product->get_global_unique_id() ) {
+            $product_data['gtin'] = $gtin;
+        }
 
-		// Only use checkout URLs if they exist.
-		$checkout_url = $this->build_checkout_url( $product_url );
-		if ( $checkout_url ) {
-			$product_data['checkout_url'] = $checkout_url;
-		}
+        // Only use checkout URLs if they exist.
+        $checkout_url = $this->build_checkout_url( $product_url );
+        if ( $checkout_url ) {
+            $product_data['checkout_url'] = $checkout_url;
+        }
 
-		// IF using WPML, set the product to hidden unless it is in the
-		// default language. WPML >= 3.2 Supported.
-		if ( defined( 'ICL_LANGUAGE_CODE' ) ) {
-			if ( class_exists( 'WC_Facebook_WPML_Injector' ) && WC_Facebook_WPML_Injector::should_hide( $id ) ) {
-				$product_data['visibility'] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
-			}
-		}
+        // IF using WPML, set the product to hidden unless it is in the
+        // default language. WPML >= 3.2 Supported.
+        if ( defined( 'ICL_LANGUAGE_CODE' ) ) {
+            if ( class_exists( 'WC_Facebook_WPML_Injector' ) && WC_Facebook_WPML_Injector::should_hide( $id ) ) {
+                $product_data['visibility'] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
+            }
+        }
 
-			// Exclude variations that are "virtual" products from export to Facebook &&
-			// No Visibility Option for Variations
-			// get_virtual() returns true for "unassembled bundles", so we exclude
-			// bundles from this check.
-			if ( true === $this->get_virtual() && 'bundle' !== $this->get_type() ) {
-				$product_data['visibility'] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
-			}
+            // Exclude variations that are "virtual" products from export to Facebook &&
+            // No Visibility Option for Variations
+            // get_virtual() returns true for "unassembled bundles", so we exclude
+            // bundles from this check.
+            if ( true === $this->get_virtual() && 'bundle' !== $this->get_type() ) {
+                $product_data['visibility'] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
+            }
 
-		if ( self::PRODUCT_PREP_TYPE_FEED !== $type_to_prepare_for ) {
-			$this->prepare_variants_for_item( $product_data );
-		} elseif (
-		WC_Facebookcommerce_Utils::is_all_caps( $product_data['description'] )
-		) {
-			$product_data['description'] =
-			mb_strtolower( $product_data['description'] );
-		}
+        if ( self::PRODUCT_PREP_TYPE_FEED !== $type_to_prepare_for ) {
+            $this->prepare_variants_for_item( $product_data );
+        } elseif (
+        WC_Facebookcommerce_Utils::is_all_caps( $product_data['description'] )
+        ) {
+            $product_data['description'] =
+            mb_strtolower( $product_data['description'] );
+        }
 
-		/**
-		   * Filters the generated product data.
-		   *
-		   * @param int   $id           Woocommerce product id
-		   * @param array $product_data An array of product data
-		   */
-		return apply_filters(
-			'facebook_for_woocommerce_integration_prepare_product',
-			$product_data,
-			$id
-		);
-	}
+        /**
+           * Filters the generated product data.
+           *
+           * @param int   $id           Woocommerce product id
+           * @param array $product_data An array of product data
+           */
+        return apply_filters(
+            'facebook_for_woocommerce_integration_prepare_product',
+            $product_data,
+            $id
+        );
+    }
 
-	/**
-	 * Adds enhanced catalog fields to product data array. Separated from
-	 * the main function to make it easier to develop and debug, potentially
-	 * worth refactoring into main prepare_product function when complete.
-	 *
-	 * @param array  $product_data       The preparted product data map.
-	 * @param string $google_category_id The Google product category id string.
-	 * @return array
-	 */
-	private function apply_enhanced_catalog_fields_from_attributes( $product_data, $google_category_id ) {
-		$category_handler   = facebook_for_woocommerce()->get_facebook_category_handler();
-		if ( empty( $google_category_id ) || ! $category_handler->is_category( $google_category_id ) ) {
-			return $product_data;
-		}
-		$enhanced_data = array();
+    /**
+     * Adds enhanced catalog fields to product data array. Separated from
+     * the main function to make it easier to develop and debug, potentially
+     * worth refactoring into main prepare_product function when complete.
+     *
+     * @param array  $product_data       The preparted product data map.
+     * @param string $google_category_id The Google product category id string.
+     * @return array
+     */
+    private function apply_enhanced_catalog_fields_from_attributes( $product_data, $google_category_id ) {
+        $category_handler   = facebook_for_woocommerce()->get_facebook_category_handler();
+        if ( empty( $google_category_id ) || ! $category_handler->is_category( $google_category_id ) ) {
+            return $product_data;
+        }
+        $enhanced_data = array();
 
-		$all_attributes = $category_handler->get_attributes_with_fallback_to_parent_category( $google_category_id );
+        $all_attributes = $category_handler->get_attributes_with_fallback_to_parent_category( $google_category_id );
 
-		foreach ( $all_attributes as $attribute ) {
-			$value            = Products::get_enhanced_catalog_attribute( $attribute['key'], $this->woo_product );
-			$convert_to_array = (
-				isset( $attribute['can_have_multiple_values'] ) &&
-				true === $attribute['can_have_multiple_values'] &&
-				'string' === $attribute['type']
-			);
+        foreach ( $all_attributes as $attribute ) {
+            $value            = Products::get_enhanced_catalog_attribute( $attribute['key'], $this->woo_product );
+            $convert_to_array = (
+                isset( $attribute['can_have_multiple_values'] ) &&
+                true === $attribute['can_have_multiple_values'] &&
+                'string' === $attribute['type']
+            );
 
-			if ( ! empty( $value ) &&
-				$category_handler->is_valid_value_for_attribute( $google_category_id, $attribute['key'], $value )
-			) {
-				if ( $convert_to_array ) {
-					$value = array_map( 'trim', explode( ',', $value ) );
-				}
-				$enhanced_data[ $attribute['key'] ] = $value;
-			}
-		}
+            if ( ! empty( $value ) &&
+                $category_handler->is_valid_value_for_attribute( $google_category_id, $attribute['key'], $value )
+            ) {
+                if ( $convert_to_array ) {
+                    $value = array_map( 'trim', explode( ',', $value ) );
+                }
+                $enhanced_data[ $attribute['key'] ] = $value;
+            }
+        }
 
-		return array_merge( $product_data, $enhanced_data );
-	}
+        return array_merge( $product_data, $enhanced_data );
+    }
 
 
 	/**
@@ -923,233 +953,233 @@ class WC_Facebook_Product {
 	}
 
 
-	/**
-	 * Normalizes variant data for Facebook.
-	 *
-	 * @param array $product_data variation product data
-	 * @return array
-	 */
-	public function prepare_variants_for_item( &$product_data ) {
+    /**
+     * Normalizes variant data for Facebook.
+     *
+     * @param array $product_data variation product data
+     * @return array
+     */
+    public function prepare_variants_for_item( &$product_data ) {
 
-		/** @var \WC_Product_Variation $product */
-		$product = $this;
+        /** @var \WC_Product_Variation $product */
+        $product = $this;
 
-		if ( ! $product->is_type( 'variation' ) ) {
-			return array();
-		}
+        if ( ! $product->is_type( 'variation' ) ) {
+            return array();
+        }
 
-		$attributes = $product->get_variation_attributes();
+        $attributes = $product->get_variation_attributes();
 
-		if ( ! $attributes ) {
-			return array();
-		}
+        if ( ! $attributes ) {
+            return array();
+        }
 
-		$variant_names = array_keys( $attributes );
-		$variant_data  = array();
+        $variant_names = array_keys( $attributes );
+        $variant_data  = array();
 
-		// Loop through variants (size, color, etc) if they exist
-		// For each product field type, pull the single variant
-		foreach ( $variant_names as $original_variant_name ) {
+        // Loop through variants (size, color, etc) if they exist
+        // For each product field type, pull the single variant
+        foreach ( $variant_names as $original_variant_name ) {
 
 			// Ensure that the attribute exists before accessing it
 			if ( !isset( $attributes[ $original_variant_name ] ) ) {
 				continue; // Skip if the attribute is not set
 			}
 
-			// don't handle any attributes that are designated as Commerce attributes
-			if ( in_array( str_replace( 'attribute_', '', strtolower( $original_variant_name ) ), Products::get_distinct_product_attributes( $this->woo_product ), true ) ) {
-				continue;
-			}
+            // don't handle any attributes that are designated as Commerce attributes
+            if ( in_array( str_replace( 'attribute_', '', strtolower( $original_variant_name ) ), Products::get_distinct_product_attributes( $this->woo_product ), true ) ) {
+                continue;
+            }
 
-			// Retrieve label name for attribute
-			$label = wc_attribute_label( $original_variant_name, $product );
+            // Retrieve label name for attribute
+            $label = wc_attribute_label( $original_variant_name, $product );
 
-			// Clean up variant name (e.g. pa_color should be color)
-			$new_name = \WC_Facebookcommerce_Utils::sanitize_variant_name( $original_variant_name, false );
+            // Clean up variant name (e.g. pa_color should be color)
+            $new_name = \WC_Facebookcommerce_Utils::sanitize_variant_name( $original_variant_name, false );
 
-			// Sometimes WC returns an array, sometimes it's an assoc array, depending
-			// on what type of taxonomy it's using.  array_values will guarantee we
-			// only get a flat array of values.
-			if ( $options = \WC_Facebookcommerce_Utils::get_variant_option_name( $this->id, $label, $attributes[ $original_variant_name ] ) ) {
+            // Sometimes WC returns an array, sometimes it's an assoc array, depending
+            // on what type of taxonomy it's using.  array_values will guarantee we
+            // only get a flat array of values.
+            if ( $options = \WC_Facebookcommerce_Utils::get_variant_option_name( $this->id, $label, $attributes[ $original_variant_name ] ) ) {
 
-				if ( is_array( $options ) ) {
+                if ( is_array( $options ) ) {
 
-					$option_values = array_values( $options );
+                    $option_values = array_values( $options );
 
-				} else {
+                } else {
 
-					$option_values = array( $options );
+                    $option_values = array( $options );
 
-					// If this attribute has value 'any', options will be empty strings
-					// Redirect to product page to select variants.
-					// Reset checkout url since checkout_url (build from query data will
-					// be invalid in this case.
-					if ( count( $option_values ) === 1 && empty( $option_values[0] ) ) {
-							$option_values[0]             = 'any';
-							$product_data['checkout_url'] = $product_data['url'];
-					}
-				}
+                    // If this attribute has value 'any', options will be empty strings
+                    // Redirect to product page to select variants.
+                    // Reset checkout url since checkout_url (build from query data will
+                    // be invalid in this case.
+                    if ( count( $option_values ) === 1 && empty( $option_values[0] ) ) {
+                            $option_values[0]             = 'any';
+                            $product_data['checkout_url'] = $product_data['url'];
+                    }
+                }
 
-				if ( \WC_Facebookcommerce_Utils::FB_VARIANT_GENDER === $new_name && ! isset( $product_data[ \WC_Facebookcommerce_Utils::FB_VARIANT_GENDER ] ) ) {
+                if ( \WC_Facebookcommerce_Utils::FB_VARIANT_GENDER === $new_name && ! isset( $product_data[ \WC_Facebookcommerce_Utils::FB_VARIANT_GENDER ] ) ) {
 
-					// If we can't validate the gender, this will be null.
-					$product_data[ $new_name ] = \WC_Facebookcommerce_Utils::validateGender( $option_values[0] );
-				}
+                    // If we can't validate the gender, this will be null.
+                    $product_data[ $new_name ] = \WC_Facebookcommerce_Utils::validateGender( $option_values[0] );
+                }
 
-				switch ( $new_name ) {
+                switch ( $new_name ) {
 
-					case \WC_Facebookcommerce_Utils::FB_VARIANT_GENDER:
-						// If we can't validate the GENDER field, we'll fall through to the
-						// default case and set the gender into custom data.
-						if ( $product_data[ $new_name ] ) {
+                    case \WC_Facebookcommerce_Utils::FB_VARIANT_GENDER:
+                        // If we can't validate the GENDER field, we'll fall through to the
+                        // default case and set the gender into custom data.
+                        if ( $product_data[ $new_name ] ) {
 
-							$variant_data[] = array(
-								'product_field' => $new_name,
-								'label'         => $label,
-								'options'       => $option_values,
-							);
-						}
+                            $variant_data[] = array(
+                                'product_field' => $new_name,
+                                'label'         => $label,
+                                'options'       => $option_values,
+                            );
+                        }
 
-						break;
+                        break;
 
-					default:
-						// This is for any custom_data.
-						if ( ! isset( $product_data['custom_data'] ) ) {
-							$product_data['custom_data'] = array();
-						}
-						$new_name                                 = wc_attribute_label( $new_name, $product );
-						$product_data['custom_data'][ $new_name ] = urldecode( $option_values[0] );
-						break;
-				}//end switch
-			} else {
+                    default:
+                        // This is for any custom_data.
+                        if ( ! isset( $product_data['custom_data'] ) ) {
+                            $product_data['custom_data'] = array();
+                        }
+                        $new_name                                 = wc_attribute_label( $new_name, $product );
+                        $product_data['custom_data'][ $new_name ] = urldecode( $option_values[0] );
+                        break;
+                }//end switch
+            } else {
 
-				\WC_Facebookcommerce_Utils::log( $product->get_id() . ': No options for ' . $original_variant_name );
-				continue;
-			}//end if
-		}//end foreach
+                \WC_Facebookcommerce_Utils::log( $product->get_id() . ': No options for ' . $original_variant_name );
+                continue;
+            }//end if
+        }//end foreach
 
-		return $variant_data;
-	}
+        return $variant_data;
+    }
 
 
-	/**
-	 * Normalizes variable product variations data for Facebook.
-	 *
-	 * @param bool $feed_data whether this is used for feed data
-	 * @return array
-	 */
-	public function prepare_variants_for_group( $feed_data = false ) {
+    /**
+     * Normalizes variable product variations data for Facebook.
+     *
+     * @param bool $feed_data whether this is used for feed data
+     * @return array
+     */
+    public function prepare_variants_for_group( $feed_data = false ) {
 
-		/** @var \WC_Product_Variable $product */
-		$product        = $this;
-		$final_variants = array();
+        /** @var \WC_Product_Variable $product */
+        $product        = $this;
+        $final_variants = array();
 
-		try {
+        try {
 
-			if ( ! $product->is_type( 'variable' ) ) {
-				throw new \Exception( 'prepare_variants_for_group called on non-variable product' );
-			}
+            if ( ! $product->is_type( 'variable' ) ) {
+                throw new \Exception( 'prepare_variants_for_group called on non-variable product' );
+            }
 
-			$variation_attributes = $product->get_variation_attributes();
+            $variation_attributes = $product->get_variation_attributes();
 
-			if ( ! $variation_attributes ) {
-				return array();
-			}
+            if ( ! $variation_attributes ) {
+                return array();
+            }
 
-			foreach ( array_keys( $product->get_attributes() ) as $name ) {
+            foreach ( array_keys( $product->get_attributes() ) as $name ) {
 
-				$label = wc_attribute_label( $name, $product );
+                $label = wc_attribute_label( $name, $product );
 
-				if ( taxonomy_is_product_attribute( $name ) ) {
-					$key = $name;
-				} else {
-					// variation_attributes keys are labels for custom attrs for some reason
-					$key = $label;
-				}
+                if ( taxonomy_is_product_attribute( $name ) ) {
+                    $key = $name;
+                } else {
+                    // variation_attributes keys are labels for custom attrs for some reason
+                    $key = $label;
+                }
 
-				if ( ! $key ) {
-					throw new \Exception( "Critical error: can't get attribute name or label!" );
-				}
+                if ( ! $key ) {
+                    throw new \Exception( "Critical error: can't get attribute name or label!" );
+                }
 
-				if ( isset( $variation_attributes[ $key ] ) ) {
-					// array of the options (e.g. small, medium, large)
-					$option_values = $variation_attributes[ $key ];
-				} else {
-					// skip variations without valid attribute options
-					\WC_Facebookcommerce_Utils::log( $product->get_id() . ': No options for ' . $name );
-					continue;
-				}
+                if ( isset( $variation_attributes[ $key ] ) ) {
+                    // array of the options (e.g. small, medium, large)
+                    $option_values = $variation_attributes[ $key ];
+                } else {
+                    // skip variations without valid attribute options
+                    \WC_Facebookcommerce_Utils::log( $product->get_id() . ': No options for ' . $name );
+                    continue;
+                }
 
-				// If this is a variable product, check default attribute.
-				// If it's being used, show it as the first option on Facebook.
-				if ( $first_option = $product->get_variation_default_attribute( $key ) ) {
+                // If this is a variable product, check default attribute.
+                // If it's being used, show it as the first option on Facebook.
+                if ( $first_option = $product->get_variation_default_attribute( $key ) ) {
 
-					$index = array_search( $first_option, $option_values, false );
+                    $index = array_search( $first_option, $option_values, false );
 
-					unset( $option_values[ $index ] );
+                    unset( $option_values[ $index ] );
 
-					array_unshift( $option_values, $first_option );
-				}
+                    array_unshift( $option_values, $first_option );
+                }
 
-				if ( function_exists( 'taxonomy_is_product_attribute' ) && taxonomy_is_product_attribute( $name ) ) {
-					$option_values = $this->get_grouped_product_option_names( $key, $option_values );
-				}
+                if ( function_exists( 'taxonomy_is_product_attribute' ) && taxonomy_is_product_attribute( $name ) ) {
+                    $option_values = $this->get_grouped_product_option_names( $key, $option_values );
+                }
 
-				switch ( $name ) {
+                switch ( $name ) {
 
-					case Products::get_product_color_attribute( $this->woo_product ):
-						$name = WC_Facebookcommerce_Utils::FB_VARIANT_COLOR;
-						break;
+                    case Products::get_product_color_attribute( $this->woo_product ):
+                        $name = WC_Facebookcommerce_Utils::FB_VARIANT_COLOR;
+                        break;
 
-					case Products::get_product_size_attribute( $this->woo_product ):
-						$name = WC_Facebookcommerce_Utils::FB_VARIANT_SIZE;
-						break;
+                    case Products::get_product_size_attribute( $this->woo_product ):
+                        $name = WC_Facebookcommerce_Utils::FB_VARIANT_SIZE;
+                        break;
 
-					case Products::get_product_pattern_attribute( $this->woo_product ):
-						$name = WC_Facebookcommerce_Utils::FB_VARIANT_PATTERN;
-						break;
+                    case Products::get_product_pattern_attribute( $this->woo_product ):
+                        $name = WC_Facebookcommerce_Utils::FB_VARIANT_PATTERN;
+                        break;
 
-					default:
-						/**
-						 * For API approach, product_field need to start with 'custom_data:'
-						 *
-						 * @link https://developers.facebook.com/docs/marketing-api/reference/product-variant/
-						 */
-						$name = \WC_Facebookcommerce_Utils::sanitize_variant_name( $name );
-				}//end switch
+                    default:
+                        /**
+                         * For API approach, product_field need to start with 'custom_data:'
+                         *
+                         * @link https://developers.facebook.com/docs/marketing-api/reference/product-variant/
+                         */
+                        $name = \WC_Facebookcommerce_Utils::sanitize_variant_name( $name );
+                }//end switch
 
-				// for feed uploading, product field should remove prefix 'custom_data:'
-				if ( $feed_data ) {
-					$name = str_replace( 'custom_data:', '', $name );
-				}
+                // for feed uploading, product field should remove prefix 'custom_data:'
+                if ( $feed_data ) {
+                    $name = str_replace( 'custom_data:', '', $name );
+                }
 
-				$final_variants[] = array(
-					'product_field' => $name,
-					'label'         => $label,
-					'options'       => $option_values,
-				);
-			}//end foreach
-		} catch ( \Exception $e ) {
+                $final_variants[] = array(
+                    'product_field' => $name,
+                    'label'         => $label,
+                    'options'       => $option_values,
+                );
+            }//end foreach
+        } catch ( \Exception $e ) {
 
-			\WC_Facebookcommerce_Utils::fblog( $e->getMessage() );
+            \WC_Facebookcommerce_Utils::fblog( $e->getMessage() );
 
-			return array();
-		}//end try
+            return array();
+        }//end try
 
-		return $final_variants;
-	}
+        return $final_variants;
+    }
 
-	/**
-	 * Returns information about which fields are using Facebook-specific values.
-	 *
-	 * @return array
-	 */
-	private function get_facebook_specific_fields(): array {
-		return array(
-			'has_fb_description' => (bool) get_post_meta($this->id, self::FB_PRODUCT_DESCRIPTION, true),
-			'has_fb_price'       => (bool) get_post_meta($this->id, self::FB_PRODUCT_PRICE, true),
-			'has_fb_image'       => (bool) get_post_meta($this->id, self::FB_PRODUCT_IMAGE, true)
-		);
-	}
+    /**
+     * Returns information about which fields are using Facebook-specific values.
+     *
+     * @return array
+     */
+    private function get_facebook_specific_fields(): array {
+        return array(
+            'has_fb_description' => (bool) get_post_meta($this->id, self::FB_PRODUCT_DESCRIPTION, true),
+            'has_fb_price'       => (bool) get_post_meta($this->id, self::FB_PRODUCT_PRICE, true),
+            'has_fb_image'       => (bool) get_post_meta($this->id, self::FB_PRODUCT_IMAGE, true)
+        );
+    }
 
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "facebook-for-woocommerce",
-      "version": "3.2.10",
+      "version": "3.3.0",
       "license": "GPL-2.0",
       "devDependencies": {
         "@wordpress/env": "^9.10.0",
@@ -4619,13 +4619,24 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001230",
+      "version": "1.0.30001696",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001696.tgz",
+      "integrity": "sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==",
       "dev": true,
-      "license": "CC-BY-4.0",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -22310,7 +22321,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001230",
+      "version": "1.0.30001696",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001696.tgz",
+      "integrity": "sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==",
       "dev": true
     },
     "capture-exit": {

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -556,6 +556,24 @@ class fbproductTest extends WP_UnitTestCase {
         $this->assertEquals(true, $product_data['custom_fields']['has_fb_image']);
     }
 
+	public function test_prepare_product_with_video_field() {
+		// Set facebook specific fields
+		$video_urls = [
+			'https://example.com/video1.mp4',
+			'https://example.com/video2.mp4',
+		];
+
+		$expected_video_urls = array_map(function($url) {
+			return ['url' => $url];
+		}, $video_urls);
+
+		update_post_meta($this->product->get_id(), WC_Facebook_Product::FB_PRODUCT_VIDEO, $video_urls);
+		$product_data = $this->fb_product->prepare_product(null, WC_Facebook_Product::PRODUCT_PREP_TYPE_ITEMS_BATCH);
+		
+		$this->assertArrayHasKey('video', $product_data);
+		$this->assertEquals($expected_video_urls, $product_data['video']);
+	}
+
     public function test_prepare_product_with_mixed_fields() {
         // Set only facebook description
         $fb_description = 'Facebook specific description';


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR introduces new functionality to add support for the video syncing capabilities for WooCommerce products, allowing users to select and sync videos directly using the WooCommerce Media Library.

### Existing Functionality
 - **Video Syncing**: Previously, only videos present in the Long or Short description fields were synced using the batch API.
> Reason: Natively due to current design, users can't add video to WC Product Gallery(requires 3p plugin support)

### New Functionality
<img width="859" alt="image" src="https://github.com/user-attachments/assets/47040390-b2f5-4fba-8f0b-23c2a8dba160" />

- **Video Selection for Syncing**: Users can now select specific videos to sync for their products.
- **Integration using WooCommerce Media Library**: By reusing the WooCommerce Media Library, users can easily select or upload video files. This integration ensures video validation, guaranteeing that the correct video URLs are always obtained.

---- 

### Flow 

https://github.com/user-attachments/assets/85745ee9-5f42-4c31-9bc4-da65a7e368f3


- [ ] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
1. Run all tests : `npm run test:php`
<img width="578" alt="image" src="https://github.com/user-attachments/assets/74e6b20e-9522-42b3-881f-7abb2301d268" />

2. Lint: `./vendor/bin/phpcs`
3. Run new test `./vendor/bin/phpunit --filter test_prepare_product_videos`
4. **E2E Tests**
   - Single Product Update
       * Go to individual product. Upload a video using FB product video form field.
       * Click Publish->Update
       * Outcome : Video Synced to facebook
       
   - Batch API Update
      * Disconnect from facebook
      * Connect back and create a new catalog
      * Products are synced with batch API flow
      * Outcomes : New catalog created on facebook, with Videos synced at product level.

### Additional details:
 - This update is backward compatible and does not affect existing video syncing functionality.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry
 - Add FB product video field to add videos.
 - Added products sync to support the video field with Batch API.
