### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,21 +12,6 @@ Please delete options that are not relevant.
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
-
-## Screenshots
-Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
-### Before
-
-### After
-
-
-## Test instructions
-
-Please describe the tests that you ran to verify your changes. 
-Provide instructions so we can reproduce. 
-Please also list any relevant details for your test configuration.
-
-
 ## Checklist
 
 - [ ] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
@@ -38,3 +23,16 @@ Please also list any relevant details for your test configuration.
 ## Changelog entry
 
 One liner entry to be surfaced in changelog.txt
+
+
+## Test Plan
+
+Please describe the tests that you ran to verify your changes. 
+Provide instructions so we can reproduce. 
+Please also list any relevant details for your test configuration.
+
+## Screenshots
+Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
+### Before
+
+### After


### PR DESCRIPTION
## Description

For Meta Phabricator diff, we need to name the test section as "Test Plan" for it to automatically to go into the diff's "Test Plan". Also everything after the Test Plan keyphrase will go into the Test Plan, that's why I rearrange other sections too.  

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests and all the new and existing unit tests pass locally with my changes
- [ ] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.


## Changelog entry

Update PULL_REQUEST_TEMPLATE.md

## Test Plan
You will see this message in the Meta's Phabricator tool in the test section. 

## Screenshots
N/A



