### PR TITLE
Syncing plugin version info regularly

### DIFF
--- a/includes/ExternalVersionUpdate/Update.php
+++ b/includes/ExternalVersionUpdate/Update.php
@@ -35,7 +35,7 @@ class Update {
 	 * @since 3.0.10
 	 */
 	public function __construct() {
-		add_action( Heartbeat::HOURLY, array( $this, 'maybe_update_external_plugin_version' ) );
+		add_action( Heartbeat::DAILY, array( $this, 'maybe_update_external_plugin_version' ) );
 	}
 
 	/**
@@ -59,13 +59,6 @@ class Update {
 	 * @return bool
 	 */
 	public function should_update_version() {
-		$latest_version_sent = get_option( self::LATEST_VERSION_SENT, '0.0.0' );
-
-		if ( WC_Facebookcommerce_Utils::PLUGIN_VERSION === $latest_version_sent ) {
-			// Up to date. Nothing to do.
-			return false;
-		}
-
 		$plugin = facebook_for_woocommerce();
 
 		if ( ! $plugin->get_connection_handler()->is_connected() ) {

--- a/tests/Unit/ExternalVersionUpdate/UpdateTest.php
+++ b/tests/Unit/ExternalVersionUpdate/UpdateTest.php
@@ -92,12 +92,6 @@ class UpdateTest extends WP_UnitTestCase {
 	 */
 	public function test_should_update_version() {
 		$plugin = facebook_for_woocommerce();
-
-		// Assert update not required when the versions match.
-		update_option( 'facebook_for_woocommerce_latest_version_sent_to_server', WC_Facebookcommerce_Utils::PLUGIN_VERSION );
-		$should_update = $this->update->should_update_version();
-		$this->assertFalse( $should_update );
-
 		/**
 		 * Set the $plugin->connection_handler and $plugin->api access to true. This will allow us
 		 * to assign the mock objects to these properties.
@@ -113,7 +107,6 @@ class UpdateTest extends WP_UnitTestCase {
 									->getMock();
 		$mock_connection_handler->expects( $this->any() )->method( 'is_connected' )->willReturn( false );
 		$prop_connection_handler->setValue( $plugin, $mock_connection_handler );
-
 		update_option( 'facebook_for_woocommerce_latest_version_sent_to_server', '0.0.0' ); // Reset the option.
 		$should_update2 = $this->update->should_update_version();
 		$this->assertFalse( $should_update2 );
@@ -127,7 +120,7 @@ class UpdateTest extends WP_UnitTestCase {
 		$prop_connection_handler->setValue( $plugin, $mock_connection_handler );
 		update_option( 'facebook_for_woocommerce_latest_version_sent_to_server', WC_Facebookcommerce_Utils::PLUGIN_VERSION );
 		$should_update3 = $this->update->should_update_version();
-		$this->assertFalse( $should_update3 ); // Because the versions match.
+		$this->assertTrue( $should_update3 ); // Because the versions match.
 
 		update_option( 'facebook_for_woocommerce_latest_version_sent_to_server', '0.0.0' ); // Reset the option.
 		$should_update4 = $this->update->should_update_version();


### PR DESCRIPTION
## Description

Currently, the plugin version is sent to Meta APIs once after each plugin upgrade. However, due to the current reliability issues with the APIs, many of these values are being lost, making it difficult to determine which plugin version is being used for a given connection. Therefore, we will now send the plugin version once daily.

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Screenshots
N/A


## Test instructions

npm run test:php

Following relevant tests are updated 
/tests/Unit/ExternalVersionUpdate/UpdateTest.php 


## Checklist

- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests and all the new and existing unit tests pass locally with my changes
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.


## Changelog entry

> Syncing plugin version info 