### PR TITLE
feat(product-sync): Add separate short_description field to Facebook product data

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,21 +12,6 @@ Please delete options that are not relevant.
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
-
-## Screenshots
-Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
-### Before
-
-### After
-
-
-## Test instructions
-
-Please describe the tests that you ran to verify your changes. 
-Provide instructions so we can reproduce. 
-Please also list any relevant details for your test configuration.
-
-
 ## Checklist
 
 - [ ] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
@@ -38,3 +23,16 @@ Please also list any relevant details for your test configuration.
 ## Changelog entry
 
 One liner entry to be surfaced in changelog.txt
+
+
+## Test Plan
+
+Please describe the tests that you ran to verify your changes. 
+Provide instructions so we can reproduce. 
+Please also list any relevant details for your test configuration.
+
+## Screenshots
+Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
+### Before
+
+### After

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,16 +8,19 @@ List any dependencies that are required for this change.
 
 Please delete options that are not relevant.
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- Bug fix (non-breaking change which fixes an issue)
+- New feature (non-breaking change which adds functionality)
+- Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)
+- Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
 ## Checklist
 
-- [ ] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have added tests and all the new and existing unit tests pass locally with my changes
-- [ ] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
+- [] I have commented my code, particularly in hard-to-understand areas.
+- [] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
+- [] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
+- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
+- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
+- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).
 
 
 ## Changelog entry

--- a/assets/css/admin/facebook-for-woocommerce-connection.css
+++ b/assets/css/admin/facebook-for-woocommerce-connection.css
@@ -82,14 +82,6 @@
 	min-height: calc(100vh - 200px);
 }
 
-#facebook-commerce-iframe-enhanced {
-	width: 100%;
-	max-width: 1100px;
-	min-height: calc(100vh - 200px);
-	background: transparent;
-	border: none;
-}
-
 .woocommerce-embed-page #wpbody-content {
 	padding-bottom: 0;
 }

--- a/assets/css/admin/facebook-for-woocommerce-shops.css
+++ b/assets/css/admin/facebook-for-woocommerce-shops.css
@@ -1,0 +1,80 @@
+#facebook-commerce-iframe-enhanced {
+	width: 100%;
+	max-width: 1100px;
+	min-height: calc(100vh - 200px);
+	background: transparent;
+	border: none;
+}
+
+.centered-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    margin-top: 20px;
+}
+
+.drawer-toggle-button {
+    width: 100%;
+    max-width: 1100px;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    padding: 10px 20px;
+    text-align: left;
+    cursor: pointer;
+    font-size: 16px;
+    font-weight: 600;
+    position: relative;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+                box-sizing: border-box;
+}
+
+.drawer-toggle-button:hover {
+    background-color: #f9f9f9;
+}
+
+.caret {
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 5px solid #000;
+    transition: transform 0.3s ease;
+}
+
+.settings-drawer {
+    width: 100%;
+    max-width: 1100px;
+    background-color: #fff;
+    border-bottom: 1px solid #ccc;
+                border-right: 1px solid #ccc;
+                border-left: 1px solid #ccc;
+    overflow: hidden;
+    transition: max-height 0.3s ease, margin-bottom 0.3s ease;
+    max-height: 0;
+    margin: 0 auto;
+                box-sizing: border-box;
+}
+
+.settings-drawer-content {
+    padding: 20px;
+    padding-bottom: 0;
+}
+
+.button:disabled {
+    background-color: #f1f1f1;
+    cursor: not-allowed;
+}
+
+.sync-description {
+    font-size: 12px;
+    color: #666;
+    padding-top: 8px;
+}
+
+.woocommerce-embed-page #wpbody-content {
+	padding-bottom: 0;
+}

--- a/assets/js/admin/enhanced-settings-sync.js
+++ b/assets/js/admin/enhanced-settings-sync.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+jQuery(document).ready(function($) {
+    /**
+     * Handle the sync products button click event
+     *
+     * @since 3.5.0
+     *
+     * @param {object} event
+     */
+    $('#wc-facebook-enhanced-settings-sync-products').click(function(event) {
+        event.preventDefault();
+        var button = $(this);
+
+        button.html('Syncing...');
+        button.prop('disabled', true);
+
+        var data = {
+            action: "wc_facebook_sync_products",
+            nonce: wc_facebook_enhanced_settings_sync.sync_products_nonce
+        };
+
+        $.post(wc_facebook_enhanced_settings_sync.ajax_url, data, function(response) {
+            if (response.success) {
+                button.html('Sync completed');
+                button.prop('disabled', false);
+            } else {
+                button.html('Sync failed');
+                button.prop('disabled', false);
+            }
+        }).fail(function() {
+            button.html('Sync failed');
+            button.prop('disabled', false);
+        });
+    });
+
+    /**
+     * Handle the sync coupons button click event
+     *
+     * @since 3.5.0
+     *
+     * @param {object} event
+     */
+    $('#wc-facebook-enhanced-settings-sync-coupons').click(function(event) {
+        event.preventDefault();
+        var button = $(this);
+
+        button.html('Syncing...');
+        button.prop('disabled', true);
+
+        var data = {
+            action: "wc_facebook_sync_coupons",
+            nonce: wc_facebook_enhanced_settings_sync.sync_coupons_nonce
+        };
+
+        $.post(wc_facebook_enhanced_settings_sync.ajax_url, data, function(response) {
+            if (response.success) {
+                button.html('Sync completed');
+                button.prop('disabled', false);
+            } else {
+                button.html('Sync failed');
+                button.prop('disabled', false);
+            }
+        }).fail(function() {
+            button.html('Sync failed');
+            button.prop('disabled', false);
+        });
+    });
+});

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,27 @@
 *** Facebook for WooCommerce Changelog ***
 
+= 3.4.4 - 2025-03-26 =
+* Add - Create tests for ProductFeedUploads create endpoint by @ajello-meta in #2902
+* Add - Create tests for ProductFeedUploads read endpoint by @ajello-meta in #2903
+* Tweak - Remove phpcs:ignoreFile annotation + Enable code coverage report generation with phpunit by @sol-loup in #2897 and #2901
+* Fix - Restores the original dynamic property behavior in the AsyncRequest class by @sol-loup in #2921
+* Tweak - Changing APP to PLUGIN on README.MD by @SayanPandey in #2916
+* Tweak - Update README.md - Added noification for ownership transfer by @SayanPandey in #2910
+* Tweak - Added is_multisite logging to the update_plugin_version_configuration request by @carterbuce in #2955
+* Tweak - Add woo_commerce_retailer_id to products API request by @crisojog in #2958
+* Tweak - Syncing plugin version info by @vinkmeta in #2960
+* Fix - sync products out of stock to meta despite visibility config by @francorisso in #2952
+* Fix - Update woo_commerce_retailer_id to existing field external_variant_id by @crisojog in #2963
+* Tweak - Update readme.txt by @vinkmeta in #2949
+
+= 3.4.3 - 2025-03-19 =
+* Add - Items batch request and response tests by @nrostrow-meta in #2917
+* Tweak - Always run PHP-based github workflows by @carterbuce in #2926
+* Fix - feed upload error "feed_column_count_mismatch" when product has multiple colors separated by a comma by @mshymon in #2947
+* Tweak - Updated Pull Request Template by @vinkmeta in #2948
+* Dev - Improved readability of function prepare_product() in fbproduct.php by @mshymon in #2889
+* Tweak - Enabled PHPUnit code coverage report generation by @carterbuce in #2893
+
 = 3.4.2 - 2025-03-13 =
 * Tweak - Update README.md - Added noification for ownership transfer by @SayanPandey in #2910 and #2916
 

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -237,7 +237,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 
 			// load admin handlers, before admin_init
 			if ( is_admin() ) {
-				if ($this->get_integration()->use_enhanced_onboarding()) {
+				if ($this->use_enhanced_onboarding()) {
 					$this->admin_enhanced_settings = new WooCommerce\Facebook\Admin\Enhanced_Settings( $this->connection_handler->is_connected() );
 				} else {
 					$this->admin_settings = new WooCommerce\Facebook\Admin\Settings( $this->connection_handler->is_connected() );
@@ -860,8 +860,24 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 		}
 		return $current_screen_id;
 	}
-}
 
+	/**
+	 * Determines if the enhanced onboarding (iframe) should be used.
+	 *
+	 * @return bool
+	 *
+	 */
+	public function use_enhanced_onboarding(): bool {
+		$connection_handler              = $this->get_connection_handler();
+		$commerce_partner_integration_id = $connection_handler->get_commerce_partner_integration_id();
+
+		// If current connection is using the non-enhanced flow, don't show the new experience
+		if ( $connection_handler->is_connected() && empty( $commerce_partner_integration_id ) ) {
+			return false;
+		}
+		return false;
+	}
+}
 
 /**
  * Gets the Facebook for WooCommerce plugin instance.
@@ -871,5 +887,5 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
  * @return \WC_Facebookcommerce instance of the plugin
  */
 function facebook_for_woocommerce() {
-	return \WC_Facebookcommerce::instance();
+	return apply_filters('wc_facebook_instance', \WC_Facebookcommerce::instance());
 }

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -951,11 +951,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			$woo_product->set_rich_text_description( $_POST[ self::FB_PRODUCT_DESCRIPTION ] );
 		}
 
-		// Save Short Description
-		if ( isset( $_POST[ WC_Facebook_Product::FB_SHORT_DESCRIPTION ] ) ) {
-			$woo_product->set_short_description( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_SHORT_DESCRIPTION ] ) ) );
-		}
-
 		if ( isset( $_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ] ) ) {
 			$woo_product->set_price( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ] ) ) );
 		}

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -853,9 +853,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				$this->save_product_settings( $product );
 		} else {
 			// if previously enabled, add a notice on the next page load
-			if ( Products::is_sync_enabled_for_product( $product ) ) {
-				Admin::add_product_disabled_sync_notice();
-			}
 			Products::disable_sync_for_products( [ $product ] );
 			if ( in_array( $wp_id, $products_to_delete_from_facebook, true ) ) {
 				$this->delete_fb_product( $product );

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -133,7 +133,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	const OPTION_HAS_AUTHORIZED_PAGES_READ_ENGAGEMENT = 'wc_facebook_has_authorized_pages_read_engagement';
 
 	/** @var string the WordPress option name where the messenger chat status is stored */
-	const OPTION_ENABLE_MESSENGER = 'wc_facebook_enable_messenger';	
+	const OPTION_ENABLE_MESSENGER = 'wc_facebook_enable_messenger';
 
 	/** @var string|null the configured product catalog ID */
 	public $product_catalog_id;
@@ -900,27 +900,27 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		if ( isset( $_POST[ WC_Facebook_Product::FB_SIZE ] ) ) {
 			$woo_product->set_fb_size( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_SIZE ] ) ) );
 		}
-		
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_COLOR ] ) ) {
 			$woo_product->set_fb_color( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_COLOR ] ) ) );
 		}
-		
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_MATERIAL ] ) ) {
 			$woo_product->set_fb_material( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_MATERIAL ] ) ) );
 		}
-		
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_PATTERN ] ) ) {
 			$woo_product->set_fb_pattern( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PATTERN ] ) ) );
 		}
-		
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_AGE_GROUP ] ) ) {
 			$woo_product->set_fb_age_group( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_AGE_GROUP ] ) ) );
 		}
-		
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_GENDER ] ) ) {
 			$woo_product->set_fb_gender( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_GENDER ] ) ) );
 		}
-		
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_PRODUCT_CONDITION ] ) ) {
 			$woo_product->set_fb_condition( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PRODUCT_CONDITION ] ) ) );
 		}

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -951,6 +951,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			$woo_product->set_rich_text_description( $_POST[ self::FB_PRODUCT_DESCRIPTION ] );
 		}
 
+		// Save Short Description
+		if ( isset( $_POST[ WC_Facebook_Product::FB_SHORT_DESCRIPTION ] ) ) {
+			$woo_product->set_short_description( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_SHORT_DESCRIPTION ] ) ) );
+		}
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ] ) ) {
 			$woo_product->set_price( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ] ) ) );
 		}

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -3174,14 +3174,4 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		wp_die();
 	}
 
-	/**
-	 * Determines if the enhanced onboarding (iframe) should be used.
-	 *
-	 * @return bool
-	 *
-	 */
-	public function use_enhanced_onboarding() {
-		return false;
-	}
-
 }

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -10,7 +10,7 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 3.4.2
+ * Version: 3.4.4
  * Requires at least: 5.6
  * Requires PHP: 7.4
  * Text Domain: facebook-for-woocommerce
@@ -48,7 +48,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '3.4.2'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '3.4.4'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.4.0';

--- a/includes/API/FBE/Configuration/Read/Response.php
+++ b/includes/API/FBE/Configuration/Read/Response.php
@@ -18,6 +18,10 @@ class Response extends API\Response {
 	 * @return boolean
 	 */
 	public function is_ig_shopping_enabled(): bool {
+
+		if ( empty( $this->response_data['ig_shopping'] ) ) {
+			return false;
+		}
 		return (bool) $this->response_data['ig_shopping']['enabled'] ?? false;
 	}
 
@@ -27,6 +31,10 @@ class Response extends API\Response {
 	 * @return boolean
 	 */
 	public function is_ig_cta_enabled(): bool {
+
+		if ( empty( $this->response_data['ig_cta'] ) ) {
+			return false;
+		}
 		return (bool) $this->response_data['ig_cta']['enabled'] ?? false;
 	}
 
@@ -36,6 +44,10 @@ class Response extends API\Response {
 	 * @return string Commerce extension URI or empty string if not available.
 	 */
 	public function get_commerce_extension_uri(): string {
+
+		if ( empty( $this->response_data['commerce_extension'] ) ) {
+			return '';
+		}
 		return $this->response_data['commerce_extension']['uri'] ?? '';
 	}
 }

--- a/includes/Admin/Abstract_Settings_Screen.php
+++ b/includes/Admin/Abstract_Settings_Screen.php
@@ -130,7 +130,7 @@ abstract class Abstract_Settings_Screen {
 		}
 		// assume we are on the Connection tab by default because the link under Marketing doesn't include the tab query arg
 		$connection_handler      = facebook_for_woocommerce()->get_connection_handler();
-		$use_enhanced_onboarding = facebook_for_woocommerce()->get_integration()->use_enhanced_onboarding();
+		$use_enhanced_onboarding = facebook_for_woocommerce()->use_enhanced_onboarding();
 		$default_tab             = $use_enhanced_onboarding ? 'shops' : ( $connection_handler->is_connected() ? 'advertise' : 'connection' );
 		$tab                     = Helper::get_requested_value( 'tab', $default_tab );
 

--- a/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
+++ b/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
@@ -135,6 +135,7 @@ class Enhanced_Catalog_Attribute_Fields {
 			'default'        => 100,
 		);
 
+		$priority = array(); // Initialize priority array.
 		foreach ( $recommended_attributes as $key => $attribute ) {
 			$recommended_attributes[ $key ]['priority'] = 5; // Assign 5 initially to each attribute
 			if ( 'measurement' === $attribute['type'] ) {
@@ -145,7 +146,10 @@ class Enhanced_Catalog_Attribute_Fields {
 
 		$should_render_checkbox = ! empty( $recommended_attributes );
 
-		array_multisort( $priority, SORT_DESC, $recommended_attributes );
+		// Only sort if we have recommended attributes.
+		if ( ! empty( $priority ) ) {
+			array_multisort( $priority, SORT_DESC, $recommended_attributes );
+		}
 		$selector_value      = $this->get_value( self::OPTIONAL_SELECTOR_KEY, $category_id );
 		$is_showing_optional = 'on' === $selector_value;
 

--- a/includes/Admin/Enhanced_Settings.php
+++ b/includes/Admin/Enhanced_Settings.php
@@ -141,30 +141,12 @@ class Enhanced_Settings {
 	 */
 	private function connect_to_enhanced_admin( $screen_id ) {
 		if ( is_callable( 'wc_admin_connect_page' ) ) {
-			$crumbs = array(
-				__( 'Facebook for WooCommerce', 'facebook-for-woocommerce' ),
-			);
-			//phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			if ( ! empty( $_GET['tab'] ) ) {
-				//phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				switch ( $_GET['tab'] ) {
-					case Shops::ID:
-						$crumbs[] = __( 'Shops', 'facebook-for-woocommerce' );
-						break;
-					case Settings_Screens\Product_Sync::ID:
-						$crumbs[] = __( 'Product sync', 'facebook-for-woocommerce' );
-						break;
-					case Settings_Screens\Advertise::ID:
-						$crumbs[] = __( 'Advertise', 'facebook-for-woocommerce' );
-						break;
-				}
-			}
 			wc_admin_connect_page(
 				array(
 					'id'        => self::PAGE_ID,
 					'screen_id' => $screen_id,
 					'path'      => add_query_arg( 'page', self::PAGE_ID, 'admin.php' ),
-					'title'     => $crumbs,
+					'title'     => [ __( 'Facebook for WooCommerce', 'facebook-for-woocommerce' ) ],
 				)
 			);
 		}

--- a/includes/Admin/Enhanced_Settings.php
+++ b/includes/Admin/Enhanced_Settings.php
@@ -70,7 +70,6 @@ class Enhanced_Settings {
 			// TODO: Remove Product sync and Product sets tab once catalog changes are complete
 			return array(
 				Settings_Screens\Shops::ID        => new Settings_Screens\Shops(),
-				Settings_Screens\Advertise::ID    => new Settings_Screens\Advertise(),
 				Settings_Screens\Product_Sync::ID => new Settings_Screens\Product_Sync(),
 				Settings_Screens\Product_Sets::ID => new Settings_Screens\Product_Sets(),
 			);

--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -19,8 +19,6 @@ use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
  * The Connection settings screen object.
  */
 class Connection extends Abstract_Settings_Screen {
-
-
 	/** @var string screen ID */
 	const ID = 'connection';
 
@@ -57,28 +55,6 @@ class Connection extends Abstract_Settings_Screen {
 		$this->id    = self::ID;
 		$this->label = __( 'Connection', 'facebook-for-woocommerce' );
 		$this->title = __( 'Connection', 'facebook-for-woocommerce' );
-	}
-
-	/**
-	 * Determines if we should use enhanced onboarding.
-	 *
-	 * @return bool
-	 */
-	protected function use_enhanced_onboarding() {
-		// First check if the integration has enabled enhanced onboarding
-		$integration = facebook_for_woocommerce()->get_integration();
-		if ( ! $integration->use_enhanced_onboarding() ) {
-			return false;
-		}
-
-		// No connection, new user returns true
-		$connection_handler              = facebook_for_woocommerce()->get_connection_handler();
-		$commerce_partner_integration_id = $connection_handler->get_commerce_partner_integration_id();
-
-		if ( ! $connection_handler->is_connected() || ! empty( $commerce_partner_integration_id ) ) {
-			return true;
-		}
-		return false;
 	}
 
 	/**
@@ -139,7 +115,7 @@ class Connection extends Abstract_Settings_Screen {
 	 */
 	public function render() {
 		// Check if we should render iframe
-		if ( $this->use_enhanced_onboarding() ) {
+		if ( facebook_for_woocommerce()->use_enhanced_onboarding() ) {
 			$this->render_facebook_iframe();
 
 			return;
@@ -386,7 +362,7 @@ class Connection extends Abstract_Settings_Screen {
 	 * @since 3.5.0
 	 */
 	public function render_message_handler() {
-		if ( ! $this->is_current_screen_page() || ! $this->use_enhanced_onboarding() ) {
+		if ( ! $this->is_current_screen_page() || ! facebook_for_woocommerce()->use_enhanced_onboarding() ) {
 			return;
 		}
 		// Add the inline script as a dependent script

--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -453,7 +453,7 @@ class Connection extends Abstract_Settings_Screen {
 				'title'    => __( 'Enable meta diagnosis', 'facebook-for-woocommerce' ),
 				'type'     => 'checkbox',
 				'desc'     => __( 'Upload plugin events to Meta', 'facebook-for-woocommerce' ),
-				'desc_tip' => sprintf( __( 'Allow Meta to monitor your logs and help fix issues. Personally identifiable information will not be collected.', 'facebook-for-woocommerce' ) ),
+				'desc_tip' => sprintf( __( 'Allow Meta to monitor event and error logs to help fix issues.', 'facebook-for-woocommerce' ) ),
 				'default'  => 'yes',
 			),
 

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -282,18 +282,18 @@ class Shops extends Abstract_Settings_Screen {
 
 			array(
 				'id'       => \WC_Facebookcommerce_Integration::SETTING_ENABLE_META_DIAGNOSIS,
-				'title'    => __( 'Upload plugin events to Meta', 'facebook-for-woocommerce' ),
+				'title'    => __( 'Enable meta diagnosis', 'facebook-for-woocommerce' ),
 				'type'     => 'checkbox',
-				'desc'     => __( 'Enable', 'facebook-for-woocommerce' ),
-				'desc_tip' => sprintf( __( 'Allow Meta to monitor your logs and help fix issues. Personally identifiable information will not be collected.', 'facebook-for-woocommerce' ) ),
+				'desc'     => __( 'Upload plugin events to Meta', 'facebook-for-woocommerce' ),
+				'desc_tip' => sprintf( __( 'Allow Meta to monitor event and error logs to help fix issues.', 'facebook-for-woocommerce' ) ),
 				'default'  => 'yes',
 			),
 
 			array(
 				'id'       => \WC_Facebookcommerce_Integration::SETTING_ENABLE_DEBUG_MODE,
-				'title'    => __( 'Log plugin events to your computer for debugging', 'facebook-for-woocommerce' ),
+				'title'    => __( 'Enable debug mode', 'facebook-for-woocommerce' ),
 				'type'     => 'checkbox',
-				'desc'     => __( 'Enable', 'facebook-for-woocommerce' ),
+				'desc'     => __( 'Log plugin events for debugging.', 'facebook-for-woocommerce' ),
 				/* translators: %s URL to the documentation page. */
 				'desc_tip' => sprintf( __( 'Only enable this if you are experiencing problems with the plugin. <a href="%s" target="_blank">Learn more</a>.', 'facebook-for-woocommerce' ), 'https://woocommerce.com/document/facebook-for-woocommerce/#debug-tools' ),
 				'default'  => 'no',

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -112,7 +112,7 @@ class Shops extends Abstract_Settings_Screen {
 			return;
 		}
 
-		wp_enqueue_style( 'wc-facebook-admin-connection-settings', facebook_for_woocommerce()->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-connection.css', array(), \WC_Facebookcommerce::VERSION );
+		wp_enqueue_style( 'wc-facebook-admin-shops-settings', facebook_for_woocommerce()->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-shops.css', array(), \WC_Facebookcommerce::VERSION );
 
 		wp_enqueue_script(
 			'wc-facebook-enhanced-settings-sync',
@@ -191,7 +191,6 @@ class Shops extends Abstract_Settings_Screen {
 	 */
 	private function render_troubleshooting_button_and_drawer() {
 		?>
-	<!-- Toggle Button -->
 	<div class="centered-container">
 		<button id="toggle-troubleshooting-drawer" class="drawer-toggle-button">
 			Troubleshooting
@@ -199,12 +198,11 @@ class Shops extends Abstract_Settings_Screen {
 		</button>
 	</div>
 
-	<!-- Drawer -->
 	<div id="troubleshooting-drawer" class="settings-drawer" style="display: none;">
 		<div class="settings-drawer-content">
 			<table class="form-table">
 				<tbody>
-					<tr valign="top" class="wc-facebook-connected-sample">
+					<tr valign="top" class="wc-facebook-shops-sample">
 						<th scope="row" class="titledesc">
 							Product data sync
 						</th>
@@ -220,7 +218,7 @@ class Shops extends Abstract_Settings_Screen {
 							</p>
 						</td>
 					</tr>
-					<tr valign="top" class="wc-facebook-connected-sample">
+					<tr valign="top" class="wc-facebook-shops-sample">
 						<th scope="row" class="titledesc">
 							Coupon codes sync
 						</th>
@@ -242,79 +240,7 @@ class Shops extends Abstract_Settings_Screen {
 		</div>
 	</div>
 
-	<style>
-		.centered-container {
-			display: flex;
-			justify-content: center;
-			align-items: center;
-			width: 100%;
-			margin-top: 20px;
-		}
-
-		.drawer-toggle-button {
-			width: 100%;
-			max-width: 1100px;
-			background-color: #fff;
-			border: 1px solid #ccc;
-			padding: 10px 20px;
-			text-align: left;
-			cursor: pointer;
-			font-size: 16px;
-			font-weight: 600;
-			position: relative;
-			display: flex;
-			justify-content: space-between;
-			align-items: center;
-			margin-bottom: 20px;
-			box-sizing: border-box;
-		}
-
-		.drawer-toggle-button:hover {
-			background-color: #f9f9f9;
-		}
-
-		.caret {
-			width: 0;
-			height: 0;
-			border-left: 5px solid transparent;
-			border-right: 5px solid transparent;
-			border-top: 5px solid #000;
-			transition: transform 0.3s ease;
-		}
-
-		.settings-drawer {
-			width: 100%;
-			max-width: 1100px;
-			background-color: #fff;
-			border-bottom: 1px solid #ccc;
-			border-right: 1px solid #ccc;
-			border-left: 1px solid #ccc;
-			overflow: hidden;
-			transition: max-height 0.3s ease, margin-bottom 0.3s ease;
-			max-height: 0;
-			margin: 0 auto;
-			box-sizing: border-box;
-		}
-
-		.settings-drawer-content {
-			padding: 20px;
-			padding-bottom: 0;
-		}
-
-		.button:disabled {
-			background-color: #f1f1f1;
-			cursor: not-allowed;
-		}
-
-		.sync-description {
-			font-size: 12px;
-			color: #666;
-			padding-top: 8px;
-		}
-	</style>
-
 	<script>
-		// Toggle drawer visibility
 		document.getElementById('toggle-troubleshooting-drawer').addEventListener('click', function() {
 			var drawer = document.getElementById('troubleshooting-drawer');
 			var caret = document.getElementById('caret');

--- a/includes/Feed/FeedManager.php
+++ b/includes/Feed/FeedManager.php
@@ -88,6 +88,18 @@ class FeedManager {
 	}
 
 	/**
+	 * Run all feed uploads.
+	 *
+	 * @return void
+	 * @since 3.5.0
+	 */
+	public function run_all_feed_uploads(): void {
+		foreach ( $this->feed_instances as $feed_type ) {
+			$feed_type->regenerate_feed();
+		}
+	}
+
+	/**
 	 * Get the feed instance for the given feed type.
 	 *
 	 * @param string $feed_type the specific feed in question.

--- a/includes/Feed/FeedUploadUtils.php
+++ b/includes/Feed/FeedUploadUtils.php
@@ -163,9 +163,13 @@ class FeedUploadUtils {
 
 					// Map target type. Coupons that apply both a discount and free shipping are already
 					// filtered out in is_valid_coupon
-					$is_free_shipping = $coupon->get_free_shipping();
+					$is_free_shipping        = $coupon->get_free_shipping();
+					$target_shipping_options = '';
 					if ( $is_free_shipping ) {
-						$target_type = self::TARGET_TYPE_SHIPPING;
+						$target_type             = self::TARGET_TYPE_SHIPPING;
+						$value_type              = self::VALUE_TYPE_PERCENTAGE;
+						$percent_off             = '100'; // 100% off shipping
+						$target_shipping_options = [ 'STANDARD' ]; // options are STANDARD, RUSH, EXPEDITED, TWO_DAY
 					} else {
 						$target_type = self::TARGET_TYPE_LINE_ITEM;
 					}
@@ -212,7 +216,7 @@ class FeedUploadUtils {
 						'fixed_amount_off'                => $fixed_amount_off,
 						'application_type'                => self::APPLICATION_TYPE_BUYER_APPLIED,
 						'target_type'                     => $target_type,
-						'target_shipping_option_types'    => '', // Not needed for offsite checkout
+						'target_shipping_option_types'    => $target_shipping_options,
 						'target_granularity'              => $target_granularity,
 						'target_selection'                => $target_selection,
 						'start_date_time'                 => $start_date_time,

--- a/includes/Feed/PromotionsFeed.php
+++ b/includes/Feed/PromotionsFeed.php
@@ -25,7 +25,7 @@ use WooCommerce\Facebook\Utilities\Heartbeat;
  */
 class PromotionsFeed extends AbstractFeed {
 	/** Header for the promotions feed file. @var string */
-	const PROMOTIONS_FEED_HEADER = 'offer_id,title,value_type,percent_off,fixed_amount_off,application_type,target_type,target_shipipng_option_types,target_granularity,target_selection,start_date_time,end_date_time,coupon_codes,public_coupon_code,target_filter,target_product_retailer_ids,target_product_group_retailer_ids,target_product_set_retailer_ids,redeem_limit_per_user,min_subtotal,min_quantity,offer_terms,redemption_limit_per_seller,target_quantity,prerequisite_filter,prerequisite_product_retailer_ids,prerequisite_product_group_retailer_ids,prerequisite_product_set_retailer_ids,exclude_sale_priced_products' . PHP_EOL;
+	const PROMOTIONS_FEED_HEADER = 'offer_id,title,value_type,percent_off,fixed_amount_off,application_type,target_type,target_shipping_option_types,target_granularity,target_selection,start_date_time,end_date_time,coupon_codes,public_coupon_code,target_filter,target_product_retailer_ids,target_product_group_retailer_ids,target_product_set_retailer_ids,redeem_limit_per_user,min_subtotal,min_quantity,offer_terms,redemption_limit_per_seller,target_quantity,prerequisite_filter,prerequisite_product_retailer_ids,prerequisite_product_group_retailer_ids,prerequisite_product_set_retailer_ids,exclude_sale_priced_products' . PHP_EOL;
 
 	/**
 	 * Constructor for promotions feed.

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -29,20 +29,6 @@ class ProductValidator {
 	public const SYNC_ENABLED_META_KEY = '_wc_facebook_sync_enabled';
 
 	/**
-	 * Maximum length of product description.
-	 *
-	 * @var int
-	 */
-	public const MAX_DESCRIPTION_LENGTH = 5000;
-
-	/**
-	 * Maximum length of product title.
-	 *
-	 * @var int
-	 */
-	public const MAX_TITLE_LENGTH = 150;
-
-	/**
 	 * Maximum allowed attributes in a variation;
 	 *
 	 * @var int
@@ -134,11 +120,8 @@ class ProductValidator {
 		$this->validate_sync_enabled_globally();
 		$this->validate_product_status();
 		$this->validate_product_sync_field();
-		$this->validate_product_price();
 		$this->validate_product_visibility();
 		$this->validate_product_terms();
-		$this->validate_product_description();
-		$this->validate_product_title();
 	}
 
 	/**
@@ -151,11 +134,8 @@ class ProductValidator {
 	public function validate_but_skip_status_check() {
 		$this->validate_sync_enabled_globally();
 		$this->validate_product_sync_field();
-		$this->validate_product_price();
 		$this->validate_product_visibility();
 		$this->validate_product_terms();
-		$this->validate_product_description();
-		$this->validate_product_title();
 	}
 
 	/**
@@ -166,11 +146,8 @@ class ProductValidator {
 	 */
 	public function validate_but_skip_sync_field() {
 		$this->validate_sync_enabled_globally();
-		$this->validate_product_price();
 		$this->validate_product_visibility();
 		$this->validate_product_terms();
-		$this->validate_product_description();
-		$this->validate_product_title();
 	}
 
 	/**
@@ -358,72 +335,6 @@ class ProductValidator {
 			throw $invalid_exception;
 		} elseif ( 'no' === $this->product->get_meta( self::SYNC_ENABLED_META_KEY ) ) {
 				throw $invalid_exception;
-		}
-	}
-
-	/**
-	 * "allow simple or variable products (and their variations) with zero or empty price - exclude other product types with zero or empty price"
-	 * unsure why but that's what we're doing
-	 *
-	 * @throws ProductExcludedException If product should not be synced.
-	 */
-	protected function validate_product_price() {
-		$primary_product = $this->product_parent ? $this->product_parent : $this->product;
-
-		// Variable and simple products are allowed to have no price.
-		if ( in_array( $primary_product->get_type(), [ 'simple', 'variable' ], true ) ) {
-			return;
-		}
-
-		if ( ! Products::get_product_price( $this->product ) ) {
-			throw new ProductExcludedException( __( 'If product is not simple, variable or variation it must have a price.', 'facebook-for-woocommerce' ) );
-		}
-	}
-
-	/**
-	 * Check if the description field has correct format according to:
-	 * Product Description Specifications for Catalogs : https://www.facebook.com/business/help/2302017289821154
-	 *
-	 * @throws ProductInvalidException If product description does not meet the requirements.
-	 */
-	protected function validate_product_description() {
-		/*
-		 * First step is to select the description that we want to evaluate.
-		 * Main description is the one provided for the product in the Facebook.
-		 * If it is blank, product description will be used.
-		 * If product description is blank, shortname will be used.
-		 */
-		$description = $this->facebook_product->get_fb_description();
-
-		/*
-		 * Requirements:
-		 * - No all caps descriptions.
-		 * - Max length 5000.
-		 * - Min length 30 ( tested and not required, will not enforce until this will become a hard requirement )
-		 */
-		if ( \WC_Facebookcommerce_Utils::is_all_caps( $description ) ) {
-			throw new ProductInvalidException( __( 'Product description is all capital letters. Please change the description to sentence case in order to allow synchronization of your product.', 'facebook-for-woocommerce' ) );
-		}
-		if ( strlen( $description ) > self::MAX_DESCRIPTION_LENGTH ) {
-			throw new ProductInvalidException( __( 'Product description is too long. Maximum allowed length is 5000 characters.', 'facebook-for-woocommerce' ) );
-		}
-	}
-
-	/**
-	 * Check if the title field has correct format according to:
-	 * Product Title Specifications for Catalogs : https://www.facebook.com/business/help/2104231189874655
-	 *
-	 * @throws ProductInvalidException If product title does not meet the requirements.
-	 */
-	protected function validate_product_title() {
-		$title = $this->product->get_title();
-
-		/*
-		 * Requirements:
-		 * - Max length 150.
-		 */
-		if ( mb_strlen( $title, 'UTF-8' ) > self::MAX_TITLE_LENGTH ) {
-			throw new ProductInvalidException( __( 'Product title is too long. Maximum allowed length is 150 characters.', 'facebook-for-woocommerce' ) );
 		}
 	}
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -288,6 +288,10 @@ class Products {
 	 * @return bool
 	 */
 	public static function is_product_visible( \WC_Product $product ) {
+		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $product->is_in_stock() ) {
+			self::$products_visibility[ $product->get_id() ] = false;
+			return false;
+		}
 		// accounts for a legacy bool value, current should be (string) 'yes' or (string) 'no'
 		if ( ! isset( self::$products_visibility[ $product->get_id() ] ) ) {
 			if ( $product->is_type( 'variable' ) ) {

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -91,7 +91,7 @@ class Products {
 				}
 
 				// Remove excluded product from FB.
-				if ( "no" === $enabled && self::product_should_be_deleted( $product ) ) {
+				if ( "no" === $enabled ) {
 					facebook_for_woocommerce()->get_integration()->delete_fb_product( $product );
 				}
 

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -169,6 +169,22 @@ class Feed {
 		$store_allows_feed = $configured_ok && $integration->is_legacy_feed_file_generation_enabled();
 		if ( ! $store_allows_sync || ! $store_allows_feed ) {
 			as_unschedule_all_actions( self::GENERATE_FEED_ACTION );
+
+			$message = '';
+			if ( ! $configured_ok ) {
+				$message = 'Integration not configured.';
+			} elseif ( ! $store_allows_feed ) {
+				$message = 'Store does not allow feed.';
+			} elseif ( ! $store_allows_sync ) {
+				$message = 'Store does not allow sync.';
+			}
+			WC_Facebookcommerce_Utils::logToMeta(
+				sprintf( 'Product feed scheduling failed: %s', $message ),
+				array(
+					'flow_name' => 'product_feed',
+					'flow_step' => 'schedule_feed_generation',
+				)
+			);
 			return;
 		}
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -668,29 +668,34 @@ class WC_Facebook_Product {
 	public function get_fb_short_description() {
 		$short_description = '';
 
-		// For variable products, check if the variation has a short description
-		if ( empty( $short_description ) && WC_Facebookcommerce_Utils::is_variation_type( $this->woo_product->get_type() ) ) {
-			$short_description = WC_Facebookcommerce_Utils::clean_string( $this->woo_product->get_short_description() );
+		// For variations, inherit the short description from the parent product
+		if (WC_Facebookcommerce_Utils::is_variation_type($this->woo_product->get_type())) {
+			// Get the parent product
+			$parent_id = $this->woo_product->get_parent_id();
+			if ($parent_id) {
+				$parent_post = get_post($parent_id);
+				if ($parent_post && !empty($parent_post->post_excerpt)) {
+					$short_description = WC_Facebookcommerce_Utils::clean_string($parent_post->post_excerpt);
+				}
+			}
+			return apply_filters('facebook_for_woocommerce_fb_product_short_description', $short_description, $this->id);
 		}
 
 		// Use the product's short description (excerpt) from WooCommerce
-		if ( empty( $short_description ) ) {
-			$post = $this->get_post_data();
-			$post_excerpt = WC_Facebookcommerce_Utils::clean_string( $post->post_excerpt );
-			
-			if ( ! empty( $post_excerpt ) ) {
-				$short_description = $post_excerpt;
-			}
+		$post = $this->get_post_data();
+		$post_excerpt = WC_Facebookcommerce_Utils::clean_string($post->post_excerpt);
+		
+		if (!empty($post_excerpt)) {
+			$short_description = $post_excerpt;
 		}
 
 		/**
 		 * Filters the FB product short description.
 		 *
-		 *
 		 * @param string  $short_description Facebook product short description.
 		 * @param int     $id                WooCommerce Product ID.
 		 */
-		return apply_filters( 'facebook_for_woocommerce_fb_product_short_description', $short_description, $this->id );
+		return apply_filters('facebook_for_woocommerce_fb_product_short_description', $short_description, $this->id);
 	}
 
 	/**

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -752,7 +752,7 @@ class WC_Facebook_Product {
 		}
 
 		// For variable products, we want to use the rich text description of the variant.
-		// If that's not available, fall back to the main (parent) product's rich text description as a fallback
+		// If that's not available, fall back to the main (parent) product's rich text description.
 		if ( empty( $rich_text_description ) && WC_Facebookcommerce_Utils::is_variation_type( $this->woo_product->get_type() ) ) {
 			$rich_text_description = WC_Facebookcommerce_Utils::clean_string( $this->woo_product->get_description(), false );
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -78,6 +78,7 @@ class WC_Facebook_Product {
 	// Should match facebook-commerce.php while we migrate that code over
 	// to this object.
 	const FB_PRODUCT_DESCRIPTION   = 'fb_product_description';
+	const FB_SHORT_DESCRIPTION     = 'fb_product_short_description';
 	const FB_PRODUCT_PRICE         = 'fb_product_price';
 	const FB_SIZE                  = 'fb_size';
 	const FB_COLOR                 = 'fb_color';
@@ -659,61 +660,32 @@ class WC_Facebook_Product {
 	/**
 	 * Get the short description for a product.
 	 *
-	 * This function retrieves the short product description, following the same
-	 * fallback pattern as the main description.
+	 * This function retrieves the short product description, but unlike the main description
+	 * it should only use values specifically set for short description.
 	 *
 	 * @return string The short description for the product.
 	 */
 	public function get_fb_short_description() {
 		$short_description = '';
 
-		if ( $this->fb_description ) {
-			$short_description = $this->fb_description;
-		}
-
-		if ( empty( $short_description ) ) {
-			// Try to get short description from post meta
-			$short_description = get_post_meta(
-				$this->id,
-				self::FB_PRODUCT_DESCRIPTION,
-				true
-			);
-		}
-
-		// Check if the product type is a variation and no short description is found yet
+		// For variable products, check if the variation has a short description
 		if ( empty( $short_description ) && WC_Facebookcommerce_Utils::is_variation_type( $this->woo_product->get_type() ) ) {
 			$short_description = WC_Facebookcommerce_Utils::clean_string( $this->woo_product->get_short_description() );
-
-			// Fallback to main short description
-			if ( empty( $short_description ) && $this->main_description ) {
-				$short_description = $this->main_description;
-			}
 		}
 
-		// If no short description is found from meta or variation, get from post
+		// Use the product's short description (excerpt) from WooCommerce
 		if ( empty( $short_description ) ) {
-			$post         = $this->get_post_data();
-			$post_content = WC_Facebookcommerce_Utils::clean_string( $post->post_content );
+			$post = $this->get_post_data();
 			$post_excerpt = WC_Facebookcommerce_Utils::clean_string( $post->post_excerpt );
-			$post_title   = WC_Facebookcommerce_Utils::clean_string( $post->post_title );
-
-			// Prioritize excerpt, then content, then title
+			
 			if ( ! empty( $post_excerpt ) ) {
 				$short_description = $post_excerpt;
 			}
-
-			if ( empty( $short_description ) && ! empty( $post_content ) ) {
-				$short_description = $post_content;
-			}
-
-			if ( empty( $short_description ) ) {
-				$short_description = $post_title;
-			}
 		}
+
 		/**
 		 * Filters the FB product short description.
 		 *
-		 * @since 3.2.6
 		 *
 		 * @param string  $short_description Facebook product short description.
 		 * @param int     $id                WooCommerce Product ID.
@@ -1293,7 +1265,7 @@ class WC_Facebook_Product {
 
 		$google_product_category = Products::get_google_product_category_id( $this->woo_product );
 		if ( $google_product_category ) {
-			$product_data['google_product_category'] = $google_product_category;
+			$product_data['google_product_category'] = (int) $google_product_category;
 		}
 
 		// Currently only items batch and feed support enhanced catalog fields

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1187,6 +1187,7 @@ class WC_Facebook_Product {
 		$product_data[ 'gender' ] = $this->get_fb_gender();
 		$product_data[ 'material' ] = Helper::str_truncate( $this->get_fb_material(), 100 );
 		$product_data[ 'pattern' ] = Helper::str_truncate( $this->get_fb_pattern(), 100 );
+		$product_data[ 'woo_product_type' ] = $this->get_type();
 
 		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
 			$product_data['title'] = WC_Facebookcommerce_Utils::clean_string( $this->get_title() );

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1316,6 +1316,10 @@ class WC_Facebook_Product {
 
 		$all_attributes = $category_handler->get_attributes_with_fallback_to_parent_category( $google_category_id );
 
+		if ( empty( $all_attributes ) ) {
+			return $product_data;
+		}
+
 		foreach ( $all_attributes as $attribute ) {
 			$value            = Products::get_enhanced_catalog_attribute( $attribute['key'], $this->woo_product );
 			$convert_to_array = (

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -385,7 +385,9 @@ class WC_Facebook_Product_Feed {
 		return 'id,title,description,image_link,link,product_type,' .
 		'brand,price,availability,item_group_id,checkout_url,' .
 		'additional_image_link,sale_price_effective_date,sale_price,condition,' .
-		'visibility,gender,color,size,pattern,google_product_category,default_product,variant,gtin,quantity_to_sell_on_facebook,rich_text_description,external_update_time' . PHP_EOL;
+		'visibility,gender,color,size,pattern,google_product_category,default_product,'.
+		'variant,gtin,quantity_to_sell_on_facebook,rich_text_description,external_update_time,'.
+		'external_variant_id'. PHP_EOL;
 	}
 
 
@@ -535,7 +537,8 @@ class WC_Facebook_Product_Feed {
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'gtin' )) . ',' .
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'quantity_to_sell_on_facebook' )) . ',' .
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'rich_text_description' ) ) . ',' .
-		static::get_value_from_product_data( $product_data, 'external_update_time' ) . PHP_EOL;
+		static::get_value_from_product_data( $product_data, 'external_update_time' ) . ',' .
+		static::get_value_from_product_data( $product_data, 'external_variant_id' ) . PHP_EOL;
 	}
 
 	private static function format_additional_image_url( $product_image_urls ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.3.0",
+  "version": "3.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "facebook-for-woocommerce",
-      "version": "3.3.0",
+      "version": "3.4.1",
       "license": "GPL-2.0",
       "devDependencies": {
         "@wordpress/env": "^9.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.4.2",
+  "version": "3.4.4",
   "author": "Facebook",
   "homepage": "https://woocommerce.com/products/facebook/",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, woocommerce, marketing, product catalog feed, pixel
 Requires at least: 5.6
 Tested up to: 6.7
-Stable tag: 3.4.2
+Stable tag: 3.4.4
 Requires PHP: 7.4
 MySQL: 5.6 or greater
 License: GPLv2 or later
@@ -40,6 +40,18 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
-= 3.4.X 2025-XX-XX =
+= 3.4.4 - 2025-03-26 =
+* Add - Create tests for ProductFeedUploads create endpoint by @ajello-meta in #2902
+* Add - Create tests for ProductFeedUploads read endpoint by @ajello-meta in #2903
+* Tweak - Remove phpcs:ignoreFile annotation + Enable code coverage report generation with phpunit by @sol-loup in #2897 and #2901
+* Fix - Restores the original dynamic property behavior in the AsyncRequest class by @sol-loup in #2921
+* Tweak - Changing APP to PLUGIN on README.MD by @SayanPandey in #2916
+* Tweak - Update README.md - Added noification for ownership transfer by @SayanPandey in #2910
+* Tweak - Added is_multisite logging to the update_plugin_version_configuration request by @carterbuce in #2955
+* Tweak - Add woo_commerce_retailer_id to products API request by @crisojog in #2958
+* Tweak - Syncing plugin version info by @vinkmeta in #2960
+* Fix - sync products out of stock to meta despite visibility config by @francorisso in #2952
+* Fix - Update woo_commerce_retailer_id to existing field external_variant_id by @crisojog in #2963
+* Tweak - Update readme.txt by @vinkmeta in #2949
 
 [See changelog for all versions](https://raw.githubusercontent.com/facebook/facebook-for-woocommerce/refs/heads/main/changelog.txt).

--- a/tests/Unit/Admin/Settings/ConnectionTest.php
+++ b/tests/Unit/Admin/Settings/ConnectionTest.php
@@ -18,22 +18,22 @@ class ConnectionTest extends \WP_UnitTestCase {
         $connection = $this->getMockBuilder(Connection::class)
             ->onlyMethods(['is_current_screen_page'])
             ->getMock();
-        
+
         $connection->method('is_current_screen_page')
             ->willReturn(false);
-            
+
         // No styles should be enqueued
         $connection->enqueue_assets();
-        
+
         $this->assertFalse(wp_style_is('wc-facebook-admin-connection-settings'));
     }
 
     public function testGetSettings(): void {
         $settings = $this->connection->get_settings();
-        
+
         $this->assertIsArray($settings);
         $this->assertNotEmpty($settings);
-        
+
         // Check that the settings array has the expected structure
         $this->assertArrayHasKey('type', $settings[0]);
         $this->assertEquals('title', $settings[0]['type']);
@@ -42,12 +42,12 @@ class ConnectionTest extends \WP_UnitTestCase {
         $debug_setting = $settings[1];
         $this->assertEquals('checkbox', $debug_setting['type']);
         $this->assertEquals('yes', $debug_setting['default']);
-        
+
         // Check debug mode setting
         $debug_setting = $settings[2];
         $this->assertEquals('checkbox', $debug_setting['type']);
         $this->assertEquals('no', $debug_setting['default']);
-        
+
         // Check feed generator setting
         $feed_setting = $settings[3];
         $this->assertEquals('checkbox', $feed_setting['type']);

--- a/tests/Unit/Admin/Settings/ShopsTest.php
+++ b/tests/Unit/Admin/Settings/ShopsTest.php
@@ -36,7 +36,7 @@ class ShopsTest extends \WP_UnitTestCase {
         // No styles should be enqueued
         $shops->enqueue_assets();
 
-        $this->assertFalse(wp_style_is('wc-facebook-admin-connection-settings'));
+        $this->assertFalse(wp_style_is('wc-facebook-admin-shops-settings'));
     }
 
     /**

--- a/tests/Unit/Admin/Settings_Screens/ConnectionTest.php
+++ b/tests/Unit/Admin/Settings_Screens/ConnectionTest.php
@@ -2,21 +2,15 @@
 namespace WooCommerce\Facebook\Tests\Unit\Admin\Settings_Screens;
 
 use PHPUnit\Framework\TestCase;
+use WC_Facebookcommerce;
 use WooCommerce\Facebook\Admin\Settings_Screens\Connection;
 
 /**
  * Class ConnectionTest
- * 
+ *
  * @package WooCommerce\Facebook\Tests\Unit\Admin\Settings_Screens
  */
 class ConnectionTest extends TestCase {
-    /** @var Connection */
-    private $connection;
-
-    protected function setUp(): void {
-        parent::setUp();
-        $this->connection = new Connection();
-    }
 
     /**
      * Helper method to invoke private/protected methods
@@ -31,65 +25,71 @@ class ConnectionTest extends TestCase {
         $reflection = new \ReflectionClass(get_class($object));
         $method = $reflection->getMethod($methodName);
         $method->setAccessible(true);
-        
+
         return $method->invokeArgs($object, $parameters);
-    }
-
-    /**
-     * Test that iframe connection can be enabled or disabled
-     */
-    public function test_use_iframe_connection() {
-        // Test the actual implementation (currently returns false)
-        $reflection = new \ReflectionClass($this->connection);
-        $method = $reflection->getMethod('use_enhanced_onboarding');
-        $method->setAccessible(true);
-
-        // REMOVE WHEN READY TO RELEASE ENHANCED ONBOARDING FLOW
-        // Test to ensure that the use_enhanced_onboarding method returns false
-        $actual_value = $method->invoke($this->connection);
-        $this->assertFalse($actual_value);
-        
-        // Create a mock that returns true for testing the true case
-        $connection_mock = $this->getMockBuilder(Connection::class)
-            ->onlyMethods(['use_enhanced_onboarding'])
-            ->getMock();
-        
-        $connection_mock->method('use_enhanced_onboarding')
-            ->willReturn(true);
-            
-        // Use reflection to call the protected method on the mock
-        $reflection = new \ReflectionClass($connection_mock);
-        $method = $reflection->getMethod('use_enhanced_onboarding');
-        $method->setAccessible(true);
-        $mock_value = $method->invoke($connection_mock);
-        
-        $this->assertTrue($mock_value);
     }
 
     /**
      * Test that render method calls render_facebook_iframe when enhanced onboarding is enabled
      */
     public function test_render_facebook_box_iframe() {
-        // Create a partial mock of the Connection class
-        $connection = $this->getMockBuilder(Connection::class)
+        // Create a partial mock of the facebook_for_woocommerce() class
+        $fb_for_wc = $this->getMockBuilder(WC_Facebookcommerce::class)
             ->onlyMethods(['use_enhanced_onboarding'])
             ->getMock();
-        
+
         // Configure the mock to return true for use_enhanced_onboarding
-        $connection->expects($this->once())
+	    $fb_for_wc->expects($this->once())
             ->method('use_enhanced_onboarding')
             ->willReturn(true);
-            
+
+        // Override the facebook_for_woocommerce method to return the mock
+	    add_filter('wc_facebook_instance', function() use ( $fb_for_wc ) {
+	        return $fb_for_wc;
+	    });
+
         // Start output buffering to capture the render output
+	    $connection = new Connection();
         ob_start();
         $connection->render();
         $output = ob_get_clean();
-        
+
         // Since we can't directly test the private render_facebook_iframe method,
         // we'll verify that the render method doesn't output the legacy Facebook box
         // when enhanced onboarding is enabled
         $this->assertStringNotContainsString('wc-facebook-connection-box', $output);
     }
+
+	/**
+	 * Test that render method calls render_facebook_iframe when enhanced onboarding is disabled
+	 */
+	public function test_render_facebook_box_legacy() {
+		// Create a partial mock of the facebook_for_woocommerce() class
+		$fb_for_wc = $this->getMockBuilder(WC_Facebookcommerce::class)
+		                  ->onlyMethods(['use_enhanced_onboarding'])
+		                  ->getMock();
+
+		// Configure the mock to return false for use_enhanced_onboarding
+		$fb_for_wc->expects($this->once())
+		          ->method('use_enhanced_onboarding')
+		          ->willReturn(false);
+
+		// Override the facebook_for_woocommerce method to return the mock
+		add_filter('wc_facebook_instance', function() use ( $fb_for_wc ) {
+			return $fb_for_wc;
+		});
+
+		// Start output buffering to capture the render output
+		$connection = new Connection();
+		ob_start();
+		$connection->render();
+		$output = ob_get_clean();
+
+		// Since we can't directly test the private render_facebook_iframe method,
+		// we'll verify that the render method doesn't output the legacy Facebook box
+		// when enhanced onboarding is enabled
+		$this->assertStringContainsString('wc-facebook-connection-box', $output);
+	}
 
     /**
      * Test that render_message_handler outputs the expected JavaScript
@@ -97,17 +97,13 @@ class ConnectionTest extends TestCase {
     public function test_render_message_handler() {
         // Create a mock of the Connection class
         $connection_mock = $this->getMockBuilder(Connection::class)
-            ->onlyMethods(['is_current_screen_page', 'use_enhanced_onboarding'])
+            ->onlyMethods(['is_current_screen_page'])
             ->getMock();
 
         // Configure the mock to return true for is_current_screen_page
         $connection_mock->method('is_current_screen_page')
             ->willReturn(true);
-            
-        // Configure the mock to return true for use_enhanced_onboarding
-        $connection_mock->method('use_enhanced_onboarding')
-            ->willReturn(true);
-        
+
         // Call the method
         $output = $connection_mock->generate_inline_enhanced_onboarding_script();
 
@@ -116,7 +112,7 @@ class ConnectionTest extends TestCase {
         $this->assertStringContainsString('CommerceExtension::INSTALL', $output);
         $this->assertStringContainsString('CommerceExtension::RESIZE', $output);
         $this->assertStringContainsString('CommerceExtension::UNINSTALL', $output);
-        
+
         // Assert fetch request setup - check for wpApiSettings.root instead of hardcoded path
         $this->assertStringContainsString('GeneratePluginAPIClient', $output);
         $this->assertStringContainsString('fbAPI.updateSettings', $output);
@@ -127,9 +123,9 @@ class ConnectionTest extends TestCase {
      */
     public function test_render_message_handler_not_current_screen() {
         $connection_mock = $this->getMockBuilder(Connection::class)
-            ->onlyMethods(['is_current_screen_page'])
+	        ->onlyMethods(['is_current_screen_page'])
             ->getMock();
-        
+
         $connection_mock->method('is_current_screen_page')
             ->willReturn(false);
 
@@ -144,26 +140,19 @@ class ConnectionTest extends TestCase {
      * Test that the management URL is used when merchant token exists
      */
     public function test_renders_management_url_based_on_merchant_token() {
-        // Create a mock for testing the private render_facebook_iframe method
-        $connection = $this->getMockBuilder(Connection::class)
-            ->onlyMethods(['use_enhanced_onboarding'])
-            ->getMock();
-        
-        $connection->expects($this->any())
-            ->method('use_enhanced_onboarding')
-            ->willReturn(true);
-        
+		$connection = new Connection();
+
         // Set up the merchant token
         update_option('wc_facebook_merchant_access_token', 'test_token');
-        
+
         // Use output buffering to capture the iframe HTML
         ob_start();
         $this->invoke_method($connection, 'render_facebook_iframe');
         $output = ob_get_clean();
-        
+
         // Check that the iframe is rendered
         $this->assertStringContainsString('<iframe', $output);
         $this->assertStringContainsString('frameborder="0"', $output);
         $this->assertStringContainsString('id="facebook-commerce-iframe"', $output);
     }
-} 
+}

--- a/tests/Unit/Admin/Settings_Screens/ShopsTest.php
+++ b/tests/Unit/Admin/Settings_Screens/ShopsTest.php
@@ -55,7 +55,7 @@ class ShopsTest extends TestCase {
         // Since we can't directly test the private render_facebook_iframe method,
         // we'll verify that the render method doesn't output the legacy Facebook box
         // when enhanced onboarding is enabled
-        $this->assertStringNotContainsString('wc-facebook-shops-box', $output);
+        $this->assertStringNotContainsString('wc-facebook-connection-box', $output);
     }
 
     /**

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -526,7 +526,6 @@ class WCFacebookCommerceIntegrationTest extends \WooCommerce\Facebook\Tests\Unit
 		/* Data coming from _POST data. */
 		$facebook_product_data['description']				 = 'Facebook product description.';
 		$facebook_product_data['rich_text_description']		 = 'Facebook product description.';
-		// $facebook_product_data['short_description']			 = 'Facebook product description.';
 		$facebook_product_data['price']                      = '199 USD';
 		$facebook_product_data['google_product_category']    = 1718;
 

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -526,6 +526,7 @@ class WCFacebookCommerceIntegrationTest extends \WooCommerce\Facebook\Tests\Unit
 		/* Data coming from _POST data. */
 		$facebook_product_data['description']				 = 'Facebook product description.';
 		$facebook_product_data['rich_text_description']		 = 'Facebook product description.';
+		// $facebook_product_data['short_description']			 = 'Facebook product description.';
 		$facebook_product_data['price']                      = '199 USD';
 		$facebook_product_data['google_product_category']    = 1718;
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,7 @@ const jQueryUIAdminFileNames = [
 	'products-admin',
 	'settings-commerce',
 	'settings-sync',
+	'enhanced-settings-sync',
 ];
 
 const jQueryUIAdminFileEntries = {};


### PR DESCRIPTION
# Add separate short_description field to Facebook product catalog

## Description
This PR modifies how product descriptions are synced to Facebook by sending the short description as a separate field rather than using it as a fallback for the main description. This change allows both description types to be utilized independently in the Facebook catalog.

### Changes Made
- Added `short_description` field to product data sent to Facebook
- Modified `get_fb_short_description()` method to handle variation products consistently with main description
- Added fallback logic for variation products to use parent product's short description when needed
- Maintained separation between main description and short description fields

### Before
Previously, short descriptions were only used as a fallback when the main description was empty or when specifically configured to use short descriptions instead of main descriptions.

### After
Now both descriptions are sent to Facebook as separate fields:
- `description`: Contains the main product description
- `short_description`: Contains the product's short description
- Both fields maintain their own content and fallback logic

### Testing
- [ ] Verify that both main and short descriptions are sent to Facebook
- [ ] Test with variation products to ensure proper fallback behavior
- [ ] Confirm that existing product syncs continue to work as expected
- [ ] Verify that products with only one description type still sync correctly

## Impact
This change provides more flexibility in how product descriptions are displayed on Facebook, allowing merchants to utilize both description types for different purposes in their product catalog.