### PR TITLE
[WAUM][5/n] Scaffold WA Utility Messaging Onboarding UI

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
+++ b/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
@@ -1,15 +1,38 @@
 .onboarding-card {
-	background-color: #f7f7f7;
-	padding: 20px;
-	border: 1px solid #ddd;
-	border-radius: 10px;
-	box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    background-color: #f7f7f7;
+    border: 1px solid #ccc;
+    border-radius: 10px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    margin-left: 500px;
+    margin-right: 500px;
+    margin-top: 50px;
 }
-.connect-button {
-    background-color: rgb( 24, 119, 242 );
-    color: #fff;
-    padding: 10px 20px;
-    border: none;
-    border-radius: 5px;
-    cursor: pointer;
+.card-item {
+  padding: 20px;
+}
+.divider {
+  border-bottom: 1px solid #ccc;
+}
+.add-payment-section {
+    margin-bottom: 10px;
+    border-bottom: none;
+}
+.review-payment-block {
+    box-shadow: 0 0 10px rgba(165, 162, 162, 0.1);
+    border: 1px solid #c4c3c3;
+    border-radius: 10px;
+    margin-bottom: 10px;
+    display: flex;
+}
+.review-payment-content {
+    padding: 20px;
+    margin-bottom: 10px;
+}
+.add-payment-button {
+    float: right;
+    margin-top: 20px;
+    margin-left: 400px;
+}
+.whatsapp-onboarding-button {
+    text-align: right;
 }

--- a/assets/js/admin/whatsapp-consent.js
+++ b/assets/js/admin/whatsapp-consent.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+jQuery( document ).ready( function( $ ) {
+    // handle the whatsapp consent collect button click should save setting to wp_options table
+	$( '#wc-whatsapp-collect-consent' ).click( function( event ) {
+
+        $.post( facebook_for_woocommerce_whatsapp_consent.ajax_url, {
+			action: 'wc_facebook_whatsapp_consent_collection_enable',
+			nonce:  facebook_for_woocommerce_whatsapp_consent.nonce
+		}, function ( response ) {
+
+            if ( response.success ) {
+				console.log( 'success', response ); // TODO: update the UI with the consent collection section progress and remove console.log
+			}
+		} );
+
+    });
+
+} );

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -169,6 +169,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 		add_action( 'init', array( $this, 'get_integration' ) );
 		add_action( 'init', array( $this, 'register_custom_taxonomy' ) );
 		add_action( 'add_meta_boxes_product', array( $this, 'remove_product_fb_product_set_metabox' ), 50 );
+		add_action( 'woocommerce_init', array($this, 'add_whatsapp_consent_checkout_fields'));
 		add_filter( 'fb_product_set_row_actions', array( $this, 'product_set_links' ) );
 		add_filter( 'manage_edit-fb_product_set_columns', array( $this, 'manage_fb_product_set_columns' ) );
 
@@ -854,6 +855,30 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 			$current_screen_id = $current_screen->id;
 		}
 		return $current_screen_id;
+	}
+
+	/**
+	* Add checkout fields to collect whatsapp consent if consent collection is enabled
+	*
+	* @since 2.3.0
+	*
+	* @param array $fields
+	*
+	* @return array
+	*/
+	function add_whatsapp_consent_checkout_fields($fields) {
+		if (get_option('wc_facebook_whatsapp_consent_collection_setting_status', 'disabled') === 'enabled') {
+			woocommerce_register_additional_checkout_field(
+					array(
+						'id'       => 'wc_facebook/whatsapp_consent_checkbox', // id = namespace/field_name
+						'label'    => esc_html('Get order updates on Whatsapp'),
+						'location' => 'address',
+						'type'     => 'checkbox',
+						'optionalLabel' => esc_html('Get order updates on Whatsapp')
+					)
+				);
+		}
+		return $fields;
 	}
 }
 

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -46,6 +46,9 @@ class AJAX {
 		// get the current sync status
 		add_action( 'wp_ajax_wc_facebook_get_sync_status', array( $this, 'get_sync_status' ) );
 
+		// update the wp_options with wc_facebook_whatsapp_consent_collection_setting_status to enabled
+		add_action( 'wp_ajax_wc_facebook_whatsapp_consent_collection_enable', array( $this, 'whatsapp_consent_collection_enable' ) );
+
 		// search a product's attributes for the given term
 		add_action( 'wp_ajax_' . self::ACTION_SEARCH_PRODUCT_ATTRIBUTES, array( $this, 'admin_search_product_attributes' ) );
 	}
@@ -154,6 +157,17 @@ class AJAX {
 		}
 
 		wp_send_json_success( $remaining_products );
+	}
+
+
+	public function whatsapp_consent_collection_enable() {
+		if ( ! check_ajax_referer( 'facebook-for-wc-whatsapp-consent-nonce', 'nonce', false ) ) {
+    	wp_send_json_error( 'Invalid security token sent.' );
+		}
+		if(get_option('wc_facebook_whatsapp_consent_collection_setting_status') !== 'enabled') {
+			update_option('wc_facebook_whatsapp_consent_collection_setting_status', 'enabled');
+		}
+		wp_send_json_success();
 	}
 
 

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -74,14 +74,72 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	public function render() {
 
 		?>
+
 	<div class="onboarding-card">
+	<div class="card-item">
+	<h1><b><?php esc_html_e( 'Send Updates to customers on WhatsApp', 'facebook-for-woocommerce' ); ?></b></h1>
+		<?php esc_html_e( 'Send important updates and notifications directly to customers through WhatsApp.', 'facebook-for-woocommerce' ); ?>
+	</div>
+	<div class="divider"></div>
+	<div class="card-item">
 	<h2><?php esc_html_e( 'Get started with WhatsApp utility messages', 'facebook-for-woocommerce' ); ?></h2>
 	<p><?php esc_html_e( 'Connect your WhatsApp Business Account to start sending utility messages.', 'facebook-for-woocommerce' ); ?></p>
+	<div class="whatsapp-onboarding-button">
 	<a
 			id="woocommerce-whatsapp-connection"
-			class="connect-button"
+			class="button button-primary"
 			href="#"
 		><?php esc_html_e( 'Connect Whatsapp Account', 'facebook-for-woocommerce' ); ?></a>
+	</div>
+	</div>
+	<div class="divider"></div>
+	<div class="card-item">
+	<h2>Collect phone numbers at checkout</h2>
+	<p>To collect phone numbers, a checkbox will be added to your store’s checkout page. This lets customers sign up to receive your messages. You can preview what this looks like in your checkout page preview.</p>
+		<p>This will allow you to send messages to your customers on WhatsApp.</p>
+		<div class="whatsapp-onboarding-button">
+		<a
+			class="button button-primary"
+			id="wc-whatsapp-collect-consent"
+			href="#"
+		><?php esc_html_e( 'Collect', 'facebook-for-woocommerce' ); ?></a>
+		</div>
+	</div>
+	<div class="divider"></div>
+	<div class="card-item">
+		<h2>Add a payment method</h2>
+		<p>Confirm your payment method in Billings & payments.
+				<a
+					href="#"
+					id="wc-whatsapp-about-pricing"
+				><?php esc_html_e( 'About pricing', 'facebook-for-woocommerce' ); ?>
+				</a>
+
+			</p>
+			<div class="add-payment-section">
+				<div class="review-payment-block">
+					<div class="review-payment-content">
+					Add a payment method
+					</div>
+						<div class="add-payment-button">
+							<a
+								class="button button-primary"
+								id="wc-whatsapp-add-payment"
+								href="#"
+								><?php esc_html_e( 'Add', 'facebook-for-woocommerce' ); ?>
+							</a>
+						</div>
+				</div>
+				<div class="whatsapp-onboarding-button">
+					<a
+						class="button button-primary"
+						id="wc-whatsapp-onboarding-finish"
+						href="#"
+					><?php esc_html_e( 'Finish', 'facebook-for-woocommerce' ); ?></a>
+				</div>
+			</div>
+
+		</div>
 	</div>
 		<?php
 

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -63,6 +63,23 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			array( 'jquery', 'jquery-blockui', 'jquery-tiptip', 'wc-enhanced-select' ),
 			\WC_Facebookcommerce::PLUGIN_VERSION
 		);
+		wp_enqueue_script(
+			'facebook-for-woocommerce-whatsapp-consent',
+			facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/whatsapp-consent.js',
+			array( 'jquery', 'jquery-blockui', 'jquery-tiptip', 'wc-enhanced-select' ),
+			\WC_Facebookcommerce::PLUGIN_VERSION
+		);
+		wp_localize_script(
+			'facebook-for-woocommerce-whatsapp-consent',
+			'facebook_for_woocommerce_whatsapp_consent',
+			array(
+				'ajax_url' => admin_url( 'admin-ajax.php' ),
+				'nonce'    => wp_create_nonce( 'facebook-for-wc-whatsapp-consent-nonce' ),
+				'i18n'     => array(
+					'result' => true,
+				),
+			)
+		);
 	}
 
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ const jQueryUIAdminFileNames = [
     'settings-commerce',
     'settings-sync',
     'whatsapp-connection',
+    'whatsapp-consent',
 ];
 
 const jQueryUIAdminFileEntries = {};


### PR DESCRIPTION
## Description

Build the onboarding UI for the whatsapp onboarding flow under utility messaging tab. Currently, the UI is a scaffold.

Next diffs:
1. Link the buttons for each step to appropriate actions
2. Add progress UI an update it when onboarding step completes.
3. Make the sections collapsible. 

### Type of change
-  New feature (non-breaking change which adds functionality)


## Changelog entry
Add scaffold whatsapp utility message UI under utility messaging tab

## Test Plan

Figma:
<img width="763" alt="Screenshot 2025-04-01 at 5 23 14 PM" src="https://github.com/user-attachments/assets/9870143c-ada7-4ba5-a9f1-e893022e3405" />
<img width="769" alt="Screenshot 2025-04-01 at 5 23 21 PM" src="https://github.com/user-attachments/assets/693756d7-10b5-4b19-b43a-b87aab9bb3b1" />
<img width="795" alt="Screenshot 2025-04-01 at 5 23 56 PM" src="https://github.com/user-attachments/assets/931af393-be6d-47a4-95b1-74910bc5fb35" />


After:
<img width="959" alt="Screenshot 2025-04-01 at 5 25 24 PM" src="https://github.com/user-attachments/assets/d82bce2f-748a-423e-b029-e964de713e44" />

