### PR TITLE
Remove custom FB Description field for simple products and variants 

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -134,7 +134,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	// TODO probably some of these meta keys need to be moved to Facebook\Products {FN 2020-01-13}.
 	public const FB_PRODUCT_GROUP_ID    = 'fb_product_group_id';
 	public const FB_PRODUCT_ITEM_ID     = 'fb_product_item_id';
-	// public const FB_PRODUCT_DESCRIPTION = 'fb_product_description';
 
 	/** @var string the API flag to set a product as visible in the Facebook shop */
 	public const FB_SHOP_PRODUCT_VISIBLE = 'published';
@@ -864,11 +863,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 */
 	private function save_product_settings( WC_Product $product ) {
 		$woo_product = new WC_Facebook_Product( $product->get_id() );
-
-		// phpcs:disable WordPress.Security.NonceVerification.Missing
-		// if ( isset( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) {
-		// 	$woo_product->set_description( sanitize_text_field( wp_unslash( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) );
-		// }
 
 		if ( isset( $_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ] ) ) {
 			$woo_product->set_price( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ] ) ) );

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1180,8 +1180,6 @@ class Admin {
 		$sync_enabled = 'no' !== get_post_meta( $post->ID, Products::SYNC_ENABLED_META_KEY, true );
 		$is_visible   = ( $visibility = get_post_meta( $post->ID, Products::VISIBILITY_META_KEY, true ) ) ? wc_string_to_bool( $visibility ) : true;
 		$product 	  = wc_get_product( $post );
-
-		// $description  = get_post_meta( $post->ID, \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, true );
 		$price        = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_PRICE, true );
 		$image_source = get_post_meta( $post->ID, Products::PRODUCT_IMAGE_SOURCE_META_KEY, true );
 		$image        = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_IMAGE, true );
@@ -1214,19 +1212,6 @@ class Admin {
 						'description' => __( 'Choose whether to sync this product to Facebook and, if synced, whether it should be visible in the catalog.', 'facebook-for-woocommerce' ),
 					)
 				);
-
-				// woocommerce_wp_textarea_input(
-				// 	array(
-				// 		'id'          => \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
-				// 		'label'       => __( 'Facebook Description', 'facebook-for-woocommerce' ),
-				// 		'desc_tip'    => true,
-				// 		'description' => __( 'Custom (plain-text only) description for product on Facebook. If blank, product description will be used. If product description is blank, shortname will be used.', 'facebook-for-woocommerce' ),
-				// 		'cols'        => 40,
-				// 		'rows'        => 20,
-				// 		'value'       => $description,
-				// 		'class'       => 'short enable-if-sync-enabled',
-				// 	)
-				// );
 
 				woocommerce_wp_radio(
 					array(
@@ -1348,8 +1333,6 @@ class Admin {
 
 		$sync_enabled = 'no' !== $this->get_product_variation_meta( $variation, Products::SYNC_ENABLED_META_KEY, $parent );
 		$is_visible   = ( $visibility = $this->get_product_variation_meta( $variation, Products::VISIBILITY_META_KEY, $parent ) ) ? wc_string_to_bool( $visibility ) : true;
-
-		// $description  = $this->get_product_variation_meta( $variation, \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $parent );
 		$price        = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_PRICE, $parent );
 		$image_url    = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_IMAGE, $parent );
 		$image_source = $variation->get_meta( Products::PRODUCT_IMAGE_SOURCE_META_KEY );
@@ -1378,21 +1361,6 @@ class Admin {
 				'wrapper_class' => 'form-row form-row-full',
 			)
 		);
-
-		// woocommerce_wp_textarea_input(
-		// 	array(
-		// 		'id'            => sprintf( 'variable_%s%s', \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $index ),
-		// 		'name'          => sprintf( "variable_%s[$index]", \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION ),
-		// 		'label'         => __( 'Facebook Description', 'facebook-for-woocommerce' ),
-		// 		'desc_tip'      => true,
-		// 		'description'   => __( 'Custom (plain-text only) description for product on Facebook. If blank, product description will be used. If product description is blank, shortname will be used.', 'facebook-for-woocommerce' ),
-		// 		'cols'          => 40,
-		// 		'rows'          => 5,
-		// 		'value'         => $description,
-		// 		'class'         => 'enable-if-sync-enabled',
-		// 		'wrapper_class' => 'form-row form-row-full',
-		// 	)
-		// );
 
 		woocommerce_wp_radio(
 			array(
@@ -1501,8 +1469,6 @@ class Admin {
 		if ( $sync_enabled ) {
 			Products::enable_sync_for_products( array( $variation ) );
 			Products::set_product_visibility( $variation, self::SYNC_MODE_SYNC_AND_HIDE !== $sync_mode );
-			// $posted_param = 'variable_' . \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION;
-			// $description  = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_text_field( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
 			$posted_param = 'variable_' . \WC_Facebook_Product::FB_MPN;
 			$fb_mpn  = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_text_field( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
 			$posted_param = 'variable_fb_product_image_source';
@@ -1511,7 +1477,6 @@ class Admin {
 			$image_url    = isset( $_POST[ $posted_param ][ $index ] ) ? esc_url_raw( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
 			$posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_PRICE;
 			$price        = isset( $_POST[ $posted_param ][ $index ] ) ? wc_format_decimal( wc_clean( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) ) : '';
-			// $variation->update_meta_data( \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $description );
 			$variation->update_meta_data( Products::PRODUCT_IMAGE_SOURCE_META_KEY, $image_source );
 			$variation->update_meta_data( \WC_Facebook_Product::FB_MPN, $fb_mpn );
 			$variation->update_meta_data( \WC_Facebook_Product::FB_PRODUCT_IMAGE, $image_url );

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -30,7 +30,6 @@ class WC_Facebook_Product {
 
 	// Should match facebook-commerce.php while we migrate that code over
 	// to this object.
-	// const FB_PRODUCT_DESCRIPTION = 'fb_product_description';
 	const FB_PRODUCT_PRICE       = 'fb_product_price';
 	const FB_PRODUCT_IMAGE       = 'fb_product_image';
 	const FB_VARIANT_IMAGE       = 'fb_image';
@@ -337,18 +336,6 @@ class WC_Facebook_Product {
 		return null;
 	}
 
-	// public function set_description( $description ) {
-	// 	$description          = stripslashes(
-	// 		WC_Facebookcommerce_Utils::clean_string( $description )
-	// 	);
-	// 	$this->fb_description = $description;
-	// 	update_post_meta(
-	// 		$this->id,
-	// 		self::FB_PRODUCT_DESCRIPTION,
-	// 		$description
-	// 	);
-	// }
-
 	public function set_product_image( $image ) {
 		if ( $image !== null && strlen( $image ) !== 0 ) {
 			$image = WC_Facebookcommerce_Utils::clean_string( $image );
@@ -454,15 +441,6 @@ class WC_Facebook_Product {
 		if ( $this->fb_description ) {
 			$description = $this->fb_description;
 		}
-
-		// if ( empty( $description ) ) {
-		// 	// Try to get description from post meta
-		// 	$description = get_post_meta(
-		// 		$this->id,
-		// 		self::FB_PRODUCT_DESCRIPTION,
-		// 		true
-		// 	);
-		// }
 
 		// Check if the product type is a variation and no description is found yet
 		if ( empty( $description ) && WC_Facebookcommerce_Utils::is_variation_type( $this->woo_product->get_type() ) ) {
@@ -1146,7 +1124,6 @@ class WC_Facebook_Product {
 	 */
 	private function get_facebook_specific_fields(): array {
 		return array(
-			// 'has_fb_description' => (bool) get_post_meta($this->id, self::FB_PRODUCT_DESCRIPTION, true),
 			'has_fb_price'       => (bool) get_post_meta($this->id, self::FB_PRODUCT_PRICE, true),
 			'has_fb_image'       => (bool) get_post_meta($this->id, self::FB_PRODUCT_IMAGE, true)
 		);

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -495,7 +495,6 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 
 		$_POST[ WC_Facebook_Product::FB_REMOVE_FROM_SYNC ] = $product_to_delete->get_id();
 
-		// $_POST[ WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION ] = 'Facebook product description.';
 		$_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ]                   = '199';
 		$_POST['fb_product_image_source']                                 = 'Image source meta key value.';
 		$_POST[ WC_Facebook_Product::FB_PRODUCT_IMAGE ]                   = 'Facebook product image.';
@@ -563,7 +562,6 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 		$this->assertEquals(true, $updated_product_data['custom_fields']['has_fb_image']);
 
 		// Verify the actual values are still stored in meta
-		// $this->assertEquals( 'Facebook product description.', get_post_meta( $facebook_product_to_update->get_id(), WC_Facebook_Product::FB_PRODUCT_DESCRIPTION, true ) );
 		$this->assertEquals( '199', get_post_meta( $facebook_product_to_update->get_id(), WC_Facebook_Product::FB_PRODUCT_PRICE, true ) );
 		$this->assertEquals( 'http://example.orgFacebook product image.', get_post_meta( $facebook_product_to_update->get_id(), WC_Facebook_Product::FB_PRODUCT_IMAGE, true ) );
 	}

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -28,20 +28,6 @@ class fbproductTest extends WP_UnitTestCase {
 		$this->product->delete(true);
 	}
 
-	// /**
-	//  * Test it gets description from post meta.
-	//  * @return void
-	//  */
-	// public function test_get_fb_description_from_post_meta() {
-	// 	$product = WC_Helper_Product::create_simple_product();
-
-	// 	$facebook_product = new \WC_Facebook_Product( $product );
-	// 	$facebook_product->set_description( 'fb description' );
-	// 	$description = $facebook_product->get_fb_description();
-
-	// 	$this->assertEquals( $description, 'fb description');
-	// }
-
 	/**
 	 * Test it gets description from parent product if it is a variation.
 	 * @return void
@@ -103,29 +89,6 @@ class fbproductTest extends WP_UnitTestCase {
 		$description      = $facebook_product->get_fb_description();
 		$this->assertEquals( $description, get_post( $product->get_id() )->post_excerpt );
 	}
-
-	/**
-	 * Test it filters description.
-	 * @return void
-	 */
-	// public function test_filter_fb_description() {
-	// 	$product = WC_Helper_Product::create_simple_product();
-	// 	$facebook_product = new \WC_Facebook_Product( $product );
-	// 	$facebook_product->set_description( 'fb description' );
-
-	// 	add_filter( 'facebook_for_woocommerce_fb_product_description', function( $description ) {
-	// 		return 'filtered description';
-	// 	});
-
-	// 	$description = $facebook_product->get_fb_description();
-	// 	$this->assertEquals( $description, 'filtered description' );
-
-	// 	remove_all_filters( 'facebook_for_woocommerce_fb_product_description' );
-
-	// 	$description = $facebook_product->get_fb_description();
-	// 	$this->assertEquals( $description, 'fb description' );
-
-	// }
 
 	/**
 	 * Test Data Provider for sale_price related fields
@@ -533,7 +496,6 @@ class fbproductTest extends WP_UnitTestCase {
         $product_data = $this->fb_product->prepare_product();
 
         $this->assertArrayHasKey('custom_fields', $product_data);
-        // $this->assertEquals(false, $product_data['custom_fields']['has_fb_description']);
         $this->assertEquals(false, $product_data['custom_fields']['has_fb_price']);
         $this->assertEquals(false, $product_data['custom_fields']['has_fb_image']);
     }
@@ -551,7 +513,6 @@ class fbproductTest extends WP_UnitTestCase {
         $product_data = $this->fb_product->prepare_product();
 
         $this->assertArrayHasKey('custom_fields', $product_data);
-        // $this->assertEquals(true, $product_data['custom_fields']['has_fb_description']);
         $this->assertEquals(true, $product_data['custom_fields']['has_fb_price']);
         $this->assertEquals(true, $product_data['custom_fields']['has_fb_image']);
     }
@@ -565,21 +526,15 @@ class fbproductTest extends WP_UnitTestCase {
         $product_data = $this->fb_product->prepare_product();
 
         $this->assertArrayHasKey('custom_fields', $product_data);
-        // $this->assertEquals(true, $product_data['custom_fields']['has_fb_description']);
         $this->assertEquals(false, $product_data['custom_fields']['has_fb_price']);
         $this->assertEquals(false, $product_data['custom_fields']['has_fb_image']);
     }
 
     public function test_prepare_product_items_batch() {
         // Test the PRODUCT_PREP_TYPE_ITEMS_BATCH preparation type
-        $fb_description = 'Facebook specific description';
-
-        // update_post_meta($this->product->get_id(), WC_Facebook_Product::FB_PRODUCT_DESCRIPTION, $fb_description);
-
         $product_data = $this->fb_product->prepare_product(null, WC_Facebook_Product::PRODUCT_PREP_TYPE_ITEMS_BATCH);
 
         $this->assertArrayHasKey('custom_fields', $product_data);
-        // $this->assertEquals(true, $product_data['custom_fields']['has_fb_description']);
         $this->assertEquals(false, $product_data['custom_fields']['has_fb_price']);
         $this->assertEquals(false, $product_data['custom_fields']['has_fb_image']);
 


### PR DESCRIPTION
Before 
![Screenshot 2025-02-11 at 15 27 14](https://github.com/user-attachments/assets/be5a5a4b-d3c2-4998-bc33-f1ba97c8802c)
![Screenshot 2025-02-11 at 15 26 26](https://github.com/user-attachments/assets/73607575-1f8e-457e-b1f1-78abaeec5402)

After
<img width="1101" alt="Screenshot 2025-02-11 at 15 15 54" src="https://github.com/user-attachments/assets/5df96f71-d5e1-4d2a-bea6-35c28bd6cf50" />
<img width="787" alt="Screenshot 2025-02-11 at 15 31 18" src="https://github.com/user-attachments/assets/43dd8807-9b34-4090-be9b-d4bdbedbe5d9" />
