### PR TITLE
Update README.md - Added noification for ownership transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
-# Facebook for WooCommerce
+# The Facebook for WooCommerce plugin is now an official app from Meta.
 
 [![PHP Coding Standards](https://github.com/woocommerce/facebook-for-woocommerce/actions/workflows/php-cs-on-changes.yml/badge.svg)](https://github.com/woocommerce/facebook-for-woocommerce/actions/workflows/php-coding-standards.yml)
 
-This is the development repository for the Facebook for WooCommerce plugin.
+**We're excited to announce that the app is now owned by Meta, and we invite the developer community to join us in shaping its future through contributions.**
+
+Grow your business on Facebook and Instagram. Easily promote your products and target accurately using powerful sales and marketing tools. Reach new customers and drive traffic to your website with seamless ad experiences, from discovery to conversion. Automatically sync your eligible products to your Meta catalog, so you can easily create ads right where your customers are.
+- Help drive better ad performance by setting up a conversion pixel
+- Easily set up your ads with a one-time account connection
+- Sell from one inventory that automatically syncs to your catalog used for ads
+
+
+### This is the development repository for the Facebook for WooCommerce plugin.
 
 - [WooCommerce.com product page](https://woocommerce.com/products/facebook/)
 - [WordPress.org plugin page](https://wordpress.org/plugins/facebook-for-woocommerce/)


### PR DESCRIPTION
This is a update to notify developers that the facebook-for-woocommerce plugin is now part of Meta and development is taken care by the engineers at Meta. We also have encouraged for contributions on this repo.

### Changes proposed in this Pull Request:

This PR contains mostly the changes around **README.md**.
Since mostly developers of any kind prefer looking at the **README** of a GitHub repo.
We have now changed the README emphasising the changes of the new **Owneship of the plugin** by Meta.
And the invitation for **opensource community** for their contributions.

### Screenshots:

![image](https://github.com/user-attachments/assets/6f6ee04d-3fcf-40a1-88e4-0a2d4c8f021b)


Pull Request resolved: https://github.com/facebook/facebook-for-woocommerce/pull/2910
GitHub Author: Sayan Pandey <sayanpandey@meta.com>