### PR TITLE
Add manual product and coupon sync buttons

### DIFF
--- a/assets/js/admin/enhanced-settings-sync.js
+++ b/assets/js/admin/enhanced-settings-sync.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+jQuery(document).ready(function($) {
+    /**
+     * Handle the sync products button click event
+     *
+     * @since 3.5.0
+     *
+     * @param {object} event
+     */
+    $('#wc-facebook-enhanced-settings-sync-products').click(function(event) {
+        event.preventDefault();
+        var button = $(this);
+
+        button.html('Syncing...');
+        button.prop('disabled', true);
+
+        var data = {
+            action: "wc_facebook_sync_products",
+            nonce: wc_facebook_enhanced_settings_sync.sync_products_nonce
+        };
+
+        $.post(wc_facebook_enhanced_settings_sync.ajax_url, data, function(response) {
+            if (response.success) {
+                button.html('Sync completed');
+                button.prop('disabled', true); // Disable the button after success
+            } else {
+                button.html('Sync failed');
+                button.prop('disabled', false); // Re-enable the button if failed
+            }
+        }).fail(function() {
+            button.html('Sync failed');
+            button.prop('disabled', false);
+        });
+    });
+
+    /**
+     * Handle the sync coupons button click event
+     *
+     * @since 3.5.0
+     *
+     * @param {object} event
+     */
+    $('#wc-facebook-enhanced-settings-sync-coupons').click(function(event) {
+        event.preventDefault();
+        var button = $(this);
+
+        button.html('Syncing...');
+        button.prop('disabled', true);
+
+        var data = {
+            action: "wc_facebook_sync_coupons",
+            nonce: wc_facebook_enhanced_settings_sync.sync_coupons_nonce
+        };
+
+        $.post(wc_facebook_enhanced_settings_sync.ajax_url, data, function(response) {
+            if (response.success) {
+                button.html('Sync completed');
+                button.prop('disabled', true); // Disable the button after success
+            } else {
+                button.html('Sync failed');
+                button.prop('disabled', false); // Re-enable the button if failed
+            }
+        }).fail(function() {
+            button.html('Sync failed');
+            button.prop('disabled', false);
+        });
+    });
+});

--- a/assets/js/admin/enhanced-settings-sync.js
+++ b/assets/js/admin/enhanced-settings-sync.js
@@ -30,10 +30,10 @@ jQuery(document).ready(function($) {
         $.post(wc_facebook_enhanced_settings_sync.ajax_url, data, function(response) {
             if (response.success) {
                 button.html('Sync completed');
-                button.prop('disabled', true); // Disable the button after success
+                button.prop('disabled', false);
             } else {
                 button.html('Sync failed');
-                button.prop('disabled', false); // Re-enable the button if failed
+                button.prop('disabled', false);
             }
         }).fail(function() {
             button.html('Sync failed');
@@ -63,10 +63,10 @@ jQuery(document).ready(function($) {
         $.post(wc_facebook_enhanced_settings_sync.ajax_url, data, function(response) {
             if (response.success) {
                 button.html('Sync completed');
-                button.prop('disabled', true); // Disable the button after success
+                button.prop('disabled', false);
             } else {
                 button.html('Sync failed');
-                button.prop('disabled', false); // Re-enable the button if failed
+                button.prop('disabled', false);
             }
         }).fail(function() {
             button.html('Sync failed');

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -141,7 +141,7 @@ class Shops extends Abstract_Settings_Screen {
 	public function render() {
 		$is_connected = facebook_for_woocommerce()->get_connection_handler()->is_connected();
 
-		$this->render_facebook_iframe( $is_connected );
+		$this->render_facebook_iframe();
 
 		if ( $is_connected ) {
 			$this->render_troubleshooting_button_and_drawer();
@@ -155,8 +155,9 @@ class Shops extends Abstract_Settings_Screen {
 	 *
 	 * @param bool $is_connected
 	 */
-	private function render_facebook_iframe( bool $is_connected ) {
+	private function render_facebook_iframe() {
 		$connection            = facebook_for_woocommerce()->get_connection_handler();
+		$is_connected          = $connection->is_connected();
 		$merchant_access_token = get_option( 'wc_facebook_merchant_access_token', '' );
 
 		if ( ! empty( $merchant_access_token ) && $is_connected ) {

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -25,6 +25,12 @@ class Shops extends Abstract_Settings_Screen {
 	/** @var string */
 	const ID = 'shops';
 
+	/** @var string */
+	const ACTION_SYNC_PRODUCTS = 'wc_facebook_sync_products';
+
+	/** @var string */
+	const ACTION_SYNC_COUPONS = 'wc_facebook_sync_coupons';
+
 	/**
 	 * Shops constructor.
 	 *
@@ -107,6 +113,24 @@ class Shops extends Abstract_Settings_Screen {
 		}
 
 		wp_enqueue_style( 'wc-facebook-admin-connection-settings', facebook_for_woocommerce()->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-connection.css', array(), \WC_Facebookcommerce::VERSION );
+
+		wp_enqueue_script(
+			'wc-facebook-enhanced-settings-sync',
+			facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/enhanced-settings-sync.js',
+			array( 'jquery' ),
+			\WC_Facebookcommerce::PLUGIN_VERSION,
+			true
+		);
+
+		wp_localize_script(
+			'wc-facebook-enhanced-settings-sync',
+			'wc_facebook_enhanced_settings_sync',
+			array(
+				'ajax_url'            => admin_url( 'admin-ajax.php' ),
+				'sync_products_nonce' => wp_create_nonce( self::ACTION_SYNC_PRODUCTS ),
+				'sync_coupons_nonce'  => wp_create_nonce( self::ACTION_SYNC_COUPONS ),
+			)
+		);
 	}
 
 	/**
@@ -115,17 +139,24 @@ class Shops extends Abstract_Settings_Screen {
 	 * @since 3.5.0
 	 */
 	public function render() {
-		$this->render_facebook_iframe();
+		$is_connected = facebook_for_woocommerce()->get_connection_handler()->is_connected();
+
+		$this->render_facebook_iframe( $is_connected );
+
+		if ( $is_connected ) {
+			$this->render_troubleshooting_button_and_drawer();
+		}
 	}
 
 	/**
 	 * Renders the appropriate Facebook iframe based on connection status.
 	 *
 	 * @since 3.5.0
+	 *
+	 * @param bool $is_connected
 	 */
-	private function render_facebook_iframe() {
+	private function render_facebook_iframe( bool $is_connected ) {
 		$connection            = facebook_for_woocommerce()->get_connection_handler();
-		$is_connected          = $connection->is_connected();
 		$merchant_access_token = get_option( 'wc_facebook_merchant_access_token', '' );
 
 		if ( ! empty( $merchant_access_token ) && $is_connected ) {
@@ -147,17 +178,18 @@ class Shops extends Abstract_Settings_Screen {
 		?>
 	<div style="display: flex; justify-content: center; max-width: 1200px; margin: 0 auto;">
 		<iframe
-		id="facebook-commerce-iframe-enhanced"
-		src="<?php echo esc_url( $iframe_url ); ?>"
-		></iframe>
+			id="facebook-commerce-iframe-enhanced"
+			src="<?php echo esc_url( $iframe_url ); ?>"
+			></iframe>
 	</div>
 		<?php
-
-		if ( $is_connected ) {
-			$this->render_troubleshooting_button_and_drawer();
-		}
 	}
 
+	/**
+	 * Renders the troubleshooting button and drawer.
+	 *
+	 * @since 3.5.0
+	 */
 	private function render_troubleshooting_button_and_drawer() {
 		?>
 	<!-- Toggle Button -->
@@ -171,6 +203,42 @@ class Shops extends Abstract_Settings_Screen {
 	<!-- Drawer -->
 	<div id="troubleshooting-drawer" class="settings-drawer" style="display: none;">
 		<div class="settings-drawer-content">
+			<table class="form-table">
+				<tbody>
+					<tr valign="top" class="wc-facebook-connected-sample">
+						<th scope="row" class="titledesc">
+							Product data sync
+						</th>
+						<td class="forminp">
+							<button
+								id="wc-facebook-enhanced-settings-sync-products"
+								class="button"
+								type="button">
+								<?php esc_html_e( 'Sync now', 'facebook-for-woocommerce' ); ?>
+							</button>
+							<p id="product-sync-description" class="sync-description">
+								Manually sync your products from WooCommerce to your shop. It may take a couple of minutes for the changes to populate.
+							</p>
+						</td>
+					</tr>
+					<tr valign="top" class="wc-facebook-connected-sample">
+						<th scope="row" class="titledesc">
+							Coupon codes sync
+						</th>
+						<td class="forminp">
+							<button
+								id="wc-facebook-enhanced-settings-sync-coupons"
+								class="button"
+								type="button">
+								<?php esc_html_e( 'Sync now', 'facebook-for-woocommerce' ); ?>
+							</button>
+							<p id="coupon-sync-description" class="sync-description">
+								Manually sync your coupons from WooCommerce to your shop. It may take a couple of minutes for the changes to populate.
+							</p>
+						</td>
+					</tr>
+				</tbody>
+			</table>
 			<?php parent::render(); ?>
 		</div>
 	</div>
@@ -199,7 +267,7 @@ class Shops extends Abstract_Settings_Screen {
 			justify-content: space-between;
 			align-items: center;
 			margin-bottom: 20px;
-						box-sizing: border-box;
+			box-sizing: border-box;
 		}
 
 		.drawer-toggle-button:hover {
@@ -220,22 +288,34 @@ class Shops extends Abstract_Settings_Screen {
 			max-width: 1100px;
 			background-color: #fff;
 			border-bottom: 1px solid #ccc;
-						border-right: 1px solid #ccc;
-						border-left: 1px solid #ccc;
+			border-right: 1px solid #ccc;
+			border-left: 1px solid #ccc;
 			overflow: hidden;
 			transition: max-height 0.3s ease, margin-bottom 0.3s ease;
 			max-height: 0;
 			margin: 0 auto;
-						box-sizing: border-box;
+			box-sizing: border-box;
 		}
 
 		.settings-drawer-content {
 			padding: 20px;
 			padding-bottom: 0;
 		}
+
+		.button:disabled {
+			background-color: #f1f1f1;
+			cursor: not-allowed;
+		}
+
+		.sync-description {
+			font-size: 12px;
+			color: #666;
+			padding-top: 8px;
+		}
 	</style>
 
 	<script>
+		// Toggle drawer visibility
 		document.getElementById('toggle-troubleshooting-drawer').addEventListener('click', function() {
 			var drawer = document.getElementById('troubleshooting-drawer');
 			var caret = document.getElementById('caret');

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -152,8 +152,6 @@ class Shops extends Abstract_Settings_Screen {
 	 * Renders the appropriate Facebook iframe based on connection status.
 	 *
 	 * @since 3.5.0
-	 *
-	 * @param bool $is_connected
 	 */
 	private function render_facebook_iframe() {
 		$connection            = facebook_for_woocommerce()->get_connection_handler();

--- a/tests/Unit/Admin/Settings_Screens/ShopsTest.php
+++ b/tests/Unit/Admin/Settings_Screens/ShopsTest.php
@@ -119,7 +119,7 @@ class ShopsTest extends TestCase {
 
         // Start output buffering to capture the render output
         ob_start();
-        $this->invoke_method($shops, 'render_facebook_iframe');
+        $this->invoke_method($shops, 'render_facebook_iframe', array(true));
         $output = ob_get_clean();
 
         // Check that the iframe is rendered

--- a/tests/Unit/Admin/Settings_Screens/ShopsTest.php
+++ b/tests/Unit/Admin/Settings_Screens/ShopsTest.php
@@ -119,7 +119,7 @@ class ShopsTest extends TestCase {
 
         // Start output buffering to capture the render output
         ob_start();
-        $this->invoke_method($shops, 'render_facebook_iframe', array(true));
+        $this->invoke_method($shops, 'render_facebook_iframe');
         $output = ob_get_clean();
 
         // Check that the iframe is rendered

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,7 @@ const jQueryUIAdminFileNames = [
 	'products-admin',
 	'settings-commerce',
 	'settings-sync',
+	'enhanced-settings-sync',
 ];
 
 const jQueryUIAdminFileEntries = {};


### PR DESCRIPTION
## Description
This PR introduces manual product and coupon sync buttons to the "Troubleshooting" drawer under the "Shops" tab in the enhanced settings UI. The buttons have three states: "Sync now" (enabled), "Syncing..." (disabled), "Sync completed" (disabled), and "Sync failed" (enabled). The button clicks are handled vis Javascript and AJAX in `assets/js/admin/enhanced-settings-sync.js` and `includes/AJAX.php`. 

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots
Before Sync:
<img width="1726" alt="Screenshot 2025-03-28 at 6 44 05 PM" src="https://github.com/user-attachments/assets/86d03a0d-7475-468a-8023-cac44db7a012" />

Sync Completed:
<img width="1726" alt="Screenshot 2025-03-28 at 9 36 54 PM" src="https://github.com/user-attachments/assets/62477287-c4a9-4b79-8910-08e649a2f8e8" />

Sync Failed:
<img width="1726" alt="Screenshot 2025-03-28 at 6 45 28 PM" src="https://github.com/user-attachments/assets/965525a4-29f3-48ce-b088-d5f768d3f3f4" />

Video Demo:
https://github.com/user-attachments/assets/9a9e2a58-ab53-4b31-9113-e4e18ff6bb57


## Test instructions
1. Set `use_enhanced_onboarding()` in `facebook-for-woocommerce/facebook-commerce.php` to `true`.
2. Go to http://test-site-i.local/wp-admin/admin.php?page=wc-facebook. Make sure you are in the "Shops" tab.
3. Ensure that your WooCommerce in connected to Meta so that the "Troubleshooting" drawer is visible.
4. Click on "Sync now" for either "Product data sync" or "Coupon codes sync".