### PR TITLE
Fixed PHP Warning for empty attributes

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1316,7 +1316,7 @@ class WC_Facebook_Product {
 
 		$all_attributes = $category_handler->get_attributes_with_fallback_to_parent_category( $google_category_id );
 
-		if( empty( $all_attributes )){
+		if ( empty( $all_attributes )){
 			return $product_data;
 		}
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1316,7 +1316,7 @@ class WC_Facebook_Product {
 
 		$all_attributes = $category_handler->get_attributes_with_fallback_to_parent_category( $google_category_id );
 
-		if ( empty( $all_attributes )){
+		if ( empty( $all_attributes ) ) {
 			return $product_data;
 		}
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1316,6 +1316,10 @@ class WC_Facebook_Product {
 
 		$all_attributes = $category_handler->get_attributes_with_fallback_to_parent_category( $google_category_id );
 
+		if( empty( $all_attributes )){
+			return $product_data;
+		}
+
 		foreach ( $all_attributes as $attribute ) {
 			$value            = Products::get_enhanced_catalog_attribute( $attribute['key'], $this->woo_product );
 			$convert_to_array = (


### PR DESCRIPTION
## Description

Fixed PHP Warning for empty attributes when selected Google product Category doesn't have any associated attributes. In such cases simply returning the products data without enhancing it.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests and all the new and existing unit tests pass locally with my changes
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.


## Changelog entry

Fixed PHP Warning for empty attributes


## Test Plan

npm run test:php