### PR TITLE
Trigger feed uploads on onboarding completion

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -133,7 +133,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	const OPTION_HAS_AUTHORIZED_PAGES_READ_ENGAGEMENT = 'wc_facebook_has_authorized_pages_read_engagement';
 
 	/** @var string the WordPress option name where the messenger chat status is stored */
-	const OPTION_ENABLE_MESSENGER = 'wc_facebook_enable_messenger';	
+	const OPTION_ENABLE_MESSENGER = 'wc_facebook_enable_messenger';
 
 	/** @var string|null the configured product catalog ID */
 	public $product_catalog_id;
@@ -900,27 +900,27 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		if ( isset( $_POST[ WC_Facebook_Product::FB_SIZE ] ) ) {
 			$woo_product->set_fb_size( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_SIZE ] ) ) );
 		}
-		
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_COLOR ] ) ) {
 			$woo_product->set_fb_color( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_COLOR ] ) ) );
 		}
-		
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_MATERIAL ] ) ) {
 			$woo_product->set_fb_material( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_MATERIAL ] ) ) );
 		}
-		
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_PATTERN ] ) ) {
 			$woo_product->set_fb_pattern( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PATTERN ] ) ) );
 		}
-		
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_AGE_GROUP ] ) ) {
 			$woo_product->set_fb_age_group( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_AGE_GROUP ] ) ) );
 		}
-		
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_GENDER ] ) ) {
 			$woo_product->set_fb_gender( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_GENDER ] ) ) );
 		}
-		
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_PRODUCT_CONDITION ] ) ) {
 			$woo_product->set_fb_condition( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PRODUCT_CONDITION ] ) ) );
 		}

--- a/includes/API/Plugin/Settings/Handler.php
+++ b/includes/API/Plugin/Settings/Handler.php
@@ -62,7 +62,7 @@ class Handler extends AbstractRESTEndpoint {
 	 * @param \WP_REST_Request $wp_request The WordPress request object.
 	 * @return \WP_REST_Response
 	 */
-	public function handle_update( \WP_REST_Request $wp_request ) {
+	public function handle_update( \WP_REST_Request $wp_request ): \WP_REST_Response {
 		try {
 			$request           = new UpdateRequest( $wp_request );
 			$request_data      = $request->get_data();
@@ -75,8 +75,11 @@ class Handler extends AbstractRESTEndpoint {
 				);
 			}
 
-			// Maybe trigger products sync and/or metadata feed uploads
-			$this->maybe_trigger_feed_uploads( $request_data );
+			// Check if we should trigger product sync and/or metadata feed uploads for this update
+			// Only trigger product sync if catalog id is being updated
+			$should_trigger_product_sync = ! empty( $params['product_catalog_id'] ) && facebook_for_woocommerce()->get_integration()->get_product_catalog_id() !== $params['product_catalog_id'];
+			// Only trigger metadata feed uploads if CPI id is being updated
+			$should_trigger_metadata_feed_uploads = ! empty( $params['commerce_partner_integration_id'] ) && facebook_for_woocommerce()->get_connection_handler()->get_commerce_partner_integration_id() !== $params['commerce_partner_integration_id'];
 
 			// Map parameters to options and update settings
 			$options = $this->map_params_to_options( $request_data );
@@ -84,6 +87,9 @@ class Handler extends AbstractRESTEndpoint {
 
 			// Update connection status flags
 			$this->update_connection_status( $request_data );
+
+			// Maybe trigger products sync and/or metadata feed uploads
+			$this->maybe_trigger_feed_uploads( $should_trigger_product_sync, $should_trigger_metadata_feed_uploads, $request_data );
 
 			return $this->success_response(
 				[
@@ -108,7 +114,7 @@ class Handler extends AbstractRESTEndpoint {
 	 * @param \WP_REST_Request $wp_request The WordPress request object.
 	 * @return \WP_REST_Response
 	 */
-	public function handle_uninstall( \WP_REST_Request $wp_request ) {
+	public function handle_uninstall( \WP_REST_Request $wp_request ): \WP_REST_Response {
 		try {
 			$request           = new UninstallRequest( $wp_request );
 			$validation_result = $request->validate();
@@ -144,7 +150,7 @@ class Handler extends AbstractRESTEndpoint {
 	 * @param array $params Request parameters.
 	 * @return array Mapped options.
 	 */
-	private function map_params_to_options( $params ) {
+	private function map_params_to_options( array $params ): array {
 		$options = [];
 
 		// Map access tokens
@@ -196,7 +202,7 @@ class Handler extends AbstractRESTEndpoint {
 	 * @param array $settings Array of settings to update.
 	 * @return void
 	 */
-	private function update_settings( $settings ) {
+	private function update_settings( array $settings ) {
 		foreach ( $settings as $key => $value ) {
 			if ( ! empty( $key ) ) {
 				update_option( $key, $value );
@@ -212,7 +218,7 @@ class Handler extends AbstractRESTEndpoint {
 	 * @param array $params Request parameters.
 	 * @return void
 	 */
-	private function update_connection_status( $params ) {
+	private function update_connection_status( array $params ) {
 		// Set the connection is complete
 		update_option( 'wc_facebook_has_connected_fbe_2', 'yes' );
 		update_option( 'wc_facebook_has_authorized_pages_read_engagement', 'yes' );
@@ -257,13 +263,14 @@ class Handler extends AbstractRESTEndpoint {
 	 *
 	 * @since 3.5.0
 	 *
-	 * @param array $params Request parameters.
+	 * @param bool  $should_trigger_product_sync
+	 * @param bool  $should_trigger_metadata_feed_uploads
+	 * @param array $params
 	 * @return void
 	 */
-	private function maybe_trigger_feed_uploads( $params ) {
-		// Only sync products if catalog id has been updated.
+	private function maybe_trigger_feed_uploads( bool $should_trigger_product_sync, bool $should_trigger_metadata_feed_uploads, array $params ) {
 		try {
-			if ( ! empty( $params['product_catalog_id'] ) && facebook_for_woocommerce()->get_integration()->get_product_catalog_id() !== $params['product_catalog_id'] ) {
+			if ( $should_trigger_product_sync ) {
 				// Allow opt-out of full batch-API sync, for example if store has a large number of products.
 				if ( facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
 					facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_all_products();
@@ -283,9 +290,8 @@ class Handler extends AbstractRESTEndpoint {
 				]
 			);
 		}
-		// Only trigger metadata feed uploads if commerce partner integration id has been updated.
 		try {
-			if ( ! empty( $params['commerce_partner_integration_id'] ) && facebook_for_woocommerce()->get_connection_handler()->get_commerce_partner_integration_id() !== $params['commerce_partner_integration_id'] ) {
+			if ( $should_trigger_metadata_feed_uploads ) {
 				facebook_for_woocommerce()->feed_manager->run_all_feed_uploads();
 			}
 		} catch ( \Exception $exception ) {

--- a/includes/API/Plugin/Settings/Handler.php
+++ b/includes/API/Plugin/Settings/Handler.php
@@ -253,6 +253,7 @@ class Handler extends AbstractRESTEndpoint {
 
 	/**
 	 * Triggers products sync if catalog id is being set to a different value.
+	 * Triggers metadata feed uploads if CPI id is being set to a different value.
 	 *
 	 * @since 3.5.0
 	 *
@@ -277,7 +278,24 @@ class Handler extends AbstractRESTEndpoint {
 					'event'      => 'product_sync',
 					'event_type' => 'sync_products_after_settings_update',
 					'extra_data' => [
-						'message' => 'failed sync products during the update settings request.',
+						'params' => wp_json_encode( $params ),
+					],
+				]
+			);
+		}
+		// Only trigger metadata feed uploads if commerce partner integration id has been updated.
+		try {
+			if ( ! empty( $params['commerce_partner_integration_id'] ) && facebook_for_woocommerce()->get_connection_handler()->get_commerce_partner_integration_id() !== $params['commerce_partner_integration_id'] ) {
+				facebook_for_woocommerce()->feed_manager->run_all_feed_uploads();
+			}
+		} catch ( \Exception $exception ) {
+			\WC_Facebookcommerce_Utils::logExceptionImmediatelyToMeta(
+				$exception,
+				[
+					'event'      => 'feed_upload',
+					'event_type' => 'trigger_feed_uploads_after_settings_update',
+					'extra_data' => [
+						'params' => wp_json_encode( $params ),
 					],
 				]
 			);

--- a/includes/API/Plugin/Settings/Handler.php
+++ b/includes/API/Plugin/Settings/Handler.php
@@ -77,9 +77,9 @@ class Handler extends AbstractRESTEndpoint {
 
 			// Check if we should trigger product sync and/or metadata feed uploads for this update
 			// Only trigger product sync if catalog id is being updated
-			$should_trigger_product_sync = ! empty( $params['product_catalog_id'] ) && facebook_for_woocommerce()->get_integration()->get_product_catalog_id() !== $params['product_catalog_id'];
+			$should_trigger_product_sync = ! empty( $request_data['product_catalog_id'] ) && facebook_for_woocommerce()->get_integration()->get_product_catalog_id() !== $request_data['product_catalog_id'];
 			// Only trigger metadata feed uploads if CPI id is being updated
-			$should_trigger_metadata_feed_uploads = ! empty( $params['commerce_partner_integration_id'] ) && facebook_for_woocommerce()->get_connection_handler()->get_commerce_partner_integration_id() !== $params['commerce_partner_integration_id'];
+			$should_trigger_metadata_feed_uploads = ! empty( $request_data['commerce_partner_integration_id'] ) && facebook_for_woocommerce()->get_connection_handler()->get_commerce_partner_integration_id() !== $request_data['commerce_partner_integration_id'];
 
 			// Map parameters to options and update settings
 			$options = $this->map_params_to_options( $request_data );

--- a/includes/Feed/FeedManager.php
+++ b/includes/Feed/FeedManager.php
@@ -88,6 +88,18 @@ class FeedManager {
 	}
 
 	/**
+	 * Run all feed uploads.
+	 *
+	 * @return void
+	 * @since 3.5.0
+	 */
+	public function run_all_feed_uploads(): void {
+		foreach ( $this->feed_instances as $feed_type ) {
+			$feed_type->regenerate_feed();
+		}
+	}
+
+	/**
 	 * Get the feed instance for the given feed type.
 	 *
 	 * @param string $feed_type the specific feed in question.


### PR DESCRIPTION
## Description

This PR builds on https://github.com/facebook/facebook-for-woocommerce/pull/2983 to trigger metadata feed uploads to run if CPI ID is updated (will have metadata feed uploads triggered on onboarding completion).

To accomplish this a new run_all_feed_uploads() function was added to FeedManager to call to trigger all of the feed uploads to run.

The logic of handle_update() was updated a little bit as well. We only want to trigger catalog sync if catalog ID is being updated and only trigger the metadata feed uploads if CPI ID is being updated. Previously we were checking if these values were being updated and then triggering the sync/feed uploads before calling update_settings(). The product sync/feed uploads logic depends on the values that are being updated though. So we actually need to be checking to see if the values are being updated before calling update_settings() but then we shouldn't actually trigger the sync/feed uploads until after calling update_settings().

I also went through and fixed several lint warnings I found in facebook-commerce.php and Handler.php

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Test instructions
1. Locally changed maybe_trigger_feed_uploads() to be public instead of private (so it could be called from WP Console) and then pushed the code to my lightsail instance
2. Used WP Console to run some code to manually test the new logic
3. Verified that when $should_trigger_metadata_feed_uploads is true that the call to maybe_trigger_feed_uploads() triggers the metadata feed uploads
![Screenshot 2025-03-31 at 2 22 49 PM](https://github.com/user-attachments/assets/05ec497f-ba9e-48d4-91ef-c2689c0d86d5)
![Screenshot 2025-03-31 at 2 23 16 PM](https://github.com/user-attachments/assets/fd8ee0c4-7d13-4a70-9358-ee0a0fb575e3)
4. Verified that when $should_trigger_metadata_feed_uploads is false that the call to maybe_trigger_feed_uploads() doesn't trigger the metadata feed uploads (no logs on Meta side for calls to GraphCommercePartnerIntegrationFileUpdatePost)
![Screenshot 2025-03-31 at 2 26 45 PM](https://github.com/user-attachments/assets/b220bc58-95d9-49ce-bf1b-eb159a824a23)

## Checklist

- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests and all the new and existing unit tests pass locally with my changes
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.


## Changelog entry

Triggering metadata feed uploads to run on CPI ID update
