### PR TITLE
Improve Test Filter Management

### DIFF
--- a/tests/Unit/AbstractWPUnitTestWithSafeFiltering.php
+++ b/tests/Unit/AbstractWPUnitTestWithSafeFiltering.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Abstract test case for unit tests.
+ */
+
+namespace WooCommerce\Facebook\Tests\Unit;
+
+use WP_UnitTestCase;
+
+/**
+ * Abstract test case that provides filter management functionality.
+ */
+abstract class AbstractWPUnitTestWithSafeFiltering extends WP_UnitTestCase {
+    /**
+     * Store filter callbacks to remove them after tests
+     * 
+     * @var array
+     */
+    private $filter_callbacks = [];
+    
+    /**
+     * Set up before each test.
+     */
+    public function setUp(): void {
+        parent::setUp();
+        $this->filter_callbacks = [];
+    }
+    
+    /**
+     * Clean up after each test.
+     */
+    public function tearDown(): void {
+        // Remove specific filters that were added by this test
+        foreach ($this->filter_callbacks as $hook => $callbacks) {
+            foreach ($callbacks as $callback_data) {
+                remove_filter($hook, $callback_data['callback'], $callback_data['priority']);
+            }
+        }
+        
+        parent::tearDown();
+    }
+
+    /**
+     * Helper method to remove all filters for a specific hook safely
+     *
+     * @param string $hook The filter hook name to remove all callbacks for
+     * @return void
+     */
+    protected function teardown_callback_category_safely($hook) {
+        if (isset($this->filter_callbacks[$hook])) {
+            foreach ($this->filter_callbacks[$hook] as $callback_data) {
+                remove_filter($hook, $callback_data['callback'], $callback_data['priority']);
+            }
+            // Clear the tracking for this hook
+            unset($this->filter_callbacks[$hook]);
+        }
+    }
+    
+    /**
+     * Helper method to add a filter and store its callback for later removal
+     *
+     * @param string   $hook     The filter hook name
+     * @param callable $callback The filter callback function
+     * @param int      $priority The priority of the filter
+     * @param int      $accepted_args The number of arguments the function accepts
+     * @return object A simple object with remove() method for easy cleanup
+     */
+    protected function add_filter_with_safe_teardown($hook, $callback, $priority = 10, $accepted_args = 1) {
+        add_filter($hook, $callback, $priority, $accepted_args);
+        
+        if (!isset($this->filter_callbacks[$hook])) {
+            $this->filter_callbacks[$hook] = [];
+        }
+        
+        $this->filter_callbacks[$hook][] = [
+            'callback' => $callback,
+            'priority' => $priority
+        ];
+        
+        $self = $this;
+        
+        // Return a simple object with a remove method
+        return new class($hook, $callback, $priority, $self) {
+            private $hook;
+            private $callback;
+            private $priority;
+            private $test_case;
+            
+            public function __construct($hook, $callback, $priority, $test_case) {
+                $this->hook = $hook;
+                $this->callback = $callback;
+                $this->priority = $priority;
+                $this->test_case = $test_case;
+            }
+            
+            public function teardown_safely_immediately() {
+                remove_filter($this->hook, $this->callback, $this->priority);
+                $this->test_case->removeFilterFromTracking($this->hook, $this->callback, $this->priority);
+            }
+        };
+    }
+    
+    /**
+     * Remove a filter from the tracking array
+     * 
+     * @param string   $hook     The filter hook name
+     * @param callable $callback The filter callback function
+     * @param int      $priority The priority of the filter
+     */
+    public function removeFilterFromTracking($hook, $callback, $priority) {
+        if (isset($this->filter_callbacks[$hook])) {
+            foreach ($this->filter_callbacks[$hook] as $key => $callback_data) {
+                if ($callback_data['callback'] === $callback && $callback_data['priority'] === $priority) {
+                    unset($this->filter_callbacks[$hook][$key]);
+                    break;
+                }
+            }
+            
+            // Clean up empty arrays
+            if (empty($this->filter_callbacks[$hook])) {
+                unset($this->filter_callbacks[$hook]);
+            }
+        }
+    }
+}

--- a/tests/Unit/ApiTest.php
+++ b/tests/Unit/ApiTest.php
@@ -7,7 +7,7 @@ use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
 /**
  * Api unit test clas.
  */
-class ApiTest extends WP_UnitTestCase {
+class ApiTest extends \WooCommerce\Facebook\Tests\Unit\AbstractWPUnitTestWithSafeFiltering {
 
 	/**
 	 * Facebook Graph API endpoint.
@@ -54,7 +54,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->get_catalog( '726635365295186' );
 
@@ -78,7 +78,7 @@ class ApiTest extends WP_UnitTestCase {
 			$this->assertEquals( "{$this->endpoint}{$this->version}/726635365295186?fields=name", $url );
 			return new WP_Error( 007, 'WP Error Message' );
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$this->api->get_catalog( '726635365295186' );
 	}
@@ -103,7 +103,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->get_installation_ids( $external_business_id );
 
@@ -130,7 +130,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->get_catalog( $catalog_id );
 
@@ -158,7 +158,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->get_user( $user_id );
 
@@ -187,7 +187,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->delete_mbe_connection( $external_business_id );
 
@@ -214,7 +214,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->get_business_configuration( $external_business_id );
 
@@ -267,7 +267,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->send_item_updates( $facebook_catalog_id, $requests );
 
@@ -313,7 +313,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->create_product_group( $facebook_product_catalog_id, $data );
 
@@ -355,7 +355,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->update_product_group( $facebook_product_group_id, $data );
 
@@ -382,7 +382,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->delete_product_group( $facebook_product_group_id );
 
@@ -410,7 +410,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->get_product_group_products( $facebook_product_group_id, $limit );
 
@@ -473,7 +473,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->create_product_item( $facebook_product_group_id, $data );
 
@@ -520,7 +520,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->update_product_item( $facebook_product_id, $data );
 
@@ -552,7 +552,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->get_product_facebook_ids( $facebook_product_catalog_id, $facebook_product_retailer_id );
 
@@ -580,7 +580,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->delete_product_item( $facebook_product_id );
 
@@ -613,7 +613,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->create_product_set_item( $facebook_product_catalog_id, $data );
 
@@ -646,7 +646,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->update_product_set_item( $facebook_product_set_id, $data );
 
@@ -673,7 +673,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->delete_product_set_item( $facebook_product_set_id, true );
 
@@ -700,7 +700,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->read_feeds( $facebook_product_catalog_id );
 
@@ -740,7 +740,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response_feed = $this->api->create_feed( $facebook_product_catalog_id, $data );
 
@@ -770,7 +770,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->create_product_feed_upload( $product_feed_id, $data );
 		$this->assertFalse( $response->has_api_error() );
@@ -801,7 +801,7 @@ class ApiTest extends WP_UnitTestCase {
 				],
 			];
 		};
-		add_filter( 'pre_http_request', $response, 10, 3 );
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
 
 		$response = $this->api->create_common_data_feed_upload( $cpi, $data );
 		$this->assertFalse( $response->has_api_error() );

--- a/tests/Unit/Feed/FeedUploadUtilsTest.php
+++ b/tests/Unit/Feed/FeedUploadUtilsTest.php
@@ -14,7 +14,7 @@ require_once __DIR__ . '/../../../includes/Feed/FeedUploadUtils.php';
  *
  * Sets up environment to test various logic in FeedUploadUtils
  */
-class FeedUploadUtilsTest extends WP_UnitTestCase {
+class FeedUploadUtilsTest extends \WooCommerce\Facebook\Tests\Unit\AbstractWPUnitTestWithSafeFiltering {
 
 	/** @var int Shop page ID */
 	protected static $shop_page_id;
@@ -27,9 +27,10 @@ class FeedUploadUtilsTest extends WP_UnitTestCase {
 		parent::setUp();
 
 		// Force a pretty permalink structure.
-		add_filter( 'pre_option_permalink_structure', function () {
+		$this->add_filter_with_safe_teardown('pre_option_permalink_structure', function () {
 			return '/%postname%/';
-		} );
+		});
+		
 		update_option( 'permalink_structure', '/%postname%/' );
 		global $wp_rewrite;
 		if ( ! ( $wp_rewrite instanceof WP_Rewrite ) ) {
@@ -56,21 +57,18 @@ class FeedUploadUtilsTest extends WP_UnitTestCase {
 		flush_rewrite_rules();
 
 		// Add high–priority filters to force URLs.
-		add_filter( 'woocommerce_get_page_permalink', [ $this, 'forceShopPermalink' ], 9999, 2 );
-		add_filter( 'get_permalink', [ $this, 'forceGetPermalink' ], 9999, 2 );
-		add_filter( 'post_type_link', [ $this, 'forcePostTypeLink' ], 9999, 3 );
-		add_filter( 'woocommerce_product_get_permalink', [ $this, 'forceProductPermalink' ], 9999, 2 );
+		$this->add_filter_with_safe_teardown('woocommerce_get_page_permalink', [ $this, 'forceShopPermalink' ], 9999, 2);
+		$this->add_filter_with_safe_teardown('get_permalink', [ $this, 'forceGetPermalink' ], 9999, 2);
+		$this->add_filter_with_safe_teardown('post_type_link', [ $this, 'forcePostTypeLink' ], 9999, 3);
+		$this->add_filter_with_safe_teardown('woocommerce_product_get_permalink', [ $this, 'forceProductPermalink' ], 9999, 2);
 	}
 
 	/**
 	 * Clean up filters and rewrite rules.
 	 */
 	public function tearDown(): void {
-		remove_filter( 'woocommerce_get_page_permalink', [ $this, 'forceShopPermalink' ], 9999 );
-		remove_filter( 'get_permalink', [ $this, 'forceGetPermalink' ], 9999 );
-		remove_filter( 'post_type_link', [ $this, 'forcePostTypeLink' ], 9999 );
-		remove_filter( 'woocommerce_product_get_permalink', [ $this, 'forceProductPermalink' ], 9999 );
 		flush_rewrite_rules();
+		// No need to manually remove filters, parent tearDown will handle it
 		parent::tearDown();
 	}
 

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -16,7 +16,7 @@ use WooCommerce\Facebook\Framework\AdminMessageHandler;
 /**
  * Unit tests for Facebook Graph API calls.
  */
-class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
+class WCFacebookCommerceIntegrationTest extends \WooCommerce\Facebook\Tests\Unit\AbstractWPUnitTestWithSafeFiltering {
 
 	/**
 	 * @var WC_Facebookcommerce
@@ -151,7 +151,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 			self::$default_options
 		);
 
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'wc_facebook_pixel_id',
 			function ( $wc_facebook_pixel_id ) {
 				return '998877665544332211';
@@ -189,7 +189,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 			self::$default_options
 		);
 
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'wc_facebook_is_advanced_matching_enabled',
 			function ( $use_pii ) {
 				return false;
@@ -329,7 +329,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 			->with( $facebook_product_group_id )
 			->willReturn( $facebook_response );
 
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'wc_facebook_fb_retailer_id',
 			function ( $retailer_id ) {
 				return $retailer_id . '_modified';
@@ -368,7 +368,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_product_count_returns_product_count_with_filters() {
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'wp_count_posts',
 			function( $counts ) {
 				$counts->publish = 21;
@@ -402,7 +402,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_allow_full_batch_api_sync_uses_block_full_batch_api_sync_filter() {
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'facebook_for_woocommerce_block_full_batch_api_sync',
 			function ( bool $status ) {
 				return true;
@@ -425,7 +425,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	public function test_allow_full_batch_api_sync_uses_allow_full_batch_api_sync_filter() {
 		$this->markTestSkipped( 'Some problems with phpunit polyfills notices handling.' );
 
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'facebook_for_woocommerce_allow_full_batch_api_sync',
 			function ( bool $status ) {
 				return false;
@@ -1950,7 +1950,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 */
 	public function test_get_product_catalog_id_returns_product_catalog_from_initialised_property_using_no_filter() {
 		$this->integration->product_catalog_id = '123123123123123123';
-		remove_all_filters( 'wc_facebook_product_catalog_id' );
+		$this->teardown_callback_category_safely( 'wc_facebook_product_catalog_id' );
 
 		$product_catalog_id = $this->integration->get_product_catalog_id();
 
@@ -1965,7 +1965,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	public function test_get_product_catalog_id_returns_product_catalog_from_options_using_no_filter() {
 		$this->integration->product_catalog_id = null;
 		add_option( WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, '321321321321321321' );
-		remove_all_filters( 'wc_facebook_product_catalog_id' );
+		$this->teardown_callback_category_safely( 'wc_facebook_product_catalog_id' );
 
 		$product_catalog_id = $this->integration->get_product_catalog_id();
 
@@ -1979,7 +1979,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_product_catalog_id_returns_product_catalog_with_filter() {
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'wc_facebook_product_catalog_id',
 			function ( $product_catalog_id ) {
 				return '3213-2132-1321-3213-2132';
@@ -1998,7 +1998,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 */
 	public function test_get_external_merchant_settings_id_returns_settings_id_from_initialised_property_using_no_filter() {
 		$this->integration->external_merchant_settings_id = '123123123123123123';
-		remove_all_filters( 'wc_facebook_external_merchant_settings_id' );
+		$this->teardown_callback_category_safely( 'wc_facebook_external_merchant_settings_id' );
 
 		$external_merchant_settings_id = $this->integration->get_external_merchant_settings_id();
 
@@ -2013,7 +2013,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	public function test_get_external_merchant_settings_id_returns_settings_id_from_options_using_no_filter() {
 		$this->integration->external_merchant_settings_id = null;
 		add_option( WC_Facebookcommerce_Integration::OPTION_EXTERNAL_MERCHANT_SETTINGS_ID, '321321321321321321' );
-		remove_all_filters( 'wc_facebook_external_merchant_settings_id' );
+		$this->teardown_callback_category_safely( 'wc_facebook_external_merchant_settings_id' );
 
 		$external_merchant_settings_id = $this->integration->get_external_merchant_settings_id();
 
@@ -2027,7 +2027,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_external_merchant_settings_id_returns_settings_id_with_filter() {
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'wc_facebook_external_merchant_settings_id',
 			function ( $external_merchant_settings_id ) {
 				return '3213-2132-1321-3213-2132';
@@ -2046,7 +2046,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 */
 	public function test_get_feed_id_returns_id_from_initialised_property_using_no_filter() {
 		$this->integration->feed_id = '123123123123123123';
-		remove_all_filters( 'wc_facebook_feed_id' );
+		$this->teardown_callback_category_safely( 'wc_facebook_feed_id' );
 
 		$feed_id = $this->integration->get_feed_id();
 
@@ -2061,7 +2061,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	public function test_get_feed_id_returns_id_from_options_using_no_filter() {
 		$this->integration->feed_id = null;
 		add_option( WC_Facebookcommerce_Integration::OPTION_FEED_ID, '321321321321321321' );
-		remove_all_filters( 'wc_facebook_feed_id' );
+		$this->teardown_callback_category_safely( 'wc_facebook_feed_id' );
 
 		$feed_id = $this->integration->get_feed_id();
 
@@ -2075,7 +2075,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_feed_id_returns_id_with_filter() {
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'wc_facebook_feed_id',
 			function ( $feed_id ) {
 				return '3213-2132-1321-3213-2132';
@@ -2094,7 +2094,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 */
 	public function test_get_upload_id_returns_id_from_options_using_no_filter() {
 		add_option( WC_Facebookcommerce_Integration::OPTION_UPLOAD_ID, '321321321321321321' );
-		remove_all_filters( 'wc_facebook_upload_id' );
+		$this->teardown_callback_category_safely( 'wc_facebook_upload_id' );
 
 		$upload_id = $this->integration->get_upload_id();
 
@@ -2107,7 +2107,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_upload_id_returns_id_with_filter() {
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'wc_facebook_upload_id',
 			function ( $upload_id ) {
 				return '3213-2132-1321-3213-2132';
@@ -2126,7 +2126,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 */
 	public function test_get_pixel_install_time_returns_id_from_initialised_property_using_no_filter() {
 		$this->integration->pixel_install_time = '123123123123123123';
-		remove_all_filters( 'wc_facebook_pixel_install_time' );
+		$this->teardown_callback_category_safely( 'wc_facebook_pixel_install_time' );
 
 		$pixel_install_time = $this->integration->get_pixel_install_time();
 
@@ -2141,7 +2141,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	public function test_get_pixel_install_time_returns_id_from_options_using_no_filter() {
 		$this->integration->pixel_install_time = null;
 		add_option( WC_Facebookcommerce_Integration::OPTION_PIXEL_INSTALL_TIME, '321321321321321321' );
-		remove_all_filters( 'wc_facebook_pixel_install_time' );
+		$this->teardown_callback_category_safely( 'wc_facebook_pixel_install_time' );
 
 		$pixel_install_time = $this->integration->get_pixel_install_time();
 
@@ -2155,7 +2155,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_pixel_install_time_returns_id_with_filter() {
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'wc_facebook_pixel_install_time',
 			function ( $pixel_install_time ) {
 				return '321321321321';
@@ -2176,7 +2176,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 		$this->markTestSkipped( 'get_js_sdk_version method is called in constructor which makes it impossible to test it in isolation w/o refactoring the constructor.' );
 
 		add_option( WC_Facebookcommerce_Integration::OPTION_JS_SDK_VERSION, 'v1.0.0' );
-		remove_all_filters( 'wc_facebook_js_sdk_version' );
+		$this->teardown_callback_category_safely( 'wc_facebook_js_sdk_version' );
 
 		$js_sdk_version = $this->integration->get_js_sdk_version();
 
@@ -2191,7 +2191,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	public function test_get_js_sdk_version_returns_id_with_filter() {
 		$this->markTestSkipped( 'get_js_sdk_version method is called in constructor which makes it impossible to test it in isolation w/o refactoring the constructor.' );
 
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'wc_facebook_js_sdk_version',
 			function ( $js_sdk_version ) {
 				return 'v2.0.0';
@@ -2209,7 +2209,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_facebook_page_id_no_filters() {
-		remove_all_filters( 'wc_facebook_page_id' );
+		$this->teardown_callback_category_safely( 'wc_facebook_page_id' );
 		add_option( WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, '222333111444555666777' );
 
 		$facebook_page_id = $this->integration->get_facebook_page_id();
@@ -2223,7 +2223,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_facebook_page_id_with_filter() {
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'wc_facebook_page_id',
 			function ( $facebook_page_id ) {
 				return '444333222111999888777666555';
@@ -2241,7 +2241,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_facebook_pixel_id_no_filters() {
-		remove_all_filters( 'wc_facebook_pixel_id' );
+		$this->teardown_callback_category_safely( 'wc_facebook_pixel_id' );
 		add_option( WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, '222333111444555666777' );
 
 		$facebook_pixel_id = $this->integration->get_facebook_pixel_id();
@@ -2255,7 +2255,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_facebook_pixel_id_with_filter() {
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'wc_facebook_pixel_id',
 			function ( $facebook_pixel_id ) {
 				return '444333222111999888777666555';
@@ -2273,7 +2273,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_excluded_product_category_ids_no_filter_no_option() {
-		remove_all_filters( 'wc_facebook_excluded_product_category_ids' );
+		$this->teardown_callback_category_safely( 'wc_facebook_excluded_product_category_ids' );
 		delete_option( WC_Facebookcommerce_Integration::SETTING_EXCLUDED_PRODUCT_CATEGORY_IDS );
 
 		$categories = $this->integration->get_excluded_product_category_ids();
@@ -2287,7 +2287,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_excluded_product_category_ids_no_filter() {
-		remove_all_filters( 'wc_facebook_excluded_product_category_ids' );
+		$this->teardown_callback_category_safely( 'wc_facebook_excluded_product_category_ids' );
 		add_option(
 			WC_Facebookcommerce_Integration::SETTING_EXCLUDED_PRODUCT_CATEGORY_IDS,
 			[ 121, 221, 321, 421, 521, 621 ]
@@ -2304,7 +2304,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_excluded_product_category_ids_with_filter() {
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'wc_facebook_excluded_product_category_ids',
 			function ( $ids ) {
 				return [ 111, 222, 333 ];
@@ -2327,7 +2327,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_excluded_product_tag_ids_no_filter_no_option() {
-		remove_all_filters( 'wc_facebook_excluded_product_tag_ids' );
+		$this->teardown_callback_category_safely( 'wc_facebook_excluded_product_tag_ids' );
 		delete_option( WC_Facebookcommerce_Integration::SETTING_EXCLUDED_PRODUCT_TAG_IDS );
 
 		$tags = $this->integration->get_excluded_product_tag_ids();
@@ -2341,7 +2341,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_excluded_product_tag_ids_no_filter() {
-		remove_all_filters( 'wc_facebook_excluded_product_tag_ids' );
+		$this->teardown_callback_category_safely( 'wc_facebook_excluded_product_tag_ids' );
 		add_option(
 			WC_Facebookcommerce_Integration::SETTING_EXCLUDED_PRODUCT_TAG_IDS,
 			[ 121, 221, 321, 421, 521, 621 ]
@@ -2358,7 +2358,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_excluded_product_tag_ids_with_filter() {
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'wc_facebook_excluded_product_tag_ids',
 			function ( $ids ) {
 				return [ 111, 222, 333 ];
@@ -2381,7 +2381,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_product_description_mode_no_filter_no_options() {
-		remove_all_filters( 'wc_facebook_product_description_mode' );
+		$this->teardown_callback_category_safely( 'wc_facebook_product_description_mode' );
 		delete_option( WC_Facebookcommerce_Integration::SETTING_PRODUCT_DESCRIPTION_MODE );
 
 		$mode = $this->integration->get_product_description_mode();
@@ -2395,7 +2395,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_product_description_mode_no_filter() {
-		remove_all_filters( 'wc_facebook_product_description_mode' );
+		$this->teardown_callback_category_safely( 'wc_facebook_product_description_mode' );
 		add_option(
 			WC_Facebookcommerce_Integration::SETTING_PRODUCT_DESCRIPTION_MODE,
 			WC_Facebookcommerce_Integration::PRODUCT_DESCRIPTION_MODE_SHORT
@@ -2412,7 +2412,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_product_description_mode_with_filter() {
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'wc_facebook_product_description_mode',
 			function ( $mode ) {
 				return WC_Facebookcommerce_Integration::PRODUCT_DESCRIPTION_MODE_STANDARD;
@@ -2435,7 +2435,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_product_description_mode_falls_back_to_default_when_unknown_mode() {
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'wc_facebook_product_description_mode',
 			function ( $mode ) {
 				return 'super-duper-description-mode-123';
@@ -2668,7 +2668,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_is_advanced_matching_enabled_no_filter() {
-		remove_all_filters( 'wc_facebook_is_advanced_matching_enabled' );
+		$this->teardown_callback_category_safely( 'wc_facebook_is_advanced_matching_enabled' );
 
 		$output = $this->integration->is_advanced_matching_enabled();
 
@@ -2681,7 +2681,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_is_advanced_matching_enabled_with_filter() {
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'wc_facebook_is_advanced_matching_enabled',
 			function ( $is_enabled ) {
 				return false;
@@ -2699,7 +2699,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_is_product_sync_enabled_no_filter_no_option() {
-		remove_all_filters( 'wc_facebook_is_product_sync_enabled' );
+		$this->teardown_callback_category_safely( 'wc_facebook_is_product_sync_enabled' );
 		delete_option( WC_Facebookcommerce_Integration::SETTING_ENABLE_PRODUCT_SYNC );
 
 		$result = $this->integration->is_product_sync_enabled();
@@ -2713,7 +2713,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_is_product_sync_enabled_no_filter() {
-		remove_all_filters( 'wc_facebook_is_product_sync_enabled' );
+		$this->teardown_callback_category_safely( 'wc_facebook_is_product_sync_enabled' );
 		add_option(
 			WC_Facebookcommerce_Integration::SETTING_ENABLE_PRODUCT_SYNC,
 			'no'
@@ -2730,7 +2730,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_is_product_sync_enabled_with_filter() {
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'wc_facebook_is_product_sync_enabled',
 			function ( $is_enabled ) {
 				return false;
@@ -2781,7 +2781,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_is_debug_mode_enabled_returns_default_value() {
-		remove_all_filters( 'wc_facebook_is_debug_mode_enabled' );
+		$this->teardown_callback_category_safely( 'wc_facebook_is_debug_mode_enabled' );
 		delete_option( WC_Facebookcommerce_Integration::SETTING_ENABLE_DEBUG_MODE );
 
 		$result = $this->integration->is_debug_mode_enabled();
@@ -2795,7 +2795,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_is_debug_mode_enabled_returns_option_value() {
-		remove_all_filters( 'wc_facebook_is_debug_mode_enabled' );
+		$this->teardown_callback_category_safely( 'wc_facebook_is_debug_mode_enabled' );
 		add_option(
 			WC_Facebookcommerce_Integration::SETTING_ENABLE_DEBUG_MODE,
 			'yes'
@@ -2812,7 +2812,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_is_debug_mode_enabled_with_filter() {
-		add_filter(
+		$this->add_filter_with_safe_teardown(
 			'wc_facebook_is_debug_mode_enabled',
 			function ( $is_enabled ) {
 				return false;

--- a/tests/Unit/WPMLTest.php
+++ b/tests/Unit/WPMLTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class WPMLTest extends WP_UnitTestCase {
+class WPMLTest extends \WooCommerce\Facebook\Tests\Unit\AbstractWPUnitTestWithSafeFiltering {
 
 	/** @var int $fake_product_id */
 	private $fake_product_id = 1;
@@ -15,7 +15,8 @@ class WPMLTest extends WP_UnitTestCase {
 	public function tear_down() {
 		WC_Facebook_WPML_Injector::$settings     = null;
 		WC_Facebook_WPML_Injector::$default_lang = null;
-		remove_all_filters( 'wpml_post_language_details' );
+		// No need to manually remove filters, parent tearDown will handle it
+		parent::tear_down();
 	}
 
 	public function test_should_hide_product_when_wpml_filter_not_applied() {
@@ -23,7 +24,7 @@ class WPMLTest extends WP_UnitTestCase {
 	}
 
 	public function test_product_hidden_when_wpml_filter_returns_wp_error() {
-		add_filter(
+		$filter = $this->add_filter_with_safe_teardown(
 			'wpml_post_language_details',
 			function() {
 				return new WP_Error();
@@ -36,7 +37,7 @@ class WPMLTest extends WP_UnitTestCase {
 	public function test_product_hidden_no_settings_and_not_default() {
 		WC_Facebook_WPML_Injector::$default_lang = 'en_US';
 
-		add_filter(
+		$filter = $this->add_filter_with_safe_teardown(
 			'wpml_post_language_details',
 			function() {
 				return [
@@ -50,7 +51,7 @@ class WPMLTest extends WP_UnitTestCase {
 
 	public function test_product_not_hidden_no_settings_and_default() {
 		WC_Facebook_WPML_Injector::$default_lang = 'en_US';
-		add_filter(
+		$filter = $this->add_filter_with_safe_teardown(
 			'wpml_post_language_details',
 			function() {
 				return [
@@ -67,7 +68,7 @@ class WPMLTest extends WP_UnitTestCase {
 			'fr_FR' => FB_WPML_Language_Status::HIDDEN,
 		];
 
-		add_filter(
+		$filter = $this->add_filter_with_safe_teardown(
 			'wpml_post_language_details',
 			function() {
 				return [
@@ -84,7 +85,7 @@ class WPMLTest extends WP_UnitTestCase {
 			'fr_FR' => FB_WPML_Language_Status::VISIBLE,
 		];
 
-		add_filter(
+		$filter = $this->add_filter_with_safe_teardown(
 			'wpml_post_language_details',
 			function() {
 				return [

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 
-class fbproductTest extends WP_UnitTestCase {
+class fbproductTest extends \WooCommerce\Facebook\Tests\Unit\AbstractWPUnitTestWithSafeFiltering {
 	private $parent_fb_product;
 
 	/** @var \WC_Product_Simple */
@@ -113,18 +113,18 @@ class fbproductTest extends WP_UnitTestCase {
 		$facebook_product = new \WC_Facebook_Product( $product );
 		$facebook_product->set_description( 'fb description' );
 
-		add_filter( 'facebook_for_woocommerce_fb_product_description', function( $description ) {
+		$filter = $this->add_filter_with_safe_teardown( 'facebook_for_woocommerce_fb_product_description', function( $description ) {
 			return 'filtered description';
 		});
 
 		$description = $facebook_product->get_fb_description();
 		$this->assertEquals( $description, 'filtered description' );
 
-		remove_all_filters( 'facebook_for_woocommerce_fb_product_description' );
+		// Remove the filter early
+		$filter->teardown_safely_immediately();
 
 		$description = $facebook_product->get_fb_description();
 		$this->assertEquals( $description, 'fb description' );
-
 	}
 
 	/**
@@ -675,15 +675,16 @@ class fbproductTest extends WP_UnitTestCase {
 		$this->assertEquals('<p>short description test</p>', $description);
 
 		// Test 7: Applies filters
-		add_filter('facebook_for_woocommerce_fb_rich_text_description', function($description) {
+		$filter = $this->add_filter_with_safe_teardown('facebook_for_woocommerce_fb_rich_text_description', function($description) {
 			return '<p>filtered description</p>';
 		});
 		
 		$description = $facebook_product->get_rich_text_description();
 		$this->assertEquals('<p>filtered description</p>', $description);
 		
-		// Cleanup
-		remove_all_filters('facebook_for_woocommerce_fb_rich_text_description');
+		// Remove the filter early
+		$filter->teardown_safely_immediately();
+		
 		delete_option(WC_Facebookcommerce_Integration::SETTING_PRODUCT_DESCRIPTION_MODE);
 	}
 


### PR DESCRIPTION
# PR: Improve Test Filter Management with AbstractWPUnitTestWithSafeFiltering

This PR addresses a common source of test flakiness by implementing proper WordPress filter management in our test suite.

## The Problem

Sometimes when testing, you want to override the behavior of a global function. This can be done using a wordpress primitive called `add_filter`

While this can be helpful for mocking deep functionality, these filters present a challenge when testing across hundreds of files:

1. **Filter Leakage**: When `add_filter()` is used in tests without proper cleanup, filters persist between tests, causing unexpected behavior and interdependencies.

2. **Incomplete Cleanup**: Manual filter removal is error-prone and often forgotten, especially when tests fail before reaching teardown code.

3. **Overly Aggressive Cleanup**: Using `remove_all_filters()` is dangerous as it removes ALL filters for a hook, including those added by WordPress core or other plugins, potentially breaking functionality in subsequent tests.

## Solution Proposed by this PR

The `AbstractWPUnitTestWithSafeFiltering` class provides:

- A `add_filter_with_safe_teardown()` method that tracks all added filters
- Automatic cleanup in `tearDown()` that only removes filters added by the current test
- The ability to remove specific filters early with `teardown_safely_immediately()`
- A category-specific cleanup method with `teardown_callback_category_safely()` -- allowing you to safely wipe out all test-related filters for 'event_type_A' without affecting B or C.

## Changes

- Introduced AbstractWPUnitTestWithSafeFiltering with above functionality.
- Updated WCFacebookCommerceIntegrationTest, fbproductTest, WPMLTest, and FeedUploadUtilsTest to extend AbstractWPUnitTestWithSafeFiltering
- Replaced all `add_filter()` calls with `add_filter_with_safe_teardown()`
- in some special cases (per-test), replaced remove_all_filters with appropriate teardown calls
- In most cases, rely on default "invisible" safe teardown behavior

## Testing Performed
- Ran updated test suit using phpunit -- all succeeded. 
