### PR TITLE
phpcs hotfix

### DIFF
--- a/includes/Framework/Utilities/AsyncRequest.php
+++ b/includes/Framework/Utilities/AsyncRequest.php
@@ -87,6 +87,8 @@ abstract class AsyncRequest {
 
 		// Check if a child class has defined this property for custom query args
 		if ( property_exists( $this, 'query_args' ) ) {
+			// Dynamic property; not defined in the parent class, and not a true lint error
+			// phpcs:ignore 
 			return $this->query_args;
 		}
 
@@ -107,6 +109,8 @@ abstract class AsyncRequest {
 
 		// Check if a child class has defined this property for a custom URL
 		if ( property_exists( $this, 'query_url' ) ) {
+			// Dynamic property; not defined in the parent class, and not a true lint error
+			// phpcs:ignore 
 			return $this->query_url;
 		}
 
@@ -126,6 +130,8 @@ abstract class AsyncRequest {
 
 		// Check if a child class has defined this property for custom request args
 		if ( property_exists( $this, 'request_args' ) ) {
+			// Dynamic property; not defined in the parent class, and not a true lint error
+			// phpcs:ignore 
 			return $this->request_args;
 		}
 

--- a/includes/Framework/Utilities/AsyncRequest.php
+++ b/includes/Framework/Utilities/AsyncRequest.php
@@ -35,16 +35,6 @@ abstract class AsyncRequest {
 	/** @var array request data */
 	protected $data = [];
 
-	/** @var array query arguments */
-	protected $query_args;
-
-	/** @var string query URL */
-	protected $query_url;
-
-	/** @var array request arguments */
-	protected $request_args;
-
-
 	/**
 	 * Initiate a new async request
 	 *


### PR DESCRIPTION


# PR Summary
This PR reverts the addition of explicit property declarations in the AsyncRequest class.

We were seeing lint failures due to accessing an undefined property on the class. 

The original code relied on property_exists() checks to determine if child classes had defined custom properties for query arguments, URL, and request arguments. 

To fix the lint complaints, these variables were set to "null | undefined" on the class to indicate they were present but unused unless overridden dynamically. 

However, explicitly declaring these properties in the parent class, broke this logic since property_exists() now always returns true for these properties, even when they're null.

This change restores the original dynamic property behavior, allowing child classes to optionally define these properties while maintaining the parent class's fallback logic.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
