### PR TITLE
[fix] Make error logging event configurable

### DIFF
--- a/includes/Framework/ErrorLogHandler.php
+++ b/includes/Framework/ErrorLogHandler.php
@@ -47,8 +47,16 @@ class ErrorLogHandler extends LogHandlerBase {
 	 */
 	public function process_error_log( $raw_context ) {
 		$context = self::set_core_log_context( $raw_context );
-		facebook_for_woocommerce()->get_api()->log_to_meta( $context );
-		WC_Facebookcommerce_Utils::logWithDebugModeEnabled( 'Error log: ' . wp_json_encode( $context ) );
+		try {
+			$response = facebook_for_woocommerce()->get_api()->log_to_meta( $context );
+			if ( $response->success ) {
+				WC_Facebookcommerce_Utils::logWithDebugModeEnabled( 'Error log: ' . wp_json_encode( $context ) );
+			} else {
+				WC_Facebookcommerce_Utils::logWithDebugModeEnabled( 'Bad response from log_to_meta request' );
+			}
+		} catch ( \Exception $e ) {
+			WC_Facebookcommerce_Utils::logWithDebugModeEnabled( 'Error persisting error logs: ' . $e->getMessage() );
+		}
 	}
 
 	/**
@@ -57,16 +65,14 @@ class ErrorLogHandler extends LogHandlerBase {
 	 * @since 3.5.0
 	 *
 	 * @param Throwable $error error object
-	 * @param array     $context context example: ['catalog_id' => '1234567890', 'order_id' => '1234567890',
-	 *      'promotion_id' => '1234567890', 'flow_name' => 'checkout', 'flow_step' => 'verification',
-	 *      'extra_data' => ['dictionary type' => 'any data that is not fall into our pre-defined format.']
+	 * @param array     $context wiki: https://www.internalfb.com/wiki/Commerce_Platform/Teams/3P_Ecosystems_(3PE)/3rd_Party_platforms/Woo_Commerce/How_To_Use_WooCommerce_Side_Logging/
 	 */
 	public static function log_exception_to_meta( Throwable $error, array $context = [] ) {
 		$extra_data                = WC_Facebookcommerce_Utils::getContextData( $context, 'extra_data', [] );
 		$extra_data['php_version'] = phpversion();
 
 		$request_data = [
-			'event'             => 'error_log',
+			'event'             => WC_Facebookcommerce_Utils::getContextData( $context, 'event', 'error_log' ),
 			'event_type'        => WC_Facebookcommerce_Utils::getContextData( $context, 'event_type' ),
 			'exception_message' => $error->getMessage(),
 			'exception_trace'   => $error->getTraceAsString(),

--- a/includes/Framework/ErrorLogHandler.php
+++ b/includes/Framework/ErrorLogHandler.php
@@ -80,8 +80,6 @@ class ErrorLogHandler extends LogHandlerBase {
 			'exception_class'   => get_class( $error ),
 			'order_id'          => WC_Facebookcommerce_Utils::getContextData( $context, 'order_id' ),
 			'promotion_id'      => WC_Facebookcommerce_Utils::getContextData( $context, 'promotion_id' ),
-			'flow_name'         => WC_Facebookcommerce_Utils::getContextData( $context, 'flow_name' ),
-			'flow_step'         => WC_Facebookcommerce_Utils::getContextData( $context, 'flow_step' ),
 			'incoming_params'   => WC_Facebookcommerce_Utils::getContextData( $context, 'incoming_params' ),
 			'extra_data'        => $extra_data,
 		];

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -864,9 +864,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		 * @since 3.5.0
 		 * 
 		 * @param Throwable $error error object
-		 * @param array $context context example: ['catalog_id' => '1234567890', 'order_id' => '1234567890', 
-		 * 		'promotion_id' => '1234567890', 'flow_name' => 'checkout', 'flow_step' => 'verification', 
-		 * 		'extra_data' => ['dictionary type' => 'any data that is not fall into our pre-defined format.']
+		 * @param array $context wiki: https://www.internalfb.com/wiki/Commerce_Platform/Teams/3P_Ecosystems_(3PE)/3rd_Party_platforms/Woo_Commerce/How_To_Use_WooCommerce_Side_Logging/
 		 */
 		public static function logExceptionImmediatelyToMeta(Throwable $error, array $context = []) {
 			ErrorLogHandler::log_exception_to_meta($error, $context);
@@ -875,6 +873,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		/**
 		 * Utility function for sending telemetry logs to Meta.
 		 * @since 3.5.0
+		 * 
+		 * @param string $message
+		 * @param array $context wiki: https://www.internalfb.com/wiki/Commerce_Platform/Teams/3P_Ecosystems_(3PE)/3rd_Party_platforms/Woo_Commerce/How_To_Use_WooCommerce_Side_Logging/
 		 */
 		public static function logTelemetryToMeta(string $message, array $context = []) {
 			$extra_data = self::getContextData( $context, 'extra_data', [] );


### PR DESCRIPTION
## Description

Currently event field in error logging is 'error_log' by default and doesn't consume any input. this pr makes error logging event configurable, so that it can be used to filter for specific logs in our Scuba queries.

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Test instructions

Tested with customized event: 'catalog_sync': https://fburl.com/scuba/commerce_3p_platform_event/9ptul6yy 

