### PR TITLE
Updating regenerate_feed to always use feed_generator

### DIFF
--- a/includes/Feed/AbstractFeed.php
+++ b/includes/Feed/AbstractFeed.php
@@ -131,11 +131,7 @@ abstract class AbstractFeed {
 			return;
 		}
 
-		if ( facebook_for_woocommerce()->get_integration()->is_new_style_feed_generation_enabled() ) {
-			$this->feed_generator->queue_start();
-		} else {
-			$this->feed_handler->generate_feed_file();
-		}
+		$this->feed_generator->queue_start();
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR is updating AbstractFeed.php to have the feed uploads always use the feed generator to run the feed uploads.

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test instructions

1. Pushed code to lightsail instance
2. Verified through Tools -> Scheduled Actions tab that the ratings and reviews feed upload ran successfully with the changes
![Screenshot 2025-03-26 at 12 11 46 PM](https://github.com/user-attachments/assets/8060fd8a-291c-4125-b1b9-ad2550bcda3c)
![Screenshot 2025-03-26 at 12 11 58 PM](https://github.com/user-attachments/assets/3388bc97-6fe7-42d1-a0c3-6cda400fef1c)
![Screenshot 2025-03-26 at 12 12 09 PM](https://github.com/user-attachments/assets/89416c19-9fc2-4d74-9f16-87f38835cf08)
![Screenshot 2025-03-26 at 12 12 29 PM](https://github.com/user-attachments/assets/4e035345-6e10-4a77-b7e3-cb582943af3a)
![Screenshot 2025-03-26 at 12 12 41 PM](https://github.com/user-attachments/assets/49dcbb06-1fbe-4772-bab4-2d95adee7c46)
![Screenshot 2025-03-26 at 12 13 02 PM](https://github.com/user-attachments/assets/3ef22381-0082-4883-9e66-d4642491b956)
![Screenshot 2025-03-26 at 12 13 18 PM](https://github.com/user-attachments/assets/6d43c2da-11d4-4197-a90d-080034742427)

## Checklist

- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests and all the new and existing unit tests pass locally with my changes
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.


## Changelog entry

One liner entry to be surfaced in changelog.txt
