### PR TITLE
Replace woo_commerce_retailer_id with external_variant_id

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -832,7 +832,7 @@ class WC_Facebook_Product {
 		$product_data[ 'availability' ] = $this->is_in_stock() ? 'in stock' : 'out of stock';
 		$product_data[ 'visibility' ] = Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
 		$product_data[ 'retailer_id' ] = $retailer_id;
-		$product_data[ 'woo_commerce_retailer_id' ] = $this->get_id();
+		$product_data[ 'external_variant_id' ] = $this->get_id();
 
 		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
 			$product_data['title'] = WC_Facebookcommerce_Utils::clean_string( $this->get_title() );


### PR DESCRIPTION
## Description

This PR changes the API response to include the actual product retailer ID set in WooCommerce. This will later be used to generate the checkout URL. After Marian's comment on the previous PR we're changing to use the existing field external_variant_id

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Screenshots
N/A

## Test instructions

./vendor/bin/phpunit --filter fbproductTest

## Checklist

- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests and all the new and existing unit tests pass locally with my changes
- [ ] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.


## Changelog entry

Update woo_commerce_retailer_id to existing field external_variant_id
