### PR TITLE
Release/3.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ Grow your business on Facebook and Instagram. Easily promote your products and t
 
 
 ### This is the development repository for the Facebook for WooCommerce plugin.
+**We're excited to announce that the app is now owned by Meta, and we invite the developer community to join us in shaping its future through contributions.**
+
+Grow your business on Facebook and Instagram. Easily promote your products and target accurately using powerful sales and marketing tools. Reach new customers and drive traffic to your website with seamless ad experiences, from discovery to conversion. Automatically sync your eligible products to your Meta catalog, so you can easily create ads right where your customers are.
+- Help drive better ad performance by setting up a conversion pixel
+- Easily set up your ads with a one-time account connection
+- Sell from one inventory that automatically syncs to your catalog used for ads
+
+
+### This is the development repository for the Facebook for WooCommerce plugin.
 
 - [WooCommerce.com product page](https://woocommerce.com/products/facebook/)
 - [WordPress.org plugin page](https://wordpress.org/plugins/facebook-for-woocommerce/)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,17 @@
 *** Facebook for WooCommerce Changelog ***
 
+= 3.4.4 - 2025-03-26 =
+* Add - Create tests for ProductFeedUploads create endpoint by @ajello-meta in #2902
+* Add - Create tests for ProductFeedUploads read endpoint by @ajello-meta in #2903
+* Tweak - Remove phpcs:ignoreFile annotation + Enable code coverage report generation with phpunit by @sol-loup in #2897 and #2901
+* Tweak - Changing APP to PLUGIN on README.MD by @SayanPandey in #2916
+* Tweak - Update README.md - Added noification for ownership transfer by @SayanPandey in #2910
+* Tweak - Added is_multisite logging to the update_plugin_version_configuration request by @carterbuce in #2955
+* Tweak - Add woo_commerce_retailer_id to products API request by @crisojog in #2958
+* Tweak - Syncing plugin version info by @vinkmeta in #2960
+* Fix - sync products out of stock to meta despite visibility config by @francorisso in #2952
+* Fix - Update woo_commerce_retailer_id to existing field external_variant_id by @crisojog in #2963
+
 = 3.4.3 - 2025-03-19 =
 * Add - Items batch request and response tests by @nrostrow-meta in #2917
 * Tweak - Always run PHP-based github workflows by @carterbuce in #2926

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Add - Create tests for ProductFeedUploads create endpoint by @ajello-meta in #2902
 * Add - Create tests for ProductFeedUploads read endpoint by @ajello-meta in #2903
 * Tweak - Remove phpcs:ignoreFile annotation + Enable code coverage report generation with phpunit by @sol-loup in #2897 and #2901
+* Fix - Restores the original dynamic property behavior in the AsyncRequest class by @sol-loup in #2921
 * Tweak - Changing APP to PLUGIN on README.MD by @SayanPandey in #2916
 * Tweak - Update README.md - Added noification for ownership transfer by @SayanPandey in #2910
 * Tweak - Added is_multisite logging to the update_plugin_version_configuration request by @carterbuce in #2955
@@ -11,6 +12,7 @@
 * Tweak - Syncing plugin version info by @vinkmeta in #2960
 * Fix - sync products out of stock to meta despite visibility config by @francorisso in #2952
 * Fix - Update woo_commerce_retailer_id to existing field external_variant_id by @crisojog in #2963
+* Tweak - Update readme.txt by @vinkmeta in #2949
 
 = 3.4.3 - 2025-03-19 =
 * Add - Items batch request and response tests by @nrostrow-meta in #2917

--- a/facebook-config-warmer.php
+++ b/facebook-config-warmer.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,9 +10,39 @@
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Class WC_Facebookcommerce_WarmConfig
+ *
+ * This class stores pre-configured Facebook Pixel settings that can be used
+ * to initialize the Facebook Pixel when user settings are not yet available.
+ * It serves as a configuration warmer for Facebook integration with WooCommerce.
+ */
 class WC_Facebookcommerce_WarmConfig {
-	static $fb_warm_pixel_id                     = null;
-	static $fb_warm_is_advanced_matching_enabled = null;
-	static $fb_warm_use_s2s                      = null;
-	static $fb_warm_access_token                 = null;
+	/**
+	 * Facebook Pixel ID for tracking
+	 *
+	 * @var string|null
+	 */
+	public static $fb_warm_pixel_id = null;
+
+	/**
+	 * Whether advanced matching is enabled for the Facebook Pixel
+	 *
+	 * @var bool|null
+	 */
+	public static $fb_warm_is_advanced_matching_enabled = null;
+
+	/**
+	 * Whether server-side (S2S) events are enabled
+	 *
+	 * @var bool|null
+	 */
+	public static $fb_warm_use_s2s = null;
+
+	/**
+	 * Facebook API access token
+	 *
+	 * @var string|null
+	 */
+	public static $fb_warm_access_token = null;
 }

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -10,7 +10,7 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 3.4.3
+ * Version: 3.4.4
  * Requires at least: 5.6
  * Requires PHP: 7.4
  * Text Domain: facebook-for-woocommerce
@@ -48,7 +48,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '3.4.3'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '3.4.4'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.4.0';

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -33,7 +32,7 @@ defined( 'ABSPATH' ) || exit;
 // HPOS compatibility declaration.
 add_action(
 	'before_woocommerce_init',
-	function() {
+	function () {
 		if ( class_exists( FeaturesUtil::class ) ) {
 			FeaturesUtil::declare_compatibility( 'custom_order_tables', plugin_basename( __FILE__ ), true );
 		}
@@ -318,8 +317,6 @@ class WC_Facebook_Loader {
 
 		return self::$instance;
 	}
-
-
 }
 
 // fire it up!

--- a/includes/API.php
+++ b/includes/API.php
@@ -283,12 +283,18 @@ class API extends Base {
 	 *
 	 * @param string $external_business_id external business ID
 	 * @param string $plugin_version The plugin version.
-	 * @return API\Response|API\FBE\Configuration\Update\Response
-	 * @throws WooCommerce\Facebook\Framework\Api\Exception
+	 *
+	 * @return Response|API\FBE\Configuration\Update\Response
+	 * @throws ApiException
 	 */
 	public function update_plugin_version_configuration( string $external_business_id, string $plugin_version ): API\FBE\Configuration\Update\Response {
 		$request = new API\FBE\Configuration\Update\Request( $external_business_id );
-		$request->set_plugin_version( $plugin_version );
+		$request->set_external_client_metadata(
+			array(
+				'version_id' => $plugin_version,
+				'is_multisite'   => is_multisite(),
+			)
+		);
 		$this->set_response_handler( API\FBE\Configuration\Update\Response::class );
 		return $this->perform_request( $request );
 	}

--- a/includes/API/FBE/Configuration/Update/Request.php
+++ b/includes/API/FBE/Configuration/Update/Request.php
@@ -35,21 +35,20 @@ class Request extends Configuration\Request {
 		$this->data['fbe_external_business_id'] = $external_business_id;
 	}
 
-
 	/**
-	 * Sets the plugin version for configuration update request.
+	 * Sets the external client metadata for logging
 	 *
-	 * @since 3.0.10
+	 * @since 3.4.4
 	 *
-	 * @param string $plugin_version current plugin version.
+	 * @param array $metadata map of metadata to include. Example: array ('version_id' => '0.0.0', 'is_multisite' => True)
+	 *
+	 * @return void
 	 */
-	public function set_plugin_version( string $plugin_version ) {
-
+	public function set_external_client_metadata( array $metadata ) {
 		$this->data['business_config'] = array(
-			'external_client' =>
-				array(
-					'version_id' => "$plugin_version",
-				),
+			'external_client' => $metadata,
 		);
+
+		is_multisite();
 	}
 }

--- a/includes/Admin/Settings_Screens/Product_Sets.php
+++ b/includes/Admin/Settings_Screens/Product_Sets.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\Admin\Settings_Screens;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 use WooCommerce\Facebook\Admin\Abstract_Settings_Screen;
 

--- a/includes/Commerce.php
+++ b/includes/Commerce.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Base handler for Commerce-specific functionality.
@@ -28,7 +27,7 @@ class Commerce {
 	/**
 	 * Gets the plugin-level fallback Google product category ID.
 	 *
-	 * This will be used when the category or product-level settings don’t override it.
+	 * This will be used when the category or product-level settings don't override it.
 	 *
 	 * @since 2.1.0
 	 *
@@ -61,5 +60,4 @@ class Commerce {
 
 		update_option( self::OPTION_GOOGLE_PRODUCT_CATEGORY_ID, is_string( $id ) ? $id : '' );
 	}
-
 }

--- a/includes/Debug/ProfilingLogger.php
+++ b/includes/Debug/ProfilingLogger.php
@@ -1,6 +1,4 @@
 <?php
-// phpcs:ignoreFile
-
 namespace WooCommerce\Facebook\Debug;
 
 defined( 'ABSPATH' ) || exit;
@@ -101,5 +99,4 @@ class ProfilingLogger {
 	protected function log( $message ) {
 		wc_get_logger()->log( 'debug', $message, array( 'source' => 'facebook_for_woocommerce_profiling' ) );
 	}
-
 }

--- a/includes/Debug/ProfilingLoggerProcess.php
+++ b/includes/Debug/ProfilingLoggerProcess.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 
 namespace WooCommerce\Facebook\Debug;
 
@@ -51,5 +50,4 @@ class ProfilingLoggerProcess {
 	public function get_time_used() {
 		return $this->stop_time - $this->start_time;
 	}
-
 }

--- a/includes/Events/AAMSettings.php
+++ b/includes/Events/AAMSettings.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\Events;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Base Automatic advanced matching settings object
@@ -121,7 +120,7 @@ class AAMSettings {
 	 * Sets the enable automatic matching flag
 	 *
 	 * @since 2.0.3
-	 *
+	 * @param bool $enable_automatic_matching Whether automatic matching is enabled
 	 * @return AAMSettings
 	 */
 	public function set_enable_automatic_matching( $enable_automatic_matching ) {
@@ -133,7 +132,7 @@ class AAMSettings {
 	 * Sets the enabled automatic matching fields flag
 	 *
 	 * @since 2.0.3
-	 *
+	 * @param string[] $enabled_automatic_matching_fields Array of enabled matching fields
 	 * @return AAMSettings
 	 */
 	public function set_enabled_automatic_matching_fields( $enabled_automatic_matching_fields ) {
@@ -145,7 +144,7 @@ class AAMSettings {
 	 * Sets the pixel id
 	 *
 	 * @since 2.0.3
-	 *
+	 * @param string $pixel_id The Facebook pixel ID
 	 * @return AAMSettings
 	 */
 	public function set_pixel_id( $pixel_id ) {

--- a/includes/ExternalVersionUpdate/Update.php
+++ b/includes/ExternalVersionUpdate/Update.php
@@ -35,7 +35,7 @@ class Update {
 	 * @since 3.0.10
 	 */
 	public function __construct() {
-		add_action( Heartbeat::HOURLY, array( $this, 'maybe_update_external_plugin_version' ) );
+		add_action( Heartbeat::DAILY, array( $this, 'maybe_update_external_plugin_version' ) );
 	}
 
 	/**
@@ -59,13 +59,6 @@ class Update {
 	 * @return bool
 	 */
 	public function should_update_version() {
-		$latest_version_sent = get_option( self::LATEST_VERSION_SENT, '0.0.0' );
-
-		if ( WC_Facebookcommerce_Utils::PLUGIN_VERSION === $latest_version_sent ) {
-			// Up to date. Nothing to do.
-			return false;
-		}
-
 		$plugin = facebook_for_woocommerce();
 
 		if ( ! $plugin->get_connection_handler()->is_connected() ) {

--- a/includes/Feed/FeedConfigurationDetection.php
+++ b/includes/Feed/FeedConfigurationDetection.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 
 namespace WooCommerce\Facebook\Feed;
 
@@ -183,22 +182,15 @@ class FeedConfigurationDetection {
 	/**
 	 * Given catalog id this function fetches all feed configurations defined for this catalog.
 	 *
-	 * @throws Error Feed configurations fetch was not successful.
-	 * @param String                        $catalog_id Facebook Catalog ID.
-	 *
+	 * @param string $product_catalog_id Facebook Catalog ID.
 	 * @return array Array of feed configurations.
-	 */
-
-	/**
-	 * @param string $product_catalog_id
-	 *
-	 * @return array Facebook Product Feeds.
-	 * @throws Request_Limit_Reached
-	 * @throws ApiException
+	 * @throws Request_Limit_Reached When API request limit is reached.
+	 * @throws ApiException When there is an error in the API request.
+	 * @throws Error Feed configurations fetch was not successful.
 	 */
 	private function get_feed_nodes_for_catalog( string $product_catalog_id ) {
 		try {
-			$response = facebook_for_woocommerce()->get_api()->read_feeds($product_catalog_id);
+			$response = facebook_for_woocommerce()->get_api()->read_feeds( $product_catalog_id );
 		} catch ( \Exception $e ) {
 			$message = sprintf( 'There was an error trying to get feed nodes for catalog: %s', $e->getMessage() );
 			facebook_for_woocommerce()->log( $message );
@@ -213,8 +205,8 @@ class FeedConfigurationDetection {
 	 * @param string $feed_id Facebook Product Feed ID.
 	 *
 	 * @return Response
-	 * @throws Request_Limit_Reached
-	 * @throws ApiException
+	 * @throws Request_Limit_Reached When API request limit is reached.
+	 * @throws ApiException When there is an error in the API request.
 	 */
 	private function get_feed_metadata( string $feed_id ) {
 		return facebook_for_woocommerce()->get_api()->read_feed( $feed_id );
@@ -230,7 +222,7 @@ class FeedConfigurationDetection {
 	 */
 	private function get_feed_upload_metadata( $upload_id ) {
 		try {
-			$response = facebook_for_woocommerce()->get_api()->read_upload($upload_id);
+			$response = facebook_for_woocommerce()->get_api()->read_upload( $upload_id );
 		} catch ( \Exception $e ) {
 			$message = sprintf( 'There was an error trying to get feed upload metadata: %s', $e->getMessage() );
 			facebook_for_woocommerce()->log( $message );
@@ -238,5 +230,4 @@ class FeedConfigurationDetection {
 		}
 		return $response;
 	}
-
 }

--- a/includes/Framework/Plugin/Exception.php
+++ b/includes/Framework/Plugin/Exception.php
@@ -1,12 +1,11 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Facebook for WooCommerce.
  */
 
 namespace WooCommerce\Facebook\Framework\Plugin;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Plugin Framework Exception - generic Exception

--- a/includes/Framework/Utilities/AsyncRequest.php
+++ b/includes/Framework/Utilities/AsyncRequest.php
@@ -35,16 +35,6 @@ abstract class AsyncRequest {
 	/** @var array request data */
 	protected $data = [];
 
-	/** @var array query arguments */
-	protected $query_args;
-
-	/** @var string query URL */
-	protected $query_url;
-
-	/** @var array request arguments */
-	protected $request_args;
-
-
 	/**
 	 * Initiate a new async request
 	 *
@@ -97,6 +87,8 @@ abstract class AsyncRequest {
 
 		// Check if a child class has defined this property for custom query args
 		if ( property_exists( $this, 'query_args' ) ) {
+			// Dynamic property; not defined in the parent class, and not a true lint error
+			// phpcs:ignore 
 			return $this->query_args;
 		}
 
@@ -117,6 +109,8 @@ abstract class AsyncRequest {
 
 		// Check if a child class has defined this property for a custom URL
 		if ( property_exists( $this, 'query_url' ) ) {
+			// Dynamic property; not defined in the parent class, and not a true lint error
+			// phpcs:ignore 
 			return $this->query_url;
 		}
 
@@ -136,6 +130,8 @@ abstract class AsyncRequest {
 
 		// Check if a child class has defined this property for custom request args
 		if ( property_exists( $this, 'request_args' ) ) {
+			// Dynamic property; not defined in the parent class, and not a true lint error
+			// phpcs:ignore 
 			return $this->request_args;
 		}
 

--- a/includes/Framework/Utilities/AsyncRequest.php
+++ b/includes/Framework/Utilities/AsyncRequest.php
@@ -1,15 +1,14 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Facebook for WooCommerce.
  */
 
 namespace WooCommerce\Facebook\Framework\Utilities;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
- * SkyVerge Wordpress Async Request class
+ * SkyVerge WordPress Async Request class
  *
  * Based on the incredible work by deliciousbrains - most of the code is from
  * here: https://github.com/A5hleyRich/wp-background-processing
@@ -36,6 +35,15 @@ abstract class AsyncRequest {
 	/** @var array request data */
 	protected $data = [];
 
+	/** @var array query arguments */
+	protected $query_args;
+
+	/** @var string query URL */
+	protected $query_url;
+
+	/** @var array request arguments */
+	protected $request_args;
+
 
 	/**
 	 * Initiate a new async request
@@ -45,7 +53,7 @@ abstract class AsyncRequest {
 	public function __construct() {
 		$this->identifier = $this->prefix . '_' . $this->action;
 
-		add_action( 'wp_ajax_' . $this->identifier,        array( $this, 'maybe_handle' ) );
+		add_action( 'wp_ajax_' . $this->identifier, array( $this, 'maybe_handle' ) );
 		add_action( 'wp_ajax_nopriv_' . $this->identifier, array( $this, 'maybe_handle' ) );
 	}
 
@@ -87,6 +95,7 @@ abstract class AsyncRequest {
 	 */
 	protected function get_query_args() {
 
+		// Check if a child class has defined this property for custom query args
 		if ( property_exists( $this, 'query_args' ) ) {
 			return $this->query_args;
 		}
@@ -106,6 +115,7 @@ abstract class AsyncRequest {
 	 */
 	protected function get_query_url() {
 
+		// Check if a child class has defined this property for a custom URL
 		if ( property_exists( $this, 'query_url' ) ) {
 			return $this->query_url;
 		}
@@ -124,6 +134,7 @@ abstract class AsyncRequest {
 	 */
 	protected function get_request_args() {
 
+		// Check if a child class has defined this property for custom request args
 		if ( property_exists( $this, 'request_args' ) ) {
 			return $this->request_args;
 		}
@@ -142,6 +153,7 @@ abstract class AsyncRequest {
 	 * Maybe handle
 	 *
 	 * Check for correct nonce and pass to handler.
+	 *
 	 * @since 4.4.0
 	 */
 	public function maybe_handle() {

--- a/includes/Handlers/WebHook.php
+++ b/includes/Handlers/WebHook.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\Handlers;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * The WebHook handler.

--- a/includes/Integrations/Bookings.php
+++ b/includes/Integrations/Bookings.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\Integrations;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Integration with WooCommerce Bookings.
@@ -82,7 +81,4 @@ class Bookings {
 
 		return class_exists( 'WC_Product_Booking' ) && is_callable( 'is_wc_booking_product' ) && is_wc_booking_product( $product );
 	}
-
-
 }
-

--- a/includes/Jobs/AbstractChainedJob.php
+++ b/includes/Jobs/AbstractChainedJob.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 
 namespace WooCommerce\Facebook\Jobs;
 
@@ -36,5 +35,4 @@ abstract class AbstractChainedJob extends FrameworkAbstractChainedJob {
 
 		$logger->stop( $process_name );
 	}
-
 }

--- a/includes/Jobs/GenerateProductFeed.php
+++ b/includes/Jobs/GenerateProductFeed.php
@@ -1,6 +1,4 @@
 <?php
-// phpcs:ignoreFile
-
 namespace WooCommerce\Facebook\Jobs;
 
 use Automattic\WooCommerce\ActionSchedulerJobFramework\Utilities\BatchQueryOffset;
@@ -16,7 +14,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class GenerateProductFeed extends AbstractChainedJob {
 
-	use BatchQueryOffset, LoggingTrait;
+	use BatchQueryOffset;
+	use LoggingTrait;
 
 	/**
 	 * Called before starting the job.
@@ -36,7 +35,7 @@ class GenerateProductFeed extends AbstractChainedJob {
 		$feed_handler->rename_temporary_feed_file_to_final_feed_file();
 		facebook_for_woocommerce()->get_tracker()->save_batch_generation_time();
 
-		do_action('wc_facebook_feed_generation_completed');
+		do_action( 'wc_facebook_feed_generation_completed' );
 	}
 
 	/**
@@ -72,7 +71,7 @@ class GenerateProductFeed extends AbstractChainedJob {
 		return array_map( 'intval', $product_ids );
 	}
 
-/**
+	/**
 	 * Processes a batch of items.
 	 *
 	 * @since 1.1.0
@@ -85,6 +84,7 @@ class GenerateProductFeed extends AbstractChainedJob {
 	protected function process_items( array $items, array $args ) {
 		// Grab start time.
 		$start_time = microtime( true );
+
 		/*
 		 * Pre-fetch full product objects.
 		 * Variable products will be filtered out here since we don't need them for the feed. It's important to not
@@ -111,6 +111,9 @@ class GenerateProductFeed extends AbstractChainedJob {
 	/**
 	 * Empty function to satisfy parent class requirements.
 	 * We don't use it because we are processing the whole batch at once in process_items.
+	 *
+	 * @param mixed $item The item to process.
+	 * @param array $args The args for the job.
 	 */
 	protected function process_item( $item, array $args ) {}
 
@@ -140,5 +143,4 @@ class GenerateProductFeed extends AbstractChainedJob {
 	protected function get_batch_size(): int {
 		return 15;
 	}
-
 }

--- a/includes/Jobs/JobManager.php
+++ b/includes/Jobs/JobManager.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 
 namespace WooCommerce\Facebook\Jobs;
 
@@ -46,11 +45,10 @@ class JobManager {
 		$this->cleanup_skyverge_job_options = new CleanupSkyvergeFrameworkJobOptions();
 		$this->cleanup_skyverge_job_options->init();
 
-		$this->reset_all_product_fb_settings = new ResetAllProductsFBSettings( $action_scheduler_proxy);
+		$this->reset_all_product_fb_settings = new ResetAllProductsFBSettings( $action_scheduler_proxy );
 		$this->reset_all_product_fb_settings->init();
 
-		$this->delete_all_products = new DeleteProductsFromFBCatalog( $action_scheduler_proxy);
+		$this->delete_all_products = new DeleteProductsFromFBCatalog( $action_scheduler_proxy );
 		$this->delete_all_products->init();
 	}
-
 }

--- a/includes/Jobs/LoggingTrait.php
+++ b/includes/Jobs/LoggingTrait.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 
 namespace WooCommerce\Facebook\Jobs;
 

--- a/includes/Locale.php
+++ b/includes/Locale.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Helper class with utility methods for handling locales in Facebook.
@@ -150,7 +149,8 @@ class Locale {
 
 			foreach ( self::$supported_locales as $locale ) {
 
-				if ( $name = \Locale::getDisplayName( $locale, substr( $locale, 0, 2 ) ) ) {
+				$name = \Locale::getDisplayName( $locale, substr( $locale, 0, 2 ) );
+				if ( $name ) {
 
 					$locales[ $locale ] = ucfirst( $name );
 				}
@@ -208,6 +208,4 @@ class Locale {
 
 		return array_key_exists( $locale, self::get_supported_locales() );
 	}
-
-
 }

--- a/includes/ProductSets/Sync.php
+++ b/includes/ProductSets/Sync.php
@@ -76,7 +76,7 @@ class Sync {
 	 *
 	 * @var string
 	 */
-	protected static $prev_product_name = "";
+	protected static $prev_product_name = '';
 
 	/**
 	 * Product's Product Set New List
@@ -94,7 +94,7 @@ class Sync {
 	 *
 	 * @var string
 	 */
-	protected static $new_product_name = "";
+	protected static $new_product_name = '';
 
 	/**
 	 * Categories field name
@@ -255,7 +255,7 @@ class Sync {
 	 * @param int $term_id Term ID.
 	 */
 	public function fb_product_set_hook_before( $term_id ) {
-		self::$prev_product_cat = get_term_meta( $term_id, $this->categories_field, true );
+		self::$prev_product_cat  = get_term_meta( $term_id, $this->categories_field, true );
 		self::$prev_product_name = get_term( $term_id )->name;
 	}
 
@@ -268,7 +268,7 @@ class Sync {
 	 * @param int $term_id Term ID.
 	 */
 	public function fb_product_set_hook_after( $term_id ) {
-		self::$new_product_cat = get_term_meta( $term_id, $this->categories_field, true );
+		self::$new_product_cat  = get_term_meta( $term_id, $this->categories_field, true );
 		self::$new_product_name = get_term( $term_id )->name;
 		if ( ! empty( $this->get_all_diff( 'product_cat' ) ) || self::$prev_product_name !== self::$new_product_name ) {
 			$this->maybe_sync_product_set( $term_id );
@@ -464,6 +464,4 @@ class Sync {
 
 		return array_merge( $removed, $added );
 	}
-
-
 }

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -133,7 +133,6 @@ class ProductValidator {
 	public function validate() {
 		$this->validate_sync_enabled_globally();
 		$this->validate_product_status();
-		$this->validate_product_stock_status();
 		$this->validate_product_sync_field();
 		$this->validate_product_price();
 		$this->validate_product_visibility();
@@ -151,7 +150,6 @@ class ProductValidator {
 	 */
 	public function validate_but_skip_status_check() {
 		$this->validate_sync_enabled_globally();
-		$this->validate_product_stock_status();
 		$this->validate_product_sync_field();
 		$this->validate_product_price();
 		$this->validate_product_visibility();
@@ -168,7 +166,6 @@ class ProductValidator {
 	 */
 	public function validate_but_skip_sync_field() {
 		$this->validate_sync_enabled_globally();
-		$this->validate_product_stock_status();
 		$this->validate_product_price();
 		$this->validate_product_visibility();
 		$this->validate_product_terms();
@@ -265,17 +262,6 @@ class ProductValidator {
 
 		if ( 'publish' !== $product->get_status() ) {
 			throw new ProductExcludedException( __( 'Product is not published.', 'facebook-for-woocommerce' ) );
-		}
-	}
-
-	/**
-	 * Check whether the product should be excluded due to being out of stock.
-	 *
-	 * @throws ProductExcludedException If product should not be synced.
-	 */
-	protected function validate_product_stock_status() {
-		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $this->product->is_in_stock() ) {
-			throw new ProductExcludedException( __( 'Product must be in stock.', 'facebook-for-woocommerce' ) );
 		}
 	}
 

--- a/includes/Product_Categories.php
+++ b/includes/Product_Categories.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Helper class with utility methods for getting and setting various product category values.

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -221,7 +221,7 @@ class Products {
 	 * @return bool
 	 */
 	public static function product_should_be_deleted( \WC_Product $product ) {
-		return ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $product->is_in_stock() ) || ! facebook_for_woocommerce()->get_product_sync_validator( $product )->passes_product_terms_check();
+		return ! facebook_for_woocommerce()->get_product_sync_validator( $product )->passes_product_terms_check();
 	}
 
 

--- a/includes/Products/FBCategories.php
+++ b/includes/Products/FBCategories.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -22,7 +21,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class FBCategories {
 
-	private $keys_to_exclude = ['brand' => true];
+	/** @var array Keys to exclude from attribute processing */
+	private $keys_to_exclude = [ 'brand' => true ];
 
 	/**
 	 * Fetches the attribute from a category using attribute key.

--- a/includes/Products/GoogleProductTaxonomy.php
+++ b/includes/Products/GoogleProductTaxonomy.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 namespace WooCommerce\Facebook\Products;
 // This file was generated using GenerateCategories.php, do not modify it manually
 // php GenerateCategories.php taxonomy-with-ids.en-US.txt

--- a/includes/Products/Stock.php
+++ b/includes/Products/Stock.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\Products;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 use WooCommerce\Facebook\Products;
 

--- a/includes/Utilities/Background_Remove_Duplicate_Visibility_Meta.php
+++ b/includes/Utilities/Background_Remove_Duplicate_Visibility_Meta.php
@@ -152,7 +152,7 @@ class Background_Remove_Duplicate_Visibility_Meta extends BackgroundJobHandler {
 				continue;
 			}
 
-			$products_updated++;
+			++$products_updated;
 		}
 
 		return $products_updated;
@@ -191,6 +191,4 @@ class Background_Remove_Duplicate_Visibility_Meta extends BackgroundJobHandler {
 	protected function process_item( $item, $job ) {
 		// void
 	}
-
-
 }

--- a/includes/Utilities/Heartbeat.php
+++ b/includes/Utilities/Heartbeat.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 
 namespace WooCommerce\Facebook\Utilities;
 
@@ -91,6 +90,4 @@ class Heartbeat {
 	public function schedule_daily_action() {
 		$this->queue->add( self::DAILY );
 	}
-
-
 }

--- a/includes/fbasync.php
+++ b/includes/fbasync.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -21,6 +20,11 @@ if ( ! class_exists( 'WP_Async_Request', false ) ) {
  */
 class WC_Facebookcommerce_Async_Request extends WP_Async_Request {
 
+	/**
+	 * Action name used for the async request
+	 *
+	 * @var string
+	 */
 	protected $action = 'wc_facebook_async_request';
 
 	/**

--- a/includes/fbbackground.php
+++ b/includes/fbbackground.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -16,6 +15,11 @@ if ( ! class_exists( 'WP_Background_Process', false ) ) {
 	return;
 }
 
+/**
+ * Facebook Background Process
+ *
+ * Handles background processing of product synchronization with Facebook.
+ */
 class WC_Facebookcommerce_Background_Process extends WP_Background_Process {
 
 		/**
@@ -23,9 +27,9 @@ class WC_Facebookcommerce_Background_Process extends WP_Background_Process {
 		 */
 		private $commerce;
 
-		public function __construct( $commerce ) {
-			$this->commerce = $commerce; // Full WC_Facebookcommerce_Integration obj
-		}
+	public function __construct( $commerce ) {
+		$this->commerce = $commerce; // Full WC_Facebookcommerce_Integration obj
+	}
 
 		/**
 		 * __get method for backward compatibility.
@@ -34,41 +38,41 @@ class WC_Facebookcommerce_Background_Process extends WP_Background_Process {
 		 * @return mixed
 		 * @since 3.0.32
 		 */
-		public function __get( $key ) {
-			// Add warning for private properties.
-			if ( 'commerce' === $key ) {
-				/* translators: %s property name. */
-				_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'The %s property is private and should not be accessed outside its class.', 'facebook-for-woocommerce' ), esc_html( $key ) ), '3.0.32' );
-				return $this->$key;
-			}
-
-			return null;
+	public function __get( $key ) {
+		// Add warning for private properties.
+		if ( 'commerce' === $key ) {
+			/* translators: %s property name. */
+			_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'The %s property is private and should not be accessed outside its class.', 'facebook-for-woocommerce' ), esc_html( $key ) ), '3.0.32' );
+			return $this->$key;
 		}
+
+		return null;
+	}
 
 		/**
 		 * @var string
 		 */
 		protected $action = 'fb_commerce_background_process';
 
-		public function dispatch() {
-			$commerce   = $this->commerce;
-			$dispatched = parent::dispatch();
+	public function dispatch() {
+		$commerce   = $this->commerce;
+		$dispatched = parent::dispatch();
 
-			if ( is_wp_error( $dispatched ) ) {
-				WC_Facebookcommerce_Utils::log(
-					sprintf(
-						'Unable to dispatch FB Background processor: %s',
-						$dispatched->get_error_message()
-					),
-					array( 'source' => 'wc_facebook_background_process' )
-				);
-			}
+		if ( is_wp_error( $dispatched ) ) {
+			WC_Facebookcommerce_Utils::log(
+				sprintf(
+					'Unable to dispatch FB Background processor: %s',
+					$dispatched->get_error_message()
+				),
+				array( 'source' => 'wc_facebook_background_process' )
+			);
 		}
+	}
 
-		public function get_item_count() {
-			$commerce = $this->commerce;
-			return (int) get_transient( $commerce::FB_SYNC_REMAINING );
-		}
+	public function get_item_count() {
+		$commerce = $this->commerce;
+		return (int) get_transient( $commerce::FB_SYNC_REMAINING );
+	}
 
 		/**
 		 * Handle cron healthcheck
@@ -76,55 +80,54 @@ class WC_Facebookcommerce_Background_Process extends WP_Background_Process {
 		 * Restart the background process if not already running
 		 * and data exists in the queue.
 		 */
-		public function handle_cron_healthcheck() {
-			$commerce = $this->commerce;
-			if ( $this->is_process_running() ) {
-				// Background process already running, no-op
-				return true;  // Return "is running? status"
-			}
-
-			if ( $this->is_queue_empty() ) {
-				// No data to process.
-				$this->clear_scheduled_event();
-				delete_transient( $commerce::FB_SYNC_REMAINING );
-				return;
-			}
-
-			$this->handle();
-			return true;
-
+	public function handle_cron_healthcheck() {
+		$commerce = $this->commerce;
+		if ( $this->is_process_running() ) {
+			// Background process already running, no-op
+			return true;  // Return "is running? status"
 		}
+
+		if ( $this->is_queue_empty() ) {
+			// No data to process.
+			$this->clear_scheduled_event();
+			delete_transient( $commerce::FB_SYNC_REMAINING );
+			return;
+		}
+
+		$this->handle();
+		return true;
+	}
 
 		/**
 		 * Schedule fallback event.
 		 */
-		protected function schedule_event() {
-			if ( ! wp_next_scheduled( $this->cron_hook_identifier ) ) {
-				wp_schedule_event(
-					time() + 10,
-					$this->cron_interval_identifier,
-					$this->cron_hook_identifier
-				);
-			}
+	protected function schedule_event() {
+		if ( ! wp_next_scheduled( $this->cron_hook_identifier ) ) {
+			wp_schedule_event(
+				time() + 10,
+				$this->cron_interval_identifier,
+				$this->cron_hook_identifier
+			);
 		}
+	}
 
 		/**
 		 * Is the processor updating?
 		 *
 		 * @return boolean
 		 */
-		public function is_updating() {
-			return false === $this->is_queue_empty();
-		}
+	public function is_updating() {
+		return false === $this->is_queue_empty();
+	}
 
 		/**
 		 * Is the processor running?
 		 *
 		 * @return boolean
 		 */
-		public function is_running() {
-			return $this->is_process_running();
-		}
+	public function is_running() {
+		return $this->is_process_running();
+	}
 
 		/**
 		 * Process individual product
@@ -136,30 +139,30 @@ class WC_Facebookcommerce_Background_Process extends WP_Background_Process {
 		 *
 		 * @return mixed
 		 */
-		protected function task( $item ) {
-			$commerce      = $this->commerce;  // PHP5 compatibility for static access
-			$remaining     = $this->get_item_count();
-			$count_message = sprintf(
-				'Background syncing products to Facebook. Products remaining: %1$d',
-				$remaining
-			);
+	protected function task( $item ) {
+		$commerce      = $this->commerce;  // PHP5 compatibility for static access
+		$remaining     = $this->get_item_count();
+		$count_message = sprintf(
+			'Background syncing products to Facebook. Products remaining: %1$d',
+			$remaining
+		);
 
-			$this->commerce->display_sticky_message( $count_message, true );
+		$this->commerce->display_sticky_message( $count_message, true );
 
-			$this->commerce->on_product_publish( $item );
-			$remaining--;
-			set_transient(
-				$commerce::FB_SYNC_IN_PROGRESS,
-				true,
-				$commerce::FB_SYNC_TIMEOUT
-			);
-			set_transient(
-				$commerce::FB_SYNC_REMAINING,
-				$remaining
-			);
+		$this->commerce->on_product_publish( $item );
+		--$remaining;
+		set_transient(
+			$commerce::FB_SYNC_IN_PROGRESS,
+			true,
+			$commerce::FB_SYNC_TIMEOUT
+		);
+		set_transient(
+			$commerce::FB_SYNC_REMAINING,
+			$remaining
+		);
 
-			return false;
-		}
+		return false;
+	}
 
 		/**
 		 * Complete
@@ -167,15 +170,14 @@ class WC_Facebookcommerce_Background_Process extends WP_Background_Process {
 		 * Override if applicable, but ensure that the below actions are
 		 * performed, or, call parent::complete().
 		 */
-		protected function complete() {
-			$commerce = $this->commerce;  // PHP5 compatibility for static access
-			delete_transient( $commerce::FB_SYNC_IN_PROGRESS );
-			delete_transient( $commerce::FB_SYNC_REMAINING );
-			WC_Facebookcommerce_Utils::log( 'Background sync complete!' );
-			WC_Facebookcommerce_Utils::fblog( 'Background sync complete!' );
-			$this->commerce->remove_sticky_message();
-			$this->commerce->display_info_message( 'Facebook product sync complete!' );
-			parent::complete();
-		}
-
+	protected function complete() {
+		$commerce = $this->commerce;  // PHP5 compatibility for static access
+		delete_transient( $commerce::FB_SYNC_IN_PROGRESS );
+		delete_transient( $commerce::FB_SYNC_REMAINING );
+		WC_Facebookcommerce_Utils::log( 'Background sync complete!' );
+		WC_Facebookcommerce_Utils::fblog( 'Background sync complete!' );
+		$this->commerce->remove_sticky_message();
+		$this->commerce->display_info_message( 'Facebook product sync complete!' );
+		parent::complete();
 	}
+}

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -832,6 +832,7 @@ class WC_Facebook_Product {
 		$product_data[ 'availability' ] = $this->is_in_stock() ? 'in stock' : 'out of stock';
 		$product_data[ 'visibility' ] = Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
 		$product_data[ 'retailer_id' ] = $retailer_id;
+		$product_data[ 'woo_commerce_retailer_id' ] = $this->get_id();
 
 		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
 			$product_data['title'] = WC_Facebookcommerce_Utils::clean_string( $this->get_title() );

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -832,7 +832,7 @@ class WC_Facebook_Product {
 		$product_data[ 'availability' ] = $this->is_in_stock() ? 'in stock' : 'out of stock';
 		$product_data[ 'visibility' ] = Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
 		$product_data[ 'retailer_id' ] = $retailer_id;
-		$product_data[ 'woo_commerce_retailer_id' ] = $this->get_id();
+		$product_data[ 'external_variant_id' ] = $this->get_id();
 
 		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
 			$product_data['title'] = WC_Facebookcommerce_Utils::clean_string( $this->get_title() );

--- a/includes/test/fbproductfeed-test.php
+++ b/includes/test/fbproductfeed-test.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -22,18 +21,28 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed_Test' ) ) :
 	 */
 	class WC_Facebook_Product_Feed_Test_Mock extends WC_Facebook_Product_Feed {
 
+		/** @var int|null Product post ID for testing */
 		public static $product_post_wpid = null;
 
-		// Return test product post id.
-		// Don't mess up actual products.
+		/**
+		 * Return test product post id.
+		 * Don't mess up actual products.
+		 *
+		 * @return int|null Product post ID
+		 */
 		public function get_product_wpid() {
 			return self::$product_post_wpid;
 		}
 
-		// Log progress in local log file for testing.
-		// Not to overwhelm DB log to track important signals.
-		public function log_feed_progress( $msg, $object = array() ) {
-			$msg = empty( $object ) ? $msg : $msg . json_encode( $object );
+		/**
+		 * Log progress in local log file for testing.
+		 * Not to overwhelm DB log to track important signals.
+		 *
+		 * @param string $msg  Message to log
+		 * @param array  $data Optional data to include in the log
+		 */
+		public function log_feed_progress( $msg, $data = array() ) {
+			$msg = empty( $data ) ? $msg : $msg . wp_json_encode( $data );
 			WC_Facebookcommerce_Utils::log( 'Test - ' . $msg );
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "author": "Facebook",
   "homepage": "https://woocommerce.com/products/facebook/",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,18 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
-= 3.4.X 2025-XX-XX =
+= 3.4.4 - 2025-03-26 =
+* Add - Create tests for ProductFeedUploads create endpoint by @ajello-meta in #2902
+* Add - Create tests for ProductFeedUploads read endpoint by @ajello-meta in #2903
+* Tweak - Remove phpcs:ignoreFile annotation + Enable code coverage report generation with phpunit by @sol-loup in #2897 and #2901
+* Fix - Restores the original dynamic property behavior in the AsyncRequest class by @sol-loup in #2921
+* Tweak - Changing APP to PLUGIN on README.MD by @SayanPandey in #2916
+* Tweak - Update README.md - Added noification for ownership transfer by @SayanPandey in #2910
+* Tweak - Added is_multisite logging to the update_plugin_version_configuration request by @carterbuce in #2955
+* Tweak - Add woo_commerce_retailer_id to products API request by @crisojog in #2958
+* Tweak - Syncing plugin version info by @vinkmeta in #2960
+* Fix - sync products out of stock to meta despite visibility config by @francorisso in #2952
+* Fix - Update woo_commerce_retailer_id to existing field external_variant_id by @crisojog in #2963
+* Tweak - Update readme.txt by @vinkmeta in #2949
 
 [See changelog for all versions](https://raw.githubusercontent.com/facebook/facebook-for-woocommerce/refs/heads/main/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -39,43 +39,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 * Current version of Facebook-for-WooCommerce, WooCommerce, Wordpress, PHP
 
 == Changelog ==
-= 3.4.4 - 2025-03-26 =
-* Add - Create tests for ProductFeedUploads create endpoint by @ajello-meta in #2902
-* Add - Create tests for ProductFeedUploads read endpoint by @ajello-meta in #2903
-* Tweak - Remove phpcs:ignoreFile annotation + Enable code coverage report generation with phpunit by @sol-loup in #2897 and #2901
-* Tweak - Changing APP to PLUGIN on README.MD by @SayanPandey in #2916
-* Tweak - Update README.md - Added noification for ownership transfer by @SayanPandey in #2910
-* Tweak - Added is_multisite logging to the update_plugin_version_configuration request by @carterbuce in #2955
-* Tweak - Add woo_commerce_retailer_id to products API request by @crisojog in #2958
-* Tweak - Syncing plugin version info by @vinkmeta in #2960
-* Fix - sync products out of stock to meta despite visibility config by @francorisso in #2952
-* Fix - Update woo_commerce_retailer_id to existing field external_variant_id by @crisojog in #2963
 
-= 3.4.3 - 2025-03-19 =
-* Add - Items batch request and response tests by @nrostrow-meta in #2917
-* Tweak - Always run PHP-based github workflows by @carterbuce in #2926
-* Fix - feed upload error "feed_column_count_mismatch" when product has multiple colors separated by a comma by @mshymon in #2947
-* Tweak - Updated Pull Request Template by @vinkmeta in #2948
-* Dev - Improved readability of function prepare_product() in fbproduct.php by @mshymon in #2889
-* Tweak - Enabled PHPUnit code coverage report generation by @carterbuce in #2893
+= 3.4.X 2025-XX-XX =
 
-= 3.4.2 - 2025-03-13 =
-* Tweak - Update README.md - Added noification for ownership transfer by @SayanPandey in #2910 and #2916
-
-= 3.4.1 - 2025-02-27 = 
-* Tweak - Removed custom field definitions by @devbodaghe in #2876
-* Dev - Improved readability of function prepare_product() in fbproduct.php by @mshymon in #2889
-* Dev - Enabled PHPUnit code coverage report generation by @carterbruce in #2893
-
-= 3.4.0 - 2025-02-19 =
-* Add - FB product video field to add videos. Also added products sync to support the video field with Batch API by @gurtejrehal in #2874
-* Tweak - tests for #2874 by @gurtejrehal in #2888
-* Tweak - tests for Product Update action as ramp up task by @nealweiMeta in #2883
-* Fix - translations loading before the init hook by @iodic in #2866
-* Fix - Fixed feeds by requesting a feed file upload session after feed file is generated and added missing new fields to the feed file by @mshymon in #2841
-
-= 3.3.5 - 2025-02-12 = 
-* Add - Rich Text Description to Woo Product Sync with Meta by devbodaghe in #2843
-
-= 3.3.4 - 2025-02-11 =
-* Fix - Fixing the issue with version number
+[See changelog for all versions](https://raw.githubusercontent.com/facebook/facebook-for-woocommerce/refs/heads/main/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,18 @@ When opening a bug on GitHub, please give us as many details as possible.
 * Current version of Facebook-for-WooCommerce, WooCommerce, Wordpress, PHP
 
 == Changelog ==
+= 3.4.4 - 2025-03-26 =
+* Add - Create tests for ProductFeedUploads create endpoint by @ajello-meta in #2902
+* Add - Create tests for ProductFeedUploads read endpoint by @ajello-meta in #2903
+* Tweak - Remove phpcs:ignoreFile annotation + Enable code coverage report generation with phpunit by @sol-loup in #2897 and #2901
+* Tweak - Changing APP to PLUGIN on README.MD by @SayanPandey in #2916
+* Tweak - Update README.md - Added noification for ownership transfer by @SayanPandey in #2910
+* Tweak - Added is_multisite logging to the update_plugin_version_configuration request by @carterbuce in #2955
+* Tweak - Add woo_commerce_retailer_id to products API request by @crisojog in #2958
+* Tweak - Syncing plugin version info by @vinkmeta in #2960
+* Fix - sync products out of stock to meta despite visibility config by @francorisso in #2952
+* Fix - Update woo_commerce_retailer_id to existing field external_variant_id by @crisojog in #2963
+
 = 3.4.3 - 2025-03-19 =
 * Add - Items batch request and response tests by @nrostrow-meta in #2917
 * Tweak - Always run PHP-based github workflows by @carterbuce in #2926
@@ -67,7 +79,3 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 = 3.3.4 - 2025-02-11 =
 * Fix - Fixing the issue with version number
-
-= 3.3.3 - 2025-02-06 = 
-* Fix - Use of recommended delete connection endpoint over delete permission endpoint by atuld123 in #2844
-* Add - Expose Brand & MPN to Woocommerce UI by @devbodaghe in #2842

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, woocommerce, marketing, product catalog feed, pixel
 Requires at least: 5.6
 Tested up to: 6.7
-Stable tag: 3.4.3
+Stable tag: 3.4.4
 Requires PHP: 7.4
 MySQL: 5.6 or greater
 License: GPLv2 or later

--- a/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Create/ReponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Create/ReponseTest.php
@@ -1,0 +1,27 @@
+<?php
+declare( strict_types=1 );
+
+use WooCommerce\Facebook\API\ProductCatalog\ProductFeedUploads\Create\Response;
+
+/**
+ * Response unit test class.
+ */
+class ProductFeedUploadResponseTest extends WP_UnitTestCase {
+
+    /**
+     * @return void
+     */
+    public function test_response() {
+        $json = '{
+            "id": "product_feed_upload_id",
+            "data": {
+                "upload_status": "success"
+            }
+        }';
+
+        $response = new Response($json);
+
+        $this->assertEquals('product_feed_upload_id', $response->id);
+        $this->assertEquals('success', $response->data['upload_status']);
+    }
+}

--- a/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Create/RequestTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Create/RequestTest.php
@@ -1,0 +1,30 @@
+<?php
+declare( strict_types=1 );
+
+use WooCommerce\Facebook\API\ProductCatalog\ProductFeedUploads\Create\Request;
+
+/**
+ * Request unit test class.
+ */
+class ProductFeedUploadRequestTest extends WP_UnitTestCase {
+
+    /**
+     * @return void
+     */
+    public function test_request() {
+        $product_feed_id = 'product_feed_upload_id';
+        $data = [
+            'name' => 'Test Product Feed',
+            'schedule' => [
+                'interval' => 'DAILY',
+                'url' => 'http://example.com/feed.xml',
+            ],
+        ];
+
+        $request = new Request($product_feed_id, $data);
+
+        $this->assertEquals('POST', $request->get_method());
+        $this->assertEquals('/product_feed_upload_id/uploads', $request->get_path());
+        $this->assertEquals($data, $request->get_data());
+    }
+}

--- a/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Read/RequestTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Read/RequestTest.php
@@ -1,0 +1,23 @@
+<?php
+declare( strict_types=1 );
+
+use WooCommerce\Facebook\API\ProductCatalog\ProductFeedUploads\Read\Request;
+
+/**
+ * Request unit test class for reading product feed uploads.
+ */
+class ProductFeedUploadReadRequestTest extends WP_UnitTestCase {
+
+    /**
+     * @return void
+     */
+    public function test_request() {
+        $product_feed_upload_id = 'product_feed_upload_id';
+        $request = new Request($product_feed_upload_id);
+
+        $expected_path = '/product_feed_upload_id/?fields=error_count,warning_count,num_detected_items,num_persisted_items,url,end_time';
+
+        $this->assertEquals('GET', $request->get_method());
+        $this->assertEquals($expected_path, $request->get_path());
+    }
+}

--- a/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Read/ResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Read/ResponseTest.php
@@ -1,0 +1,37 @@
+<?php
+declare( strict_types=1 );
+
+use WooCommerce\Facebook\API\ProductCatalog\ProductFeedUploads\Read\Response;
+
+/**
+ * Response unit test class for reading product feed uploads.
+ */
+class ProductFeedUploadReadResponseTest extends WP_UnitTestCase {
+
+    /**
+     * @return void
+     */
+    public function test_response() {
+        $json = '{
+            "id": "product_feed_upload_id",
+            "data": {
+                "error_count": 0,
+                "warning_count": 2,
+                "num_detected_items": 100,
+                "num_persisted_items": 98,
+                "url": "http://example.com/feed.xml",
+                "end_time": "2023-10-01T12:00:00+0000"
+            }
+        }';
+
+        $response = new Response($json);
+
+        $this->assertEquals('product_feed_upload_id', $response->id);
+        $this->assertEquals(0, $response->data['error_count']);
+        $this->assertEquals(2, $response->data['warning_count']);
+        $this->assertEquals(100, $response->data['num_detected_items']);
+        $this->assertEquals(98, $response->data['num_persisted_items']);
+        $this->assertEquals('http://example.com/feed.xml', $response->data['url']);
+        $this->assertEquals('2023-10-01T12:00:00+0000', $response->data['end_time']);
+    }
+}

--- a/tests/Unit/ExternalVersionUpdate/UpdateTest.php
+++ b/tests/Unit/ExternalVersionUpdate/UpdateTest.php
@@ -40,12 +40,6 @@ class UpdateTest extends WP_UnitTestCase {
 	 */
 	public function test_should_update_version() {
 		$plugin = facebook_for_woocommerce();
-
-		// Assert update not required when the versions match.
-		update_option( 'facebook_for_woocommerce_latest_version_sent_to_server', WC_Facebookcommerce_Utils::PLUGIN_VERSION );
-		$should_update = $this->update->should_update_version();
-		$this->assertFalse( $should_update );
-
 		/**
 		 * Set the $plugin->connection_handler and $plugin->api access to true. This will allow us
 		 * to assign the mock objects to these properties.
@@ -61,7 +55,6 @@ class UpdateTest extends WP_UnitTestCase {
 									->getMock();
 		$mock_connection_handler->expects( $this->any() )->method( 'is_connected' )->willReturn( false );
 		$prop_connection_handler->setValue( $plugin, $mock_connection_handler );
-
 		update_option( 'facebook_for_woocommerce_latest_version_sent_to_server', '0.0.0' ); // Reset the option.
 		$should_update2 = $this->update->should_update_version();
 		$this->assertFalse( $should_update2 );
@@ -75,7 +68,7 @@ class UpdateTest extends WP_UnitTestCase {
 		$prop_connection_handler->setValue( $plugin, $mock_connection_handler );
 		update_option( 'facebook_for_woocommerce_latest_version_sent_to_server', WC_Facebookcommerce_Utils::PLUGIN_VERSION );
 		$should_update3 = $this->update->should_update_version();
-		$this->assertFalse( $should_update3 ); // Because the versions match.
+		$this->assertTrue( $should_update3 ); // Because the versions match.
 
 		update_option( 'facebook_for_woocommerce_latest_version_sent_to_server', '0.0.0' ); // Reset the option.
 		$should_update4 = $this->update->should_update_version();

--- a/tests/Unit/ExternalVersionUpdate/UpdateTest.php
+++ b/tests/Unit/ExternalVersionUpdate/UpdateTest.php
@@ -128,6 +128,7 @@ class UpdateTest extends WP_UnitTestCase {
 			'business_config'          => array(
 				'external_client' => array(
 					'version_id' => WC_Facebookcommerce_Utils::PLUGIN_VERSION,
+					'is_multisite' => false,
 				),
 			),
 		);

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -909,13 +909,13 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 
 		add_post_meta( $product->get_id(), WC_Facebookcommerce_Integration::FB_PRODUCT_ITEM_ID, 'facebook-product-item-id' );
 
-		$this->api->expects( $this->once() )
+		$this->api->expects( $this->never() )
 			->method( 'delete_product_item' )
 			->with( 'facebook-product-item-id' );
 
 		$result = $this->integration->delete_on_out_of_stock( $product->get_id(), $product );
 
-		$this->assertTrue( $result );
+		$this->assertFalse( $result );
 	}
 
 	/**


### PR DESCRIPTION
* Add - Create tests for ProductFeedUploads create endpoint by @ajello-meta in #2902
* Add - Create tests for ProductFeedUploads read endpoint by @ajello-meta in #2903
* Tweak - Remove phpcs:ignoreFile annotation + Enable code coverage report generation with phpunit by @sol-loup in #2897 and #2901
* Fix - Restores the original dynamic property behavior in the AsyncRequest class by @sol-loup in #2921
* Tweak - Changing APP to PLUGIN on README.MD by @SayanPandey in #2916
* Tweak - Update README.md - Added noification for ownership transfer by @SayanPandey in #2910
* Tweak - Added is_multisite logging to the update_plugin_version_configuration request by @carterbuce in #2955
* Tweak - Add woo_commerce_retailer_id to products API request by @crisojog in #2958
* Tweak - Syncing plugin version info by @vinkmeta in #2960
* Fix - sync products out of stock to meta despite visibility config by @francorisso in #2952
* Fix - Update woo_commerce_retailer_id to existing field external_variant_id by @crisojog in #2963
* Tweak - Update readme.txt by @vinkmeta in #2949
