### PR TITLE
Make page title in enhanced settings static

### DIFF
--- a/includes/Admin/Enhanced_Settings.php
+++ b/includes/Admin/Enhanced_Settings.php
@@ -141,30 +141,12 @@ class Enhanced_Settings {
 	 */
 	private function connect_to_enhanced_admin( $screen_id ) {
 		if ( is_callable( 'wc_admin_connect_page' ) ) {
-			$crumbs = array(
-				__( 'Facebook for WooCommerce', 'facebook-for-woocommerce' ),
-			);
-			//phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			if ( ! empty( $_GET['tab'] ) ) {
-				//phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				switch ( $_GET['tab'] ) {
-					case Shops::ID:
-						$crumbs[] = __( 'Shops', 'facebook-for-woocommerce' );
-						break;
-					case Settings_Screens\Product_Sync::ID:
-						$crumbs[] = __( 'Product sync', 'facebook-for-woocommerce' );
-						break;
-					case Settings_Screens\Advertise::ID:
-						$crumbs[] = __( 'Advertise', 'facebook-for-woocommerce' );
-						break;
-				}
-			}
 			wc_admin_connect_page(
 				array(
 					'id'        => self::PAGE_ID,
 					'screen_id' => $screen_id,
 					'path'      => add_query_arg( 'page', self::PAGE_ID, 'admin.php' ),
-					'title'     => $crumbs,
+					'title'     => [ __( 'Facebook for WooCommerce', 'facebook-for-woocommerce' ) ],
 				)
 			);
 		}


### PR DESCRIPTION
## Description

This PR makes the page title "Facebook for WooCommerce" in enhanced settings static. Previously, it would display the name of the tab that the user was on, which is redundant information.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots
### Before
https://github.com/user-attachments/assets/5caafc38-ca9c-40d5-8679-26d435f08abb

### After
https://github.com/user-attachments/assets/343243e2-7924-4c9b-a946-81241ed5a828

## Test instructions
1. Set `use_enhanced_onboarding()` in `facebook-for-woocommerce/facebook-commerce.php` to `true`.
2. Go to http://test-site-i.local/wp-admin/admin.php?page=wc-facebook. Click into various tabs to obverse the page title.
