### PR TITLE
Removing Variant Level Sync

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -841,7 +841,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				}
 				$this->delete_fb_product( $delete_product );
 			}
-		} elseif ( $sync_enabled ) {
+		} 
+		
+		if( $sync_enabled ) {
 				Products::enable_sync_for_products( [ $product ] );
 				Products::set_product_visibility( $product, Admin::SYNC_MODE_SYNC_AND_HIDE !== $sync_mode );
 				$this->save_product_settings( $product );

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1129,7 +1129,7 @@ class Admin {
 		// 'id' attribute needs to match the 'target' parameter set above
 		?>
 		<div id='facebook_options' class='panel woocommerce_options_panel'>
-			<div class='options_group'>
+			<div>
 				<?php
 
 				woocommerce_wp_select(
@@ -1146,7 +1146,12 @@ class Admin {
 						'description' => __( 'Choose whether to sync this product to Facebook and, if synced, whether it should be visible in the catalog.', 'facebook-for-woocommerce' ),
 					)
 				);
-
+				?>
+			</div>
+			
+			
+			<div class='options_group hide_if_variable'>
+				<?php
 				echo '<div class="wp-editor-wrap">';
 				echo '<label for="' . esc_attr( \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION ) . '">' .
 					esc_html__( 'Facebook Description', 'facebook-for-woocommerce' ) .

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1129,7 +1129,7 @@ class Admin {
 		// 'id' attribute needs to match the 'target' parameter set above
 		?>
 		<div id='facebook_options' class='panel woocommerce_options_panel'>
-			<div class='options_group hide_if_variable'>
+			<div class='options_group'>
 				<?php
 
 				woocommerce_wp_select(
@@ -1155,7 +1155,7 @@ class Admin {
 					$rich_text_description,
 					\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
 					array(
-						'id'            => 'wc_facebook_sync_mode',
+						'id'            => \WC_Facebook_Product::FB_PRODUCT_DESCRIPTION,
 						'textarea_name' => \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
 						'textarea_rows' => 10,
 						'media_buttons' => true,
@@ -1415,20 +1415,11 @@ class Admin {
 		}
 
 		// Get variation meta values
-		$sync_enabled = 'no' !== $this->get_product_variation_meta( $variation, Products::SYNC_ENABLED_META_KEY, $parent );
-		$visibility   = $this->get_product_variation_meta( $variation, Products::VISIBILITY_META_KEY, $parent );
-		$is_visible   = $visibility ? wc_string_to_bool( $visibility ) : true;
 		$description  = $this->get_product_variation_meta( $variation, \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $parent );
 		$price        = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_PRICE, $parent );
 		$image_url    = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_IMAGE, $parent );
 		$image_source = $variation->get_meta( Products::PRODUCT_IMAGE_SOURCE_META_KEY );
 		$fb_mpn       = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_MPN, $parent );
-
-		if ( $sync_enabled ) {
-			$sync_mode = $is_visible ? self::SYNC_MODE_SYNC_AND_SHOW : self::SYNC_MODE_SYNC_AND_HIDE;
-		} else {
-			$sync_mode = self::SYNC_MODE_SYNC_DISABLED;
-		}
 
 		?>
 		<div class="facebook-metabox wc-metabox closed">
@@ -1438,25 +1429,6 @@ class Admin {
 			</h3>
 			<div class="wc-metabox-content" style="display: none;">
 				<?php
-				// Sync Mode Select
-				woocommerce_wp_select(
-					array(
-						'id'            => "variable_facebook_sync_mode$index",
-						'name'          => "variable_facebook_sync_mode[$index]",
-						'label'         => __( 'Facebook Sync', 'facebook-for-woocommerce' ),
-						'options'       => array(
-							self::SYNC_MODE_SYNC_AND_SHOW => __( 'Sync and show in catalog', 'facebook-for-woocommerce' ),
-							self::SYNC_MODE_SYNC_AND_HIDE => __( 'Sync and hide in catalog', 'facebook-for-woocommerce' ),
-							self::SYNC_MODE_SYNC_DISABLED => __( 'Do not sync', 'facebook-for-woocommerce' ),
-						),
-						'value'         => $sync_mode,
-						'desc_tip'      => true,
-						'description'   => __( 'Choose whether to sync this product to Facebook and, if synced, whether it should be visible in the catalog.', 'facebook-for-woocommerce' ),
-						'class'         => 'js-variable-fb-sync-toggle',
-						'wrapper_class' => 'form-row form-row-full',
-					)
-				);
-
 				woocommerce_wp_textarea_input(
 					array(
 						'id'            => sprintf( 'variable_%s%s', \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $index ),
@@ -1596,7 +1568,7 @@ class Admin {
 			return;
 		}
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
-		$sync_mode    = isset( $_POST['variable_facebook_sync_mode'][ $index ] ) ? wc_clean( wp_unslash( $_POST['variable_facebook_sync_mode'][ $index ] ) ) : self::SYNC_MODE_SYNC_DISABLED;
+		$sync_mode    = isset( $_POST['wc_facebook_sync_mode'] ) ? wc_clean( wp_unslash( $_POST['wc_facebook_sync_mode'] ) ) : self::SYNC_MODE_SYNC_DISABLED;
 		$sync_enabled = self::SYNC_MODE_SYNC_DISABLED !== $sync_mode;
 		if ( self::SYNC_MODE_SYNC_AND_SHOW === $sync_mode && $variation->is_virtual() ) {
 			// force to Sync and hide

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -338,7 +338,6 @@ class ProductValidator {
 		}
 	}
 
-
 	/**
 	 * Check if variation product has proper settings.
 	 *

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -341,9 +341,9 @@ class ProductValidator {
 		 * This validation will be used for product updates.
 		 * Hence we are only condidering the value of the parent and not the variation
 		 */
-		$sync_status = $this->product->get_meta( self::SYNC_ENABLED_META_KEY ) || "yes";
+		$sync_status = $this->product->get_meta( self::SYNC_ENABLED_META_KEY ) === 'yes';
 
-		if($sync_status === "yes"){
+		if( $sync_status ){
 			return;
 		}
 		else {
@@ -370,25 +370,20 @@ class ProductValidator {
 			throw new ProductExcludedException( __( 'Product excluded by wc_facebook_should_sync_product filter.', 'facebook-for-woocommerce' ) );
 		}
 
-		$sync_status = $this->product->get_meta( self::SYNC_ENABLED_META_KEY ) || "yes";
-
-		if($sync_status === "yes"){
-			if ( $this->product->is_type( 'variable' ) ) {
-				foreach ( $this->product->get_children() as $child_id ) {
-					$child_product = wc_get_product( $child_id );
-					if ( $child_product && 'no' !== $child_product->get_meta( self::SYNC_ENABLED_META_KEY ) ) {
-						// At least one product is "sync-enabled" so bail before exception.
-						return;
-					}
+		if ( $this->product->is_type( 'variable' ) ) {
+			foreach ( $this->product->get_children() as $child_id ) {
+				$child_product = wc_get_product( $child_id );
+				if ( $child_product && 'no' !== $child_product->get_meta( self::SYNC_ENABLED_META_KEY ) ) {
+					// At least one product is "sync-enabled" so bail before exception.
+					return;
 				}
-	
-				// Variable product has no variations with sync enabled so it shouldn't be synced.
-				throw $invalid_exception;
-			} 
-		}
-		elseif ( 'no' === $sync_status ) {
+			}
+
+			// Variable product has no variations with sync enabled so it shouldn't be synced.
 			throw $invalid_exception;
-		}	
+		} elseif ( 'no' === $this->product->get_meta( self::SYNC_ENABLED_META_KEY ) ) {
+				throw $invalid_exception;
+		}
 	}
 
 

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -111,31 +111,17 @@ class ProductValidator {
 		return null;
 	}
 
-	public function validate_base() {
-		$this->validate_sync_enabled_globally();
-		$this->validate_product_status();
-		$this->validate_product_visibility();
-		$this->validate_product_terms();
-	}
-
 	/**
 	 * Validate whether the product should be synced to Facebook.
 	 *
 	 * @throws ProductExcludedException If product should not be synced.
 	 */
 	public function validate() {
-		$this->validate_base();
+		$this->validate_sync_enabled_globally();
 		$this->validate_product_sync_field();
-	}
-
-	/**
-	 * Validate whether the product should be synced to Facebook for background jobs.
-	 *
-	 * @throws ProductExcludedException If product should not be synced.
-	 */
-	public function validate_background_jobs() {
-		$this->validate_base();
-		$this->validate_product_sync_field_for_background_jobs();
+		$this->validate_product_status();
+		$this->validate_product_visibility();
+		$this->validate_product_terms();
 	}
 
 	/**
@@ -323,38 +309,6 @@ class ProductValidator {
 	 * @throws ProductExcludedException If product should not be synced.
 	 */
 	protected function validate_product_sync_field() {
-		$invalid_exception = new ProductExcludedException( __( 'Sync disabled in product field.', 'facebook-for-woocommerce' ) );
-
-		/**
-		 * Filters whether a product should be synced to FB.
-		 *
-		 * @since 2.6.26
-		 *
-		 * @param WC_Product $product the product object.
-		 */
-		if ( ! apply_filters( 'wc_facebook_should_sync_product', true, $this->product ) ) {
-			throw new ProductExcludedException( __( 'Product excluded by wc_facebook_should_sync_product filter.', 'facebook-for-woocommerce' ) );
-		}
-
-		/**
-		 * This validation will be used for product updates.
-		 * Hence we are only condidering the value of the parent and not the variation
-		 */
-		$sync_status = $this->product->get_meta( self::SYNC_ENABLED_META_KEY ) === 'yes';
-
-		if ( $sync_status ) {
-			return;
-		} else {
-			throw $invalid_exception;
-		}
-	}
-
-	/**
-	 * Validate if the product is excluded from at the "product level" (product meta value).
-	 *
-	 * @throws ProductExcludedException If product should not be synced.
-	 */
-	protected function validate_product_sync_field_for_background_jobs() {
 		$invalid_exception = new ProductExcludedException( __( 'Sync disabled in product field.', 'facebook-for-woocommerce' ) );
 
 		/**

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -336,22 +336,20 @@ class ProductValidator {
 			throw new ProductExcludedException( __( 'Product excluded by wc_facebook_should_sync_product filter.', 'facebook-for-woocommerce' ) );
 		}
 
-
 		/**
 		 * This validation will be used for product updates.
 		 * Hence we are only condidering the value of the parent and not the variation
 		 */
 		$sync_status = $this->product->get_meta( self::SYNC_ENABLED_META_KEY ) === 'yes';
 
-		if( $sync_status ){
+		if ( $sync_status ) {
 			return;
-		}
-		else {
+		} else {
 			throw $invalid_exception;
 		}
 	}
 
-		/**
+	/**
 	 * Validate if the product is excluded from at the "product level" (product meta value).
 	 *
 	 * @throws ProductExcludedException If product should not be synced.

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -111,17 +111,31 @@ class ProductValidator {
 		return null;
 	}
 
+	public function validate_base() {
+		$this->validate_sync_enabled_globally();
+		$this->validate_product_status();
+		$this->validate_product_visibility();
+		$this->validate_product_terms();
+	}
+
 	/**
 	 * Validate whether the product should be synced to Facebook.
 	 *
 	 * @throws ProductExcludedException If product should not be synced.
 	 */
 	public function validate() {
-		$this->validate_sync_enabled_globally();
-		$this->validate_product_status();
+		$this->validate_base();
 		$this->validate_product_sync_field();
-		$this->validate_product_visibility();
-		$this->validate_product_terms();
+	}
+
+	/**
+	 * Validate whether the product should be synced to Facebook for background jobs.
+	 *
+	 * @throws ProductExcludedException If product should not be synced.
+	 */
+	public function validate_background_jobs() {
+		$this->validate_base();
+		$this->validate_product_sync_field_for_background_jobs();
 	}
 
 	/**
@@ -322,21 +336,61 @@ class ProductValidator {
 			throw new ProductExcludedException( __( 'Product excluded by wc_facebook_should_sync_product filter.', 'facebook-for-woocommerce' ) );
 		}
 
-		if ( $this->product->is_type( 'variable' ) ) {
-			foreach ( $this->product->get_children() as $child_id ) {
-				$child_product = wc_get_product( $child_id );
-				if ( $child_product && 'no' !== $child_product->get_meta( self::SYNC_ENABLED_META_KEY ) ) {
-					// At least one product is "sync-enabled" so bail before exception.
-					return;
-				}
-			}
 
-			// Variable product has no variations with sync enabled so it shouldn't be synced.
+		/**
+		 * This validation will be used for product updates.
+		 * Hence we are only condidering the value of the parent and not the variation
+		 */
+		$sync_status = $this->product->get_meta( self::SYNC_ENABLED_META_KEY ) || "yes";
+
+		if($sync_status === "yes"){
+			return;
+		}
+		else {
 			throw $invalid_exception;
-		} elseif ( 'no' === $this->product->get_meta( self::SYNC_ENABLED_META_KEY ) ) {
-				throw $invalid_exception;
 		}
 	}
+
+		/**
+	 * Validate if the product is excluded from at the "product level" (product meta value).
+	 *
+	 * @throws ProductExcludedException If product should not be synced.
+	 */
+	protected function validate_product_sync_field_for_background_jobs() {
+		$invalid_exception = new ProductExcludedException( __( 'Sync disabled in product field.', 'facebook-for-woocommerce' ) );
+
+		/**
+		 * Filters whether a product should be synced to FB.
+		 *
+		 * @since 2.6.26
+		 *
+		 * @param WC_Product $product the product object.
+		 */
+		if ( ! apply_filters( 'wc_facebook_should_sync_product', true, $this->product ) ) {
+			throw new ProductExcludedException( __( 'Product excluded by wc_facebook_should_sync_product filter.', 'facebook-for-woocommerce' ) );
+		}
+
+		$sync_status = $this->product->get_meta( self::SYNC_ENABLED_META_KEY ) || "yes";
+
+		if($sync_status === "yes"){
+			if ( $this->product->is_type( 'variable' ) ) {
+				foreach ( $this->product->get_children() as $child_id ) {
+					$child_product = wc_get_product( $child_id );
+					if ( $child_product && 'no' !== $child_product->get_meta( self::SYNC_ENABLED_META_KEY ) ) {
+						// At least one product is "sync-enabled" so bail before exception.
+						return;
+					}
+				}
+	
+				// Variable product has no variations with sync enabled so it shouldn't be synced.
+				throw $invalid_exception;
+			} 
+		}
+		elseif ( 'no' === $sync_status ) {
+			throw $invalid_exception;
+		}	
+	}
+
 
 	/**
 	 * Check if variation product has proper settings.

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -85,10 +85,11 @@ class Products {
 							$product_variation->save_meta_data();
 						}
 					}
-				} else {
-					$product->update_meta_data( self::SYNC_ENABLED_META_KEY, $enabled );
-					$product->save_meta_data();
 				}
+
+				// Adding sync mode settings to simple product as well as main product for variants.
+				$product->update_meta_data( self::SYNC_ENABLED_META_KEY, $enabled );
+				$product->save_meta_data();
 
 				// Remove excluded product from FB.
 				if ( "no" === $enabled ) {
@@ -272,6 +273,18 @@ class Products {
 		if ( ! is_bool( $visibility ) ) {
 			return false;
 		}
+
+		// Updating visibility for the all variable products
+		if ( $product->is_type( 'variable' ) ) {
+			foreach ( $product->get_children() as $variation ) {
+				$product_variation = wc_get_product( $variation );
+				if ( $product_variation instanceof \WC_Product ) {
+					$product_variation->update_meta_data( self::VISIBILITY_META_KEY, wc_bool_to_string($visibility));
+					$product_variation->save_meta_data();
+				}
+			}
+		} 
+		
 		$product->update_meta_data( self::VISIBILITY_META_KEY, wc_bool_to_string( $visibility ) );
 		$product->save_meta_data();
 		self::$products_visibility[ $product->get_id() ] = $visibility;

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -187,6 +187,24 @@ class Products {
 		}
 	}
 
+		/**
+	 * Determines whether the given product should be synced.
+	 *
+	 *
+	 * @since 1.10.0
+	 *
+	 * @param \WC_Product $product
+	 * @return bool
+	 */
+	public static function product_should_be_synced_for_background_jobs( \WC_Product $product ) {
+		try {
+			facebook_for_woocommerce()->get_product_sync_validator( $product )->validate_background_jobs();
+			return true;
+		} catch ( \Exception $e ) {
+			return false;
+		}
+	}
+
 
 	/**
 	 * Determines whether the given product should be synced assuming the product is published.

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -187,25 +187,6 @@ class Products {
 		}
 	}
 
-		/**
-	 * Determines whether the given product should be synced.
-	 *
-	 *
-	 * @since 1.10.0
-	 *
-	 * @param \WC_Product $product
-	 * @return bool
-	 */
-	public static function product_should_be_synced_for_background_jobs( \WC_Product $product ) {
-		try {
-			facebook_for_woocommerce()->get_product_sync_validator( $product )->validate_background_jobs();
-			return true;
-		} catch ( \Exception $e ) {
-			return false;
-		}
-	}
-
-
 	/**
 	 * Determines whether the given product should be synced assuming the product is published.
 	 *

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -182,7 +182,7 @@ class Background extends BackgroundJobHandler {
 		}
 
 		$request = null;
-		if ( ! Products::product_should_be_deleted( $product ) && Products::product_should_be_synced_for_background_jobs( $product ) ) {
+		if ( ! Products::product_should_be_deleted( $product ) && Products::product_should_be_synced( $product ) ) {
 
 			if ( $product->is_type( 'variation' ) ) {
 				$product_data = \WC_Facebookcommerce_Utils::prepare_product_variation_data_items_batch( $product );

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -182,7 +182,7 @@ class Background extends BackgroundJobHandler {
 		}
 
 		$request = null;
-		if ( ! Products::product_should_be_deleted( $product ) && Products::product_should_be_synced( $product ) ) {
+		if ( ! Products::product_should_be_deleted( $product ) && Products::product_should_be_synced_for_background_jobs( $product ) ) {
 
 			if ( $product->is_type( 'variation' ) ) {
 				$product_data = \WC_Facebookcommerce_Utils::prepare_product_variation_data_items_batch( $product );

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1724,12 +1724,15 @@ class WC_Facebook_Product {
 				else{
 					$variations = $parent_product->get_children(); 
 					$variation_visibility = false;
+
 					foreach ($variations as $variation_id) {
 						$variation = wc_get_product($variation_id);
 				
 						if ($variation) {
 							$variation_visibility = $variation_visibility || Products::is_product_visible($variation);
 						}
+
+						if ($variation_visibility) break;
 					}
 					$product_data[ 'visibility' ] = $variation_visibility ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
 					update_post_meta($parent_id,Products::VISIBILITY_META_KEY, $variation_visibility ? "yes" : "no");

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1715,6 +1715,9 @@ class WC_Facebook_Product {
 			if( $parent_product ){
 				$parent_product_visibility =  $parent_product->get_meta( Products::VISIBILITY_META_KEY );
 
+				/**
+				 * If parent's visibility is already marked we know we should assign it to the child/variation as well
+				 */
 				if($parent_product_visibility === "yes"){
 					$product_data[ 'visibility' ] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE;
 				}
@@ -1722,6 +1725,12 @@ class WC_Facebook_Product {
 					$product_data[ 'visibility' ] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
 				}
 				else{
+					/**
+					 * If the visibility is empty,
+					 * We then check for the variation's visibility.
+					 * If even a single one is marked yes, we bail it out as published.
+					 * If all marked no we honor the visibility as hidden.
+					 */
 					$variations = $parent_product->get_children(); 
 					$variation_visibility = false;
 
@@ -1735,6 +1744,12 @@ class WC_Facebook_Product {
 						if ($variation_visibility) break;
 					}
 					$product_data[ 'visibility' ] = $variation_visibility ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
+					/**
+					 *  Since this function will be called again for other variations as well for the same parent product.
+					 *  We can now assign the visibility marker to the parent product
+					 *  That way it won't come to this block next time
+					 */
+	
 					update_post_meta($parent_id,Products::VISIBILITY_META_KEY, $variation_visibility ? "yes" : "no");
 				}
 			}

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1708,29 +1708,32 @@ class WC_Facebook_Product {
 		// $product_data[ 'unmapped_attributes' ] = $this->get_unmapped_attributes();
 		$product_data[ 'disabled_capabilities' ] = $this->get_disabled_capabilities();
 
-		if($this->get_type() === "variable"){
+		if($this->get_type() === "variation"){
 			$parent_id = $this->woo_product->get_parent_id();	
 			$parent_product =  wc_get_product( $parent_id );
-			$parent_product_visibility = $parent_product->get_catalog_visibility();
 
-			if($parent_product_visibility === "yes"){
-				$product_data[ 'visibility' ] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE;
-			}
-			else if ($parent_product_visibility === "no"){
-				$product_data[ 'visibility' ] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
-			}
-			else{
-				$variations = $parent_product->get_children(); 
-				$variation_visibility = false;
-				foreach ($variations as $variation_id) {
-					$variation = wc_get_product($variation_id);
-			
-					if ($variation) {
-						$variation_visibility = $variation_visibility || Products::is_product_visible($variation);
-					}
+			if( $parent_product ){
+				$parent_product_visibility =  $parent_product->get_meta( Products::VISIBILITY_META_KEY );
+
+				if($parent_product_visibility === "yes"){
+					$product_data[ 'visibility' ] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE;
 				}
-				$product_data[ 'visibility' ] = Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
-				$parent_product->update_meta_data(Products::VISIBILITY_META_KEY, $variation_visibility ? "yes" : "no");
+				else if ($parent_product_visibility === "no"){
+					$product_data[ 'visibility' ] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
+				}
+				else{
+					$variations = $parent_product->get_children(); 
+					$variation_visibility = false;
+					foreach ($variations as $variation_id) {
+						$variation = wc_get_product($variation_id);
+				
+						if ($variation) {
+							$variation_visibility = $variation_visibility || Products::is_product_visible($variation);
+						}
+					}
+					$product_data[ 'visibility' ] = $variation_visibility ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
+					update_post_meta($parent_id,Products::VISIBILITY_META_KEY, $variation_visibility ? "yes" : "no");
+				}
 			}
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

1. The Variant level sync  is removed in this PR for Variable products.
2. The Sync option now exist in Facebook tab.
3. Selecting your choice of sync will be effective on the product and all its variants.

_In general we are moving forward with Syncing at Product level than Variant level._

### Screenshots:

| Before | After| 
|----------|----------|
| 1. At Variant level sync controls   | 1. At variant level sync controls removed      | 
|  ![image](https://github.com/user-attachments/assets/e045e46e-9db6-4f47-b2d3-305982d8fbfb)  | ![image](https://github.com/user-attachments/assets/9d92d68b-9018-4692-989f-bc773229c201) | 
| 2. At facebook tab sync controls missing   | 2. At facebook tab Sync controls added    |
| ![image](https://github.com/user-attachments/assets/7128288e-43bc-4ab4-8ce8-ff2166106e27) | ![image](https://github.com/user-attachments/assets/c75cf62a-f777-4505-91ef-7048fb6a816c) |


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Make a variant product
2. Add some variant attributes
3. Now make variants
4. Try to use the sync - do not sync options in facebook tabs
5. Observe the changes in Catalog in commerce manager

