### PR TITLE
Added external_variant_id to the feed file

### DIFF
--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -385,7 +385,9 @@ class WC_Facebook_Product_Feed {
 		return 'id,title,description,image_link,link,product_type,' .
 		'brand,price,availability,item_group_id,checkout_url,' .
 		'additional_image_link,sale_price_effective_date,sale_price,condition,' .
-		'visibility,gender,color,size,pattern,google_product_category,default_product,variant,gtin,quantity_to_sell_on_facebook,rich_text_description,external_update_time' . PHP_EOL;
+		'visibility,gender,color,size,pattern,google_product_category,default_product,'.
+		'variant,gtin,quantity_to_sell_on_facebook,rich_text_description,external_update_time,'.
+		'external_variant_id'. PHP_EOL;
 	}
 
 
@@ -535,7 +537,8 @@ class WC_Facebook_Product_Feed {
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'gtin' )) . ',' .
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'quantity_to_sell_on_facebook' )) . ',' .
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'rich_text_description' ) ) . ',' .
-		static::get_value_from_product_data( $product_data, 'external_update_time' ) . PHP_EOL;
+		static::get_value_from_product_data( $product_data, 'external_update_time' ) . ',' .
+		static::get_value_from_product_data( $product_data, 'external_variant_id' ) . PHP_EOL;
 	}
 
 	private static function format_additional_image_url( $product_image_urls ) {


### PR DESCRIPTION
## Description
Earlier the external_variant_id (a Woo product ID by value) was added to sync via Batch API. This is a quick follow up to add it to the feed file generation too.

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests and all the new and existing unit tests pass locally with my changes
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.


## Changelog entry

- Added external_variant_id to the feed file


## Test Plan

Tested manually by triggering feed file generation, verified both the generated feed file and there are no feed ingestion errors via Meta internal tooling.  

