### PR TITLE
Remove custom fields from FB Product Creation

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -825,8 +825,6 @@ class WC_Facebook_Product {
 		$categories =
 		WC_Facebookcommerce_Utils::get_product_categories( $id );
 
-		$custom_fields = $this->get_facebook_specific_fields();
-
 		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
 			$product_data   = array(
 					'title'                 => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
@@ -842,7 +840,6 @@ class WC_Facebook_Product {
 					'price'                 => $this->get_fb_price( true ),
 					'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
 					'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
-					'custom_fields'			=> $custom_fields,
 			);
 			$product_data   = $this->add_sale_price( $product_data, true );
 			if ( ! empty( $video_urls ) ) {
@@ -875,7 +872,6 @@ class WC_Facebook_Product {
 					'currency'              => get_woocommerce_currency(),
 					'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
 					'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
-					'custom_fields'			=> $custom_fields
 			);
 
 			if ( self::PRODUCT_PREP_TYPE_NORMAL !== $type_to_prepare_for && ! empty( $video_urls ) ) {
@@ -1238,19 +1234,6 @@ class WC_Facebook_Product {
 		}//end try
 
 		return $final_variants;
-	}
-
-	/**
-	 * Returns information about which fields are using Facebook-specific values.
-	 *
-	 * @return array
-	 */
-	private function get_facebook_specific_fields(): array {
-		return array(
-			'has_fb_description' => (bool) get_post_meta($this->id, self::FB_PRODUCT_DESCRIPTION, true),
-			'has_fb_price'       => (bool) get_post_meta($this->id, self::FB_PRODUCT_PRICE, true),
-			'has_fb_image'       => (bool) get_post_meta($this->id, self::FB_PRODUCT_IMAGE, true)
-		);
 	}
 
 }

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -528,11 +528,6 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 		$facebook_product_data['rich_text_description']		 = 'Facebook product description.';
 		$facebook_product_data['price']                      = '199 USD';
 		$facebook_product_data['google_product_category']    = 1718;
-		$facebook_product_data['custom_fields']	= [
-			'has_fb_description' => true,
-			'has_fb_price' => true,
-			'has_fb_image' => true
-		];
 
 		$requests = WC_Facebookcommerce_Utils::prepare_product_requests_items_batch($facebook_product_data);
 

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -560,10 +560,6 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 		$this->assertEquals( 'Facebook product description.', get_post_meta( $facebook_product_to_update->get_id(), WC_Facebook_Product::FB_PRODUCT_DESCRIPTION, true ) );
 		$this->assertEquals( 'Facebook product description.', get_post_meta( $facebook_product_to_update->get_id(), WC_Facebook_Product::FB_RICH_TEXT_DESCRIPTION, true ) );
 
-		$this->assertEquals(true, $updated_product_data['custom_fields']['has_fb_description']);
-		$this->assertEquals(true, $updated_product_data['custom_fields']['has_fb_price']);
-		$this->assertEquals(true, $updated_product_data['custom_fields']['has_fb_image']);
-
 		// Verify the actual values are still stored in meta
 		$this->assertEquals( 'Facebook product description.', get_post_meta( $facebook_product_to_update->get_id(), WC_Facebook_Product::FB_PRODUCT_DESCRIPTION, true ) );
 		$this->assertEquals( '199', get_post_meta( $facebook_product_to_update->get_id(), WC_Facebook_Product::FB_PRODUCT_PRICE, true ) );

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -594,15 +594,6 @@ class fbproductTest extends WP_UnitTestCase {
 		$this->assertNotContains('', $saved_video_urls);
     }
 
-    public function test_prepare_product_with_mixed_fields() {
-        // Set only facebook description
-        $fb_description = 'Facebook specific description';
-
-        update_post_meta($this->product->get_id(), WC_Facebook_Product::FB_PRODUCT_DESCRIPTION, $fb_description);
-
-        $product_data = $this->fb_product->prepare_product();
-    }
-
     public function test_prepare_product_items_batch() {
         // Test the PRODUCT_PREP_TYPE_ITEMS_BATCH preparation type
         $fb_description = 'Facebook specific description';

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -531,30 +531,8 @@ class fbproductTest extends WP_UnitTestCase {
     public function test_prepare_product_with_default_fields() {
         // test when no fb specific fields are set
         $product_data = $this->fb_product->prepare_product();
-
-        $this->assertArrayHasKey('custom_fields', $product_data);
-        $this->assertEquals(false, $product_data['custom_fields']['has_fb_description']);
-        $this->assertEquals(false, $product_data['custom_fields']['has_fb_price']);
-        $this->assertEquals(false, $product_data['custom_fields']['has_fb_image']);
     }
 
-    public function test_prepare_product_with_custom_fields() {
-        // Set facebook specific fields
-        $fb_description = 'Facebook specific description';
-        $fb_price = '15';
-        $fb_image = 'https:example.com/fb-image.jpg';
-
-        update_post_meta($this->product->get_id(), WC_Facebook_Product::FB_PRODUCT_DESCRIPTION, $fb_description);
-        update_post_meta($this->product->get_id(), WC_Facebook_Product::FB_PRODUCT_PRICE, $fb_price);
-        update_post_meta($this->product->get_id(), WC_Facebook_Product::FB_PRODUCT_IMAGE, $fb_image);
-
-        $product_data = $this->fb_product->prepare_product();
-
-        $this->assertArrayHasKey('custom_fields', $product_data);
-        $this->assertEquals(true, $product_data['custom_fields']['has_fb_description']);
-        $this->assertEquals(true, $product_data['custom_fields']['has_fb_price']);
-        $this->assertEquals(true, $product_data['custom_fields']['has_fb_image']);
-    }
 
 	public function test_prepare_product_with_video_field() {
 		// Set facebook specific fields
@@ -623,11 +601,6 @@ class fbproductTest extends WP_UnitTestCase {
         update_post_meta($this->product->get_id(), WC_Facebook_Product::FB_PRODUCT_DESCRIPTION, $fb_description);
 
         $product_data = $this->fb_product->prepare_product();
-
-        $this->assertArrayHasKey('custom_fields', $product_data);
-        $this->assertEquals(true, $product_data['custom_fields']['has_fb_description']);
-        $this->assertEquals(false, $product_data['custom_fields']['has_fb_price']);
-        $this->assertEquals(false, $product_data['custom_fields']['has_fb_image']);
     }
 
     public function test_prepare_product_items_batch() {
@@ -637,11 +610,6 @@ class fbproductTest extends WP_UnitTestCase {
         update_post_meta($this->product->get_id(), WC_Facebook_Product::FB_PRODUCT_DESCRIPTION, $fb_description);
 
         $product_data = $this->fb_product->prepare_product(null, WC_Facebook_Product::PRODUCT_PREP_TYPE_ITEMS_BATCH);
-
-        $this->assertArrayHasKey('custom_fields', $product_data);
-        $this->assertEquals(true, $product_data['custom_fields']['has_fb_description']);
-        $this->assertEquals(false, $product_data['custom_fields']['has_fb_price']);
-        $this->assertEquals(false, $product_data['custom_fields']['has_fb_image']);
 
         // Also verify the main product data structure for items batch
         $this->assertArrayHasKey('title', $product_data);

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -527,12 +527,6 @@ class fbproductTest extends WP_UnitTestCase {
 			$this->assertEquals($product_data[$key], $value);
 		}
 	}
-  
-    public function test_prepare_product_with_default_fields() {
-        // test when no fb specific fields are set
-        $product_data = $this->fb_product->prepare_product();
-    }
-
 
 	public function test_prepare_product_with_video_field() {
 		// Set facebook specific fields


### PR DESCRIPTION
This pull request removes custom fields from the Facebook product creation process. 

Changes:
Removed custom field definitions