### PR TITLE
Create tests for ProductFeedUploads read endpoint

### DIFF
--- a/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Read/RequestTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Read/RequestTest.php
@@ -1,0 +1,23 @@
+<?php
+declare( strict_types=1 );
+
+use WooCommerce\Facebook\API\ProductCatalog\ProductFeedUploads\Read\Request;
+
+/**
+ * Request unit test class for reading product feed uploads.
+ */
+class ProductFeedUploadReadRequestTest extends WP_UnitTestCase {
+
+    /**
+     * @return void
+     */
+    public function test_request() {
+        $product_feed_upload_id = 'facebook-upload-id';
+        $request = new Request($product_feed_upload_id);
+
+        $expected_path = '/facebook-upload-id/?fields=error_count,warning_count,num_detected_items,num_persisted_items,url,end_time';
+
+        $this->assertEquals('GET', $request->get_method());
+        $this->assertEquals($expected_path, $request->get_path());
+    }
+}

--- a/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Read/RequestTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Read/RequestTest.php
@@ -12,10 +12,10 @@ class ProductFeedUploadReadRequestTest extends WP_UnitTestCase {
      * @return void
      */
     public function test_request() {
-        $product_feed_upload_id = 'facebook-upload-id';
+        $product_feed_upload_id = 'product_feed_upload_id';
         $request = new Request($product_feed_upload_id);
 
-        $expected_path = '/facebook-upload-id/?fields=error_count,warning_count,num_detected_items,num_persisted_items,url,end_time';
+        $expected_path = '/product_feed_upload_id/?fields=error_count,warning_count,num_detected_items,num_persisted_items,url,end_time';
 
         $this->assertEquals('GET', $request->get_method());
         $this->assertEquals($expected_path, $request->get_path());

--- a/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Read/ResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Read/ResponseTest.php
@@ -1,0 +1,33 @@
+<?php
+declare( strict_types=1 );
+
+use WooCommerce\Facebook\API\ProductCatalog\ProductFeedUploads\Read\Response;
+
+/**
+ * Response unit test class for reading product feed uploads.
+ */
+class ProductFeedUploadReadResponseTest extends WP_UnitTestCase {
+
+    /**
+     * @return void
+     */
+    public function test_response() {
+        $json = '{
+            "error_count": 0,
+            "warning_count": 2,
+            "num_detected_items": 100,
+            "num_persisted_items": 98,
+            "url": "http://example.com/feed.xml",
+            "end_time": "2023-10-01T12:00:00+0000"
+        }';
+
+        $response = new Response($json);
+
+        $this->assertEquals(0, $response->data['error_count']);
+        $this->assertEquals(2, $response->data['warning_count']);
+        $this->assertEquals(100, $response->data['num_detected_items']);
+        $this->assertEquals(98, $response->data['num_persisted_items']);
+        $this->assertEquals('http://example.com/feed.xml', $response->data['url']);
+        $this->assertEquals('2023-10-01T12:00:00+0000', $response->data['end_time']);
+    }
+}

--- a/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Read/ResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Read/ResponseTest.php
@@ -13,16 +13,20 @@ class ProductFeedUploadReadResponseTest extends WP_UnitTestCase {
      */
     public function test_response() {
         $json = '{
-            "error_count": 0,
-            "warning_count": 2,
-            "num_detected_items": 100,
-            "num_persisted_items": 98,
-            "url": "http://example.com/feed.xml",
-            "end_time": "2023-10-01T12:00:00+0000"
+            "id": "product_feed_upload_id",
+            "data": {
+                "error_count": 0,
+                "warning_count": 2,
+                "num_detected_items": 100,
+                "num_persisted_items": 98,
+                "url": "http://example.com/feed.xml",
+                "end_time": "2023-10-01T12:00:00+0000"
+            }
         }';
 
         $response = new Response($json);
 
+        $this->assertEquals('product_feed_upload_id', $response->id);
         $this->assertEquals(0, $response->data['error_count']);
         $this->assertEquals(2, $response->data['warning_count']);
         $this->assertEquals(100, $response->data['num_detected_items']);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces unit tests for the `Request` and `Response` classes in the `WooCommerce\Facebook\API\ProductCatalog\ProductFeedUploads\Read` namespace. These tests ensure that the classes behave as expected when handling API requests and responses for reading product feed uploads.

### Detailed test instructions:
1. Run the unit tests using the WordPress testing framework to ensure they pass successfully.
2. Verify that the `Request` test checks the HTTP method and path properties.
3. Verify that the `Response` test checks the `data` properties for correct parsing.