### PR TITLE
[WooCommerce]fix: auto products sync

### DIFF
--- a/includes/API/Plugin/Settings/Handler.php
+++ b/includes/API/Plugin/Settings/Handler.php
@@ -81,6 +81,13 @@ class Handler extends AbstractRESTEndpoint {
 			// Update connection status flags
 			$this->update_connection_status( $request->get_data() );
 
+			// Allow opt-out of full batch-API sync, for example if store has a large number of products.
+			if ( facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
+				facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_all_products();
+			} else {
+				\WC_Facebookcommerce_Utils::logToMeta( 'Initial full product sync disabled by filter hook `facebook_for_woocommerce_allow_full_batch_api_sync`' );
+			}
+
 			return $this->success_response(
 				[
 					'message' => __( 'Facebook settings updated successfully', 'facebook-for-woocommerce' ),


### PR DESCRIPTION
## Description

Fixes products sync not triggered automatically once completed MBE workflow.

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

Test Plan:
Tested in local hosts. products got synced after complete MBE:
 https://pxl.cl/6SqBm 
