### PR TITLE
[WAUM][3/n]Add a rest api endpoint to receive whatsapp webhooks

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -96,6 +96,9 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	/** @var WooCommerce\Facebook\Handlers\WebHook webhook handler */
 	private $webhook_handler;
 
+	/** @var WooCommerce\Facebook\Handlers\Whatsapp_WebHook whatsapp webhook handler */
+	private $whatsapp_webhook_handler;
+
 	/** @var WooCommerce\Facebook\Commerce commerce handler */
 	private $commerce_handler;
 
@@ -189,7 +192,6 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 
 			$this->heartbeat = new Heartbeat( WC()->queue() );
 			$this->heartbeat->init();
-
 			$this->feed_manager              = new WooCommerce\Facebook\Feed\FeedManager();
 			$this->checkout           		 = new WooCommerce\Facebook\Checkout();
 			$this->product_feed              = new WooCommerce\Facebook\Products\Feed();
@@ -219,10 +221,11 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 				$this->background_remove_duplicate_visibility_meta = new Background_Remove_Duplicate_Visibility_Meta();
 			}
 
-			$this->connection_handler = new WooCommerce\Facebook\Handlers\Connection( $this );
+			$this->connection_handler 			= new WooCommerce\Facebook\Handlers\Connection( $this );
 			new WooCommerce\Facebook\Handlers\MetaExtension();
-			$this->webhook_handler    = new WooCommerce\Facebook\Handlers\WebHook( $this );
-			$this->tracker            = new WooCommerce\Facebook\Utilities\Tracker();
+			$this->webhook_handler   				= new WooCommerce\Facebook\Handlers\WebHook( $this );
+			$this->whatsapp_webhook_handler = new WooCommerce\Facebook\Handlers\Whatsapp_Webhook( $this );
+			$this->tracker            			= new WooCommerce\Facebook\Utilities\Tracker();
 
 			// Init jobs
 			$this->job_manager = new WooCommerce\Facebook\Jobs\JobManager();

--- a/includes/Handlers/Whatsapp_Webhook.php
+++ b/includes/Handlers/Whatsapp_Webhook.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace WooCommerce\Facebook\Handlers;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * The Whatsapp WebHook handler to receive POST request from Meta Hosted Connectbridge.
+ *
+ * @since 2.3.0
+ */
+class Whatsapp_Webhook {
+
+	/**
+	 * Constructs a new Whatsapp WebHook.
+	 *
+	 * @param \WC_Facebookcommerce $plugin Plugin instance.
+	 *
+	 * @since 2.3.0
+	 */
+	public function __construct( \WC_Facebookcommerce $plugin ) {
+		add_action( 'rest_api_init', array( $this, 'init_whatsapp_webhook_endpoint' ) );
+	}
+
+
+	/**
+	 * Register Whatsapp WebHook REST API endpoint
+	 *
+	 * @since 2.3.0
+	 */
+	public function init_whatsapp_webhook_endpoint() {
+		register_rest_route(
+			'wc-facebook/v1',
+			'whatsapp_webhook',
+			array(
+				array(
+					'methods'             => array( 'POST' ),
+					'callback'            => array( $this, 'whatsapp_webhook_callback' ),
+					'permission_callback' => '__return_true',
+				),
+			)
+		);
+	}
+
+
+
+	/**
+	 * Whatsapp Webhook Listener
+	 *
+	 * @since 2.3.0
+	 * @see Connection
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 * @return \WP_REST_Response
+	 */
+	public function whatsapp_webhook_callback( \WP_REST_Request $request ) {
+		$request_params = $request->get_query_params();
+		// Note: The log statements will be removed in follow up PRs. This is just added to verify the whatsapp webhook is called successfully.
+		wc_get_logger()->error( 'Webhook is called successfully', $request_params );
+		// TODO: Validate the request and store the data(business_id,waba_id,access_token) received in the WooCommerce DB
+		return new \WP_REST_Response( null, 200 );
+	}
+}


### PR DESCRIPTION
## Description

We are building a Meta Hosted Connectbridge that will recieve the access tokens and waba info at the end of the onboarding flow and then forward it to the end business.  In order to receive this onboarding information we create a POST REST API in the plugin which will receive the whatsapp waba information and access token and store it in the plugin database.

### Type of change
- New feature (non-breaking change which adds functionality)


## Screenshots
https://github.com/user-attachments/assets/59f4037e-e51f-47d8-8bda-bb2593b7f933

## Test instructions
Used postman to call the REST API. Used WC_Logger to check if the params are passed as expected. 


## Changelog entry
creating rest api to receive whatsapp onboarding info
