### PR TITLE
Add new product field external_update_time to measure product update latency

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -896,6 +896,10 @@ class WC_Facebook_Product {
 			$product_data['gtin'] = $gtin;
 		}
 
+		if ( $date_modified = $this->woo_product->get_date_modified() ) {
+			$product_data[ 'external_update_time' ] = $date_modified->getTimestamp();
+		}
+
 		// Only use checkout URLs if they exist.
 		$checkout_url = $this->build_checkout_url( $product_url );
 		if ( $checkout_url ) {

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -384,7 +384,7 @@ class WC_Facebook_Product_Feed {
 		return 'id,title,description,image_link,link,product_type,' .
 		'brand,price,availability,item_group_id,checkout_url,' .
 		'additional_image_link,sale_price_effective_date,sale_price,condition,' .
-		'visibility,gender,color,size,pattern,google_product_category,default_product,variant,gtin,quantity_to_sell_on_facebook,rich_text_description' . PHP_EOL;
+		'visibility,gender,color,size,pattern,google_product_category,default_product,variant,gtin,quantity_to_sell_on_facebook,rich_text_description,external_update_time' . PHP_EOL;
 	}
 
 
@@ -533,7 +533,8 @@ class WC_Facebook_Product_Feed {
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'variant' )) . ',' .
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'gtin' )) . ',' .
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'quantity_to_sell_on_facebook' )) . ',' .
-		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'rich_text_description' ) ) . PHP_EOL;
+		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'rich_text_description' ) ) . ',' .
+		static::get_value_from_product_data( $product_data, 'external_update_time' ) . PHP_EOL;
 	}
 
 	private static function format_additional_image_url( $product_image_urls ) {

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -865,4 +865,34 @@ class fbproductTest extends \WooCommerce\Facebook\Tests\Unit\AbstractWPUnitTestW
 		$brand = $facebook_product_variation->get_fb_brand();
 		$this->assertEquals($brand, 'Adidas');
 	}
+
+	/**
+	 * Test external_update_time is populated
+	 * @return void
+	 */
+	public function test_external_update_time_set() {
+		$woo_product = WC_Helper_Product::create_simple_product();
+
+		$timestamp = time();
+		$woo_product->set_date_modified($timestamp);
+
+		$fb_product = new \WC_Facebook_Product( $woo_product );
+		$data = $fb_product->prepare_product();
+
+		$this->assertEquals( $data['external_update_time'], $timestamp);
+	}
+
+	/**
+	 * Test external_update_time is not populated
+	 * @return void
+	 */
+	public function test_external_update_time_unset() {
+		$woo_product = WC_Helper_Product::create_simple_product();
+		$woo_product->set_date_modified(null);
+
+		$fb_product = new \WC_Facebook_Product( $woo_product );
+		$data = $fb_product->prepare_product();
+
+		$this->assertEquals(isset($data['external_update_time']), false);
+	}
 }


### PR DESCRIPTION
## Description

In this PR I am adding a new product field to be passed to Meta side, which is `external_update_time` - a timestamp of when the woo product was last updated. We intend to use this field to measure a latency of when products get updated on the Meta side.

### Type of change

- [x] New feature (non-breaking change which adds functionality)


## Screenshots
N/A


## Test instructions

* Automated testing
    * Run all unit tests: `npm run test:php`
* Manual testing 
    * In WooCommerce UI I updated one product and checked that Batch API request contains the new field and the timestamp value is correct.
    * Also triggered a feed upload and verified the new field is present in the feed file and the value is as expected 


## Checklist

- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests and all the new and existing unit tests pass locally with my changes
- [x] I have completed dogfooding, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
    - A stand alone QA testing is not required, will be part of plugin release QA. 


## Changelog entry

One liner entry to be surfaced in changelog.txt
