### PR TITLE
Items batch request and response tests

### DIFF
--- a/tests/Unit/Api/ProductCatalog/ItemsBatch/Create/RequestTest.php
+++ b/tests/Unit/Api/ProductCatalog/ItemsBatch/Create/RequestTest.php
@@ -1,0 +1,37 @@
+<?php
+declare( strict_types=1 );
+
+namespace Api\ProductCatalog\ItemsBatch\Create;
+
+use WooCommerce;
+use WP_UnitTestCase;
+
+/**
+ * Test cases for Items Batch create API request
+ */
+class RequestTest extends WP_UnitTestCase {
+	/**
+	 * Tests request endpoint config
+	 *
+	 * @return void
+	 */
+	public function test_request(): void {
+		$product_catalog_id = 'facebook-product-catalog-id';
+		$requests           = [
+			[
+				'method' => 'CREATE',
+				'data'   => [
+					'retailer_id' => 'product-123',
+					'name'        => 'Test Product',
+					'price'       => '19.99 USD',
+				],
+			],
+		];
+
+		$request = new WooCommerce\Facebook\API\ProductCatalog\ItemsBatch\Create\Request( $product_catalog_id, $requests );
+
+		$this->assertEquals( 'POST', $request->get_method() );
+		$this->assertEquals( '/' . $product_catalog_id . '/items_batch', $request->get_path() );
+		$this->assertEquals( $requests, $request->get_data()['requests'] );
+	}
+}

--- a/tests/Unit/Api/ProductCatalog/ItemsBatch/Create/ResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ItemsBatch/Create/ResponseTest.php
@@ -1,0 +1,26 @@
+<?php
+declare( strict_types=1 );
+
+namespace Api\ProductCatalog\ItemsBatch\Create;
+
+use WooCommerce;
+use WP_UnitTestCase;
+
+/**
+ * Test cases for Items Batch create API response
+ */
+class ResponseTest extends WP_UnitTestCase {
+	/**
+	 * Tests response endpoint config
+	 *
+	 * @return void
+	 */
+	public function test_response(): void {
+		$json = '{"handles": ["items_1", "item_2", "item_3"],"validation_status": ["success"]}';
+
+		$response = new WooCommerce\Facebook\API\ProductCatalog\ItemsBatch\Create\Response ( $json );
+
+		$this->assertEquals( [ "items_1", "item_2", "item_3" ], $response->handles );
+		$this->assertEquals( [ "success" ], $response->validation_status );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This PR introduces unit tests for the Request and Response classes in the WooCommerce\Facebook\API\ProductCatalog\ItemsBatch\Create namespace. These tests ensure that the classes behave as expected when handling API requests and responses for creating items batches.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:
![Screenshot 2025-03-03 at 12 21 33 PM](https://github.com/user-attachments/assets/22bab0d4-50e4-4de7-8d5e-c4692e1ac9a7)

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Run the unit tests with "./vendor/bin/phpunit tests/Unit/Api/ProductCatalog/ItemsBatch/Create" to verify that they pass