### PR TITLE
Conditional feed upload scheduling

### DIFF
--- a/includes/Feed/AbstractFeed.php
+++ b/includes/Feed/AbstractFeed.php
@@ -96,9 +96,7 @@ abstract class AbstractFeed {
 	 * @since 3.5.0
 	 */
 	public function schedule_feed_generation(): void {
-		// If the Commerce Partner Integration ID isn't set then don't schedule feed generation
-		$cpi_id = facebook_for_woocommerce()->get_connection_handler()->get_commerce_partner_integration_id();
-		if ( '' === $cpi_id ) {
+		if ( $this->should_skip_feed() ) {
 			return;
 		}
 
@@ -122,9 +120,7 @@ abstract class AbstractFeed {
 	 * @since 3.5.0
 	 */
 	public function regenerate_feed(): void {
-		// If the Commerce Partner Integration ID isn't set then don't generate the feed
-		$cpi_id = facebook_for_woocommerce()->get_connection_handler()->get_commerce_partner_integration_id();
-		if ( '' === $cpi_id ) {
+		if ( $this->should_skip_feed() ) {
 			return;
 		}
 
@@ -133,6 +129,19 @@ abstract class AbstractFeed {
 		} else {
 			$this->feed_handler->generate_feed_file();
 		}
+	}
+
+	/**
+	 * The feed should be skipped if there isn't a Commerce Partner Integration ID set as the ID is required for
+	 * calls to the GraphCommercePartnerIntegrationFileUpdatePost endpoint.
+	 * Overwrite this function if your feed upload uses a different endpoint with different requirements.
+	 *
+	 * @since 3.5.0
+	 */
+	public function should_skip_feed(): bool {
+		$cpi_id = facebook_for_woocommerce()->get_connection_handler()->get_commerce_partner_integration_id();
+
+		return empty( $cpi_id );
 	}
 
 	/**

--- a/includes/Feed/AbstractFeed.php
+++ b/includes/Feed/AbstractFeed.php
@@ -287,7 +287,7 @@ abstract class AbstractFeed {
 					'event'      => 'feed_upload',
 					'event_type' => 'handle_feed_data_request',
 					'extra_data' => [
-						'feed_type' => $name,
+						'feed_name' => $name,
 					],
 				]
 			);

--- a/includes/Feed/AbstractFeed.php
+++ b/includes/Feed/AbstractFeed.php
@@ -171,7 +171,7 @@ abstract class AbstractFeed {
 			facebook_for_woocommerce()->
 			get_api()->
 			create_common_data_feed_upload( $cpi_id, $data );
-		} catch ( Exception $exception ) {
+		} catch ( \Exception $exception ) {
 			\WC_Facebookcommerce_Utils::logExceptionImmediatelyToMeta(
 				$exception,
 				[

--- a/includes/Feed/AbstractFeed.php
+++ b/includes/Feed/AbstractFeed.php
@@ -178,7 +178,7 @@ abstract class AbstractFeed {
 					'event'      => 'feed_upload',
 					'event_type' => 'send_request_to_upload_feed',
 					'extra_data' => [
-						'feed_type' => $name,
+						'feed_name' => $name,
 					],
 				]
 			);

--- a/includes/Feed/AbstractFeed.php
+++ b/includes/Feed/AbstractFeed.php
@@ -96,6 +96,12 @@ abstract class AbstractFeed {
 	 * @since 3.5.0
 	 */
 	public function schedule_feed_generation(): void {
+		// If the Commerce Partner Integration ID isn't set then don't schedule feed generation
+		$cpi_id = facebook_for_woocommerce()->get_connection_handler()->get_commerce_partner_integration_id();
+		if ( '' === $cpi_id ) {
+			return;
+		}
+
 		$schedule_action_hook_name = self::GENERATE_FEED_ACTION . $this->data_stream_name;
 		if ( ! as_next_scheduled_action( $schedule_action_hook_name ) ) {
 			as_schedule_recurring_action(
@@ -116,8 +122,13 @@ abstract class AbstractFeed {
 	 * @since 3.5.0
 	 */
 	public function regenerate_feed(): void {
-		// Maybe use new ( experimental ), feed generation framework.
-		if ( \WC_Facebookcommerce::instance()->get_integration()->is_new_style_feed_generation_enabled() ) {
+		// If the Commerce Partner Integration ID isn't set then don't generate the feed
+		$cpi_id = facebook_for_woocommerce()->get_connection_handler()->get_commerce_partner_integration_id();
+		if ( '' === $cpi_id ) {
+			return;
+		}
+
+		if ( facebook_for_woocommerce()->get_integration()->is_new_style_feed_generation_enabled() ) {
 			$this->feed_generator->queue_start();
 		} else {
 			$this->feed_handler->generate_feed_file();

--- a/includes/Feed/AbstractFeed.php
+++ b/includes/Feed/AbstractFeed.php
@@ -160,7 +160,7 @@ abstract class AbstractFeed {
 		);
 
 		try {
-			$cpi_id = get_option( 'wc_facebook_commerce_partner_integration_id', '' );
+			$cpi_id = facebook_for_woocommerce()->get_connection_handler()->get_commerce_partner_integration_id();
 			facebook_for_woocommerce()->
 			get_api()->
 			create_common_data_feed_upload( $cpi_id, $data );

--- a/includes/Feed/AbstractFeed.php
+++ b/includes/Feed/AbstractFeed.php
@@ -179,6 +179,7 @@ abstract class AbstractFeed {
 					'event_type' => 'send_request_to_upload_feed',
 					'extra_data' => [
 						'feed_name' => $name,
+						'data'      => wp_json_encode( $data ),
 					],
 				]
 			);
@@ -288,6 +289,7 @@ abstract class AbstractFeed {
 					'event_type' => 'handle_feed_data_request',
 					'extra_data' => [
 						'feed_name' => $name,
+						'file_path' => $file_path,
 					],
 				]
 			);

--- a/includes/Feed/AbstractFeed.php
+++ b/includes/Feed/AbstractFeed.php
@@ -146,9 +146,11 @@ abstract class AbstractFeed {
 	 * @since 3.5.0
 	 */
 	public function should_skip_feed(): bool {
-		$cpi_id = facebook_for_woocommerce()->get_connection_handler()->get_commerce_partner_integration_id();
+		$connection_handler = facebook_for_woocommerce()->get_connection_handler();
+		$cpi_id             = $connection_handler->get_commerce_partner_integration_id();
+		$cms_id             = $connection_handler->get_commerce_merchant_settings_id();
 
-		return empty( $cpi_id );
+		return empty( $cpi_id ) || empty( $cms_id );
 	}
 
 	/**

--- a/includes/Feed/CsvFeedFileWriter.php
+++ b/includes/Feed/CsvFeedFileWriter.php
@@ -116,7 +116,7 @@ class CsvFeedFileWriter implements FeedFileWriter {
 					'event'      => 'feed_upload',
 					'event_type' => 'csv_write_feed_file',
 					'extra_data' => [
-						'feed_type' => $this->feed_name,
+						'feed_name' => $this->feed_name,
 					],
 				]
 			);

--- a/includes/Feed/CsvFeedFileWriter.php
+++ b/includes/Feed/CsvFeedFileWriter.php
@@ -109,8 +109,17 @@ class CsvFeedFileWriter implements FeedFileWriter {
 
 			// Step 3: Rename temporary feed file to final feed file.
 			$this->promote_temp_file();
-		} catch ( PluginException $e ) {
-			WC_Facebookcommerce_Utils::logExceptionImmediatelyToMeta( $e );
+		} catch ( PluginException $exception ) {
+			\WC_Facebookcommerce_Utils::logExceptionImmediatelyToMeta(
+				$exception,
+				[
+					'event'      => 'feed_upload',
+					'event_type' => 'csv_write_feed_file',
+					'extra_data' => [
+						'feed_type' => $this->feed_name,
+					],
+				]
+			);
 			// Close the temporary file if it is still open.
 			if ( ! empty( $temp_feed_file ) && is_resource( $temp_feed_file ) ) {
 				fclose( $temp_feed_file ); // phpcs:ignore

--- a/includes/Feed/FeedUploadUtils.php
+++ b/includes/Feed/FeedUploadUtils.php
@@ -18,72 +18,97 @@ use WC_Coupon;
  * @since 3.5.0
  */
 class FeedUploadUtils {
-	const VALUE_TYPE_PERCENTAGE              = 'PERCENTAGE';
-	const VALUE_TYPE_FIXED_AMOUNT            = 'FIXED_AMOUNT';
-	const TARGET_TYPE_SHIPPING               = 'SHIPPING';
-	const TARGET_TYPE_LINE_ITEM              = 'LINE_ITEM';
-	const TARGET_GRANULARITY_ORDER_LEVEL     = 'ORDER_LEVEL';
-	const TARGET_GRANULARITY_ITEM_LEVEL      = 'ITEM_LEVEL';
-	const TARGET_SELECTION_ENTIRE_CATALOG    = 'ALL_CATALOG_PRODUCTS';
-	const TARGET_SELECTION_SPECIFIC_PRODUCTS = 'SPECIFIC_PRODUCTS';
-	const APPLICATION_TYPE_BUYER_APPLIED     = 'BUYER_APPLIED';
-	const PROMO_SYNC_LOGGING_FLOW_NAME       = 'promotion_feed_sync';
+	const VALUE_TYPE_PERCENTAGE                      = 'PERCENTAGE';
+	const VALUE_TYPE_FIXED_AMOUNT                    = 'FIXED_AMOUNT';
+	const TARGET_TYPE_SHIPPING                       = 'SHIPPING';
+	const TARGET_TYPE_LINE_ITEM                      = 'LINE_ITEM';
+	const TARGET_GRANULARITY_ORDER_LEVEL             = 'ORDER_LEVEL';
+	const TARGET_GRANULARITY_ITEM_LEVEL              = 'ITEM_LEVEL';
+	const TARGET_SELECTION_ENTIRE_CATALOG            = 'ALL_CATALOG_PRODUCTS';
+	const TARGET_SELECTION_SPECIFIC_PRODUCTS         = 'SPECIFIC_PRODUCTS';
+	const APPLICATION_TYPE_BUYER_APPLIED             = 'BUYER_APPLIED';
+	const PROMO_SYNC_LOGGING_FLOW_NAME               = 'promotion_feed_sync';
+	const RATINGS_AND_REVIEWS_SYNC_LOGGING_FLOW_NAME = 'ratings_and_reviews_feed_sync';
 
 	public static function get_ratings_and_reviews_data( array $query_args ): array {
-		$comments     = get_comments( $query_args );
-		$reviews_data = array();
+		try {
+			$comments     = get_comments( $query_args );
+			$reviews_data = array();
 
-		$store_name = get_bloginfo( 'name' );
-		$store_id   = facebook_for_woocommerce()->get_connection_handler()->get_commerce_merchant_settings_id();
-		$store_urls = [ wc_get_page_permalink( 'shop' ) ];
+			$store_name = get_bloginfo( 'name' );
+			$store_id   = facebook_for_woocommerce()->get_connection_handler()->get_commerce_merchant_settings_id();
+			$store_urls = [ wc_get_page_permalink( 'shop' ) ];
 
-		foreach ( $comments as $comment ) {
-			try {
-				$post_type = get_post_type( $comment->comment_post_ID );
-				if ( 'product' !== $post_type ) {
+			foreach ( $comments as $comment ) {
+				try {
+					$post_type = get_post_type( $comment->comment_post_ID );
+					if ( 'product' !== $post_type ) {
+						continue;
+					}
+
+					$rating = get_comment_meta( $comment->comment_ID, 'rating', true );
+					if ( ! is_numeric( $rating ) ) {
+						continue;
+					}
+
+					$reviewer_id = $comment->user_id;
+					// If reviewer_id is 0 then the reviewer is a logged-out user
+					$reviewer_is_anonymous = '0' === $reviewer_id ? 'true' : 'false';
+
+					$product = wc_get_product( $comment->comment_post_ID );
+					if ( null === $product ) {
+						continue;
+					}
+					$product_name = $product->get_name();
+					$product_url  = $product->get_permalink();
+					$product_skus = [ $product->get_sku() ];
+
+					$reviews_data[] = array(
+						'aggregator'                      => 'woocommerce',
+						'store.name'                      => $store_name,
+						'store.id'                        => $store_id,
+						'store.storeUrls'                 => "['" . implode( "','", $store_urls ) . "']",
+						'review_id'                       => $comment->comment_ID,
+						'rating'                          => intval( $rating ),
+						'title'                           => null,
+						'content'                         => $comment->comment_content,
+						'created_at'                      => $comment->comment_date,
+						'reviewer.name'                   => $comment->comment_author,
+						'reviewer.reviewerID'             => $reviewer_id,
+						'reviewer.isAnonymous'            => $reviewer_is_anonymous,
+						'product.name'                    => $product_name,
+						'product.url'                     => $product_url,
+						'product.productIdentifiers.skus' => "['" . implode( "','", $product_skus ) . "']",
+					);
+				} catch ( \Exception $e ) {
+					\WC_Facebookcommerce_Utils::logTelemetryToMeta(
+						'Exception while trying to map product review data for feed',
+						array(
+							'flow_name'  => self::RATINGS_AND_REVIEWS_SYNC_LOGGING_FLOW_NAME,
+							'flow_step'  => 'map_ratings_and_reviews_data',
+							'extra_data' => [
+								'exception_message' => $e->getMessage(),
+							],
+						)
+					);
 					continue;
 				}
-
-				$rating = get_comment_meta( $comment->comment_ID, 'rating', true );
-				if ( ! is_numeric( $rating ) ) {
-					continue;
-				}
-
-				$reviewer_id = $comment->user_id;
-				// If reviewer_id is 0 then the reviewer is a logged-out user
-				$reviewer_is_anonymous = '0' === $reviewer_id ? 'true' : 'false';
-
-				$product = wc_get_product( $comment->comment_post_ID );
-				if ( null === $product ) {
-					continue;
-				}
-				$product_name = $product->get_name();
-				$product_url  = $product->get_permalink();
-				$product_skus = [ $product->get_sku() ];
-
-				$reviews_data[] = array(
-					'aggregator'                      => 'woocommerce',
-					'store.name'                      => $store_name,
-					'store.id'                        => $store_id,
-					'store.storeUrls'                 => "['" . implode( "','", $store_urls ) . "']",
-					'review_id'                       => $comment->comment_ID,
-					'rating'                          => intval( $rating ),
-					'title'                           => null,
-					'content'                         => $comment->comment_content,
-					'created_at'                      => $comment->comment_date,
-					'reviewer.name'                   => $comment->comment_author,
-					'reviewer.reviewerID'             => $reviewer_id,
-					'reviewer.isAnonymous'            => $reviewer_is_anonymous,
-					'product.name'                    => $product_name,
-					'product.url'                     => $product_url,
-					'product.productIdentifiers.skus' => "['" . implode( "','", $product_skus ) . "']",
-				);
-			} catch ( \Exception $e ) {
-				continue;
 			}
-		}
 
-		return $reviews_data;
+			return $reviews_data;
+		} catch ( \Exception $exception ) {
+			\WC_Facebookcommerce_Utils::logExceptionImmediatelyToMeta(
+				$exception,
+				[
+					'event'      => self::RATINGS_AND_REVIEWS_SYNC_LOGGING_FLOW_NAME,
+					'event_type' => 'get_ratings_and_reviews_data',
+					'extra_data' => [
+						'query_args' => wp_json_encode( $query_args ),
+					],
+				]
+			);
+			throw $exception;
+		}
 	}
 
 	/**
@@ -124,7 +149,7 @@ class FeedUploadUtils {
 							'Unknown discount type encountered during feed processing',
 							array(
 								'promotion_id' => $coupon_post->ID,
-								'extra_data'   => array( 'discount_type' => $woo_discount_type ),
+								'extra_data'   => [ 'discount_type' => $woo_discount_type ],
 								'flow_name'    => self::PROMO_SYNC_LOGGING_FLOW_NAME,
 								'flow_step'    => 'map_discount_type',
 							)

--- a/includes/Feed/FeedUploadUtils.php
+++ b/includes/Feed/FeedUploadUtils.php
@@ -21,7 +21,7 @@ class FeedUploadUtils {
 		$reviews_data = array();
 
 		$store_name = get_bloginfo( 'name' );
-		$store_id   = facebook_for_woocommerce()->get_connection_handler()->get_commerce_partner_integration_id();
+		$store_id   = facebook_for_woocommerce()->get_connection_handler()->get_commerce_merchant_settings_id();
 		$store_urls = [ wc_get_page_permalink( 'shop' ) ];
 
 		foreach ( $comments as $comment ) {

--- a/includes/Feed/FeedUploadUtils.php
+++ b/includes/Feed/FeedUploadUtils.php
@@ -21,7 +21,7 @@ class FeedUploadUtils {
 		$reviews_data = array();
 
 		$store_name = get_bloginfo( 'name' );
-		$store_id   = get_option( 'wc_facebook_commerce_merchant_settings_id', '' );
+		$store_id   = facebook_for_woocommerce()->get_connection_handler()->get_commerce_partner_integration_id();
 		$store_urls = [ wc_get_page_permalink( 'shop' ) ];
 
 		foreach ( $comments as $comment ) {

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -97,6 +97,9 @@ class Connection {
 	/** @var string the Commerce merchant settings ID option name */
 	const OPTION_COMMERCE_MERCHANT_SETTINGS_ID = 'wc_facebook_commerce_merchant_settings_id';
 
+	/** @var string the Commerce Partner Integration ID option name */
+	const OPTION_COMMERCE_PARTNER_INTEGRATION_ID = 'wc_facebook_commerce_partner_integration_id';
+
 	/** @var string|null the generated external merchant settings ID */
 	private $external_business_id;
 
@@ -791,6 +794,17 @@ class Connection {
 	 */
 	public function get_commerce_merchant_settings_id() {
 		return get_option( self::OPTION_COMMERCE_MERCHANT_SETTINGS_ID, '' );
+	}
+
+	/**
+	 * Gets Commerce Partner Integration ID value.
+	 *
+	 * @since 3.5.0
+	 *
+	 * @return string
+	 */
+	public function get_commerce_partner_integration_id() {
+		return get_option( self::OPTION_COMMERCE_PARTNER_INTEGRATION_ID, '' );
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -796,6 +796,7 @@ class Connection {
 		return get_option( self::OPTION_COMMERCE_MERCHANT_SETTINGS_ID, '' );
 	}
 
+
 	/**
 	 * Gets Commerce Partner Integration ID value.
 	 *

--- a/tests/Unit/Feed/AbstractFeedTest.php
+++ b/tests/Unit/Feed/AbstractFeedTest.php
@@ -11,6 +11,7 @@
 namespace WooCommerce\Facebook\Feed;
 
 use WP_UnitTestCase;
+use WooCommerce\Facebook\Utilities\Heartbeat;
 
 class TestFeed extends AbstractFeed {
 	public function __construct(FeedFileWriter $file_writer, AbstractFeedHandler $feed_handler, FeedGenerator $feed_generator) {
@@ -31,6 +32,10 @@ class TestFeed extends AbstractFeed {
 
 	protected static function get_feed_gen_interval(): int {
 		return HOUR_IN_SECONDS;
+	}
+
+	protected static function get_feed_gen_scheduling_interval(): string {
+		return Heartbeat::EVERY_5_MINUTES;
 	}
 }
 
@@ -64,5 +69,41 @@ class AbstractFeedTest extends WP_UnitTestCase {
 		$secret = $this->feed->get_feed_secret();
 		$this->assertNotEmpty($secret, 'When secret is not set yet one should be generated.');
 		$this->assertEquals($secret, get_option($secret_option_name, ''), 'Secret should be set.');
+	}
+
+	public function testGetDataStreamName() {
+		$reflection = new \ReflectionClass($this->feed);
+		$method = $reflection->getMethod('get_data_stream_name');
+		$method->setAccessible(true);
+
+		$data_stream_name = $method->invoke($this->feed);
+		$this->assertEquals('test', $data_stream_name, 'The data stream name should be "test".');
+	}
+
+	public function testGetFeedType() {
+		$reflection = new \ReflectionClass($this->feed);
+		$method = $reflection->getMethod('get_feed_type');
+		$method->setAccessible(true);
+
+		$feed_type = $method->invoke($this->feed);
+		$this->assertEquals('TEST_FEED', $feed_type, 'The feed type should be "TEST_FEED".');
+	}
+
+	public function testGetFeedGenInterval() {
+		$reflection = new \ReflectionClass($this->feed);
+		$method = $reflection->getMethod('get_feed_gen_interval');
+		$method->setAccessible(true);
+
+		$feed_gen_interval = $method->invoke($this->feed);
+		$this->assertEquals(HOUR_IN_SECONDS, $feed_gen_interval, 'The feed gen interval should be HOUR_IN_SECONDS.');
+	}
+
+	public function testGetFeedGenSchedulingInterval() {
+		$reflection = new \ReflectionClass($this->feed);
+		$method = $reflection->getMethod('get_feed_gen_scheduling_interval');
+		$method->setAccessible(true);
+
+		$feed_gen_interval = $method->invoke($this->feed);
+		$this->assertEquals(Heartbeat::EVERY_5_MINUTES, $feed_gen_interval, 'The feed gen scheduling interval should be Heartbeat::EVERY_5_MINUTES.');
 	}
 }

--- a/tests/Unit/Feed/AbstractFeedTest.php
+++ b/tests/Unit/Feed/AbstractFeedTest.php
@@ -58,9 +58,17 @@ class AbstractFeedTest extends WP_UnitTestCase {
 
 	public function testShouldSkipFeed() {
 		update_option( 'wc_facebook_commerce_partner_integration_id', '1841465350002849' );
-		$this->assertFalse( $this->feed->should_skip_feed(), 'Feed should not be skipped when CPI ID is not empty.' );
+		update_option( 'wc_facebook_commerce_merchant_settings_id', '1352794439398752' );
+		$this->assertFalse( $this->feed->should_skip_feed(), 'Feed should not be skipped when CPI ID and CMS ID are set.' );
 		update_option( 'wc_facebook_commerce_partner_integration_id', '' );
+		update_option( 'wc_facebook_commerce_merchant_settings_id', '1352794439398752' );
 		$this->assertTrue( $this->feed->should_skip_feed(), 'Feed should be skipped when CPI ID is empty.' );
+		update_option( 'wc_facebook_commerce_partner_integration_id', '1841465350002849' );
+		update_option( 'wc_facebook_commerce_merchant_settings_id', '' );
+		$this->assertTrue( $this->feed->should_skip_feed(), 'Feed should be skipped when CMS ID is empty.' );
+		update_option( 'wc_facebook_commerce_partner_integration_id', '' );
+		update_option( 'wc_facebook_commerce_merchant_settings_id', '' );
+		$this->assertTrue( $this->feed->should_skip_feed(), 'Feed should be skipped when both CPI ID and CMS ID are empty.' );
 	}
 
 	public function testGetFeedSecret() {

--- a/tests/Unit/Feed/AbstractFeedTest.php
+++ b/tests/Unit/Feed/AbstractFeedTest.php
@@ -103,7 +103,7 @@ class AbstractFeedTest extends WP_UnitTestCase {
 		$method = $reflection->getMethod('get_feed_gen_scheduling_interval');
 		$method->setAccessible(true);
 
-		$feed_gen_interval = $method->invoke($this->feed);
-		$this->assertEquals(Heartbeat::EVERY_5_MINUTES, $feed_gen_interval, 'The feed gen scheduling interval should be Heartbeat::EVERY_5_MINUTES.');
+		$feed_gen_scheduling_interval = $method->invoke($this->feed);
+		$this->assertEquals(Heartbeat::EVERY_5_MINUTES, $feed_gen_scheduling_interval, 'The feed gen scheduling interval should be Heartbeat::EVERY_5_MINUTES.');
 	}
 }


### PR DESCRIPTION
## Description

This PR makes the following changes:
- Updates AbstractFeed.php to only have feed uploads that extend it scheduled/regenerated if CPI ID is set for the instance as CPI ID is required for the API call to GraphCommercePartnerIntegrationFileUpdatePost
   - This ensures that the feed uploads will only be run after onboarding is complete as CPI ID is set after onboarding
   - should_skip_feed can be overwritten for future feeds that don't hit the GraphCommercePartnerIntegrationFileUpdatePost endpoint and have different requirements
- Adds calls to logExceptionImmediatelyToMeta and logTelemetryToMeta throughout the feed upload flow to persist logs to Meta
- Creates AbstractFeedTest.php to add some unit tests for the AbstractFeed.php logic

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Test instructions
Verified that the ratings and reviews feed upload works as expected after the changes
1. Pushed changes to my lightsail instance
2. Triggered the ratings and reviews feed upload by running the pending wc_facebook_regenerate_feed_ratings_and_reviews action
![Screenshot 2025-03-24 at 11 23 44 AM](https://github.com/user-attachments/assets/63b1ddec-f68b-4068-9702-1ae23b29d3e6)
![Screenshot 2025-03-24 at 11 23 55 AM](https://github.com/user-attachments/assets/b9143c40-67e9-4677-b6d0-2b870bbcebe7)
3. Verified that there was a log for the API call to GraphCommercePartnerIntegrationFileUpdatePost for the feed upload
![Screenshot 2025-03-24 at 11 25 22 AM](https://github.com/user-attachments/assets/5645a9e2-0fcb-4f5f-ac33-0a651d7c57ec)
4. Verified that there was a successful feed upload session
![Screenshot 2025-03-24 at 11 28 24 AM](https://github.com/user-attachments/assets/f11960f7-69b4-4632-bcb5-b2f2097713c9)

Verified that the ratings and reviews feed upload is not run if CPI ID isn't set for the instance
1. Locally modified should_skip_feed to always return true
2. Pushed changes to my lightsail instance
3. Tried to trigger the ratings and reviews feed upload by running the pending wc_facebook_regenerate_feed_ratings_and_reviews action
4. Verified that there were no logs for an API call to GraphCommercePartnerIntegrationFileUpdatePost and that there was no feed upload session created

Verified that the added logging calls work as expected
1. Locally modified start of each try block associated with the catch blocks that persists log to Meta to throw PluginException
2. Pushed changes to my lightsail instance
3. Verified that logs were persisted to Meta as expected
![Screenshot 2025-03-24 at 12 35 05 PM](https://github.com/user-attachments/assets/045151ab-2c5e-4442-86da-dd92521719d7)
![Screenshot 2025-03-24 at 12 42 48 PM](https://github.com/user-attachments/assets/cd27ea99-0dac-4f78-a9eb-154eef686f70)
![Screenshot 2025-03-24 at 12 43 40 PM](https://github.com/user-attachments/assets/a3ac0903-0492-4b37-8eae-038b88be5714)
![Screenshot 2025-03-24 at 1 01 46 PM](https://github.com/user-attachments/assets/3b753626-07c0-4b07-a1df-30c32edaea49)
![Screenshot 2025-03-24 at 1 06 32 PM](https://github.com/user-attachments/assets/bd1a5084-790e-4cfc-b92b-b8d7d1b7255a)

Verified that all tests in AbstractFeedTest.php pass as expected
1. Triggered all tests in AbstractFeedTest.php to run through PHPStorm
2. Verified that all the tests passed
![Screenshot 2025-03-24 at 12 25 23 PM](https://github.com/user-attachments/assets/134fd549-e5a5-42ba-ab33-d68fc6bf53f1)

## Checklist

- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests and all the new and existing unit tests pass locally with my changes
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.


## Changelog entry

Adding logging to feed upload flow and preventing feed uploads from being scheduled/regenerated until after CPI ID is set on the instance
