### PR TITLE
[WIP] Create tests for custom checkout permalink

### DIFF
--- a/tests/Unit/CheckoutTest.php
+++ b/tests/Unit/CheckoutTest.php
@@ -1,0 +1,106 @@
+<?php
+declare( strict_types=1 );
+
+use WooCommerce\Facebook\Checkout;
+
+/**
+ * Checkout unit test class.
+ */
+class CheckoutTest extends WP_UnitTestCase {
+
+    /**
+     * The Checkout instance being tested.
+     *
+     * @var Checkout
+     */
+    protected $checkout;
+
+    /**
+     * Sets up the test environment.
+     *
+     * @return void
+     */
+    protected function setUp(): void {
+        $this->checkout = new Checkout();
+    }
+
+    /**
+     * Tests if hooks are added correctly.
+     *
+     * @return void
+     */
+    public function testAddHooks() {
+        $this->assertNotFalse(has_action('init', array($this->checkout, 'add_checkout_permalink_rewrite_rule')));
+        $this->assertNotFalse(has_filter('query_vars', array($this->checkout, 'add_checkout_permalink_query_var')));
+        $this->assertNotFalse(has_filter('template_include', array($this->checkout, 'load_checkout_permalink_template')));
+    }
+
+    /**
+     * Tests if the checkout permalink rewrite rule is added.
+     *
+     * @return void
+     */
+    public function testAddCheckoutPermalinkRewriteRule() {
+        do_action('init');
+
+        global $wp_rewrite;
+        $rules = $wp_rewrite->wp_rewrite_rules();
+        $this->assertArrayHasKey('^fb-checkout/?$', $rules);
+    }
+
+    /**
+     * Tests if the checkout permalink query vars are added.
+     *
+     * @return void
+     */
+    public function testAddCheckoutPermalinkQueryVar() {
+        $vars = apply_filters('query_vars', array());
+
+        $this->assertContains('fb_checkout', $vars);
+        $this->assertContains('products', $vars);
+        $this->assertContains('coupon', $vars);
+    }
+
+    /**
+     * Tests if the checkout permalink template is loaded.
+     *
+     * @return void
+     */
+    public function testLoadCheckoutPermalinkTemplate() {
+        $this->mockFunction('get_query_var', function($var) {
+            $values = [
+                'fb_checkout' => 1,
+                'products' => '1:2,3:4',
+                'coupon' => 'DISCOUNT10'
+            ];
+            return $values[$var] ?? null;
+        });
+
+        $cart = $this->createMock(WC_Cart::class);
+        $cart->expects($this->once())->method('empty_cart');
+        $cart->expects($this->exactly(2))->method('add_to_cart')->withConsecutive(
+            [1, 2],
+            [3, 4]
+        );
+        $cart->expects($this->once())->method('apply_coupon')->with('DISCOUNT10');
+
+        WC()->cart = $cart;
+
+        ob_start();
+        $this->checkout->load_checkout_permalink_template();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Templates/CheckoutTemplate.php', $output);
+    }
+
+    /**
+     * Mocks a global function.
+     *
+     * @param string $functionName The name of the function to mock.
+     * @param callable $callback The callback to use as the mock.
+     * @return void
+     */
+    protected function mockFunction($functionName, $callback) {
+        runkit_function_redefine($functionName, '', $callback);
+    }
+}

--- a/tests/Unit/CheckoutTest.php
+++ b/tests/Unit/CheckoutTest.php
@@ -9,70 +9,82 @@ use WooCommerce\Facebook\Checkout;
 class CheckoutTest extends WP_UnitTestCase {
 
     /**
-     * Checkout instance being tested.
+     * Instance of the Checkout class.
      *
      * @var Checkout
      */
-    private $checkout;
+    protected $checkout;
 
     /**
-     * Sets up the test case.
+     * Set up the test environment.
+     *
+     * @return void
      */
     public function setUp(): void {
         parent::setUp();
         $this->checkout = new Checkout();
+        $this->checkout->add_checkout_permalink_rewrite_rule();
+
+        flush_rewrite_rules();
     }
 
     /**
-     * Tests that hooks are added correctly.
+     * Test if hooks are added correctly.
+     *
+     * @return void
      */
-    public function test_add_hooks() {
-        $this->assertTrue(has_action('init', [$this->checkout, 'add_checkout_permalink_rewrite_rule']) !== false);
-        $this->assertTrue(has_filter('query_vars', [$this->checkout, 'add_checkout_permalink_query_var']) !== false);
-        $this->assertTrue(has_filter('template_include', [$this->checkout, 'load_checkout_permalink_template']) !== false);
+    public function test_hooks_are_added() {
+        $this->assertGreaterThan(0, has_action('init', [$this->checkout, 'add_checkout_permalink_rewrite_rule']));
+        $this->assertGreaterThan(0, has_filter('query_vars', [$this->checkout, 'add_checkout_permalink_query_var']));
+        $this->assertGreaterThan(0, has_filter('template_include', [$this->checkout, 'load_checkout_permalink_template']));
     }
 
     /**
-     * Tests that query vars are added correctly.
+     * Test if query vars are added correctly.
+     *
+     * @return void
      */
     public function test_add_checkout_permalink_query_var() {
-        $vars = ['existing_var'];
-        $new_vars = $this->checkout->add_checkout_permalink_query_var($vars);
+        $vars = apply_filters('query_vars', []);
 
-        $this->assertContains('fb_checkout', $new_vars);
-        $this->assertContains('products', $new_vars);
-        $this->assertContains('coupon', $new_vars);
+        $this->assertContains('fb_checkout', $vars);
+        $this->assertContains('products', $vars);
+        $this->assertContains('coupon', $vars);
     }
 
     /**
-     * Tests that the rewrite rule is added correctly.
+     * Test if rewrite rules are added correctly.
+     *
+     * @return void
      */
     public function test_add_checkout_permalink_rewrite_rule() {
         global $wp_rewrite;
-        $this->checkout->add_checkout_permalink_rewrite_rule();
+
+        $wp_rewrite->flush_rules();
         $rules = $wp_rewrite->wp_rewrite_rules();
 
+        $this->assertIsArray($rules, 'Rewrite rules should be an array');
         $this->assertArrayHasKey('^fb-checkout/?$', $rules);
         $this->assertEquals('index.php?fb_checkout=1', $rules['^fb-checkout/?$']);
     }
 
     /**
-     * Tests that the flush rewrite rules are called on activation.
+     * Test if rewrite rules are flushed on activation.
+     *
+     * @return void
      */
     public function test_flush_rewrite_rules_on_activation() {
         $this->checkout->flush_rewrite_rules_on_activation();
-        // Assuming flush_rewrite_rules() is a global function, we can't directly test its effect here.
-        // You would need to mock or spy on this function to verify it was called.
-        $this->assertTrue(true);
+        $this->assertTrue(did_action('flush_rewrite_rules'));
     }
 
     /**
-     * Tests that the flush rewrite rules are called on deactivation.
+     * Test if rewrite rules are flushed on deactivation.
+     *
+     * @return void
      */
     public function test_flush_rewrite_rules_on_deactivation() {
         $this->checkout->flush_rewrite_rules_on_deactivation();
-        // Assuming flush_rewrite_rules() is a global function, we can't directly test its effect here.
-        // You would need to mock or spy on this function to verify it was called.
-        $this->assertTrue(true);
+        $this->assertTrue(did_action('flush_rewrite_rules'));
     }
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces unit tests for the custom checkout permalink in the `WooCommerce\Facebook\Checkout` namespace. These tests ensure that the class behaves as expected when handling hooks, rewrite rules, and query variables. It also ensures that the correct checkout experience is loaded.

### Detailed test instructions:
1. Run the unit tests using the WordPress testing framework to ensure they pass successfully.
2. Verify that the hooks were added correctly.
3. Verify that the rewrite rules were registered correctly.
4. Verify that the query parameters were parsed correctly.
5. Verify that the correct checkout experience is loaded.