### PR TITLE
Fix free shipping coupon sync

### DIFF
--- a/includes/Feed/FeedUploadUtils.php
+++ b/includes/Feed/FeedUploadUtils.php
@@ -163,9 +163,13 @@ class FeedUploadUtils {
 
 					// Map target type. Coupons that apply both a discount and free shipping are already
 					// filtered out in is_valid_coupon
-					$is_free_shipping = $coupon->get_free_shipping();
+					$is_free_shipping        = $coupon->get_free_shipping();
+					$target_shipping_options = '';
 					if ( $is_free_shipping ) {
-						$target_type = self::TARGET_TYPE_SHIPPING;
+						$target_type             = self::TARGET_TYPE_SHIPPING;
+						$value_type              = self::VALUE_TYPE_PERCENTAGE;
+						$percent_off             = '100'; // 100% off shipping
+						$target_shipping_options = [ 'STANDARD' ]; // options are STANDARD, RUSH, EXPEDITED, TWO_DAY
 					} else {
 						$target_type = self::TARGET_TYPE_LINE_ITEM;
 					}
@@ -212,7 +216,7 @@ class FeedUploadUtils {
 						'fixed_amount_off'                => $fixed_amount_off,
 						'application_type'                => self::APPLICATION_TYPE_BUYER_APPLIED,
 						'target_type'                     => $target_type,
-						'target_shipping_option_types'    => '', // Not needed for offsite checkout
+						'target_shipping_option_types'    => $target_shipping_options,
 						'target_granularity'              => $target_granularity,
 						'target_selection'                => $target_selection,
 						'start_date_time'                 => $start_date_time,

--- a/includes/Feed/PromotionsFeed.php
+++ b/includes/Feed/PromotionsFeed.php
@@ -25,7 +25,7 @@ use WooCommerce\Facebook\Utilities\Heartbeat;
  */
 class PromotionsFeed extends AbstractFeed {
 	/** Header for the promotions feed file. @var string */
-	const PROMOTIONS_FEED_HEADER = 'offer_id,title,value_type,percent_off,fixed_amount_off,application_type,target_type,target_shipipng_option_types,target_granularity,target_selection,start_date_time,end_date_time,coupon_codes,public_coupon_code,target_filter,target_product_retailer_ids,target_product_group_retailer_ids,target_product_set_retailer_ids,redeem_limit_per_user,min_subtotal,min_quantity,offer_terms,redemption_limit_per_seller,target_quantity,prerequisite_filter,prerequisite_product_retailer_ids,prerequisite_product_group_retailer_ids,prerequisite_product_set_retailer_ids,exclude_sale_priced_products' . PHP_EOL;
+	const PROMOTIONS_FEED_HEADER = 'offer_id,title,value_type,percent_off,fixed_amount_off,application_type,target_type,target_shipping_option_types,target_granularity,target_selection,start_date_time,end_date_time,coupon_codes,public_coupon_code,target_filter,target_product_retailer_ids,target_product_group_retailer_ids,target_product_set_retailer_ids,redeem_limit_per_user,min_subtotal,min_quantity,offer_terms,redemption_limit_per_seller,target_quantity,prerequisite_filter,prerequisite_product_retailer_ids,prerequisite_product_group_retailer_ids,prerequisite_product_set_retailer_ids,exclude_sale_priced_products' . PHP_EOL;
 
 	/**
 	 * Constructor for promotions feed.


### PR DESCRIPTION
## Description

Free shipping coupons are not properly syncing to Meta right now. 

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before
<img width="2125" alt="image" src="https://github.com/user-attachments/assets/4641f6ee-1c1c-4aff-8d52-0c3f802a5423" />


### After
<img width="1265" alt="image" src="https://github.com/user-attachments/assets/c214d0eb-06e6-4878-9cf7-b6532eae4af2" />


## Test instructions

- Create a coupon with free shipping
- Sync to Meta
- Observe the coupon is created in the offers list


## Checklist

- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests and all the new and existing unit tests pass locally with my changes
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.


## Changelog entry

Fix free shipping coupon syncing
