### PR TITLE
Change MICE to use base site url instead of shop url

### DIFF
--- a/includes/Handlers/MetaExtension.php
+++ b/includes/Handlers/MetaExtension.php
@@ -459,7 +459,7 @@ class MetaExtension {
 	public static function generate_iframe_splash_url( $is_connected, $plugin, $external_business_id ): string {
 		$connection_handler       = facebook_for_woocommerce()->get_connection_handler();
 		$external_client_metadata = array(
-			'shop_domain'                           => wc_get_page_permalink( 'shop' ),
+			'shop_domain'                           => site_url( '/' ),
 			'admin_url'                             => admin_url(),
 			'client_version'                        => $plugin->get_version(),
 			'commerce_partner_seller_platform_type' => 'SELF_SERVE_PLATFORM',


### PR DESCRIPTION
### Changes proposed in this Pull Request:
MICE currently uses the shop permalink as the shop_domain parameter. This leads us to something like 'domain.com/shop/', which causes issues with generating the checkout url on Meta. The checkout url would be located at 'domain.com/fb-checkout', so this PR updates the shop_domain to use the more root-level site url.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:
<img width="635" alt="Screenshot 2025-03-11 at 12 42 16 PM" src="https://github.com/user-attachments/assets/09779e9b-c7c3-485e-a5fc-4ef1243f393b" />


### Changelog entry
- Change MICE shop_domain to use site url instead of shop url
