### PR TITLE
 Clean up CSS in enhanced settings UI

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-connection.css
+++ b/assets/css/admin/facebook-for-woocommerce-connection.css
@@ -82,14 +82,6 @@
 	min-height: calc(100vh - 200px);
 }
 
-#facebook-commerce-iframe-enhanced {
-	width: 100%;
-	max-width: 1100px;
-	min-height: calc(100vh - 200px);
-	background: transparent;
-	border: none;
-}
-
 .woocommerce-embed-page #wpbody-content {
 	padding-bottom: 0;
 }

--- a/assets/css/admin/facebook-for-woocommerce-shops.css
+++ b/assets/css/admin/facebook-for-woocommerce-shops.css
@@ -1,0 +1,80 @@
+#facebook-commerce-iframe-enhanced {
+	width: 100%;
+	max-width: 1100px;
+	min-height: calc(100vh - 200px);
+	background: transparent;
+	border: none;
+}
+
+.centered-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    margin-top: 20px;
+}
+
+.drawer-toggle-button {
+    width: 100%;
+    max-width: 1100px;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    padding: 10px 20px;
+    text-align: left;
+    cursor: pointer;
+    font-size: 16px;
+    font-weight: 600;
+    position: relative;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+                box-sizing: border-box;
+}
+
+.drawer-toggle-button:hover {
+    background-color: #f9f9f9;
+}
+
+.caret {
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 5px solid #000;
+    transition: transform 0.3s ease;
+}
+
+.settings-drawer {
+    width: 100%;
+    max-width: 1100px;
+    background-color: #fff;
+    border-bottom: 1px solid #ccc;
+                border-right: 1px solid #ccc;
+                border-left: 1px solid #ccc;
+    overflow: hidden;
+    transition: max-height 0.3s ease, margin-bottom 0.3s ease;
+    max-height: 0;
+    margin: 0 auto;
+                box-sizing: border-box;
+}
+
+.settings-drawer-content {
+    padding: 20px;
+    padding-bottom: 0;
+}
+
+.button:disabled {
+    background-color: #f1f1f1;
+    cursor: not-allowed;
+}
+
+.sync-description {
+    font-size: 12px;
+    color: #666;
+    padding-top: 8px;
+}
+
+.woocommerce-embed-page #wpbody-content {
+	padding-bottom: 0;
+}

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -3181,7 +3181,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 *
 	 */
 	public function use_enhanced_onboarding() {
-		return false;
+		return true;
 	}
 
 }

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -3181,7 +3181,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 *
 	 */
 	public function use_enhanced_onboarding() {
-		return true;
+		return false;
 	}
 
 }

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -112,7 +112,7 @@ class Shops extends Abstract_Settings_Screen {
 			return;
 		}
 
-		wp_enqueue_style( 'wc-facebook-admin-connection-settings', facebook_for_woocommerce()->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-connection.css', array(), \WC_Facebookcommerce::VERSION );
+		wp_enqueue_style( 'wc-facebook-admin-shops-settings', facebook_for_woocommerce()->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-shops.css', array(), \WC_Facebookcommerce::VERSION );
 
 		wp_enqueue_script(
 			'wc-facebook-enhanced-settings-sync',
@@ -191,7 +191,6 @@ class Shops extends Abstract_Settings_Screen {
 	 */
 	private function render_troubleshooting_button_and_drawer() {
 		?>
-	<!-- Toggle Button -->
 	<div class="centered-container">
 		<button id="toggle-troubleshooting-drawer" class="drawer-toggle-button">
 			Troubleshooting
@@ -199,12 +198,11 @@ class Shops extends Abstract_Settings_Screen {
 		</button>
 	</div>
 
-	<!-- Drawer -->
 	<div id="troubleshooting-drawer" class="settings-drawer" style="display: none;">
 		<div class="settings-drawer-content">
 			<table class="form-table">
 				<tbody>
-					<tr valign="top" class="wc-facebook-connected-sample">
+					<tr valign="top" class="wc-facebook-shops-sample">
 						<th scope="row" class="titledesc">
 							Product data sync
 						</th>
@@ -220,7 +218,7 @@ class Shops extends Abstract_Settings_Screen {
 							</p>
 						</td>
 					</tr>
-					<tr valign="top" class="wc-facebook-connected-sample">
+					<tr valign="top" class="wc-facebook-shops-sample">
 						<th scope="row" class="titledesc">
 							Coupon codes sync
 						</th>
@@ -242,79 +240,7 @@ class Shops extends Abstract_Settings_Screen {
 		</div>
 	</div>
 
-	<style>
-		.centered-container {
-			display: flex;
-			justify-content: center;
-			align-items: center;
-			width: 100%;
-			margin-top: 20px;
-		}
-
-		.drawer-toggle-button {
-			width: 100%;
-			max-width: 1100px;
-			background-color: #fff;
-			border: 1px solid #ccc;
-			padding: 10px 20px;
-			text-align: left;
-			cursor: pointer;
-			font-size: 16px;
-			font-weight: 600;
-			position: relative;
-			display: flex;
-			justify-content: space-between;
-			align-items: center;
-			margin-bottom: 20px;
-			box-sizing: border-box;
-		}
-
-		.drawer-toggle-button:hover {
-			background-color: #f9f9f9;
-		}
-
-		.caret {
-			width: 0;
-			height: 0;
-			border-left: 5px solid transparent;
-			border-right: 5px solid transparent;
-			border-top: 5px solid #000;
-			transition: transform 0.3s ease;
-		}
-
-		.settings-drawer {
-			width: 100%;
-			max-width: 1100px;
-			background-color: #fff;
-			border-bottom: 1px solid #ccc;
-			border-right: 1px solid #ccc;
-			border-left: 1px solid #ccc;
-			overflow: hidden;
-			transition: max-height 0.3s ease, margin-bottom 0.3s ease;
-			max-height: 0;
-			margin: 0 auto;
-			box-sizing: border-box;
-		}
-
-		.settings-drawer-content {
-			padding: 20px;
-			padding-bottom: 0;
-		}
-
-		.button:disabled {
-			background-color: #f1f1f1;
-			cursor: not-allowed;
-		}
-
-		.sync-description {
-			font-size: 12px;
-			color: #666;
-			padding-top: 8px;
-		}
-	</style>
-
 	<script>
-		// Toggle drawer visibility
 		document.getElementById('toggle-troubleshooting-drawer').addEventListener('click', function() {
 			var drawer = document.getElementById('troubleshooting-drawer');
 			var caret = document.getElementById('caret');

--- a/tests/Unit/Admin/Settings/ShopsTest.php
+++ b/tests/Unit/Admin/Settings/ShopsTest.php
@@ -36,7 +36,7 @@ class ShopsTest extends \WP_UnitTestCase {
         // No styles should be enqueued
         $shops->enqueue_assets();
 
-        $this->assertFalse(wp_style_is('wc-facebook-admin-connection-settings'));
+        $this->assertFalse(wp_style_is('wc-facebook-admin-shops-settings'));
     }
 
     /**

--- a/tests/Unit/Admin/Settings_Screens/ShopsTest.php
+++ b/tests/Unit/Admin/Settings_Screens/ShopsTest.php
@@ -55,7 +55,7 @@ class ShopsTest extends TestCase {
         // Since we can't directly test the private render_facebook_iframe method,
         // we'll verify that the render method doesn't output the legacy Facebook box
         // when enhanced onboarding is enabled
-        $this->assertStringNotContainsString('wc-facebook-shops-box', $output);
+        $this->assertStringNotContainsString('wc-facebook-connection-box', $output);
     }
 
     /**


### PR DESCRIPTION
## Description
This PR cleans up CSS in enhanced settings UI by (1) removing CSS from `Shops.php` and by (2) separating the enhanced settings CSS from the legacy settings CSS.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Test Plan
1. Clear your browser cache.
2. Go to `http://test-site-i.local/wp-admin/admin.php?page=wc-facebook` and test the enhanced settings UI flow to ensure all elements are still intact.

## Screenshots
https://github.com/user-attachments/assets/e987712e-b25b-4a37-90d7-bd16f80178c3