### PR TITLE
Include root directory files in code coverage report

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,12 @@
 	<coverage>
 		<include>
 			<directory>includes</directory>
+			<file>./class-wc-facebookcommerce.php</file>
+			<file>./facebook-commerce-events-tracker.php</file>
+			<file>./facebook-commerce-pixel-event.php</file>
+			<file>./facebook-commerce.php</file>
+			<file>./facebook-config-warmer.php</file>
+			<file>./facebook-for-woocommerce.php</file>
 		</include>
 	</coverage>
 </phpunit>


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Our code coverage report currently only runs for files in the `includes` directory. We do have tests, however, for some of the files in the root directory and should be tracking the coverage for those as well.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

<img width="2543" alt="image" src="https://github.com/user-attachments/assets/c57fb69d-ca5a-42e4-9916-389e34e0820a" />



### Detailed test instructions:
vendor/bin/phpunit --coverage-html=reports/coverage 

### Changelog entry
Including root directory php files in phpunit code coverage report

>
