### PR TITLE
Fix use_enhanced_onboarding for legacy connections

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -237,7 +237,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 
 			// load admin handlers, before admin_init
 			if ( is_admin() ) {
-				if ($this->get_integration()->use_enhanced_onboarding()) {
+				if ($this->use_enhanced_onboarding()) {
 					$this->admin_enhanced_settings = new WooCommerce\Facebook\Admin\Enhanced_Settings( $this->connection_handler->is_connected() );
 				} else {
 					$this->admin_settings = new WooCommerce\Facebook\Admin\Settings( $this->connection_handler->is_connected() );
@@ -860,8 +860,24 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 		}
 		return $current_screen_id;
 	}
-}
 
+	/**
+	 * Determines if the enhanced onboarding (iframe) should be used.
+	 *
+	 * @return bool
+	 *
+	 */
+	public function use_enhanced_onboarding() {
+		$connection_handler              = $this->get_connection_handler();
+		$commerce_partner_integration_id = $connection_handler->get_commerce_partner_integration_id();
+
+		// If current connection is using the non-enhanced flow, don't show the new experience
+		if ( $connection_handler->is_connected() && empty( $commerce_partner_integration_id ) ) {
+			return false;
+		}
+		return false;
+	}
+}
 
 /**
  * Gets the Facebook for WooCommerce plugin instance.

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -240,7 +240,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 				if ($this->use_enhanced_onboarding()) {
 					$this->admin_enhanced_settings = new WooCommerce\Facebook\Admin\Enhanced_Settings( $this->connection_handler->is_connected() );
 				} else {
-					$this->admin_settings = new WooCommerce\Facebook\Admin\Settings( $this->connection_handler->is_connected() );
+					$this->admin_settings = new WooCommerce\Facebook\Admin\Settings( $this, $this->connection_handler->is_connected() );
 				}
 			}
 		}
@@ -867,7 +867,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	 * @return bool
 	 *
 	 */
-	public function use_enhanced_onboarding() {
+	public function use_enhanced_onboarding(): bool {
 		$connection_handler              = $this->get_connection_handler();
 		$commerce_partner_integration_id = $connection_handler->get_commerce_partner_integration_id();
 

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -240,7 +240,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 				if ($this->use_enhanced_onboarding()) {
 					$this->admin_enhanced_settings = new WooCommerce\Facebook\Admin\Enhanced_Settings( $this->connection_handler->is_connected() );
 				} else {
-					$this->admin_settings = new WooCommerce\Facebook\Admin\Settings( $this, $this->connection_handler->is_connected() );
+					$this->admin_settings = new WooCommerce\Facebook\Admin\Settings( $this->connection_handler->is_connected() );
 				}
 			}
 		}
@@ -887,5 +887,5 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
  * @return \WC_Facebookcommerce instance of the plugin
  */
 function facebook_for_woocommerce() {
-	return \WC_Facebookcommerce::instance();
+	return apply_filters('wc_facebook_instance', \WC_Facebookcommerce::instance());
 }

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -3174,21 +3174,4 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		wp_die();
 	}
 
-	/**
-	 * Determines if the enhanced onboarding (iframe) should be used.
-	 *
-	 * @return bool
-	 *
-	 */
-	public function use_enhanced_onboarding() {
-		$connection_handler              = facebook_for_woocommerce()->get_connection_handler();
-		$commerce_partner_integration_id = $connection_handler->get_commerce_partner_integration_id();
-
-		// If current connection is using the non-enhanced flow, don't show the new experience
-		if ( $connection_handler->is_connected() && empty( $commerce_partner_integration_id ) ) {
-			return false;
-		}
-		return true;
-	}
-
 }

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -133,7 +133,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	const OPTION_HAS_AUTHORIZED_PAGES_READ_ENGAGEMENT = 'wc_facebook_has_authorized_pages_read_engagement';
 
 	/** @var string the WordPress option name where the messenger chat status is stored */
-	const OPTION_ENABLE_MESSENGER = 'wc_facebook_enable_messenger';	
+	const OPTION_ENABLE_MESSENGER = 'wc_facebook_enable_messenger';
 
 	/** @var string|null the configured product catalog ID */
 	public $product_catalog_id;
@@ -900,27 +900,27 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		if ( isset( $_POST[ WC_Facebook_Product::FB_SIZE ] ) ) {
 			$woo_product->set_fb_size( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_SIZE ] ) ) );
 		}
-		
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_COLOR ] ) ) {
 			$woo_product->set_fb_color( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_COLOR ] ) ) );
 		}
-		
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_MATERIAL ] ) ) {
 			$woo_product->set_fb_material( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_MATERIAL ] ) ) );
 		}
-		
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_PATTERN ] ) ) {
 			$woo_product->set_fb_pattern( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PATTERN ] ) ) );
 		}
-		
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_AGE_GROUP ] ) ) {
 			$woo_product->set_fb_age_group( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_AGE_GROUP ] ) ) );
 		}
-		
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_GENDER ] ) ) {
 			$woo_product->set_fb_gender( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_GENDER ] ) ) );
 		}
-		
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_PRODUCT_CONDITION ] ) ) {
 			$woo_product->set_fb_condition( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PRODUCT_CONDITION ] ) ) );
 		}
@@ -3181,7 +3181,14 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 *
 	 */
 	public function use_enhanced_onboarding() {
-		return false;
+		$connection_handler              = facebook_for_woocommerce()->get_connection_handler();
+		$commerce_partner_integration_id = $connection_handler->get_commerce_partner_integration_id();
+
+		// If current connection is using the non-enhanced flow, don't show the new experience
+		if ( $connection_handler->is_connected() && empty( $commerce_partner_integration_id ) ) {
+			return false;
+		}
+		return true;
 	}
 
 }

--- a/includes/Admin/Abstract_Settings_Screen.php
+++ b/includes/Admin/Abstract_Settings_Screen.php
@@ -130,7 +130,7 @@ abstract class Abstract_Settings_Screen {
 		}
 		// assume we are on the Connection tab by default because the link under Marketing doesn't include the tab query arg
 		$connection_handler      = facebook_for_woocommerce()->get_connection_handler();
-		$use_enhanced_onboarding = facebook_for_woocommerce()->get_integration()->use_enhanced_onboarding();
+		$use_enhanced_onboarding = facebook_for_woocommerce()->use_enhanced_onboarding();
 		$default_tab             = $use_enhanced_onboarding ? 'shops' : ( $connection_handler->is_connected() ? 'advertise' : 'connection' );
 		$tab                     = Helper::get_requested_value( 'tab', $default_tab );
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -41,12 +41,14 @@ class Settings {
 	/**
 	 * Settings constructor.
 	 *
-	 * @param bool $is_connected is the state of the plugin connection to the Facebook Marketing API
+	 * @param \WC_Facebookcommerce $plugin facebook_for_woocommerce() instance
+	 * @param bool                 $is_connected is the state of the plugin connection to the Facebook Marketing API
+	 *
 	 * @since 2.0.0
 	 */
-	public function __construct( bool $is_connected ) {
+	public function __construct( \WC_Facebookcommerce $plugin, bool $is_connected ) {
 
-		$this->screens = $this->build_menu_item_array( $is_connected );
+		$this->screens = $this->build_menu_item_array( $plugin, $is_connected );
 
 		add_action( 'admin_menu', array( $this, 'add_menu_item' ) );
 		add_action( 'wp_loaded', array( $this, 'save' ) );
@@ -58,12 +60,14 @@ class Settings {
 	/**
 	 * Arranges the tabs. If the plugin is connected to FB, Advertise tab will be first, otherwise the Connection tab will be the first tab.
 	 *
-	 * @param bool $is_connected is Facebook connected
+	 * @param \WC_Facebookcommerce $plugin facebook_for_woocommerce() instance
+	 * @param bool                 $is_connected is Facebook connected
+	 *
 	 * @since 3.0.7
 	 */
-	private function build_menu_item_array( bool $is_connected ): array {
+	private function build_menu_item_array( \WC_Facebookcommerce $plugin, bool $is_connected ): array {
 		$advertise  = [ Settings_Screens\Advertise::ID => new Settings_Screens\Advertise() ];
-		$connection = [ Settings_Screens\Connection::ID => new Settings_Screens\Connection() ];
+		$connection = [ Settings_Screens\Connection::ID => new Settings_Screens\Connection( $plugin ) ];
 
 		$first = ( $is_connected ) ? $advertise : $connection;
 		$last  = ( $is_connected ) ? $connection : $advertise;

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -41,14 +41,12 @@ class Settings {
 	/**
 	 * Settings constructor.
 	 *
-	 * @param \WC_Facebookcommerce $plugin facebook_for_woocommerce() instance
-	 * @param bool                 $is_connected is the state of the plugin connection to the Facebook Marketing API
-	 *
+	 * @param bool $is_connected is the state of the plugin connection to the Facebook Marketing API
 	 * @since 2.0.0
 	 */
-	public function __construct( \WC_Facebookcommerce $plugin, bool $is_connected ) {
+	public function __construct( bool $is_connected ) {
 
-		$this->screens = $this->build_menu_item_array( $plugin, $is_connected );
+		$this->screens = $this->build_menu_item_array( $is_connected );
 
 		add_action( 'admin_menu', array( $this, 'add_menu_item' ) );
 		add_action( 'wp_loaded', array( $this, 'save' ) );
@@ -60,14 +58,12 @@ class Settings {
 	/**
 	 * Arranges the tabs. If the plugin is connected to FB, Advertise tab will be first, otherwise the Connection tab will be the first tab.
 	 *
-	 * @param \WC_Facebookcommerce $plugin facebook_for_woocommerce() instance
-	 * @param bool                 $is_connected is Facebook connected
-	 *
+	 * @param bool $is_connected is Facebook connected
 	 * @since 3.0.7
 	 */
-	private function build_menu_item_array( \WC_Facebookcommerce $plugin, bool $is_connected ): array {
+	private function build_menu_item_array( bool $is_connected ): array {
 		$advertise  = [ Settings_Screens\Advertise::ID => new Settings_Screens\Advertise() ];
-		$connection = [ Settings_Screens\Connection::ID => new Settings_Screens\Connection( $plugin ) ];
+		$connection = [ Settings_Screens\Connection::ID => new Settings_Screens\Connection() ];
 
 		$first = ( $is_connected ) ? $advertise : $connection;
 		$last  = ( $is_connected ) ? $connection : $advertise;

--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -19,7 +19,7 @@ use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
  * The Connection settings screen object.
  */
 class Connection extends Abstract_Settings_Screen {
-	/** @var \WC_Facebookcommerce */
+	/** @var \WC_Facebookcommerce facebook_for_woocommerce() instance */
 	protected $plugin;
 
 	/** @var string screen ID */
@@ -27,9 +27,11 @@ class Connection extends Abstract_Settings_Screen {
 
 	/**
 	 * Connection constructor.
+	 *
+	 * @param \WC_Facebookcommerce $plugin facebook_for_woocommerce() instance
 	 */
-	public function __construct( $plugin = null ) {
-		$this->plugin = $plugin ?? facebook_for_woocommerce();
+	public function __construct( $plugin ) {
+		$this->plugin = $plugin;
 
 		add_action( 'init', array( $this, 'initHook' ) );
 

--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -19,7 +19,8 @@ use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
  * The Connection settings screen object.
  */
 class Connection extends Abstract_Settings_Screen {
-
+	/** @var \WC_Facebookcommerce */
+	protected $plugin;
 
 	/** @var string screen ID */
 	const ID = 'connection';
@@ -27,7 +28,9 @@ class Connection extends Abstract_Settings_Screen {
 	/**
 	 * Connection constructor.
 	 */
-	public function __construct() {
+	public function __construct( $plugin = null ) {
+		$this->plugin = $plugin ?? facebook_for_woocommerce();
+
 		add_action( 'init', array( $this, 'initHook' ) );
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
@@ -76,13 +79,13 @@ class Connection extends Abstract_Settings_Screen {
 				__( '%1$sHeads up!%2$s It looks like there was a problem with reconnecting your site to Facebook. Please %3$sclick here%4$s to try again, or %5$sget in touch with our support team%6$s for assistance.', 'facebook-for-woocommerce' ),
 				'<strong>',
 				'</strong>',
-				'<a href="' . esc_url( facebook_for_woocommerce()->get_connection_handler()->get_connect_url() ) . '">',
+				'<a href="' . esc_url( $this->plugin->get_connection_handler()->get_connect_url() ) . '">',
 				'</a>',
-				'<a href="' . esc_url( facebook_for_woocommerce()->get_support_url() ) . '" target="_blank">',
+				'<a href="' . esc_url( $this->plugin->get_support_url() ) . '" target="_blank">',
 				'</a>'
 			);
 
-			facebook_for_woocommerce()->get_admin_notice_handler()->add_admin_notice(
+			$this->plugin->get_admin_notice_handler()->add_admin_notice(
 				$message,
 				'wc_facebook_connection_failed',
 				array(
@@ -106,7 +109,7 @@ class Connection extends Abstract_Settings_Screen {
 			return;
 		}
 
-		wp_enqueue_style( 'wc-facebook-admin-connection-settings', facebook_for_woocommerce()->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-connection.css', array(), \WC_Facebookcommerce::VERSION );
+		wp_enqueue_style( 'wc-facebook-admin-connection-settings', $this->plugin->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-connection.css', array(), \WC_Facebookcommerce::VERSION );
 	}
 
 
@@ -117,13 +120,13 @@ class Connection extends Abstract_Settings_Screen {
 	 */
 	public function render() {
 		// Check if we should render iframe
-		if ( facebook_for_woocommerce()->get_integration()->use_enhanced_onboarding() ) {
+		if ( $this->plugin->use_enhanced_onboarding() ) {
 			$this->render_facebook_iframe();
 
 			return;
 		}
 
-		$is_connected = facebook_for_woocommerce()->get_connection_handler()->is_connected();
+		$is_connected = $this->plugin->get_connection_handler()->is_connected();
 
 		// always render the CTA box
 		$this->render_facebook_box( $is_connected );
@@ -151,32 +154,32 @@ class Connection extends Abstract_Settings_Screen {
 		$static_items = array(
 			'page'                          => array(
 				'label' => __( 'Page', 'facebook-for-woocommerce' ),
-				'value' => facebook_for_woocommerce()->get_integration()->get_facebook_page_id(),
+				'value' => $this->plugin->get_integration()->get_facebook_page_id(),
 			),
 			'pixel'                         => array(
 				'label' => __( 'Pixel', 'facebook-for-woocommerce' ),
-				'value' => facebook_for_woocommerce()->get_integration()->get_facebook_pixel_id(),
+				'value' => $this->plugin->get_integration()->get_facebook_pixel_id(),
 			),
 			'catalog'                       => array(
 				'label' => __( 'Catalog', 'facebook-for-woocommerce' ),
-				'value' => facebook_for_woocommerce()->get_integration()->get_product_catalog_id(),
+				'value' => $this->plugin->get_integration()->get_product_catalog_id(),
 				'url'   => 'https://facebook.com/products',
 			),
 			'business-manager'              => array(
 				'label' => __( 'Business Manager account', 'facebook-for-woocommerce' ),
-				'value' => facebook_for_woocommerce()->get_connection_handler()->get_business_manager_id(),
+				'value' => $this->plugin->get_connection_handler()->get_business_manager_id(),
 			),
 			'ad-account'                    => array(
 				'label' => __( 'Ad Manager account', 'facebook-for-woocommerce' ),
-				'value' => facebook_for_woocommerce()->get_connection_handler()->get_ad_account_id(),
+				'value' => $this->plugin->get_connection_handler()->get_ad_account_id(),
 			),
 			'instagram-business-id'         => array(
 				'label' => __( 'Instagram Business ID', 'facebook-for-woocommerce' ),
-				'value' => facebook_for_woocommerce()->get_connection_handler()->get_instagram_business_id(),
+				'value' => $this->plugin->get_connection_handler()->get_instagram_business_id(),
 			),
 			'commerce-merchant-settings-id' => array(
 				'label' => __( 'Commerce Merchant Settings ID', 'facebook-for-woocommerce' ),
-				'value' => facebook_for_woocommerce()->get_connection_handler()->get_commerce_merchant_settings_id(),
+				'value' => $this->plugin->get_connection_handler()->get_commerce_merchant_settings_id(),
 			),
 		);
 
@@ -185,14 +188,14 @@ class Connection extends Abstract_Settings_Screen {
 		if ( ! empty( $catalog_id ) ) {
 			$static_items['catalog']['url'] = "https://www.facebook.com/commerce/catalogs/{$catalog_id}/products/";
 			try {
-				$response = facebook_for_woocommerce()->get_api()->get_catalog( $catalog_id );
+				$response = $this->plugin->get_api()->get_catalog( $catalog_id );
 				$name     = $response->name ?? '';
 				if ( $name ) {
 					$static_items['catalog']['value'] = $name;
 				}
 			} catch ( ApiException $exception ) {
 				// Log the exception with additional information
-				facebook_for_woocommerce()->log(
+				$this->plugin->log(
 					sprintf(
 						'Connection failed for catalog %s: %s ',
 						$catalog_id,
@@ -272,7 +275,7 @@ class Connection extends Abstract_Settings_Screen {
 	 * Renders the appropriate Facebook iframe based on connection status.
 	 */
 	private function render_facebook_iframe() {
-		$connection            = facebook_for_woocommerce()->get_connection_handler();
+		$connection            = $this->plugin->get_connection_handler();
 		$is_connected          = $connection->is_connected();
 		$merchant_access_token = get_option( 'wc_facebook_merchant_access_token', '' );
 
@@ -338,7 +341,7 @@ class Connection extends Abstract_Settings_Screen {
 			</ul>
 			<div class="actions">
 				<?php if ( $is_connected ) : ?>
-					<a href="<?php echo esc_url( facebook_for_woocommerce()->get_connection_handler()->get_disconnect_url() ); ?>"
+					<a href="<?php echo esc_url( $this->plugin->get_connection_handler()->get_disconnect_url() ); ?>"
 						class="button button-primary uninstall" onclick="return confirmDialog();">
 						<?php esc_html_e( 'Disconnect', 'facebook-for-woocommerce' ); ?>
 					</a>
@@ -348,7 +351,7 @@ class Connection extends Abstract_Settings_Screen {
 						}
 					</script>
 				<?php else : ?>
-					<a href="<?php echo esc_url( facebook_for_woocommerce()->get_connection_handler()->get_connect_url() ); ?>"
+					<a href="<?php echo esc_url( $this->plugin->get_connection_handler()->get_connect_url() ); ?>"
 						class="button button-primary">
 						<?php esc_html_e( 'Get Started', 'facebook-for-woocommerce' ); ?>
 					</a>
@@ -364,7 +367,7 @@ class Connection extends Abstract_Settings_Screen {
 	 * @since 3.5.0
 	 */
 	public function render_message_handler() {
-		if ( ! $this->is_current_screen_page() || ! facebook_for_woocommerce()->get_integration()->use_enhanced_onboarding() ) {
+		if ( ! $this->is_current_screen_page() || ! $this->plugin->use_enhanced_onboarding() ) {
 			return;
 		}
 		// Add the inline script as a dependent script

--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -60,28 +60,6 @@ class Connection extends Abstract_Settings_Screen {
 	}
 
 	/**
-	 * Determines if we should use enhanced onboarding.
-	 *
-	 * @return bool
-	 */
-	protected function use_enhanced_onboarding() {
-		// First check if the integration has enabled enhanced onboarding
-		$integration = facebook_for_woocommerce()->get_integration();
-		if ( ! $integration->use_enhanced_onboarding() ) {
-			return false;
-		}
-
-		// No connection, new user returns true
-		$connection_handler              = facebook_for_woocommerce()->get_connection_handler();
-		$commerce_partner_integration_id = $connection_handler->get_commerce_partner_integration_id();
-
-		if ( ! $connection_handler->is_connected() || ! empty( $commerce_partner_integration_id ) ) {
-			return true;
-		}
-		return false;
-	}
-
-	/**
 	 * Adds admin notices.
 	 *
 	 * @internal
@@ -139,7 +117,7 @@ class Connection extends Abstract_Settings_Screen {
 	 */
 	public function render() {
 		// Check if we should render iframe
-		if ( $this->use_enhanced_onboarding() ) {
+		if ( facebook_for_woocommerce()->get_integration()->use_enhanced_onboarding() ) {
 			$this->render_facebook_iframe();
 
 			return;
@@ -386,7 +364,7 @@ class Connection extends Abstract_Settings_Screen {
 	 * @since 3.5.0
 	 */
 	public function render_message_handler() {
-		if ( ! $this->is_current_screen_page() || ! $this->use_enhanced_onboarding() ) {
+		if ( ! $this->is_current_screen_page() || ! facebook_for_woocommerce()->get_integration()->use_enhanced_onboarding() ) {
 			return;
 		}
 		// Add the inline script as a dependent script

--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -19,20 +19,13 @@ use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
  * The Connection settings screen object.
  */
 class Connection extends Abstract_Settings_Screen {
-	/** @var \WC_Facebookcommerce facebook_for_woocommerce() instance */
-	protected $plugin;
-
 	/** @var string screen ID */
 	const ID = 'connection';
 
 	/**
 	 * Connection constructor.
-	 *
-	 * @param \WC_Facebookcommerce $plugin facebook_for_woocommerce() instance
 	 */
-	public function __construct( $plugin ) {
-		$this->plugin = $plugin;
-
+	public function __construct() {
 		add_action( 'init', array( $this, 'initHook' ) );
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
@@ -81,13 +74,13 @@ class Connection extends Abstract_Settings_Screen {
 				__( '%1$sHeads up!%2$s It looks like there was a problem with reconnecting your site to Facebook. Please %3$sclick here%4$s to try again, or %5$sget in touch with our support team%6$s for assistance.', 'facebook-for-woocommerce' ),
 				'<strong>',
 				'</strong>',
-				'<a href="' . esc_url( $this->plugin->get_connection_handler()->get_connect_url() ) . '">',
+				'<a href="' . esc_url( facebook_for_woocommerce()->get_connection_handler()->get_connect_url() ) . '">',
 				'</a>',
-				'<a href="' . esc_url( $this->plugin->get_support_url() ) . '" target="_blank">',
+				'<a href="' . esc_url( facebook_for_woocommerce()->get_support_url() ) . '" target="_blank">',
 				'</a>'
 			);
 
-			$this->plugin->get_admin_notice_handler()->add_admin_notice(
+			facebook_for_woocommerce()->get_admin_notice_handler()->add_admin_notice(
 				$message,
 				'wc_facebook_connection_failed',
 				array(
@@ -111,7 +104,7 @@ class Connection extends Abstract_Settings_Screen {
 			return;
 		}
 
-		wp_enqueue_style( 'wc-facebook-admin-connection-settings', $this->plugin->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-connection.css', array(), \WC_Facebookcommerce::VERSION );
+		wp_enqueue_style( 'wc-facebook-admin-connection-settings', facebook_for_woocommerce()->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-connection.css', array(), \WC_Facebookcommerce::VERSION );
 	}
 
 
@@ -122,13 +115,13 @@ class Connection extends Abstract_Settings_Screen {
 	 */
 	public function render() {
 		// Check if we should render iframe
-		if ( $this->plugin->use_enhanced_onboarding() ) {
+		if ( facebook_for_woocommerce()->use_enhanced_onboarding() ) {
 			$this->render_facebook_iframe();
 
 			return;
 		}
 
-		$is_connected = $this->plugin->get_connection_handler()->is_connected();
+		$is_connected = facebook_for_woocommerce()->get_connection_handler()->is_connected();
 
 		// always render the CTA box
 		$this->render_facebook_box( $is_connected );
@@ -156,32 +149,32 @@ class Connection extends Abstract_Settings_Screen {
 		$static_items = array(
 			'page'                          => array(
 				'label' => __( 'Page', 'facebook-for-woocommerce' ),
-				'value' => $this->plugin->get_integration()->get_facebook_page_id(),
+				'value' => facebook_for_woocommerce()->get_integration()->get_facebook_page_id(),
 			),
 			'pixel'                         => array(
 				'label' => __( 'Pixel', 'facebook-for-woocommerce' ),
-				'value' => $this->plugin->get_integration()->get_facebook_pixel_id(),
+				'value' => facebook_for_woocommerce()->get_integration()->get_facebook_pixel_id(),
 			),
 			'catalog'                       => array(
 				'label' => __( 'Catalog', 'facebook-for-woocommerce' ),
-				'value' => $this->plugin->get_integration()->get_product_catalog_id(),
+				'value' => facebook_for_woocommerce()->get_integration()->get_product_catalog_id(),
 				'url'   => 'https://facebook.com/products',
 			),
 			'business-manager'              => array(
 				'label' => __( 'Business Manager account', 'facebook-for-woocommerce' ),
-				'value' => $this->plugin->get_connection_handler()->get_business_manager_id(),
+				'value' => facebook_for_woocommerce()->get_connection_handler()->get_business_manager_id(),
 			),
 			'ad-account'                    => array(
 				'label' => __( 'Ad Manager account', 'facebook-for-woocommerce' ),
-				'value' => $this->plugin->get_connection_handler()->get_ad_account_id(),
+				'value' => facebook_for_woocommerce()->get_connection_handler()->get_ad_account_id(),
 			),
 			'instagram-business-id'         => array(
 				'label' => __( 'Instagram Business ID', 'facebook-for-woocommerce' ),
-				'value' => $this->plugin->get_connection_handler()->get_instagram_business_id(),
+				'value' => facebook_for_woocommerce()->get_connection_handler()->get_instagram_business_id(),
 			),
 			'commerce-merchant-settings-id' => array(
 				'label' => __( 'Commerce Merchant Settings ID', 'facebook-for-woocommerce' ),
-				'value' => $this->plugin->get_connection_handler()->get_commerce_merchant_settings_id(),
+				'value' => facebook_for_woocommerce()->get_connection_handler()->get_commerce_merchant_settings_id(),
 			),
 		);
 
@@ -190,14 +183,14 @@ class Connection extends Abstract_Settings_Screen {
 		if ( ! empty( $catalog_id ) ) {
 			$static_items['catalog']['url'] = "https://www.facebook.com/commerce/catalogs/{$catalog_id}/products/";
 			try {
-				$response = $this->plugin->get_api()->get_catalog( $catalog_id );
+				$response = facebook_for_woocommerce()->get_api()->get_catalog( $catalog_id );
 				$name     = $response->name ?? '';
 				if ( $name ) {
 					$static_items['catalog']['value'] = $name;
 				}
 			} catch ( ApiException $exception ) {
 				// Log the exception with additional information
-				$this->plugin->log(
+				facebook_for_woocommerce()->log(
 					sprintf(
 						'Connection failed for catalog %s: %s ',
 						$catalog_id,
@@ -277,7 +270,7 @@ class Connection extends Abstract_Settings_Screen {
 	 * Renders the appropriate Facebook iframe based on connection status.
 	 */
 	private function render_facebook_iframe() {
-		$connection            = $this->plugin->get_connection_handler();
+		$connection            = facebook_for_woocommerce()->get_connection_handler();
 		$is_connected          = $connection->is_connected();
 		$merchant_access_token = get_option( 'wc_facebook_merchant_access_token', '' );
 
@@ -343,7 +336,7 @@ class Connection extends Abstract_Settings_Screen {
 			</ul>
 			<div class="actions">
 				<?php if ( $is_connected ) : ?>
-					<a href="<?php echo esc_url( $this->plugin->get_connection_handler()->get_disconnect_url() ); ?>"
+					<a href="<?php echo esc_url( facebook_for_woocommerce()->get_connection_handler()->get_disconnect_url() ); ?>"
 						class="button button-primary uninstall" onclick="return confirmDialog();">
 						<?php esc_html_e( 'Disconnect', 'facebook-for-woocommerce' ); ?>
 					</a>
@@ -353,7 +346,7 @@ class Connection extends Abstract_Settings_Screen {
 						}
 					</script>
 				<?php else : ?>
-					<a href="<?php echo esc_url( $this->plugin->get_connection_handler()->get_connect_url() ); ?>"
+					<a href="<?php echo esc_url( facebook_for_woocommerce()->get_connection_handler()->get_connect_url() ); ?>"
 						class="button button-primary">
 						<?php esc_html_e( 'Get Started', 'facebook-for-woocommerce' ); ?>
 					</a>
@@ -369,7 +362,7 @@ class Connection extends Abstract_Settings_Screen {
 	 * @since 3.5.0
 	 */
 	public function render_message_handler() {
-		if ( ! $this->is_current_screen_page() || ! $this->plugin->use_enhanced_onboarding() ) {
+		if ( ! $this->is_current_screen_page() || ! facebook_for_woocommerce()->use_enhanced_onboarding() ) {
 			return;
 		}
 		// Add the inline script as a dependent script

--- a/tests/Unit/Admin/Settings/ConnectionTest.php
+++ b/tests/Unit/Admin/Settings/ConnectionTest.php
@@ -10,30 +10,31 @@ class ConnectionTest extends \WP_UnitTestCase {
 
     protected function setUp(): void {
         parent::setUp();
-        $this->connection = new Connection();
+        $this->connection = new Connection(facebook_for_woocommerce());
     }
 
     public function testEnqueueAssetsWhenNotOnPage(): void {
         // Mock is_current_screen_page to return false
         $connection = $this->getMockBuilder(Connection::class)
+	        ->setConstructorArgs([facebook_for_woocommerce()])
             ->onlyMethods(['is_current_screen_page'])
             ->getMock();
-        
+
         $connection->method('is_current_screen_page')
             ->willReturn(false);
-            
+
         // No styles should be enqueued
         $connection->enqueue_assets();
-        
+
         $this->assertFalse(wp_style_is('wc-facebook-admin-connection-settings'));
     }
 
     public function testGetSettings(): void {
         $settings = $this->connection->get_settings();
-        
+
         $this->assertIsArray($settings);
         $this->assertNotEmpty($settings);
-        
+
         // Check that the settings array has the expected structure
         $this->assertArrayHasKey('type', $settings[0]);
         $this->assertEquals('title', $settings[0]['type']);
@@ -42,12 +43,12 @@ class ConnectionTest extends \WP_UnitTestCase {
         $debug_setting = $settings[1];
         $this->assertEquals('checkbox', $debug_setting['type']);
         $this->assertEquals('yes', $debug_setting['default']);
-        
+
         // Check debug mode setting
         $debug_setting = $settings[2];
         $this->assertEquals('checkbox', $debug_setting['type']);
         $this->assertEquals('no', $debug_setting['default']);
-        
+
         // Check feed generator setting
         $feed_setting = $settings[3];
         $this->assertEquals('checkbox', $feed_setting['type']);

--- a/tests/Unit/Admin/Settings/ConnectionTest.php
+++ b/tests/Unit/Admin/Settings/ConnectionTest.php
@@ -16,7 +16,6 @@ class ConnectionTest extends \WP_UnitTestCase {
     public function testEnqueueAssetsWhenNotOnPage(): void {
         // Mock is_current_screen_page to return false
         $connection = $this->getMockBuilder(Connection::class)
-	        ->setConstructorArgs([facebook_for_woocommerce()])
             ->onlyMethods(['is_current_screen_page'])
             ->getMock();
 

--- a/tests/Unit/Admin/Settings/ConnectionTest.php
+++ b/tests/Unit/Admin/Settings/ConnectionTest.php
@@ -10,7 +10,7 @@ class ConnectionTest extends \WP_UnitTestCase {
 
     protected function setUp(): void {
         parent::setUp();
-        $this->connection = new Connection(facebook_for_woocommerce());
+        $this->connection = new Connection();
     }
 
     public function testEnqueueAssetsWhenNotOnPage(): void {

--- a/tests/Unit/Admin/Settings_Screens/ConnectionTest.php
+++ b/tests/Unit/Admin/Settings_Screens/ConnectionTest.php
@@ -87,6 +87,7 @@ class ConnectionTest extends TestCase {
     public function test_render_message_handler() {
         // Create a mock of the Connection class
         $connection_mock = $this->getMockBuilder(Connection::class)
+	        ->setConstructorArgs([facebook_for_woocommerce()])
             ->onlyMethods(['is_current_screen_page'])
             ->getMock();
 
@@ -113,7 +114,8 @@ class ConnectionTest extends TestCase {
      */
     public function test_render_message_handler_not_current_screen() {
         $connection_mock = $this->getMockBuilder(Connection::class)
-            ->onlyMethods(['is_current_screen_page'])
+	        ->setConstructorArgs([facebook_for_woocommerce()])
+	        ->onlyMethods(['is_current_screen_page'])
             ->getMock();
 
         $connection_mock->method('is_current_screen_page')
@@ -130,7 +132,7 @@ class ConnectionTest extends TestCase {
      * Test that the management URL is used when merchant token exists
      */
     public function test_renders_management_url_based_on_merchant_token() {
-		$connection = new Connection();
+		$connection = new Connection(facebook_for_woocommerce());
 
         // Set up the merchant token
         update_option('wc_facebook_merchant_access_token', 'test_token');

--- a/tests/Unit/Admin/Settings_Screens/ConnectionTest.php
+++ b/tests/Unit/Admin/Settings_Screens/ConnectionTest.php
@@ -43,6 +43,11 @@ class ConnectionTest extends TestCase {
             ->method('use_enhanced_onboarding')
             ->willReturn(true);
 
+        // Override the facebook_for_woocommerce method to return the mock
+	    add_filter('wc_facebook_instance', function() use ( $fb_for_wc ) {
+	        return $fb_for_wc;
+	    });
+
         // Start output buffering to capture the render output
 	    $connection = new Connection($fb_for_wc);
         ob_start();
@@ -68,6 +73,11 @@ class ConnectionTest extends TestCase {
 		$fb_for_wc->expects($this->once())
 		          ->method('use_enhanced_onboarding')
 		          ->willReturn(false);
+
+		// Override the facebook_for_woocommerce method to return the mock
+		add_filter('wc_facebook_instance', function() use ( $fb_for_wc ) {
+			return $fb_for_wc;
+		});
 
 		// Start output buffering to capture the render output
 		$connection = new Connection($fb_for_wc);

--- a/tests/Unit/Admin/Settings_Screens/ConnectionTest.php
+++ b/tests/Unit/Admin/Settings_Screens/ConnectionTest.php
@@ -49,7 +49,7 @@ class ConnectionTest extends TestCase {
 	    });
 
         // Start output buffering to capture the render output
-	    $connection = new Connection($fb_for_wc);
+	    $connection = new Connection();
         ob_start();
         $connection->render();
         $output = ob_get_clean();
@@ -80,7 +80,7 @@ class ConnectionTest extends TestCase {
 		});
 
 		// Start output buffering to capture the render output
-		$connection = new Connection($fb_for_wc);
+		$connection = new Connection();
 		ob_start();
 		$connection->render();
 		$output = ob_get_clean();
@@ -97,7 +97,6 @@ class ConnectionTest extends TestCase {
     public function test_render_message_handler() {
         // Create a mock of the Connection class
         $connection_mock = $this->getMockBuilder(Connection::class)
-	        ->setConstructorArgs([facebook_for_woocommerce()])
             ->onlyMethods(['is_current_screen_page'])
             ->getMock();
 
@@ -124,7 +123,6 @@ class ConnectionTest extends TestCase {
      */
     public function test_render_message_handler_not_current_screen() {
         $connection_mock = $this->getMockBuilder(Connection::class)
-	        ->setConstructorArgs([facebook_for_woocommerce()])
 	        ->onlyMethods(['is_current_screen_page'])
             ->getMock();
 
@@ -142,7 +140,7 @@ class ConnectionTest extends TestCase {
      * Test that the management URL is used when merchant token exists
      */
     public function test_renders_management_url_based_on_merchant_token() {
-		$connection = new Connection(facebook_for_woocommerce());
+		$connection = new Connection();
 
         // Set up the merchant token
         update_option('wc_facebook_merchant_access_token', 'test_token');

--- a/tests/Unit/Admin/Settings_Screens/ConnectionTest.php
+++ b/tests/Unit/Admin/Settings_Screens/ConnectionTest.php
@@ -2,21 +2,15 @@
 namespace WooCommerce\Facebook\Tests\Unit\Admin\Settings_Screens;
 
 use PHPUnit\Framework\TestCase;
+use WC_Facebookcommerce;
 use WooCommerce\Facebook\Admin\Settings_Screens\Connection;
 
 /**
  * Class ConnectionTest
- * 
+ *
  * @package WooCommerce\Facebook\Tests\Unit\Admin\Settings_Screens
  */
 class ConnectionTest extends TestCase {
-    /** @var Connection */
-    private $connection;
-
-    protected function setUp(): void {
-        parent::setUp();
-        $this->connection = new Connection();
-    }
 
     /**
      * Helper method to invoke private/protected methods
@@ -31,65 +25,61 @@ class ConnectionTest extends TestCase {
         $reflection = new \ReflectionClass(get_class($object));
         $method = $reflection->getMethod($methodName);
         $method->setAccessible(true);
-        
+
         return $method->invokeArgs($object, $parameters);
-    }
-
-    /**
-     * Test that iframe connection can be enabled or disabled
-     */
-    public function test_use_iframe_connection() {
-        // Test the actual implementation (currently returns false)
-        $reflection = new \ReflectionClass($this->connection);
-        $method = $reflection->getMethod('use_enhanced_onboarding');
-        $method->setAccessible(true);
-
-        // REMOVE WHEN READY TO RELEASE ENHANCED ONBOARDING FLOW
-        // Test to ensure that the use_enhanced_onboarding method returns false
-        $actual_value = $method->invoke($this->connection);
-        $this->assertFalse($actual_value);
-        
-        // Create a mock that returns true for testing the true case
-        $connection_mock = $this->getMockBuilder(Connection::class)
-            ->onlyMethods(['use_enhanced_onboarding'])
-            ->getMock();
-        
-        $connection_mock->method('use_enhanced_onboarding')
-            ->willReturn(true);
-            
-        // Use reflection to call the protected method on the mock
-        $reflection = new \ReflectionClass($connection_mock);
-        $method = $reflection->getMethod('use_enhanced_onboarding');
-        $method->setAccessible(true);
-        $mock_value = $method->invoke($connection_mock);
-        
-        $this->assertTrue($mock_value);
     }
 
     /**
      * Test that render method calls render_facebook_iframe when enhanced onboarding is enabled
      */
     public function test_render_facebook_box_iframe() {
-        // Create a partial mock of the Connection class
-        $connection = $this->getMockBuilder(Connection::class)
+        // Create a partial mock of the facebook_for_woocommerce() class
+        $fb_for_wc = $this->getMockBuilder(WC_Facebookcommerce::class)
             ->onlyMethods(['use_enhanced_onboarding'])
             ->getMock();
-        
+
         // Configure the mock to return true for use_enhanced_onboarding
-        $connection->expects($this->once())
+	    $fb_for_wc->expects($this->once())
             ->method('use_enhanced_onboarding')
             ->willReturn(true);
-            
+
         // Start output buffering to capture the render output
+	    $connection = new Connection($fb_for_wc);
         ob_start();
         $connection->render();
         $output = ob_get_clean();
-        
+
         // Since we can't directly test the private render_facebook_iframe method,
         // we'll verify that the render method doesn't output the legacy Facebook box
         // when enhanced onboarding is enabled
         $this->assertStringNotContainsString('wc-facebook-connection-box', $output);
     }
+
+	/**
+	 * Test that render method calls render_facebook_iframe when enhanced onboarding is disabled
+	 */
+	public function test_render_facebook_box_legacy() {
+		// Create a partial mock of the facebook_for_woocommerce() class
+		$fb_for_wc = $this->getMockBuilder(WC_Facebookcommerce::class)
+		                  ->onlyMethods(['use_enhanced_onboarding'])
+		                  ->getMock();
+
+		// Configure the mock to return false for use_enhanced_onboarding
+		$fb_for_wc->expects($this->once())
+		          ->method('use_enhanced_onboarding')
+		          ->willReturn(false);
+
+		// Start output buffering to capture the render output
+		$connection = new Connection($fb_for_wc);
+		ob_start();
+		$connection->render();
+		$output = ob_get_clean();
+
+		// Since we can't directly test the private render_facebook_iframe method,
+		// we'll verify that the render method doesn't output the legacy Facebook box
+		// when enhanced onboarding is enabled
+		$this->assertStringContainsString('wc-facebook-connection-box', $output);
+	}
 
     /**
      * Test that render_message_handler outputs the expected JavaScript
@@ -97,17 +87,13 @@ class ConnectionTest extends TestCase {
     public function test_render_message_handler() {
         // Create a mock of the Connection class
         $connection_mock = $this->getMockBuilder(Connection::class)
-            ->onlyMethods(['is_current_screen_page', 'use_enhanced_onboarding'])
+            ->onlyMethods(['is_current_screen_page'])
             ->getMock();
 
         // Configure the mock to return true for is_current_screen_page
         $connection_mock->method('is_current_screen_page')
             ->willReturn(true);
-            
-        // Configure the mock to return true for use_enhanced_onboarding
-        $connection_mock->method('use_enhanced_onboarding')
-            ->willReturn(true);
-        
+
         // Call the method
         $output = $connection_mock->generate_inline_enhanced_onboarding_script();
 
@@ -116,7 +102,7 @@ class ConnectionTest extends TestCase {
         $this->assertStringContainsString('CommerceExtension::INSTALL', $output);
         $this->assertStringContainsString('CommerceExtension::RESIZE', $output);
         $this->assertStringContainsString('CommerceExtension::UNINSTALL', $output);
-        
+
         // Assert fetch request setup - check for wpApiSettings.root instead of hardcoded path
         $this->assertStringContainsString('GeneratePluginAPIClient', $output);
         $this->assertStringContainsString('fbAPI.updateSettings', $output);
@@ -129,7 +115,7 @@ class ConnectionTest extends TestCase {
         $connection_mock = $this->getMockBuilder(Connection::class)
             ->onlyMethods(['is_current_screen_page'])
             ->getMock();
-        
+
         $connection_mock->method('is_current_screen_page')
             ->willReturn(false);
 
@@ -144,26 +130,19 @@ class ConnectionTest extends TestCase {
      * Test that the management URL is used when merchant token exists
      */
     public function test_renders_management_url_based_on_merchant_token() {
-        // Create a mock for testing the private render_facebook_iframe method
-        $connection = $this->getMockBuilder(Connection::class)
-            ->onlyMethods(['use_enhanced_onboarding'])
-            ->getMock();
-        
-        $connection->expects($this->any())
-            ->method('use_enhanced_onboarding')
-            ->willReturn(true);
-        
+		$connection = new Connection();
+
         // Set up the merchant token
         update_option('wc_facebook_merchant_access_token', 'test_token');
-        
+
         // Use output buffering to capture the iframe HTML
         ob_start();
         $this->invoke_method($connection, 'render_facebook_iframe');
         $output = ob_get_clean();
-        
+
         // Check that the iframe is rendered
         $this->assertStringContainsString('<iframe', $output);
         $this->assertStringContainsString('frameborder="0"', $output);
         $this->assertStringContainsString('id="facebook-commerce-iframe"', $output);
     }
-} 
+}


### PR DESCRIPTION
## Description

If a user has connected to Meta using use_enhanced_onboarding=false, they should continue to see the old settings screens until they've disconnected. This currently doesn't see to be the case, as I was encountering the "Shops" tab when turning use_enhanced_onboarding to true while already connected.


This PR unifies our two separate use_enhanced_onboarding methods into a single one.

Unfortunately, there isn't a sufficient mocking framework available to override the global facebook_for_woocommerce() function in tests. Therefore this PR also updates a few of the classes to take in the plugin as a parameter in the constructor to allow for dependency injection.

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before
![image](https://github.com/user-attachments/assets/5564a310-072b-4cd4-8f04-5c2a15556b48)

### After
With legacy connection:
<img width="1436" alt="image" src="https://github.com/user-attachments/assets/112db84d-6994-49b5-b1e6-99fbf13b4dc9" />

After disconnecting legacy connection:
<img width="1988" alt="image" src="https://github.com/user-attachments/assets/63498114-91d3-49b3-bbe3-dbeaee937364" />

After reconnecting to Meta:
<img width="1993" alt="image" src="https://github.com/user-attachments/assets/1ed89ba9-a3cf-46c8-a456-93d4c4add1a5" />



## Test instructions

1. Connect to Meta
2. Set the final return statement in use_enhanced_onboarding to true
3. Observe the settings screen did not change
4. Disconnect shop 
5. Observe enhanced onboarding flow is now present


## Checklist

- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests and all the new and existing unit tests pass locally with my changes
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.


## Changelog entry

Fix legacy connection view when use_enhanced_onboarding is set to true
