### PR TITLE
[WIP] Fix undefined variable warning

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1260,7 +1260,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 *
 	 * @return string
 	 */
-	public function create_product_simple( WC_Facebook_Product $woo_product, string $fb_product_group_id = null ): string {
+	public function create_product_simple( WC_Facebook_Product $woo_product, ?string $fb_product_group_id = null ): string {
 		$retailer_id = WC_Facebookcommerce_Utils::get_fb_retailer_id( $woo_product );
 
 		if ( ! $fb_product_group_id ) {

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -323,6 +323,8 @@ class WC_Facebook_Product_Feed {
 		foreach ( $wp_ids as $wp_id ) {
 
 			$product = wc_get_product( $wp_id );
+			$fb_product_parent = null;
+
 			if ( $product instanceof WC_Product && $product->get_parent_id() ) {
 				$parent_product = wc_get_product( $product->get_parent_id() );
 				if ( $parent_product instanceof WC_Product ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

These updates address two warnings:
1. Variable `$fb_product_parent` undefined — this happens when the current product processed for the feed does not have a parent.
2. Variable `$fb_product_group_id` implicitly nullable — the declaration was updated to address this warning in newer versions of PHP.

TODO:
- Check for other instances of second item.
- Check if second item is/can be covered with automated tests.

- [ ] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
