### PR TITLE
Fix - Updated logic to choose/create the feed for product sync

### DIFF
--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -218,26 +218,15 @@ class Feed {
 	 * @internal
 	 */
 	public function retrieve_or_create_integration_feed_id() {
-		// Step 1 - Get feed ID if it is already available in local cache
-		$feed_id = facebook_for_woocommerce()->get_integration()->get_feed_id();
-		if ( $feed_id ) {
-			if ( self::validate_feed_exists( $feed_id ) ) {
-				WC_Facebookcommerce_Utils::log( 'Feed: feed_id = ' . $feed_id . ', from local cache was validated.' );
-				return $feed_id;
-			} else {
-				WC_Facebookcommerce_Utils::log( 'Feed: feed_id = ' . $feed_id . ', from local cache was invalidated.' );
-			}
-		}
-
-		// Step 2 - Query feeds data from Meta and filter the right one
-		$feed_id = self::query_and_filter_integration_feed_id();
+		// Attempt 1. Request feeds data from Meta and filter the right one
+		$feed_id = self::request_and_filter_integration_feed_id();
 		if ( $feed_id ) {
 			facebook_for_woocommerce()->get_integration()->update_feed_id( $feed_id );
-			WC_Facebookcommerce_Utils::log( 'Feed: feed_id = ' . $feed_id . ', queried and filtered from Meta API.' );
+			WC_Facebookcommerce_Utils::log( 'Feed: feed_id = ' . $feed_id . ', queried and selected from Meta API.' );
 			return $feed_id;
 		}
 
-		// Step 3 - Create a new feed
+		// Attempt 2. Create a new feed
 		$feed_id = self::create_feed_id();
 		if ( $feed_id ) {
 			facebook_for_woocommerce()->get_integration()->update_feed_id( $feed_id );
@@ -249,38 +238,6 @@ class Feed {
 	}
 
 	/**
-	 * Validates that provided feed ID still exists on the Meta side
-	 *
-	 * @param       string $feed_id the feed ID
-	 *
-	 * @return      bool true if the feed ID is valid
-	 *
-	 * @internal
-	 * @throws Exception|Error If there is an error getting feed nodes or if no catalog ID is available.
-	 */
-	private function validate_feed_exists( $feed_id ) {
-		try {
-			$catalog_id = facebook_for_woocommerce()->get_integration()->get_product_catalog_id();
-			if ( '' === $catalog_id ) {
-				throw new Error( 'No catalog ID' );
-			}
-			$feed_nodes = facebook_for_woocommerce()->get_api()->read_feeds( $catalog_id )->data;
-		} catch ( Exception $e ) {
-			$message = sprintf( 'There was an error trying to get feed nodes for catalog: %s', $e->getMessage() );
-			WC_Facebookcommerce_Utils::log( $message );
-			return '';
-		}
-
-		foreach ( $feed_nodes as $feed ) {
-			if ( $feed['id'] == $feed_id ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
 	 * Queries existing feeds for the integration catalog and filters
 	 * the plugin integration feed ID
 	 *
@@ -289,7 +246,7 @@ class Feed {
 	 * @internal
 	 * @throws Exception|Error If there is an error getting feed nodes, catalog, or if no catalog ID is available.
 	 */
-	private function query_and_filter_integration_feed_id() {
+	private function request_and_filter_integration_feed_id() {
 		try {
 			$catalog_id = facebook_for_woocommerce()->get_integration()->get_product_catalog_id();
 			if ( '' === $catalog_id ) {
@@ -306,20 +263,13 @@ class Feed {
 			return '';
 		}
 
-		try {
-			$catalog = facebook_for_woocommerce()->get_api()->get_catalog( $catalog_id );
-		} catch ( Exception $e ) {
-			$message = sprintf( 'There was an error trying to get a catalog: %s', $e->getMessage() );
-			WC_Facebookcommerce_Utils::log( $message );
-		}
 
 		/*
 			We need to detect which feed is the one that was created for Facebook for WooCommerce plugin usage.
 
 			We are detecting based on the name.
 			- Option 1. Plugin can create this feed name currently.
-			- Option 2 and 3. FBE creates a catalog with feed name '{catalog name} - Feed' or '{catalog name} – Feed' (short vs long dash)
-			- Option 4. Plugin used to create a feed name 'Initial product sync from WooCommerce. DO NOT DELETE.'
+			- Option 2. Plugin used to create a feed name 'Initial product sync from WooCommerce. DO NOT DELETE.'
 		*/
 		foreach ( $feed_nodes as $feed ) {
 			try {
@@ -330,15 +280,8 @@ class Feed {
 				continue;
 			}
 
-			$woo_feed_name_option_1 = self::FEED_NAME;
-			$woo_feed_name_option_2 = sprintf( '%s - Feed', $catalog['name'] );
-			$woo_feed_name_option_3 = sprintf( '%s – Feed', $catalog['name'] );
-			$woo_feed_name_option_4 = 'Initial product sync from WooCommerce. DO NOT DELETE.';
-
-			if ( $feed_metadata['name'] === $woo_feed_name_option_1 ||
-					$feed_metadata['name'] === $woo_feed_name_option_2 ||
-					$feed_metadata['name'] === $woo_feed_name_option_3 ||
-				$feed_metadata['name'] === $woo_feed_name_option_4 ) {
+			if ( $feed_metadata['name'] === self::FEED_NAME ||
+				$feed_metadata['name'] === 'Initial product sync from WooCommerce. DO NOT DELETE.' ) {
 				return $feed['id'];
 			}
 		}


### PR DESCRIPTION
## Description

Problem. We selecting a product feed for creating one-time feed upload sessions to sync products, we are prioritising to choose an existing product feed created by MBE onboarding.  The problem is that in production some of the catalogs have that default feed already in use for creating and updating products (from some 3rd party sources).  In those cases, by uploading new one-time feed upload sessions, we are deleting all products previously ingested by the feed (as 3rd party source are almost for sure have different population of product Retailer IDs).

Fix. We should avoid choosing the default MBE created feed and just choose/create the unique Facebook for WooCommerce plugin feed.

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## Screenshots
See below in the test plan.

## Test Plan
Manual testing on my catalog.
Before start, I have two feeds, including the default MBE feed, which was used by earlier logic:
<img width="1975" alt="Screenshot 2025-03-31 at 19 20 47" src="https://github.com/user-attachments/assets/d4af0d82-a34f-465d-ab6d-c3ddbc604eae" />

I manually triggered feed file generation, which then selects a feed and start the one-time upload session. The new feed was created and chosen.
<img width="1936" alt="Screenshot 2025-03-31 at 19 24 08" src="https://github.com/user-attachments/assets/7e3158d5-e34f-42fb-aaa5-dd3476a45e26" />
Have this reflected in the WooCommerce facebook log file:

<img width="2479" alt="Screenshot 2025-03-31 at 19 23 22" src="https://github.com/user-attachments/assets/65766d31-d9cd-4673-8ff5-cc12a3b75835" />

When triggered feed file generation again, the same feed (2096188910809232) was chosen. 


## Checklist

- [ ] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests and all the new and existing unit tests pass locally with my changes
- [ ] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.


## Changelog entry

Fix - Updated logic to choose/create the feed for product sync
