### PR TITLE
Relaxing sync validation

### DIFF
--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -29,20 +29,6 @@ class ProductValidator {
 	public const SYNC_ENABLED_META_KEY = '_wc_facebook_sync_enabled';
 
 	/**
-	 * Maximum length of product description.
-	 *
-	 * @var int
-	 */
-	public const MAX_DESCRIPTION_LENGTH = 5000;
-
-	/**
-	 * Maximum length of product title.
-	 *
-	 * @var int
-	 */
-	public const MAX_TITLE_LENGTH = 150;
-
-	/**
 	 * Maximum allowed attributes in a variation;
 	 *
 	 * @var int
@@ -134,11 +120,8 @@ class ProductValidator {
 		$this->validate_sync_enabled_globally();
 		$this->validate_product_status();
 		$this->validate_product_sync_field();
-		$this->validate_product_price();
 		$this->validate_product_visibility();
 		$this->validate_product_terms();
-		$this->validate_product_description();
-		$this->validate_product_title();
 	}
 
 	/**
@@ -151,11 +134,8 @@ class ProductValidator {
 	public function validate_but_skip_status_check() {
 		$this->validate_sync_enabled_globally();
 		$this->validate_product_sync_field();
-		$this->validate_product_price();
 		$this->validate_product_visibility();
 		$this->validate_product_terms();
-		$this->validate_product_description();
-		$this->validate_product_title();
 	}
 
 	/**
@@ -166,11 +146,8 @@ class ProductValidator {
 	 */
 	public function validate_but_skip_sync_field() {
 		$this->validate_sync_enabled_globally();
-		$this->validate_product_price();
 		$this->validate_product_visibility();
 		$this->validate_product_terms();
-		$this->validate_product_description();
-		$this->validate_product_title();
 	}
 
 	/**
@@ -358,72 +335,6 @@ class ProductValidator {
 			throw $invalid_exception;
 		} elseif ( 'no' === $this->product->get_meta( self::SYNC_ENABLED_META_KEY ) ) {
 				throw $invalid_exception;
-		}
-	}
-
-	/**
-	 * "allow simple or variable products (and their variations) with zero or empty price - exclude other product types with zero or empty price"
-	 * unsure why but that's what we're doing
-	 *
-	 * @throws ProductExcludedException If product should not be synced.
-	 */
-	protected function validate_product_price() {
-		$primary_product = $this->product_parent ? $this->product_parent : $this->product;
-
-		// Variable and simple products are allowed to have no price.
-		if ( in_array( $primary_product->get_type(), [ 'simple', 'variable' ], true ) ) {
-			return;
-		}
-
-		if ( ! Products::get_product_price( $this->product ) ) {
-			throw new ProductExcludedException( __( 'If product is not simple, variable or variation it must have a price.', 'facebook-for-woocommerce' ) );
-		}
-	}
-
-	/**
-	 * Check if the description field has correct format according to:
-	 * Product Description Specifications for Catalogs : https://www.facebook.com/business/help/2302017289821154
-	 *
-	 * @throws ProductInvalidException If product description does not meet the requirements.
-	 */
-	protected function validate_product_description() {
-		/*
-		 * First step is to select the description that we want to evaluate.
-		 * Main description is the one provided for the product in the Facebook.
-		 * If it is blank, product description will be used.
-		 * If product description is blank, shortname will be used.
-		 */
-		$description = $this->facebook_product->get_fb_description();
-
-		/*
-		 * Requirements:
-		 * - No all caps descriptions.
-		 * - Max length 5000.
-		 * - Min length 30 ( tested and not required, will not enforce until this will become a hard requirement )
-		 */
-		if ( \WC_Facebookcommerce_Utils::is_all_caps( $description ) ) {
-			throw new ProductInvalidException( __( 'Product description is all capital letters. Please change the description to sentence case in order to allow synchronization of your product.', 'facebook-for-woocommerce' ) );
-		}
-		if ( strlen( $description ) > self::MAX_DESCRIPTION_LENGTH ) {
-			throw new ProductInvalidException( __( 'Product description is too long. Maximum allowed length is 5000 characters.', 'facebook-for-woocommerce' ) );
-		}
-	}
-
-	/**
-	 * Check if the title field has correct format according to:
-	 * Product Title Specifications for Catalogs : https://www.facebook.com/business/help/2104231189874655
-	 *
-	 * @throws ProductInvalidException If product title does not meet the requirements.
-	 */
-	protected function validate_product_title() {
-		$title = $this->product->get_title();
-
-		/*
-		 * Requirements:
-		 * - Max length 150.
-		 */
-		if ( mb_strlen( $title, 'UTF-8' ) > self::MAX_TITLE_LENGTH ) {
-			throw new ProductInvalidException( __( 'Product title is too long. Maximum allowed length is 150 characters.', 'facebook-for-woocommerce' ) );
 		}
 	}
 


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue. 
Please also include relevant motivation and context. 
List any dependencies that are required for this change.

### Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

| # | Field | Validation | Change |
| --- | --- | --- | ---|
| 1 | Description | ALL Cap | Remove |
| 2 | Description | length(5000) | Remove |
| 3 | Price | If missing | Remove|
| 4 | Title | length(150) | Remove |
| 5 | validate_product_visibility | if hidden| Keep for now (we need to sync items as hidden in case they are not visible) |
| 6 | Out of stock | if woocommerce_hide_out_of_stock_items we don't sync | Removed in another PR |
| 7 | product_status | ALL Cap | Keep (part of other efforts) |
| 8 | validate_product_sync_field| | Keep |
| 9 | validate_product_terms| Check whether the product's categories or tags (terms) exclude it from sync.| Keep |

Note: I am not super sure about (5) validate_product_visibility, I have removed it, but the item is being synced as active

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before
In the before nothing synced showing error in the meta_box component

### After
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/195d2190-cbbb-493c-aee4-94a9fb0bbaf8" />
https://www.facebook.com/commerce/catalogs/955650953442091/products

As you can see, I have synced items with different validations to ensure syncing is happening

## Test instructions

Create a product with a validation issue and try saving and check if it's being synced or not


## Checklist

- [X] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests and all the new and existing unit tests pass locally with my changes
- [X] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.


## Changelog entry

Relaxing sync validations
