### PR TITLE
Create tests for ProductFeedUploads create endpoint

### DIFF
--- a/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Create/ReponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Create/ReponseTest.php
@@ -1,0 +1,21 @@
+<?php
+declare( strict_types=1 );
+
+use WooCommerce\Facebook\API\ProductCatalog\ProductFeedUploads\Create\Response;
+
+/**
+ * Response unit test class.
+ */
+class ProductFeedUploadResponseTest extends WP_UnitTestCase {
+
+    /**
+     * @return void
+     */
+    public function test_response() {
+        $json = '{"id":"facebook-upload-id","data":{"upload_status":"success"}}';
+        $response = new Response($json);
+
+        $this->assertEquals('facebook-upload-id', $response->id);
+        $this->assertEquals('success', $response->data['upload_status']);
+    }
+}

--- a/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Create/ReponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Create/ReponseTest.php
@@ -12,10 +12,16 @@ class ProductFeedUploadResponseTest extends WP_UnitTestCase {
      * @return void
      */
     public function test_response() {
-        $json = '{"id":"facebook-upload-id","data":{"upload_status":"success"}}';
+        $json = '{
+            "id": "product_feed_upload_id",
+            "data": {
+                "upload_status": "success"
+            }
+        }';
+
         $response = new Response($json);
 
-        $this->assertEquals('facebook-upload-id', $response->id);
+        $this->assertEquals('product_feed_upload_id', $response->id);
         $this->assertEquals('success', $response->data['upload_status']);
     }
 }

--- a/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Create/RequestTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Create/RequestTest.php
@@ -1,0 +1,30 @@
+<?php
+declare( strict_types=1 );
+
+use WooCommerce\Facebook\API\ProductCatalog\ProductFeedUploads\Create\Request;
+
+/**
+ * Request unit test class.
+ */
+class ProductFeedUploadRequestTest extends WP_UnitTestCase {
+
+    /**
+     * @return void
+     */
+    public function test_request() {
+        $product_feed_id = 'facebook-product-feed-id';
+        $data = [
+            'name' => 'Test Product Feed',
+            'schedule' => [
+                'interval' => 'DAILY',
+                'url' => 'http://example.com/feed.xml',
+            ],
+        ];
+
+        $request = new Request($product_feed_id, $data);
+
+        $this->assertEquals('POST', $request->get_method());
+        $this->assertEquals('/facebook-product-feed-id/uploads', $request->get_path());
+        $this->assertEquals($data, $request->get_data());
+    }
+}

--- a/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Create/RequestTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Create/RequestTest.php
@@ -12,7 +12,7 @@ class ProductFeedUploadRequestTest extends WP_UnitTestCase {
      * @return void
      */
     public function test_request() {
-        $product_feed_id = 'facebook-product-feed-id';
+        $product_feed_id = 'product_feed_upload_id';
         $data = [
             'name' => 'Test Product Feed',
             'schedule' => [
@@ -24,7 +24,7 @@ class ProductFeedUploadRequestTest extends WP_UnitTestCase {
         $request = new Request($product_feed_id, $data);
 
         $this->assertEquals('POST', $request->get_method());
-        $this->assertEquals('/facebook-product-feed-id/uploads', $request->get_path());
+        $this->assertEquals('/product_feed_upload_id/uploads', $request->get_path());
         $this->assertEquals($data, $request->get_data());
     }
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces unit tests for the `Request` and `Response` classes in the `WooCommerce\Facebook\API\ProductCatalog\ProductFeedUploads\Create` namespace. These tests ensure that the classes behave as expected when handling API requests and responses for creating product feed uploads.

### Detailed test instructions:
1. Run the unit tests using the WordPress testing framework to ensure they pass successfully.
2. Verify that the `Request` test checks the HTTP method, path, and data properties.
3. Verify that the `Response` test checks the `id` and `data` properties for correct parsing.