### PR TITLE
Add logging for feed generation scheduling failure

### DIFF
--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -169,6 +169,16 @@ class Feed {
 		$store_allows_feed = $configured_ok && $integration->is_legacy_feed_file_generation_enabled();
 		if ( ! $store_allows_sync || ! $store_allows_feed ) {
 			as_unschedule_all_actions( self::GENERATE_FEED_ACTION );
+
+			$message = '';
+			if ( ! $configured_ok ) {
+				$message = 'Integration not configured.';
+			} elseif ( ! $store_allows_feed ) {
+				$message = 'Store does not allow feed.';
+			} elseif ( ! $store_allows_sync ) {
+				$message = 'Store does not allow sync.';
+			}
+			WC_Facebookcommerce_Utils::log( sprintf( 'Product feed scheduling failed: %s', $message ) );
 			return;
 		}
 

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -182,6 +182,7 @@ class Feed {
 				sprintf( 'Product feed scheduling failed: %s', $message ),
 				array(
 					'flow_name' => 'product_feed',
+					'flow_step' => 'schedule_feed_generation',
 				)
 			);
 			return;

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -178,7 +178,12 @@ class Feed {
 			} elseif ( ! $store_allows_sync ) {
 				$message = 'Store does not allow sync.';
 			}
-			WC_Facebookcommerce_Utils::log( sprintf( 'Product feed scheduling failed: %s', $message ) );
+			WC_Facebookcommerce_Utils::logToMeta(
+				sprintf( 'Product feed scheduling failed: %s', $message ),
+				array(
+					'flow_name' => 'product_feed',
+				)
+			);
 			return;
 		}
 


### PR DESCRIPTION
## Description

During dogfooding, I have been using this testing branch which adds various log messages:
https://github.com/facebook/facebook-for-woocommerce/compare/main...carterbuce:facebook-for-woocommerce:dogfooding-testing-mice

While a lot of these messages would add noise if we were to add them to the main branch, the additional error logging in schedule_feed_generation has been an extremely helpful debugging tool. This PR adds that logging to the debug log file.

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before

### After


## Test instructions

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration.


## Checklist

- [ ] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests and all the new and existing unit tests pass locally with my changes
- [ ] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.


## Changelog entry

Add error logging to schedule_feed_generation
