### PR TITLE
[Bug fix] Fix missing CMS_ID and misaligned catalog_id param name

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -3151,7 +3151,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 *
 	 */
 	public function use_enhanced_onboarding() {
-		return true;
+		return false;
 	}
 
 }

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -108,6 +108,33 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/** @var string custom taxonomy Facebook Product Set ID */
 	const FB_PRODUCT_SET_ID = 'fb_product_set_id';
 
+	/** @var string the WordPress option name where the access token is stored */
+	const OPTION_ACCESS_TOKEN = 'wc_facebook_access_token';
+
+	/** @var string the WordPress option name where the merchant access token is stored */
+	const OPTION_MERCHANT_ACCESS_TOKEN = 'wc_facebook_merchant_access_token';
+
+	/** @var string the WordPress option name where the commerce merchant settings ID is stored */
+	const OPTION_COMMERCE_MERCHANT_SETTINGS_ID = 'wc_facebook_commerce_merchant_settings_id';
+
+	/** @var string the WordPress option name where the commerce partner integration ID is stored */
+	const OPTION_COMMERCE_PARTNER_INTEGRATION_ID = 'wc_facebook_commerce_partner_integration_id';
+
+	/** @var string the WordPress option name where the profiles are stored */
+	const OPTION_PROFILES = 'wc_facebook_profiles';
+
+	/** @var string the WordPress option name where the installed features are stored */
+	const OPTION_INSTALLED_FEATURES = 'wc_facebook_installed_features';
+
+	/** @var string the WordPress option name where the FBE 2 connection status is stored */
+	const OPTION_HAS_CONNECTED_FBE_2 = 'wc_facebook_has_connected_fbe_2';
+
+	/** @var string the WordPress option name where the pages read engagement authorization status is stored */
+	const OPTION_HAS_AUTHORIZED_PAGES_READ_ENGAGEMENT = 'wc_facebook_has_authorized_pages_read_engagement';
+
+	/** @var string the WordPress option name where the messenger chat status is stored */
+	const OPTION_ENABLE_MESSENGER = 'wc_facebook_enable_messenger';	
+
 	/** @var string|null the configured product catalog ID */
 	public $product_catalog_id;
 
@@ -3124,7 +3151,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 *
 	 */
 	public function use_enhanced_onboarding() {
-		return false;
+		return true;
 	}
 
 }

--- a/includes/API/Plugin/Settings/Handler.php
+++ b/includes/API/Plugin/Settings/Handler.php
@@ -145,42 +145,44 @@ class Handler extends AbstractRESTEndpoint {
 
 		// Map access tokens
 		if ( ! empty( $params['access_token'] ) ) {
-			$options['wc_facebook_access_token'] = $params['access_token'];
+			$options[\WC_Facebookcommerce_Integration::OPTION_ACCESS_TOKEN] = $params['access_token'];
+		}
+
+		if ( ! empty( $params['commerce_merchant_settings_id'] ) ) {
+			$options[\WC_Facebookcommerce_Integration::OPTION_COMMERCE_MERCHANT_SETTINGS_ID] = $params['commerce_merchant_settings_id'];
+		}
+
+		if ( ! empty( $params['commerce_partner_integration_id'] ) ) {
+			$options[\WC_Facebookcommerce_Integration::OPTION_COMMERCE_PARTNER_INTEGRATION_ID] = $params['commerce_partner_integration_id'];
+		}
+
+		if ( ! empty( $params['installed_features'] ) ) {
+			$options[\WC_Facebookcommerce_Integration::OPTION_INSTALLED_FEATURES] = $params['installed_features'];
 		}
 
 		if ( ! empty( $params['merchant_access_token'] ) ) {
-			$options['wc_facebook_merchant_access_token'] = $params['merchant_access_token'];
+			$options[\WC_Facebookcommerce_Integration::OPTION_MERCHANT_ACCESS_TOKEN] = $params['merchant_access_token'];
 		}
 
 		if ( ! empty( $params['page_access_token'] ) ) {
-			$options['wc_facebook_page_access_token'] = $params['page_access_token'];
-		}
-
-		// Map IDs
-		if ( ! empty( $params['product_catalog_id'] ) ) {
-			$options['wc_facebook_catalog_id'] = $params['product_catalog_id'];
-		}
-
-		if ( ! empty( $params['pixel_id'] ) ) {
-			$options['wc_facebook_pixel_id'] = $params['pixel_id'];
-			update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, $params['pixel_id'] );
+			$options[\WC_Facebookcommerce_Integration::OPTION_PAGE_ACCESS_TOKEN] = $params['page_access_token'];
 		}
 
 		if ( ! empty( $params['page_id'] ) ) {
 			update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, $params['page_id'] );
 		}
 
-		if ( ! empty( $params['commerce_partner_integration_id'] ) ) {
-			$options['wc_facebook_commerce_partner_integration_id'] = $params['commerce_partner_integration_id'];
+		if ( ! empty( $params['pixel_id'] ) ) {
+			$options[\WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID] = $params['pixel_id'];
+			update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, $params['pixel_id'] );
 		}
 
-		// Map profiles and features
+		if ( ! empty( $params['product_catalog_id'] ) ) {
+			$options[\WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID] = $params['product_catalog_id'];
+		}
+
 		if ( ! empty( $params['profiles'] ) ) {
-			$options['wc_facebook_profiles'] = $params['profiles'];
-		}
-
-		if ( ! empty( $params['installed_features'] ) ) {
-			$options['wc_facebook_installed_features'] = $params['installed_features'];
+			$options[\WC_Facebookcommerce_Integration::OPTION_PROFILES] = $params['profiles'];
 		}
 
 		return $options;
@@ -230,17 +232,17 @@ class Handler extends AbstractRESTEndpoint {
 	 */
 	private function clear_integration_options() {
 		$options = [
-			'wc_facebook_access_token',
-			'wc_facebook_merchant_access_token',
-			'wc_facebook_page_access_token',
-			'wc_facebook_catalog_id',
-			'wc_facebook_pixel_id',
-			'wc_facebook_commerce_partner_integration_id',
-			'wc_facebook_profiles',
-			'wc_facebook_installed_features',
-			'wc_facebook_has_connected_fbe_2',
-			'wc_facebook_has_authorized_pages_read_engagement',
-			'wc_facebook_enable_messenger',
+			\WC_Facebookcommerce_Integration::OPTION_ACCESS_TOKEN,
+			\WC_Facebookcommerce_Integration::OPTION_COMMERCE_MERCHANT_SETTINGS_ID,
+			\WC_Facebookcommerce_Integration::OPTION_COMMERCE_PARTNER_INTEGRATION_ID,
+			\WC_Facebookcommerce_Integration::OPTION_ENABLE_MESSENGER,
+			\WC_Facebookcommerce_Integration::OPTION_HAS_AUTHORIZED_PAGES_READ_ENGAGEMENT,
+			\WC_Facebookcommerce_Integration::OPTION_HAS_CONNECTED_FBE_2,
+			\WC_Facebookcommerce_Integration::OPTION_INSTALLED_FEATURES,
+			\WC_Facebookcommerce_Integration::OPTION_MERCHANT_ACCESS_TOKEN,
+			\WC_Facebookcommerce_Integration::OPTION_PAGE_ACCESS_TOKEN,
+			\WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID,
+			\WC_Facebookcommerce_Integration::OPTION_PROFILES,
 			\WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID,
 			\WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID,
 		];

--- a/includes/API/Plugin/Settings/Handler.php
+++ b/includes/API/Plugin/Settings/Handler.php
@@ -145,27 +145,23 @@ class Handler extends AbstractRESTEndpoint {
 
 		// Map access tokens
 		if ( ! empty( $params['access_token'] ) ) {
-			$options[\WC_Facebookcommerce_Integration::OPTION_ACCESS_TOKEN] = $params['access_token'];
+			$options[ \WC_Facebookcommerce_Integration::OPTION_ACCESS_TOKEN ] = $params['access_token'];
 		}
 
 		if ( ! empty( $params['commerce_merchant_settings_id'] ) ) {
-			$options[\WC_Facebookcommerce_Integration::OPTION_COMMERCE_MERCHANT_SETTINGS_ID] = $params['commerce_merchant_settings_id'];
+			$options[ \WC_Facebookcommerce_Integration::OPTION_COMMERCE_MERCHANT_SETTINGS_ID ] = $params['commerce_merchant_settings_id'];
 		}
 
 		if ( ! empty( $params['commerce_partner_integration_id'] ) ) {
-			$options[\WC_Facebookcommerce_Integration::OPTION_COMMERCE_PARTNER_INTEGRATION_ID] = $params['commerce_partner_integration_id'];
+			$options[ \WC_Facebookcommerce_Integration::OPTION_COMMERCE_PARTNER_INTEGRATION_ID ] = $params['commerce_partner_integration_id'];
 		}
 
 		if ( ! empty( $params['installed_features'] ) ) {
-			$options[\WC_Facebookcommerce_Integration::OPTION_INSTALLED_FEATURES] = $params['installed_features'];
+			$options[ \WC_Facebookcommerce_Integration::OPTION_INSTALLED_FEATURES ] = $params['installed_features'];
 		}
 
 		if ( ! empty( $params['merchant_access_token'] ) ) {
-			$options[\WC_Facebookcommerce_Integration::OPTION_MERCHANT_ACCESS_TOKEN] = $params['merchant_access_token'];
-		}
-
-		if ( ! empty( $params['page_access_token'] ) ) {
-			$options[\WC_Facebookcommerce_Integration::OPTION_PAGE_ACCESS_TOKEN] = $params['page_access_token'];
+			$options[ \WC_Facebookcommerce_Integration::OPTION_MERCHANT_ACCESS_TOKEN ] = $params['merchant_access_token'];
 		}
 
 		if ( ! empty( $params['page_id'] ) ) {
@@ -173,16 +169,16 @@ class Handler extends AbstractRESTEndpoint {
 		}
 
 		if ( ! empty( $params['pixel_id'] ) ) {
-			$options[\WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID] = $params['pixel_id'];
+			$options[ \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID ] = $params['pixel_id'];
 			update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, $params['pixel_id'] );
 		}
 
 		if ( ! empty( $params['product_catalog_id'] ) ) {
-			$options[\WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID] = $params['product_catalog_id'];
+			$options[ \WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID ] = $params['product_catalog_id'];
 		}
 
 		if ( ! empty( $params['profiles'] ) ) {
-			$options[\WC_Facebookcommerce_Integration::OPTION_PROFILES] = $params['profiles'];
+			$options[ \WC_Facebookcommerce_Integration::OPTION_PROFILES ] = $params['profiles'];
 		}
 
 		return $options;
@@ -240,7 +236,6 @@ class Handler extends AbstractRESTEndpoint {
 			\WC_Facebookcommerce_Integration::OPTION_HAS_CONNECTED_FBE_2,
 			\WC_Facebookcommerce_Integration::OPTION_INSTALLED_FEATURES,
 			\WC_Facebookcommerce_Integration::OPTION_MERCHANT_ACCESS_TOKEN,
-			\WC_Facebookcommerce_Integration::OPTION_PAGE_ACCESS_TOKEN,
 			\WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID,
 			\WC_Facebookcommerce_Integration::OPTION_PROFILES,
 			\WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID,

--- a/tests/Unit/Api/REST/RestAPITest.php
+++ b/tests/Unit/Api/REST/RestAPITest.php
@@ -35,7 +35,7 @@ class RestAPITest extends TestCase {
             $this->markTestSkipped('Handler class not found');
             return;
         }
-        
+
         // Mock the update_option function
         if (!function_exists('update_option')) {
             function update_option($option, $value) {
@@ -47,7 +47,7 @@ class RestAPITest extends TestCase {
                 return true;
             }
         }
-        
+
         // Mock the get_option function
         if (!function_exists('get_option')) {
             function get_option($option, $default = false) {
@@ -58,17 +58,17 @@ class RestAPITest extends TestCase {
                 return isset($wp_options[$option]) ? $wp_options[$option] : $default;
             }
         }
-        
+
         // Mock the wc_bool_to_string function
         if (!function_exists('wc_bool_to_string')) {
             function wc_bool_to_string($bool) {
                 return $bool ? 'yes' : 'no';
             }
         }
-        
+
         // Create a handler instance
         $handler = new Handler();
-        
+
         // Create test data
         $test_data = [
             'merchant_access_token' => 'test_merchant_token',
@@ -80,32 +80,32 @@ class RestAPITest extends TestCase {
             'commerce_merchant_settings_id' => '789012',
             'commerce_partner_integration_id' => '12311344'
         ];
-        
+
         // Use reflection to access private methods
         $reflection = new \ReflectionClass(Handler::class);
-        
+
         // Test map_params_to_options
         $map_params_method = $reflection->getMethod('map_params_to_options');
         $map_params_method->setAccessible(true);
         $options = $map_params_method->invokeArgs($handler, [$test_data]);
-        
+
         // Verify options are mapped correctly
         $this->assertEquals('test_access_token', $options['wc_facebook_access_token']);
         $this->assertEquals('test_merchant_token', $options['wc_facebook_merchant_access_token']);
         $this->assertEquals('test_page_token', $options['wc_facebook_page_access_token']);
         $this->assertEquals('123456', $options['wc_facebook_product_catalog_id']);
         $this->assertEquals('789012', $options['wc_facebook_commerce_merchant_settings_id']);
-        
+
         // Test update_settings
         $update_settings_method = $reflection->getMethod('update_settings');
         $update_settings_method->setAccessible(true);
         $update_settings_method->invokeArgs($handler, [$options]);
-        
+
         // Test update_connection_status
         $update_connection_method = $reflection->getMethod('update_connection_status');
         $update_connection_method->setAccessible(true);
         $update_connection_method->invokeArgs($handler, [$test_data]);
-        
+
         // Verify options were updated
         $this->assertEquals('test_access_token', get_option('wc_facebook_access_token'));
         $this->assertEquals('test_merchant_token', get_option('wc_facebook_merchant_access_token'));
@@ -126,29 +126,29 @@ class RestAPITest extends TestCase {
             $this->markTestSkipped('UpdateRequest class not found');
             return;
         }
-        
+
         // Create a mock WP_REST_Request
         $request = $this->createMock('WP_REST_Request');
-        
+
         // Set up the mock to return our test data
         $request->method('get_json_params')
             ->willReturn([
                 'access_token' => 'test_access_token',
                 // Missing merchant_access_token
             ]);
-        
+
         $request->method('get_params')
             ->willReturn([
                 'access_token' => 'test_access_token',
                 // Missing merchant_access_token
             ]);
-        
+
         // Create an UpdateRequest instance
         $update_request = new UpdateRequest($request);
-        
+
         // Test the validate method
         $validation_result = $update_request->validate();
-        
+
         // Check that validation fails with the expected error
         $this->assertInstanceOf('WP_Error', $validation_result);
         $this->assertEquals('missing_merchant_token', $validation_result->get_error_code());
@@ -159,48 +159,48 @@ class RestAPITest extends TestCase {
      * Test JS API definitions match classes using JS_Exposable trait
      */
     public function test_js_exposable_classes_match_api_definitions() {
-        
+
         // Create a partial mock of InitializeRestAPI
         $initializeRestAPI = $this->getMockBuilder(InitializeRestAPI::class)
                                   ->onlyMethods(['should_generate_rest_framework'])
                                   ->getMock();
-        
+
         // Force should_generate_rest_framework to return true
         $initializeRestAPI->method('should_generate_rest_framework')
                          ->willReturn(true);
-        
+
         // Get API definitions
         $api_definitions = $initializeRestAPI->get_api_definitions();
-        
+
         // Find all classes using the JS_Exposable trait
         $js_exposable_classes = [];
-        
+
         // Get all declared classes
         $all_classes = get_declared_classes();
-        
+
         foreach ($all_classes as $class) {
             // Skip if not in the WooCommerce\Facebook namespace
             if (strpos($class, 'WooCommerce\\Facebook\\') !== 0) {
                 continue;
             }
-            
+
             // Use reflection to check if class uses the JS_Exposable trait
             $reflection = new \ReflectionClass($class);
             $traits = $reflection->getTraitNames();
-            
+
             if (in_array('WooCommerce\\Facebook\\API\\Plugin\\Traits\\JS_Exposable', $traits)) {
                 // Skip abstract classes
                 if ($reflection->isAbstract()) {
                     continue;
                 }
-                
+
                 try {
                     // Create a mock WP_REST_Request for constructor
                     $request = $this->createMock('WP_REST_Request');
-                    
+
                     // Instantiate the class
                     $instance = new $class($request);
-                    
+
                     // Get the JS function name
                     if (method_exists($instance, 'get_js_function_name')) {
                         $function_name = $instance->get_js_function_name();
@@ -212,17 +212,17 @@ class RestAPITest extends TestCase {
                 }
             }
         }
-        
+
         // Verify each API definition has a corresponding class
         foreach ($api_definitions as $function_name => $definition) {
-            $this->assertArrayHasKey($function_name, $js_exposable_classes, 
+            $this->assertArrayHasKey($function_name, $js_exposable_classes,
                 "API definition '$function_name' has no corresponding JS_Exposable class");
         }
-        
+
         // Verify each JS exposable class has a corresponding API definition
         foreach ($js_exposable_classes as $function_name => $class) {
-            $this->assertArrayHasKey($function_name, $api_definitions, 
+            $this->assertArrayHasKey($function_name, $api_definitions,
                 "JS_Exposable class '$class' with function name '$function_name' has no corresponding API definition");
         }
     }
-} 
+}

--- a/tests/Unit/Api/REST/RestAPITest.php
+++ b/tests/Unit/Api/REST/RestAPITest.php
@@ -76,7 +76,9 @@ class RestAPITest extends TestCase {
             'page_access_token' => 'test_page_token',
             'product_catalog_id' => '123456',
             'pixel_id' => '789012',
-            'msger_chat' => 'yes'
+            'msger_chat' => 'yes',
+            'commerce_merchant_settings_id' => '789012',
+            'commerce_partner_integration_id' => '12311344'
         ];
         
         // Use reflection to access private methods
@@ -91,7 +93,8 @@ class RestAPITest extends TestCase {
         $this->assertEquals('test_access_token', $options['wc_facebook_access_token']);
         $this->assertEquals('test_merchant_token', $options['wc_facebook_merchant_access_token']);
         $this->assertEquals('test_page_token', $options['wc_facebook_page_access_token']);
-        $this->assertEquals('123456', $options['wc_facebook_catalog_id']);
+        $this->assertEquals('123456', $options['wc_facebook_product_catalog_id']);
+        $this->assertEquals('789012', $options['wc_facebook_commerce_merchant_settings_id']);
         
         // Test update_settings
         $update_settings_method = $reflection->getMethod('update_settings');
@@ -107,7 +110,7 @@ class RestAPITest extends TestCase {
         $this->assertEquals('test_access_token', get_option('wc_facebook_access_token'));
         $this->assertEquals('test_merchant_token', get_option('wc_facebook_merchant_access_token'));
         $this->assertEquals('test_page_token', get_option('wc_facebook_page_access_token'));
-        $this->assertEquals('123456', get_option('wc_facebook_catalog_id'));
+        $this->assertEquals('123456', get_option('wc_facebook_product_catalog_id'));
         $this->assertEquals('789012', get_option('wc_facebook_pixel_id'));
         $this->assertEquals('yes', get_option('wc_facebook_has_connected_fbe_2'));
         $this->assertEquals('yes', get_option('wc_facebook_has_authorized_pages_read_engagement'));

--- a/tests/Unit/Api/REST/RestAPITest.php
+++ b/tests/Unit/Api/REST/RestAPITest.php
@@ -92,7 +92,6 @@ class RestAPITest extends TestCase {
         // Verify options are mapped correctly
         $this->assertEquals('test_access_token', $options['wc_facebook_access_token']);
         $this->assertEquals('test_merchant_token', $options['wc_facebook_merchant_access_token']);
-        $this->assertEquals('test_page_token', $options['wc_facebook_page_access_token']);
         $this->assertEquals('123456', $options['wc_facebook_product_catalog_id']);
         $this->assertEquals('789012', $options['wc_facebook_commerce_merchant_settings_id']);
 
@@ -109,7 +108,6 @@ class RestAPITest extends TestCase {
         // Verify options were updated
         $this->assertEquals('test_access_token', get_option('wc_facebook_access_token'));
         $this->assertEquals('test_merchant_token', get_option('wc_facebook_merchant_access_token'));
-        $this->assertEquals('test_page_token', get_option('wc_facebook_page_access_token'));
         $this->assertEquals('123456', get_option('wc_facebook_product_catalog_id'));
         $this->assertEquals('789012', get_option('wc_facebook_pixel_id'));
         $this->assertEquals('yes', get_option('wc_facebook_has_connected_fbe_2'));


### PR DESCRIPTION
## Description

We found out the catalog ID is not set properly and CMS ID is missing during dogfooding.
Turns out:
1. We are setting wc_facebook_catalog_id instead of wc_facebook_product_catalog_id
2. commerce_merchant_settings is not consumed during config update.

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before
<img width="994" alt="image" src="https://github.com/user-attachments/assets/fb415a6e-324d-41c1-a507-9f99ec4ff19c" />

### After
<img width="1257" alt="image" src="https://github.com/user-attachments/assets/b80a4e89-43b5-4bbf-a042-e53534292dad" />

## Test instructions

Go over the onboarding flow and make sure all ids in the DB/Config page is assigned properly.


## Checklist

- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests and all the new and existing unit tests pass locally with my changes
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.

## Changelog entry

Fix post onboarding config saving issue