### PR TITLE
Update woo_commerce_retailer_id to existing field external_variant_id

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -303,12 +303,18 @@ class API extends Base {
 	 *
 	 * @param string $external_business_id external business ID
 	 * @param string $plugin_version The plugin version.
-	 * @return API\Response|API\FBE\Configuration\Update\Response
-	 * @throws WooCommerce\Facebook\Framework\Api\Exception
+	 *
+	 * @return Response|API\FBE\Configuration\Update\Response
+	 * @throws ApiException
 	 */
 	public function update_plugin_version_configuration( string $external_business_id, string $plugin_version ): API\FBE\Configuration\Update\Response {
 		$request = new API\FBE\Configuration\Update\Request( $external_business_id );
-		$request->set_plugin_version( $plugin_version );
+		$request->set_external_client_metadata(
+			array(
+				'version_id' => $plugin_version,
+				'is_multisite'   => is_multisite(),
+			)
+		);
 		$this->set_response_handler( API\FBE\Configuration\Update\Response::class );
 		return $this->perform_request( $request );
 	}

--- a/includes/API/FBE/Configuration/Update/Request.php
+++ b/includes/API/FBE/Configuration/Update/Request.php
@@ -35,21 +35,20 @@ class Request extends Configuration\Request {
 		$this->data['fbe_external_business_id'] = $external_business_id;
 	}
 
-
 	/**
-	 * Sets the plugin version for configuration update request.
+	 * Sets the external client metadata for logging
 	 *
-	 * @since 3.0.10
+	 * @since 3.4.4
 	 *
-	 * @param string $plugin_version current plugin version.
+	 * @param array $metadata map of metadata to include. Example: array ('version_id' => '0.0.0', 'is_multisite' => True)
+	 *
+	 * @return void
 	 */
-	public function set_plugin_version( string $plugin_version ) {
-
+	public function set_external_client_metadata( array $metadata ) {
 		$this->data['business_config'] = array(
-			'external_client' =>
-				array(
-					'version_id' => "$plugin_version",
-				),
+			'external_client' => $metadata,
 		);
+
+		is_multisite();
 	}
 }

--- a/includes/ExternalVersionUpdate/Update.php
+++ b/includes/ExternalVersionUpdate/Update.php
@@ -35,7 +35,7 @@ class Update {
 	 * @since 3.0.10
 	 */
 	public function __construct() {
-		add_action( Heartbeat::HOURLY, array( $this, 'maybe_update_external_plugin_version' ) );
+		add_action( Heartbeat::DAILY, array( $this, 'maybe_update_external_plugin_version' ) );
 	}
 
 	/**
@@ -59,13 +59,6 @@ class Update {
 	 * @return bool
 	 */
 	public function should_update_version() {
-		$latest_version_sent = get_option( self::LATEST_VERSION_SENT, '0.0.0' );
-
-		if ( WC_Facebookcommerce_Utils::PLUGIN_VERSION === $latest_version_sent ) {
-			// Up to date. Nothing to do.
-			return false;
-		}
-
 		$plugin = facebook_for_woocommerce();
 
 		if ( ! $plugin->get_connection_handler()->is_connected() ) {

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -832,6 +832,7 @@ class WC_Facebook_Product {
 		$product_data[ 'availability' ] = $this->is_in_stock() ? 'in stock' : 'out of stock';
 		$product_data[ 'visibility' ] = Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
 		$product_data[ 'retailer_id' ] = $retailer_id;
+		$product_data[ 'woo_commerce_retailer_id' ] = $this->get_id();
 
 		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
 			$product_data['title'] = WC_Facebookcommerce_Utils::clean_string( $this->get_title() );

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -832,7 +832,7 @@ class WC_Facebook_Product {
 		$product_data[ 'availability' ] = $this->is_in_stock() ? 'in stock' : 'out of stock';
 		$product_data[ 'visibility' ] = Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
 		$product_data[ 'retailer_id' ] = $retailer_id;
-		$product_data[ 'woo_commerce_retailer_id' ] = $this->get_id();
+		$product_data[ 'external_variant_id' ] = $this->get_id();
 
 		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
 			$product_data['title'] = WC_Facebookcommerce_Utils::clean_string( $this->get_title() );

--- a/tests/Unit/ExternalVersionUpdate/UpdateTest.php
+++ b/tests/Unit/ExternalVersionUpdate/UpdateTest.php
@@ -92,12 +92,6 @@ class UpdateTest extends WP_UnitTestCase {
 	 */
 	public function test_should_update_version() {
 		$plugin = facebook_for_woocommerce();
-
-		// Assert update not required when the versions match.
-		update_option( 'facebook_for_woocommerce_latest_version_sent_to_server', WC_Facebookcommerce_Utils::PLUGIN_VERSION );
-		$should_update = $this->update->should_update_version();
-		$this->assertFalse( $should_update );
-
 		/**
 		 * Set the $plugin->connection_handler and $plugin->api access to true. This will allow us
 		 * to assign the mock objects to these properties.
@@ -113,7 +107,6 @@ class UpdateTest extends WP_UnitTestCase {
 									->getMock();
 		$mock_connection_handler->expects( $this->any() )->method( 'is_connected' )->willReturn( false );
 		$prop_connection_handler->setValue( $plugin, $mock_connection_handler );
-
 		update_option( 'facebook_for_woocommerce_latest_version_sent_to_server', '0.0.0' ); // Reset the option.
 		$should_update2 = $this->update->should_update_version();
 		$this->assertFalse( $should_update2 );
@@ -127,7 +120,7 @@ class UpdateTest extends WP_UnitTestCase {
 		$prop_connection_handler->setValue( $plugin, $mock_connection_handler );
 		update_option( 'facebook_for_woocommerce_latest_version_sent_to_server', WC_Facebookcommerce_Utils::PLUGIN_VERSION );
 		$should_update3 = $this->update->should_update_version();
-		$this->assertFalse( $should_update3 ); // Because the versions match.
+		$this->assertTrue( $should_update3 ); // Because the versions match.
 
 		update_option( 'facebook_for_woocommerce_latest_version_sent_to_server', '0.0.0' ); // Reset the option.
 		$should_update4 = $this->update->should_update_version();

--- a/tests/Unit/ExternalVersionUpdate/UpdateTest.php
+++ b/tests/Unit/ExternalVersionUpdate/UpdateTest.php
@@ -180,6 +180,7 @@ class UpdateTest extends WP_UnitTestCase {
 			'business_config'          => array(
 				'external_client' => array(
 					'version_id' => WC_Facebookcommerce_Utils::PLUGIN_VERSION,
+					'is_multisite' => false,
 				),
 			),
 		);


### PR DESCRIPTION
## Description

This PR changes the API response to include the actual product retailer ID set in WooCommerce. This will later be used to generate the checkout URL. After Marian's comment on the previous PR we're changing to use the existing field external_variant_id

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Screenshots
N/A

## Test instructions

./vendor/bin/phpunit --filter fbproductTest


## Checklist

- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests and all the new and existing unit tests pass locally with my changes
- [ ] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.


## Changelog entry

Update woo_commerce_retailer_id to existing field external_variant_id
