### PR TITLE
[WAUM][2/n] Link the connect whatsapp button to Hosted ES flow

### DIFF
--- a/assets/js/admin/whatsapp-connection.js
+++ b/assets/js/admin/whatsapp-connection.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+jQuery( document ).ready( function( $ ) {
+    // handle the whatsapp connect button click should open hosted ES flow
+	$( '#woocommerce-whatsapp-connection' ).click( function( event ) {
+        // dummy values for app id and config id, will be replaced in upcoming diffs
+        const APP_ID = '18402284156271';
+        const CONFIG_ID = '17502287264684';
+        const HOSTED_ES_URL = `https://business.facebook.com/messaging/whatsapp/onboard/?app_id=${APP_ID}&config_id=${CONFIG_ID}`;
+        window.open( HOSTED_ES_URL);
+    });
+
+} );

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -57,6 +57,12 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 		}
 
 		wp_enqueue_style( 'wc-facebook-admin-whatsapp-settings', facebook_for_woocommerce()->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css', array(), \WC_Facebookcommerce::VERSION );
+		wp_enqueue_script(
+			'facebook-for-woocommerce-connect-whatsapp',
+			facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/whatsapp-connection.js',
+			array( 'jquery', 'jquery-blockui', 'jquery-tiptip', 'wc-enhanced-select' ),
+			\WC_Facebookcommerce::PLUGIN_VERSION
+		);
 	}
 
 
@@ -69,9 +75,13 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 
 		?>
 	<div class="onboarding-card">
-		<h2>Get started with WhatsApp utility messages</h2>
-		<p>Connect your WhatsApp Business Account to start sending utility messages.</p>
-		<button class="connect-button">Connect WhatsApp Account</button>
+	<h2><?php esc_html_e( 'Get started with WhatsApp utility messages', 'facebook-for-woocommerce' ); ?></h2>
+	<p><?php esc_html_e( 'Connect your WhatsApp Business Account to start sending utility messages.', 'facebook-for-woocommerce' ); ?></p>
+	<a
+			id="woocommerce-whatsapp-connection"
+			class="connect-button"
+			href="#"
+		><?php esc_html_e( 'Connect Whatsapp Account', 'facebook-for-woocommerce' ); ?></a>
 	</div>
 		<?php
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,32 +3,33 @@ const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 
 // Legacy jQuery UI powered admin files
 const jQueryUIAdminFileNames = [
-	'google-product-category-fields',
-	'infobanner',
-	'metabox',
-	'modal',
-	'product-categories',
-	'product-sets-admin',
-	'products-admin',
-	'settings-commerce',
-	'settings-sync',
+    'google-product-category-fields',
+    'infobanner',
+    'metabox',
+    'modal',
+    'product-categories',
+    'product-sets-admin',
+    'products-admin',
+    'settings-commerce',
+    'settings-sync',
+    'whatsapp-connection',
 ];
 
 const jQueryUIAdminFileEntries = {};
 
 jQueryUIAdminFileNames.forEach( ( name ) => {
-	jQueryUIAdminFileEntries[ `admin/${ name }` ] = `./assets/js/admin/${ name }.js`;
+    jQueryUIAdminFileEntries[ `admin/${ name }` ] = `./assets/js/admin/${ name }.js`;
 } );
 
 module.exports = {
-	...defaultConfig,
-	entry: {
-		// Use admin/index.js for any new React-powered UI
-		'admin/index': './assets/js/admin/index.js',
-		...jQueryUIAdminFileEntries,
-	},
-	output: {
-		filename: '[name].js',
-		path: __dirname + '/assets/build',
-	},
+    ...defaultConfig,
+    entry: {
+        // Use admin/index.js for any new React-powered UI
+        'admin/index': './assets/js/admin/index.js',
+        ...jQueryUIAdminFileEntries,
+    },
+    output: {
+        filename: '[name].js',
+        path: __dirname + '/assets/build',
+    },
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Link the "Connect Whatsapp Account" button to Hosted ES flow.


### Screenshots:

[<!--- Optional --->](https://github.com/user-attachments/assets/830a69b1-279b-4cce-9026-fe63bf7db5b7)


### Detailed test instructions:

1. Select the Whatsapp Utility
2. Click on "Connect Whatsapp Account"
3. Verify it opens Hosted Embedded SIgn up flow


### Additional details:
> Hosted ES flow currently fails but that is not relevant to this diff and will be fixed in follow up diffs
