### PR TITLE
Version bump to address erroneous update flow/notifications

### DIFF
--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -11,7 +11,7 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 3.3.2
+ * Version: 3.3.3
  * Requires at least: 5.6
  * Requires PHP: 7.4
  * Text Domain: facebook-for-woocommerce


### PR DESCRIPTION
Version bump in WordPress plugin headers from `3.3.2` to `3.3.3`

This addresses the issue of the WordPress update API from incorrectly identifying this version as 3.3.2 and perpetually presenting out-of-date plugin update notices or continually running auto update.

### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2877