### PR TITLE
Changing APP to PLUGIN - README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# The Facebook for WooCommerce plugin is now an official app from Meta.
+# Facebook for WooCommerce is now an official plugin from Meta.
 
 [![PHP Coding Standards](https://github.com/woocommerce/facebook-for-woocommerce/actions/workflows/php-cs-on-changes.yml/badge.svg)](https://github.com/woocommerce/facebook-for-woocommerce/actions/workflows/php-coding-standards.yml)
 
-**We're excited to announce that the app is now owned by Meta, and we invite the developer community to join us in shaping its future through contributions.**
+**We're excited to announce that the plugin is now owned by Meta, and we invite the developer community to join us in shaping its future through contributions.**
 
 Grow your business on Facebook and Instagram. Easily promote your products and target accurately using powerful sales and marketing tools. Reach new customers and drive traffic to your website with seamless ad experiences, from discovery to conversion. Automatically sync your eligible products to your Meta catalog, so you can easily create ads right where your customers are.
 - Help drive better ad performance by setting up a conversion pixel


### PR DESCRIPTION
Changing the app word to plugin to more suit with the idea of facebook-for-woocommerce

### Changes proposed in this Pull Request:

This is a simple change of APP to PLUGIN in README.md text .
