### PR TITLE
Add is_multisite logging to FBE plugin version update request

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -286,7 +286,6 @@ class API extends Base {
 	 *
 	 * @return Response|API\FBE\Configuration\Update\Response
 	 * @throws ApiException
-	 * @throws Request_Limit_Reached
 	 */
 	public function update_plugin_version_configuration( string $external_business_id, string $plugin_version ): API\FBE\Configuration\Update\Response {
 		$request = new API\FBE\Configuration\Update\Request( $external_business_id );

--- a/includes/API.php
+++ b/includes/API.php
@@ -283,12 +283,19 @@ class API extends Base {
 	 *
 	 * @param string $external_business_id external business ID
 	 * @param string $plugin_version The plugin version.
-	 * @return API\Response|API\FBE\Configuration\Update\Response
-	 * @throws WooCommerce\Facebook\Framework\Api\Exception
+	 *
+	 * @return Response|API\FBE\Configuration\Update\Response
+	 * @throws ApiException
+	 * @throws Request_Limit_Reached
 	 */
 	public function update_plugin_version_configuration( string $external_business_id, string $plugin_version ): API\FBE\Configuration\Update\Response {
 		$request = new API\FBE\Configuration\Update\Request( $external_business_id );
-		$request->set_plugin_version( $plugin_version );
+		$request->set_external_client_metadata(
+			array(
+				'version_id' => $plugin_version,
+				'is_multisite'   => is_multisite(),
+			)
+		);
 		$this->set_response_handler( API\FBE\Configuration\Update\Response::class );
 		return $this->perform_request( $request );
 	}

--- a/includes/API/FBE/Configuration/Update/Request.php
+++ b/includes/API/FBE/Configuration/Update/Request.php
@@ -35,28 +35,10 @@ class Request extends Configuration\Request {
 		$this->data['fbe_external_business_id'] = $external_business_id;
 	}
 
-
-	/**
-	 * Sets the plugin version for configuration update request.
-	 *
-	 * @since 3.0.10
-	 *
-	 * @param string $plugin_version current plugin version.
-	 */
-	public function set_plugin_version( string $plugin_version ) {
-
-		$this->data['business_config'] = array(
-			'external_client' =>
-				array(
-					'version_id' => "$plugin_version",
-				),
-		);
-	}
-
 	/**
 	 * Sets the external client metadata for logging
 	 *
-	 * @since 3.4.1
+	 * @since 3.4.4
 	 *
 	 * @param array $metadata map of metadata to include. Example: array ('version_id' => '0.0.0', 'is_multisite' => True)
 	 *

--- a/includes/API/FBE/Configuration/Update/Request.php
+++ b/includes/API/FBE/Configuration/Update/Request.php
@@ -52,4 +52,21 @@ class Request extends Configuration\Request {
 				),
 		);
 	}
+
+	/**
+	 * Sets the external client metadata for logging
+	 *
+	 * @since 3.4.1
+	 *
+	 * @param array $metadata map of metadata to include. Example: array ('version_id' => '0.0.0', 'is_multisite' => True)
+	 *
+	 * @return void
+	 */
+	public function set_external_client_metadata( array $metadata ) {
+		$this->data['business_config'] = array(
+			'external_client' => $metadata,
+		);
+
+		is_multisite();
+	}
 }

--- a/tests/Unit/ExternalVersionUpdate/UpdateTest.php
+++ b/tests/Unit/ExternalVersionUpdate/UpdateTest.php
@@ -128,6 +128,7 @@ class UpdateTest extends WP_UnitTestCase {
 			'business_config'          => array(
 				'external_client' => array(
 					'version_id' => WC_Facebookcommerce_Utils::PLUGIN_VERSION,
+					'is_multisite' => false,
 				),
 			),
 		);


### PR DESCRIPTION
## Description

Adding is_multisite logging for additional context on seller setup during FBE plugin version update log. This will help us determine how to focus our compatibility efforts

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Test instructions

Called `facebook_for_woocommerce()->get_api()->update_plugin_version_configuration( 'carter-wp-dev-67381a66bf371', '9.9.1' );` and observed proper log format was sent to Meta


## Checklist

- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests and all the new and existing unit tests pass locally with my changes
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.


## Changelog entry

Added is_multisite logging to the update_plugin_version_configuration request
