### PR TITLE
Fix for 'PHP Warning:  Undefined variable $fb_product_parent'

### DIFF
--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -323,6 +323,7 @@ class WC_Facebook_Product_Feed {
 		foreach ( $wp_ids as $wp_id ) {
 
 			$product = wc_get_product( $wp_id );
+			$fb_product_parent = null;
 			if ( $product instanceof WC_Product && $product->get_parent_id() ) {
 				$parent_product = wc_get_product( $product->get_parent_id() );
 				if ( $parent_product instanceof WC_Product ) {


### PR DESCRIPTION
## Description

There is an issue raised in the WordPress forum (https://wordpress.org/support/topic/undefined-variable-fb_product_parent-in-webroot-wp-content-plugins-facebook-fo/) about PHP warning in debug log:

`PHP Warning:  Undefined variable $fb_product_parent in /bitnami/wordpress/wp-content/plugins/facebook-for-woocommerce/includes/fbproductfeed.php on line 335`.

This PR fixing the issue.

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots

### Before
Logs contains the PHP Warning after I trigger feed file generation.
<img width="2857" alt="Screenshot 2025-03-27 at 15 47 42" src="https://github.com/user-attachments/assets/b626ab60-4bc4-4901-8106-67f38000d4a4" />


### After
Logs do not contains the PHP Warning after I trigger feed file generation.
<img width="2859" alt="Screenshot 2025-03-27 at 15 49 44" src="https://github.com/user-attachments/assets/3f9aaa74-72ed-4d6b-9e89-c854cc0a0c58" />

## Test instructions
Manually trigger feed file generation (WooCommerce => Status => Scheduled Actions => wc_facebook_regenerate_feed) and monitor debug logs via "WP Console" tool.


## Checklist

- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests and all the new and existing unit tests pass locally with my changes
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.


## Changelog entry

Fix for 'PHP Warning:  Undefined variable $fb_product_parent'
