### PR TITLE
Make custom checkout UI mobile compatible

### DIFF
--- a/includes/Checkout.php
+++ b/includes/Checkout.php
@@ -130,21 +130,35 @@ class Checkout {
 			}
 
 			$checkout_url = wc_get_checkout_url();
-			echo '<style>
-                body, html {
-                    margin: 0;
-                    padding: 0;
-                    height: 100%;
-                    overflow: hidden;
-                }
-                iframe {
-                    width: 100%;
-                    height: 100vh;
-                    border: none;
-                    display: block;
-                }
-              </style>';
-			echo '<iframe src="' . esc_url( $checkout_url ) . '"></iframe>';
+			echo '<!DOCTYPE html>
+				<html lang="en">
+				<head>
+						<meta charset="UTF-8">
+						<meta name="viewport" content="width=device-width, initial-scale=1">
+						<title>Checkout</title>
+						<style>
+								body, html {
+										margin: 0;
+										padding: 0;
+										height: 100%;
+										overflow: hidden;
+								}
+								iframe {
+										width: 100%;
+										height: 100vh;
+										border: none;
+										display: block;
+										max-width: 100%;
+										max-height: 100%;
+										box-sizing: border-box;
+								}
+						</style>
+				</head>
+				<body>
+						<iframe src="' . esc_url( $checkout_url ) . '"></iframe>
+				</body>
+				</html>';
+
 			exit;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR makes the custom checkout UI mobile compatible. The iframe from the latest UI implementation was missing the `<meta name="viewport" content="width=device-width, initial-scale=1">` HTML tag, which caused the mobile UI to not appear for newer devices.

Latest UI created in https://github.com/facebook/facebook-for-woocommerce/pull/2930.

### Screenshots:
Mobile Checkout (Before):
<img width="400" alt="Screenshot 2025-03-13 at 1 10 53 PM" src="https://github.com/user-attachments/assets/bfead0ab-82db-4f0f-81ba-652a03b53ee4" />

Mobile Checkout (After):
<img width="400" alt="Screenshot 2025-03-13 at 1 06 08 PM" src="https://github.com/user-attachments/assets/e279faef-c404-4ee4-a476-38b60e8c782a" />

### Detailed test instructions:
Ensure that you are testing using a mobile device/simulator. You can also test this on the browser by using a mobile aspect ratio.
1. Test checkout permalink with one product (e.g. `/fb-checkout?products=<ID>:<#>`)
2. Test checkout permalink with two product (e.g. `/fb-checkout?products=<ID>:<#>,<ID>:<#>`)
3. Test checkout permalink with products and a coupon (e.g. `/fb-checkout?products=<ID>:<#>,:<ID>:<#>&coupon=<CODE>`)
4. Test default checkout with products and a coupon (e.g. `/checkout`)
