### PR TITLE
Always run PHP-based github workflows

### DIFF
--- a/.github/workflows/php-cs-on-changes.yml
+++ b/.github/workflows/php-cs-on-changes.yml
@@ -1,10 +1,8 @@
 name: PHP Coding Standards - PR Changed Files
 
 on:
-  pull_request:
-    paths:
-      - "**.php"
-      - .github/workflows/php-cs-on-changes.yml
+  pull_request: { }
+  # run on all PRs
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,7 +14,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        php: [7.4, 8.3]
+        php: [ 7.4, 8.3 ]
     name: Code sniff (PHP ${{ matrix.php }}, WP Latest)
     permissions:
       contents: read
@@ -45,3 +43,7 @@ jobs:
       - name: Run PHPCS
         if: steps.changed-files.outputs.any_changed == 'true'
         run: vendor/bin/phpcs-changed --warning-severity=0 -s --git --git-base ${{ github.event.pull_request.base.sha }} ${{ steps.changed-files.outputs.all_changed_files }}
+
+      - name: Skip PHPCS - No PHP Files Updated
+        if: steps.changed-files.outputs.any_changed != 'true'
+        run: echo "No PHP files changed; skipping PHPCS checks."

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -1,21 +1,8 @@
 name: PHP Unit Tests
 
 on:
-  push:
-    branches:
-      - trunk
-      - develop
-    paths:
-      - "**.php"
-      - composer.json
-      - composer.lock
-      - .github/workflows/php-unit-tests.yml
-  pull_request:
-    paths:
-      - "**.php"
-      - composer.json
-      - composer.lock
-      - .github/workflows/php-unit-tests.yml
+  pull_request: { }
+  # run on all PRs
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,9 +17,9 @@ jobs:
       WP_TESTS_DIR: "/tmp/wordpress/tests/phpunit"
     strategy:
       matrix:
-        php: [7.4, 8.3]
-        wp-version: [latest]
-        wc-version: [latest]
+        php: [ 7.4, 8.3 ]
+        wp-version: [ latest ]
+        wc-version: [ latest ]
 
     steps:
       - name: Install SVN

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -1,8 +1,6 @@
 name: PHP Unit Tests
 
-on:
-  pull_request: { }
-  # run on all PRs
+on: [ push, pull_request ] # Run on all pushes and PRs
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
In PRs that don't modify any php files, the "Code sniff" and "PHP Unit Tests" checks get stuck in a pending state (ex. https://github.com/facebook/facebook-for-woocommerce/pull/2918). They do not run because the PR doesn't match any of the filters that the workflows define. This causes issues because our repository is set up to require all checks to pass before merging.

This PR updates the filtering on these workflows to run on every PR, regardless of what files were changed.

