### PR TITLE
Create new troubleshooting drawer from legacy debug settings

### DIFF
--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -270,7 +270,7 @@ class Shops extends Abstract_Settings_Screen {
 	public function get_settings() {
 		return array(
 			array(
-				//phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
+				//phpcs:ignore WordPress.WP.I18n.NoEmptyStrings
 				'title' => __( '', 'facebook-for-woocommerce' ),
 				'type'  => 'title',
 			),

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -94,7 +94,6 @@ class Shops extends Abstract_Settings_Screen {
 		}
 	}
 
-
 	/**
 	 * Enqueues the assets.
 	 *
@@ -109,7 +108,6 @@ class Shops extends Abstract_Settings_Screen {
 
 		wp_enqueue_style( 'wc-facebook-admin-connection-settings', facebook_for_woocommerce()->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-connection.css', array(), \WC_Facebookcommerce::VERSION );
 	}
-
 
 	/**
 	 * Renders the screen.
@@ -154,6 +152,156 @@ class Shops extends Abstract_Settings_Screen {
 		></iframe>
 	</div>
 		<?php
+
+    if ($is_connected) {
+        $this->render_troubleshooting_button_and_drawer();
+    }
+	}
+
+	private function render_troubleshooting_button_and_drawer() {
+    ?>
+    <!-- Toggle Button -->
+    <div class="centered-container">
+        <button id="toggle-troubleshooting-drawer" class="drawer-toggle-button">
+            Troubleshooting
+            <span id="caret" class="caret"></span>
+        </button>
+    </div>
+
+    <!-- Drawer -->
+    <div id="troubleshooting-drawer" class="settings-drawer" style="display: none;">
+        <div class="settings-drawer-content">
+            <?php parent::render(); ?>
+        </div>
+    </div>
+
+    <style>
+        .centered-container {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            width: 100%;
+            margin-top: 20px;
+        }
+
+        .drawer-toggle-button {
+            width: 100%;
+            max-width: 1100px;
+            background-color: #fff;
+            border: 1px solid #ccc;
+            padding: 10px 20px;
+            text-align: left;
+            cursor: pointer;
+            font-size: 16px;
+            font-weight: 600;
+            position: relative;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 20px;
+        }
+
+        .drawer-toggle-button:hover {
+            background-color: #f9f9f9;
+        }
+
+        .caret {
+            width: 0;
+            height: 0;
+            border-left: 5px solid transparent;
+            border-right: 5px solid transparent;
+            border-top: 5px solid #000;
+            transition: transform 0.3s ease;
+        }
+
+        .settings-drawer {
+            width: 100%;
+            max-width: 1100px;
+            background-color: #fff;
+            border: 1px solid #ccc;
+            overflow: hidden;
+            transition: max-height 0.3s ease, margin-bottom 0.3s ease;
+            max-height: 0;
+            margin: 0 auto;
+        }
+
+        .settings-drawer-content {
+            padding: 20px;
+            padding-bottom: 0;
+        }
+    </style>
+
+    <script>
+        document.getElementById('toggle-troubleshooting-drawer').addEventListener('click', function() {
+            var drawer = document.getElementById('troubleshooting-drawer');
+            var caret = document.getElementById('caret');
+            var button = document.getElementById('toggle-troubleshooting-drawer');
+
+            if (drawer.style.maxHeight === '0px' || drawer.style.maxHeight === '') {
+                drawer.style.display = 'block';
+                drawer.style.maxHeight = drawer.scrollHeight + 'px';
+                caret.style.transform = 'rotate(180deg)';
+                drawer.style.marginBottom = '20px';
+                button.style.marginBottom = '0';
+            } else {
+                drawer.style.maxHeight = '0';
+                setTimeout(function() {
+                    drawer.style.display = 'none';
+                }, 300);
+                caret.style.transform = 'rotate(0deg)';
+                drawer.style.marginBottom = '0';
+                button.style.marginBottom = '20px';
+            }
+        });
+    </script>
+    <?php
+}
+
+	/**
+	 * Gets the screen settings.
+	 *
+	 * @return array
+	 * @since 3.5.0
+	 */
+	public function get_settings() {
+		return array(
+
+			array(
+				'title' => __( '', 'facebook-for-woocommerce' ),
+				'type'  => 'title',
+			),
+
+			array(
+				'id'       => \WC_Facebookcommerce_Integration::SETTING_ENABLE_META_DIAGNOSIS,
+				'title'    => __( 'Enable meta diagnosis', 'facebook-for-woocommerce' ),
+				'type'     => 'checkbox',
+				'desc'     => __( 'Upload plugin events to Meta', 'facebook-for-woocommerce' ),
+				'desc_tip' => sprintf( __( 'Allow Meta to monitor your logs and help fix issues. Personally identifiable information will not be collected.', 'facebook-for-woocommerce' ) ),
+				'default'  => 'yes',
+			),
+
+			array(
+				'id'       => \WC_Facebookcommerce_Integration::SETTING_ENABLE_DEBUG_MODE,
+				'title'    => __( 'Enable debug mode', 'facebook-for-woocommerce' ),
+				'type'     => 'checkbox',
+				'desc'     => __( 'Log plugin events for debugging.', 'facebook-for-woocommerce' ),
+				/* translators: %s URL to the documentation page. */
+				'desc_tip' => sprintf( __( 'Only enable this if you are experiencing problems with the plugin. <a href="%s" target="_blank">Learn more</a>.', 'facebook-for-woocommerce' ), 'https://woocommerce.com/document/facebook-for-woocommerce/#debug-tools' ),
+				'default'  => 'no',
+			),
+
+			array(
+				'id'       => \WC_Facebookcommerce_Integration::SETTING_ENABLE_NEW_STYLE_FEED_GENERATOR,
+				'title'    => __( 'Experimental! Enable new style feed generation', 'facebook-for-woocommerce' ),
+				'type'     => 'checkbox',
+				'desc'     => __( 'Use new, memory improved, feed generation process.', 'facebook-for-woocommerce' ),
+				/* translators: %s URL to the documentation page. */
+				'desc_tip' => sprintf( __( 'This is an experimental feature in testing phase. Only enable this if you are experiencing problems with feed generation. <a href="%s" target="_blank">Learn more</a>.', 'facebook-for-woocommerce' ), 'https://woocommerce.com/document/facebook-for-woocommerce/#feed-generation' ),
+				'default'  => 'no',
+			),
+
+			array( 'type' => 'sectionend' ),
+		);
 	}
 
 	/**
@@ -237,45 +385,5 @@ class Shops extends Abstract_Settings_Screen {
 				}
 			});
 		JAVASCRIPT;
-	}
-
-
-	/**
-	 * Gets the screen settings.
-	 *
-	 * @since 3.5.0
-	 *
-	 * @return array
-	 */
-	public function get_settings() {
-
-		return array(
-
-			array(
-				'title' => __( 'Debug', 'facebook-for-woocommerce' ),
-				'type'  => 'title',
-			),
-
-			array(
-				'id'       => \WC_Facebookcommerce_Integration::SETTING_ENABLE_DEBUG_MODE,
-				'title'    => __( 'Enable debug mode', 'facebook-for-woocommerce' ),
-				'type'     => 'checkbox',
-				'desc'     => __( 'Log plugin events for debugging.', 'facebook-for-woocommerce' ),
-				/* translators: %s URL to the documentation page. */
-				'desc_tip' => sprintf( __( 'Only enable this if you are experiencing problems with the plugin. <a href="%s" target="_blank">Learn more</a>.', 'facebook-for-woocommerce' ), 'https://woocommerce.com/document/facebook-for-woocommerce/#debug-tools' ),
-				'default'  => 'no',
-			),
-
-			array(
-				'id'       => \WC_Facebookcommerce_Integration::SETTING_ENABLE_NEW_STYLE_FEED_GENERATOR,
-				'title'    => __( 'Experimental! Enable new style feed generation', 'facebook-for-woocommerce' ),
-				'type'     => 'checkbox',
-				'desc'     => __( 'Use new, memory improved, feed generation process.', 'facebook-for-woocommerce' ),
-				/* translators: %s URL to the documentation page. */
-				'desc_tip' => sprintf( __( 'This is an experimental feature in testing phase. Only enable this if you are experiencing problems with feed generation. <a href="%s" target="_blank">Learn more</a>.', 'facebook-for-woocommerce' ), 'https://woocommerce.com/document/facebook-for-woocommerce/#feed-generation' ),
-				'default'  => 'no',
-			),
-			array( 'type' => 'sectionend' ),
-		);
 	}
 }

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -153,113 +153,113 @@ class Shops extends Abstract_Settings_Screen {
 	</div>
 		<?php
 
-    if ($is_connected) {
-        $this->render_troubleshooting_button_and_drawer();
-    }
+		if ( $is_connected ) {
+			$this->render_troubleshooting_button_and_drawer();
+		}
 	}
 
 	private function render_troubleshooting_button_and_drawer() {
-    ?>
-    <!-- Toggle Button -->
-    <div class="centered-container">
-        <button id="toggle-troubleshooting-drawer" class="drawer-toggle-button">
-            Troubleshooting
-            <span id="caret" class="caret"></span>
-        </button>
-    </div>
+		?>
+	<!-- Toggle Button -->
+	<div class="centered-container">
+		<button id="toggle-troubleshooting-drawer" class="drawer-toggle-button">
+			Troubleshooting
+			<span id="caret" class="caret"></span>
+		</button>
+	</div>
 
-    <!-- Drawer -->
-    <div id="troubleshooting-drawer" class="settings-drawer" style="display: none;">
-        <div class="settings-drawer-content">
-            <?php parent::render(); ?>
-        </div>
-    </div>
+	<!-- Drawer -->
+	<div id="troubleshooting-drawer" class="settings-drawer" style="display: none;">
+		<div class="settings-drawer-content">
+			<?php parent::render(); ?>
+		</div>
+	</div>
 
-    <style>
-        .centered-container {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            width: 100%;
-            margin-top: 20px;
-        }
+	<style>
+		.centered-container {
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			width: 100%;
+			margin-top: 20px;
+		}
 
-        .drawer-toggle-button {
-            width: 100%;
-            max-width: 1100px;
-            background-color: #fff;
-            border: 1px solid #ccc;
-            padding: 10px 20px;
-            text-align: left;
-            cursor: pointer;
-            font-size: 16px;
-            font-weight: 600;
-            position: relative;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 20px;
+		.drawer-toggle-button {
+			width: 100%;
+			max-width: 1100px;
+			background-color: #fff;
+			border: 1px solid #ccc;
+			padding: 10px 20px;
+			text-align: left;
+			cursor: pointer;
+			font-size: 16px;
+			font-weight: 600;
+			position: relative;
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+			margin-bottom: 20px;
 						box-sizing: border-box;
-        }
+		}
 
-        .drawer-toggle-button:hover {
-            background-color: #f9f9f9;
-        }
+		.drawer-toggle-button:hover {
+			background-color: #f9f9f9;
+		}
 
-        .caret {
-            width: 0;
-            height: 0;
-            border-left: 5px solid transparent;
-            border-right: 5px solid transparent;
-            border-top: 5px solid #000;
-            transition: transform 0.3s ease;
-        }
+		.caret {
+			width: 0;
+			height: 0;
+			border-left: 5px solid transparent;
+			border-right: 5px solid transparent;
+			border-top: 5px solid #000;
+			transition: transform 0.3s ease;
+		}
 
-        .settings-drawer {
-            width: 100%;
-            max-width: 1100px;
-            background-color: #fff;
-            border-bottom: 1px solid #ccc;
+		.settings-drawer {
+			width: 100%;
+			max-width: 1100px;
+			background-color: #fff;
+			border-bottom: 1px solid #ccc;
 						border-right: 1px solid #ccc;
 						border-left: 1px solid #ccc;
-            overflow: hidden;
-            transition: max-height 0.3s ease, margin-bottom 0.3s ease;
-            max-height: 0;
-            margin: 0 auto;
+			overflow: hidden;
+			transition: max-height 0.3s ease, margin-bottom 0.3s ease;
+			max-height: 0;
+			margin: 0 auto;
 						box-sizing: border-box;
-        }
+		}
 
-        .settings-drawer-content {
-            padding: 20px;
-            padding-bottom: 0;
-        }
-    </style>
+		.settings-drawer-content {
+			padding: 20px;
+			padding-bottom: 0;
+		}
+	</style>
 
-    <script>
-        document.getElementById('toggle-troubleshooting-drawer').addEventListener('click', function() {
-            var drawer = document.getElementById('troubleshooting-drawer');
-            var caret = document.getElementById('caret');
-            var button = document.getElementById('toggle-troubleshooting-drawer');
+	<script>
+		document.getElementById('toggle-troubleshooting-drawer').addEventListener('click', function() {
+			var drawer = document.getElementById('troubleshooting-drawer');
+			var caret = document.getElementById('caret');
+			var button = document.getElementById('toggle-troubleshooting-drawer');
 
-            if (drawer.style.maxHeight === '0px' || drawer.style.maxHeight === '') {
-                drawer.style.display = 'block';
-                drawer.style.maxHeight = drawer.scrollHeight + 'px';
-                caret.style.transform = 'rotate(180deg)';
-                drawer.style.marginBottom = '20px';
-                button.style.marginBottom = '0';
-            } else {
-                drawer.style.maxHeight = '0';
-                setTimeout(function() {
-                    drawer.style.display = 'none';
-                }, 300);
-                caret.style.transform = 'rotate(0deg)';
-                drawer.style.marginBottom = '0';
-                button.style.marginBottom = '20px';
-            }
-        });
-    </script>
-    <?php
-}
+			if (drawer.style.maxHeight === '0px' || drawer.style.maxHeight === '') {
+				drawer.style.display = 'block';
+				drawer.style.maxHeight = drawer.scrollHeight + 'px';
+				caret.style.transform = 'rotate(180deg)';
+				drawer.style.marginBottom = '20px';
+				button.style.marginBottom = '0';
+			} else {
+				drawer.style.maxHeight = '0';
+				setTimeout(function() {
+					drawer.style.display = 'none';
+				}, 300);
+				caret.style.transform = 'rotate(0deg)';
+				drawer.style.marginBottom = '0';
+				button.style.marginBottom = '20px';
+			}
+		});
+	</script>
+		<?php
+	}
 
 	/**
 	 * Gets the screen settings.
@@ -269,8 +269,8 @@ class Shops extends Abstract_Settings_Screen {
 	 */
 	public function get_settings() {
 		return array(
-
 			array(
+				//phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
 				'title' => __( '', 'facebook-for-woocommerce' ),
 				'type'  => 'title',
 			),

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -199,6 +199,7 @@ class Shops extends Abstract_Settings_Screen {
             justify-content: space-between;
             align-items: center;
             margin-bottom: 20px;
+						box-sizing: border-box;
         }
 
         .drawer-toggle-button:hover {
@@ -218,11 +219,14 @@ class Shops extends Abstract_Settings_Screen {
             width: 100%;
             max-width: 1100px;
             background-color: #fff;
-            border: 1px solid #ccc;
+            border-bottom: 1px solid #ccc;
+						border-right: 1px solid #ccc;
+						border-left: 1px solid #ccc;
             overflow: hidden;
             transition: max-height 0.3s ease, margin-bottom 0.3s ease;
             max-height: 0;
             margin: 0 auto;
+						box-sizing: border-box;
         }
 
         .settings-drawer-content {
@@ -273,18 +277,18 @@ class Shops extends Abstract_Settings_Screen {
 
 			array(
 				'id'       => \WC_Facebookcommerce_Integration::SETTING_ENABLE_META_DIAGNOSIS,
-				'title'    => __( 'Enable meta diagnosis', 'facebook-for-woocommerce' ),
+				'title'    => __( 'Upload plugin events to Meta', 'facebook-for-woocommerce' ),
 				'type'     => 'checkbox',
-				'desc'     => __( 'Upload plugin events to Meta', 'facebook-for-woocommerce' ),
+				'desc'     => __( 'Enable', 'facebook-for-woocommerce' ),
 				'desc_tip' => sprintf( __( 'Allow Meta to monitor your logs and help fix issues. Personally identifiable information will not be collected.', 'facebook-for-woocommerce' ) ),
 				'default'  => 'yes',
 			),
 
 			array(
 				'id'       => \WC_Facebookcommerce_Integration::SETTING_ENABLE_DEBUG_MODE,
-				'title'    => __( 'Enable debug mode', 'facebook-for-woocommerce' ),
+				'title'    => __( 'Log plugin events to your computer for debugging', 'facebook-for-woocommerce' ),
 				'type'     => 'checkbox',
-				'desc'     => __( 'Log plugin events for debugging.', 'facebook-for-woocommerce' ),
+				'desc'     => __( 'Enable', 'facebook-for-woocommerce' ),
 				/* translators: %s URL to the documentation page. */
 				'desc_tip' => sprintf( __( 'Only enable this if you are experiencing problems with the plugin. <a href="%s" target="_blank">Learn more</a>.', 'facebook-for-woocommerce' ), 'https://woocommerce.com/document/facebook-for-woocommerce/#debug-tools' ),
 				'default'  => 'no',
@@ -292,9 +296,9 @@ class Shops extends Abstract_Settings_Screen {
 
 			array(
 				'id'       => \WC_Facebookcommerce_Integration::SETTING_ENABLE_NEW_STYLE_FEED_GENERATOR,
-				'title'    => __( 'Experimental! Enable new style feed generation', 'facebook-for-woocommerce' ),
+				'title'    => __( '[Experimental] Use new, memory improved, feed generation process', 'facebook-for-woocommerce' ),
 				'type'     => 'checkbox',
-				'desc'     => __( 'Use new, memory improved, feed generation process.', 'facebook-for-woocommerce' ),
+				'desc'     => __( 'Enable', 'facebook-for-woocommerce' ),
 				/* translators: %s URL to the documentation page. */
 				'desc_tip' => sprintf( __( 'This is an experimental feature in testing phase. Only enable this if you are experiencing problems with feed generation. <a href="%s" target="_blank">Learn more</a>.', 'facebook-for-woocommerce' ), 'https://woocommerce.com/document/facebook-for-woocommerce/#feed-generation' ),
 				'default'  => 'no',

--- a/tests/Unit/Admin/Settings/ShopsTest.php
+++ b/tests/Unit/Admin/Settings/ShopsTest.php
@@ -38,4 +38,33 @@ class ShopsTest extends \WP_UnitTestCase {
 
         $this->assertFalse(wp_style_is('wc-facebook-admin-connection-settings'));
     }
+
+    /**
+     * Test that get_settings returns the expected settings
+     */
+     public function testGetSettings(): void {
+        $settings = $this->shops->get_settings();
+
+        $this->assertIsArray($settings);
+        $this->assertNotEmpty($settings);
+
+        // Check that the settings array has the expected structure
+        $this->assertArrayHasKey('type', $settings[0]);
+        $this->assertEquals('title', $settings[0]['type']);
+
+        // Check meta diagnosis setting
+        $debug_setting = $settings[1];
+        $this->assertEquals('checkbox', $debug_setting['type']);
+        $this->assertEquals('yes', $debug_setting['default']);
+
+        // Check debug mode setting
+        $debug_setting = $settings[2];
+        $this->assertEquals('checkbox', $debug_setting['type']);
+        $this->assertEquals('no', $debug_setting['default']);
+
+        // Check feed generator setting
+        $feed_setting = $settings[3];
+        $this->assertEquals('checkbox', $feed_setting['type']);
+        $this->assertEquals('no', $feed_setting['default']);
+    }
 }


### PR DESCRIPTION
## Description
This PR creates a new "Troubleshooting" drawer based on the debug settings from the legacy "Connection" tab UI. The "Troubleshooting" drawer lives in the new "Shops" tab. The functionality is the same as the legacy UI, but the content has been update. The "Troubleshooting" drawer only appears if the user's WooCommerce has been connected to Meta.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots
### Before
<img width="1726" alt="Screenshot 2025-03-27 at 5 24 43 PM" src="https://github.com/user-attachments/assets/9b6c6627-241e-4def-af0a-0b754103b451" />

### After
Closed Drawer:
<img width="1726" alt="Screenshot 2025-03-27 at 5 22 41 PM" src="https://github.com/user-attachments/assets/b1d1e341-1040-4b4c-b853-229a121d4c44" />

Open Drawer:
<img width="1726" alt="Screenshot 2025-03-27 at 5 22 35 PM" src="https://github.com/user-attachments/assets/62214862-9a49-4b83-9b4c-e3dd37624414" />

Video Demo:
https://github.com/user-attachments/assets/493de82b-dce1-4a08-9e8b-2aa750800c1a

## Test instructions
1. Set `use_enhanced_onboarding()` in `facebook-for-woocommerce/facebook-commerce.php` to `true`.
2. Go to http://test-site-i.local/wp-admin/admin.php?page=wc-facebook. Make sure you are in the "Shops" tab. If your WooCommerce is not connected to Meta, you should not see the "Troubleshooting" drawer. If there is an existing connection, the "Troubleshooting" drawer should appear.
