### PR TITLE
Fix feed upload error "feed_column_count_mismatch" when product has multiple colors separated by a coma

### DIFF
--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -512,27 +512,27 @@ class WC_Facebook_Product_Feed {
 		static::get_value_from_product_data( $product_data, 'url' ) . ',' .
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'product_type' ) ) . ',' .
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'brand' ) ) . ',' .
-		static::format_price_for_feed(
+		static::format_string_for_feed( static::format_price_for_feed(
 			static::get_value_from_product_data( $product_data, 'price', 0 ),
 			static::get_value_from_product_data( $product_data, 'currency' )
-		) . ',' .
-		static::get_value_from_product_data( $product_data, 'availability' ) . ',' .
+		)) . ',' .
+		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'availability' ) ) . ',' .
 		$item_group_id . ',' .
 		static::get_value_from_product_data( $product_data, 'checkout_url' ) . ',' .
 		static::format_additional_image_url( static::get_value_from_product_data( $product_data, 'additional_image_urls' ) ) . ',' .
-		$sale_price_effective_date . ',' .
-		$sale_price . ',' .
+		static::format_string_for_feed( $sale_price_effective_date ) . ',' .
+		static::format_string_for_feed( $sale_price ) . ',' .
 		'new' . ',' .
-		static::get_value_from_product_data( $product_data, 'visibility' ) . ',' .
-		static::get_value_from_product_data( $product_data, 'gender' ) . ',' .
-		static::format_string_for_feed(static::get_value_from_product_data( $product_data, 'color' )) . ',' .
-		static::get_value_from_product_data( $product_data, 'size' ) . ',' .
-		static::get_value_from_product_data( $product_data, 'pattern' ) . ',' .
-		static::get_value_from_product_data( $product_data, 'google_product_category' ) . ',' .
-		static::get_value_from_product_data( $product_data, 'default_product' ) . ',' .
-		static::get_value_from_product_data( $product_data, 'variant' ) . ',' .
-		static::get_value_from_product_data( $product_data, 'gtin' ) . ',' .
-		static::get_value_from_product_data( $product_data, 'quantity_to_sell_on_facebook' ) . ',' .
+		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'visibility' )) . ',' .
+		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'gender' )) . ',' .
+		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'color' )) . ',' .
+		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'size' )) . ',' .
+		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'pattern' )) . ',' .
+		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'google_product_category' )) . ',' .
+		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'default_product' )) . ',' .
+		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'variant' )) . ',' .
+		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'gtin' )) . ',' .
+		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'quantity_to_sell_on_facebook' )) . ',' .
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'rich_text_description' ) ) . PHP_EOL;
 	}
 

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -525,7 +525,7 @@ class WC_Facebook_Product_Feed {
 		'new' . ',' .
 		static::get_value_from_product_data( $product_data, 'visibility' ) . ',' .
 		static::get_value_from_product_data( $product_data, 'gender' ) . ',' .
-		static::get_value_from_product_data( $product_data, 'color' ) . ',' .
+		static::format_string_for_feed(static::get_value_from_product_data( $product_data, 'color' )) . ',' .
 		static::get_value_from_product_data( $product_data, 'size' ) . ',' .
 		static::get_value_from_product_data( $product_data, 'pattern' ) . ',' .
 		static::get_value_from_product_data( $product_data, 'google_product_category' ) . ',' .


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When rolling out product sync via Feeds, we noticed a fatal upload error for products that have value of a color to be multiple colors written with commas (e.g. color value: Yellow,Blue,Red). This case right leads to fatal error "feed_column_count_mismatch" on feed upload and the product is deleted from the catalog.

The fix is simple what we already fo for other fields like `name` or `description`: wrap it up with quotes by calling `format_string_for_feed`. 
Applying this not only to color but some other fields too. Manually tested feed generation and feed upload success.

<!--- Optional --->
### Additional details:
Screenshot shows multi color  value for a single product written via comas that leads to feed sync issue before this fix. 
 
<img width="1857" alt="Screenshot 2025-03-14 at 17 10 11" src="https://github.com/user-attachments/assets/1fdffc98-b245-4c86-a479-1688a2bd2aa0" />


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create or update an existing product to have multi color value written via comas, as per screenshot.
2. Trigger feed generation and check for errors.  


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - feed upload error "feed_column_count_mismatch" when product has multiple colors separated by a coma. 
