### PR TITLE
Sync products that are out of stock

### DIFF
--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -133,7 +133,6 @@ class ProductValidator {
 	public function validate() {
 		$this->validate_sync_enabled_globally();
 		$this->validate_product_status();
-		$this->validate_product_stock_status();
 		$this->validate_product_sync_field();
 		$this->validate_product_price();
 		$this->validate_product_visibility();
@@ -151,7 +150,6 @@ class ProductValidator {
 	 */
 	public function validate_but_skip_status_check() {
 		$this->validate_sync_enabled_globally();
-		$this->validate_product_stock_status();
 		$this->validate_product_sync_field();
 		$this->validate_product_price();
 		$this->validate_product_visibility();
@@ -168,7 +166,6 @@ class ProductValidator {
 	 */
 	public function validate_but_skip_sync_field() {
 		$this->validate_sync_enabled_globally();
-		$this->validate_product_stock_status();
 		$this->validate_product_price();
 		$this->validate_product_visibility();
 		$this->validate_product_terms();
@@ -265,17 +262,6 @@ class ProductValidator {
 
 		if ( 'publish' !== $product->get_status() ) {
 			throw new ProductExcludedException( __( 'Product is not published.', 'facebook-for-woocommerce' ) );
-		}
-	}
-
-	/**
-	 * Check whether the product should be excluded due to being out of stock.
-	 *
-	 * @throws ProductExcludedException If product should not be synced.
-	 */
-	protected function validate_product_stock_status() {
-		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $this->product->is_in_stock() ) {
-			throw new ProductExcludedException( __( 'Product must be in stock.', 'facebook-for-woocommerce' ) );
 		}
 	}
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -221,7 +221,7 @@ class Products {
 	 * @return bool
 	 */
 	public static function product_should_be_deleted( \WC_Product $product ) {
-		return ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $product->is_in_stock() ) || ! facebook_for_woocommerce()->get_product_sync_validator( $product )->passes_product_terms_check();
+		return ! facebook_for_woocommerce()->get_product_sync_validator( $product )->passes_product_terms_check();
 	}
 
 

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -909,13 +909,13 @@ class WCFacebookCommerceIntegrationTest extends \WooCommerce\Facebook\Tests\Unit
 
 		add_post_meta( $product->get_id(), WC_Facebookcommerce_Integration::FB_PRODUCT_ITEM_ID, 'facebook-product-item-id' );
 
-		$this->api->expects( $this->once() )
+		$this->api->expects( $this->never() )
 			->method( 'delete_product_item' )
 			->with( 'facebook-product-item-id' );
 
 		$result = $this->integration->delete_on_out_of_stock( $product->get_id(), $product );
 
-		$this->assertTrue( $result );
+		$this->assertFalse( $result );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Currently items out of stock are not synced if the user has selected a setting in inventory to hide the products that are out of stock from the catalog. We want to synced them anyways.

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## Screenshots

After clicking SYNC PRODUCTS in the plugin config:

### Before

<img width="1329" alt="Screenshot 2025-03-18 at 17 29 39" src="https://github.com/user-attachments/assets/5c3c3ed4-727b-48d0-9196-4a3bb8e47c34" />

### After

<img width="1345" alt="Screenshot 2025-03-18 at 10 19 25" src="https://github.com/user-attachments/assets/919c398d-2daf-49f0-96a6-57eb2e2ba913" />



## Test instructions

npm run test:php  ran was successful


## Checklist

- [ ] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests and all the new and existing unit tests pass locally with my changes
- [ ] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.


## Changelog entry

sync products out of stock to meta despite visibility config
