### PR TITLE
[MiCE] Adding new rules for showing the new MiCE experience

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -3107,7 +3107,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 * Determines if the enhanced onboarding (iframe) should be used.
 	 *
 	 * @return bool
-	 * @internal
 	 *
 	 */
 	public function use_enhanced_onboarding() {

--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -65,7 +65,20 @@ class Connection extends Abstract_Settings_Screen {
 	 * @return bool
 	 */
 	protected function use_enhanced_onboarding() {
-		return facebook_for_woocommerce()->get_integration()->use_enhanced_onboarding();
+		// First check if the integration has enabled enhanced onboarding
+		$integration = facebook_for_woocommerce()->get_integration();
+		if ( ! $integration->use_enhanced_onboarding() ) {
+			return false;
+		}
+
+		// No connection, new user returns true
+		$connection_handler              = facebook_for_woocommerce()->get_connection_handler();
+		$commerce_partner_integration_id = $connection_handler->get_commerce_partner_integration_id();
+
+		if ( ! $connection_handler->is_connected() || ! empty( $commerce_partner_integration_id ) ) {
+			return true;
+		}
+		return false;
 	}
 
 	/**
@@ -390,7 +403,7 @@ class Connection extends Abstract_Settings_Screen {
 			window.addEventListener('message', function(event) {
 				const message = event.data;
 				const messageEvent = message.event;
-				
+
 				if (messageEvent === 'CommerceExtension::INSTALL' && message.success) {
 					const requestBody = {
 						access_token: message.access_token,


### PR DESCRIPTION
## Description

Context: we are going to introduce the new MiCE experience for WooCommerce using a killswitch located in facebook-for-woocommerce.
However, besides that simple boolean flag, we need to add a few rules to ensure the feature rollout smoothly. This will prevent the existing sellers seeing the broken experience.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
## Screenshots
* Killswitch off with all other condition met:
<img width="1353" alt="image" src="https://github.com/user-attachments/assets/251b7b3e-79f0-438d-845c-eb7c27f5aea9" />
Showing old experience as expected.

* Killswitch on, has connection, no cpi id:
<img width="636" alt="image" src="https://github.com/user-attachments/assets/6bae346a-5527-4800-b10c-664270da906b" />
<img width="1747" alt="image" src="https://github.com/user-attachments/assets/db917fa8-3eb5-493a-a49f-092cd06f20e1" />
Showing old experience as expected.

* Killswitch on, CPI ID populated
<img width="1883" alt="image" src="https://github.com/user-attachments/assets/b4ff3226-302d-4a24-bff5-d20752da4b67" />
New experience show as expected.

## Test instructions
* Change the killswitch value in facebook-for-woocommerce(), `use_enhanced_onboarding`
* Remove the CPI ID field in database to mimic existing onboarded sellers


## Checklist

- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have added tests and all the new and existing unit tests pass locally with my changes
(Tried to add tests by didn't figure out how to mock `facebook-for-woocommerce()`. Will do a followup)
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.


## Changelog entry

Changed the logic to show enhanced onboarding experience to cover the existing extension users.
