### PR TITLE
Enable code coverage report generation with phpunit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ wp-config.php
 
 # IDE files
 .vscode/*
+
+# Code coverage report
+/reports

--- a/README.md
+++ b/README.md
@@ -9,15 +9,24 @@ This is the development repository for the Facebook for WooCommerce plugin.
 - [User documentation](https://woocommerce.com/document/facebook-for-woocommerce/)
 
 ## Support
-The best place to get support is the [WordPress.org Facebook for WooCommerce forum](https://wordpress.org/support/plugin/facebook-for-woocommerce/).
 
-If you have a WooCommerce.com account, you can [search for help or submit a help request on WooCommerce.com](https://woocommerce.com/my-account/contact-support/).
+The best place to get support is
+the [WordPress.org Facebook for WooCommerce forum](https://wordpress.org/support/plugin/facebook-for-woocommerce/).
+
+If you have a WooCommerce.com account, you
+can [search for help or submit a help request on WooCommerce.com](https://woocommerce.com/my-account/contact-support/).
 
 ### Logging
-The plugin offers logging that can help debug various problems. You can enable debug mode in the main plugin settings panel under the `Enable debug mode` section.
-By default plugin omits headers in the requests to make the logs more readable. If debugging with headers is necessary you can enable the headers in the logs by setting `wc_facebook_request_headers_in_debug_log` option to true.
+
+The plugin offers logging that can help debug various problems. You can enable debug mode in the main plugin settings
+panel under the `Enable debug mode` section.
+By default plugin omits headers in the requests to make the logs more readable. If debugging with headers is necessary
+you can enable the headers in the logs by setting `wc_facebook_request_headers_in_debug_log` option to true.
+
 ## Development
+
 ### Developing
+
 - Clone this repository into the `wp-content/plugins/` folder your WooCommerce development environment.
 - Install dependencies:
 	- `npm install`
@@ -29,14 +38,18 @@ By default plugin omits headers in the requests to make the logs more readable. 
 - Testing:
 	- `./bin/install-wp-tests.sh <test-db-name> <db-user> <db-password> [db-host]` to set up testing environment
 	- `npm run test:php` to run PHP unit tests on all PHP files
+	- `./vendor/bin/phpunit --coverage-html=reports/coverage` to run PHP unit tests with coverage
 
 #### Production build
 
 - `npm run build` : Builds a production version.
 
 ### Releasing
-Refer to the [wiki for details of how to build and release the plugin](https://github.com/woocommerce/facebook-for-woocommerce/wiki/Build-&-Release).
+
+Refer to
+the [wiki for details of how to build and release the plugin](https://github.com/woocommerce/facebook-for-woocommerce/wiki/Build-&-Release).
 
 ### PHPCS Linting and PHP 8.1+
 
-We currently do not support PHPCS on PHP 8.1+ versions. Please run PHPCS checks on PHP 8.0 or lower versions. Refer [#2624 PR](https://github.com/woocommerce/facebook-for-woocommerce/pull/2624/) for additional context.
+We currently do not support PHPCS on PHP 8.1+ versions. Please run PHPCS checks on PHP 8.0 or lower versions.
+Refer [#2624 PR](https://github.com/woocommerce/facebook-for-woocommerce/pull/2624/) for additional context.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phpunit
-		bootstrap="tests/bootstrap.php"
-		backupGlobals="false"
-		colors="true"
-		convertErrorsToExceptions="true"
-		convertNoticesToExceptions="true"
-		convertWarningsToExceptions="true"
-		convertDeprecationsToExceptions="true"
-		defaultTestSuite="unit"
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	convertDeprecationsToExceptions="true"
+	defaultTestSuite="unit"
 >
 	<testsuites>
 		<testsuite name="unit">
@@ -17,4 +17,9 @@
 			<directory suffix=".php">./tests/integration</directory>
 		</testsuite>
 	</testsuites>
+	<coverage>
+		<include>
+			<directory>includes</directory>
+		</include>
+	</coverage>
 </phpunit>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The main change of this PR is adding a <coverage> section in phpunit.xml.dist. This change, along with a local installation of a code coverage driver (xdebug), are required to get the coverage report working.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

<img width="1524" alt="image" src="https://github.com/user-attachments/assets/870b0fc3-bf0d-4eeb-b956-e0f8e1e0b870" />



### Detailed test instructions:

1. pecl install xdebug-3.1.6
2. Add xdebug.mode = coverage to php.ini or set environment variable XDEBUG_MODE=coverage
3. `./vendor/bin/phpunit --coverage-html=reports/coverage`
4. open reports/coverage/index.html in web browser


### Changelog entry

> Enabled PHPUnit code coverage report generation
