### PR TITLE
Updating some MBE params used by MiCE solution

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -955,7 +955,7 @@ class Connection {
 	 *
 	 * @return string
 	 */
-	private function get_timezone_string() {
+	public function get_timezone_string() {
 		$timezone = wc_timezone_string();
 		// convert +05:30 and +05:00 into Etc/GMT+5 - we ignore the minutes because Facebook does not allow minute offsets
 		if ( preg_match( '/([+-])(\d{2}):\d{2}/', $timezone, $matches ) ) {

--- a/includes/Handlers/MetaExtension.php
+++ b/includes/Handlers/MetaExtension.php
@@ -25,13 +25,11 @@ use WP_Error;
 class MetaExtension {
 
 	/** @var string Client token */
-	const CLIENT_TOKEN = '195311308289826|52dcd04d6c7ed113121b5eb4be23b4a7';
+	const CLIENT_TOKEN = '474166926521348|92e978eb27baf47f9df578b48d430a2e';
 	const APP_ID       = '474166926521348';
-	/** @var string Business name */
-	const BUSINESS_NAME = 'WooCommerce';
 
 	/** @var string API version */
-	const API_VERSION = 'v18.0';
+	const API_VERSION = 'v22.0';
 
 	/** @var string Commerce Hub base URL */
 	const COMMERCE_HUB_URL = 'https://www.commercepartnerhub.com/';
@@ -422,13 +420,15 @@ class MetaExtension {
 	 * @param string $external_business_id External business ID.
 	 * @return string
 	 */
-	public static function generate_iframe_splash_url( $is_connected, $plugin, $external_business_id ) {
+	public static function generate_iframe_splash_url( $is_connected, $plugin, $external_business_id ): string {
+		$connection_handler       = facebook_for_woocommerce()->get_connection_handler();
 		$external_client_metadata = array(
-			'shop_domain'                           => wc_get_page_permalink( 'shop' ) ? wc_get_page_permalink( 'shop' ) : \home_url(),
+			'shop_domain'                           => wc_get_page_permalink( 'shop' ),
 			'admin_url'                             => admin_url(),
 			'client_version'                        => $plugin->get_version(),
 			'commerce_partner_seller_platform_type' => 'SELF_SERVE_PLATFORM',
 			'country_code'                          => WC()->countries->get_base_country(),
+			'platform_store_id'                     => get_current_blog_id(),
 		);
 		return add_query_arg(
 			array(
@@ -436,9 +436,9 @@ class MetaExtension {
 				'business_vertical'        => 'ECOMMERCE',
 				'channel'                  => 'COMMERCE',
 				'app_id'                   => Connection::CLIENT_ID,
-				'business_name'            => self::BUSINESS_NAME,
+				'business_name'            => rawurlencode( $connection_handler->get_business_name() ),
 				'currency'                 => get_woocommerce_currency(),
-				'timezone'                 => 'America/Los_Angeles',
+				'timezone'                 => $connection_handler->get_timezone_string(),
 				'external_business_id'     => $external_business_id,
 				'installed'                => $is_connected,
 				'external_client_metadata' => rawurlencode( wp_json_encode( $external_client_metadata ) ),

--- a/tests/Unit/Handlers/MetaExtensionTest.php
+++ b/tests/Unit/Handlers/MetaExtensionTest.php
@@ -38,11 +38,12 @@ class MetaExtensionTest extends WP_UnitTestCase {
         $plugin = facebook_for_woocommerce();
         
         $url = MetaExtension::generate_iframe_splash_url(true, $plugin, 'test_business_id');
+        $handler = facebook_for_woocommerce()->get_connection_handler();
 
         // Assert URL contains expected parameters
         $this->assertStringContainsString('access_client_token=' . MetaExtension::CLIENT_TOKEN, $url);
         $this->assertStringContainsString('app_id=', $url);
-        $this->assertStringContainsString('business_name=' . urlencode(MetaExtension::BUSINESS_NAME), $url);
+        $this->assertStringContainsString('business_name=' . rawurlencode($handler->get_business_name()), $url);
         $this->assertStringContainsString('external_business_id=test_business_id', $url);
         $this->assertStringContainsString('installed=1', $url);
         $this->assertStringContainsString('external_client_metadata=', $url);


### PR DESCRIPTION
1. Modifying some params used by MiCE solution.
   a. Default Business name -> something meaningful
   b. Timezone to non-fixed timezone
   c. Update the client token to actually Woo's token. It was using Magento's token
   d. Adding platform_store_id
2. Also updated the API version: V18 -> V22


Testing:
```
./vendor/bin/phpunit tests/Unit/Handlers/MetaExtensionTest.php

Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
Installing WooCommerce...
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
PHPUnit 9.6.19 by Sebastian Bergmann and contributors.

.......                                                             7 / 7 (100%)

Time: 00:00.656, Memory: 95.00 MB
```

Manual test:
<img width="1530" alt="image" src="https://github.com/user-attachments/assets/eb3975c3-ac5f-4e3d-a604-d1e255756a96" />
Resulting URL:
```
{
  "client_id": 474166926521348,
  "display": "popup",
  "extras": {
    "business_config": {
      "business": {
        "name": "WooMeta"
      }
    },
    "repeat": false,
    "setup": {
      "business_vertical": "ECOMMERCE",
      "channel": "COMMERCE",
      "currency": "USD",
      "domain": "http://localhost:10009/",
      "external_business_id": "woometa-67bd40a6d219d",
      "external_client_metadata": {
        "admin_url": "http://localhost:10009/wp-admin/",
        "client_version": "3.4.1",
        "commerce_partner_seller_platform_type": "SELF_SERVE_PLATFORM",
        "country_code": "US",
        "feature_set_eligibility": "SHOP_FIRST",
        "platform_store_id": "1",
        "shop_domain": "http://localhost:10009/shop/"
      },
      "timezone": " 00:00"
    }
  },
  "redirect_uri": "https://www.commercepartnerhub.com/commerce_extension/splash/oauth_redirect_handler/",
  "response_type": "token",
  "scope": "manage_business_extension,business_management,ads_management,pages_read_engagement,catalog_management",
  "state": "648eb712-3a11-4e67-9abc-ab4d3228981a"
}
```