### PR TITLE
Improve local log

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -340,15 +340,16 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	 * @since 2.3.3
 	 * @param string $message error or message to save to log
 	 * @param string $log_id optional log id to segment the files by, defaults to plugin id
+	 * @param string $level optional log level represents log's tag
 	 */
-	public function log( $message, $log_id = null ) {
+	public function log( $message, $log_id = null, $level = null ) {
 		// Bail if site is connected and user has disabled logging.
 		// If site is disconnected, force-enable logging so merchant can diagnose connection issues.
 		if ( ( ! $this->get_integration() || ! $this->get_integration()->is_debug_mode_enabled() ) && $this->get_connection_handler()->is_connected() ) {
 			return;
 		}
 
-		parent::log( $message, $log_id );
+		parent::log( $message, $log_id, $level );
 	}
 
 	/**

--- a/includes/Framework/ErrorLogHandler.php
+++ b/includes/Framework/ErrorLogHandler.php
@@ -50,12 +50,12 @@ class ErrorLogHandler extends LogHandlerBase {
 		try {
 			$response = facebook_for_woocommerce()->get_api()->log_to_meta( $context );
 			if ( $response->success ) {
-				WC_Facebookcommerce_Utils::logWithDebugModeEnabled( 'Error log: ' . wp_json_encode( $context ) );
+				WC_Facebookcommerce_Utils::logWithDebugModeEnabled( 'Error log: ' . wp_json_encode( $context ), \WC_Log_Levels::ERROR );
 			} else {
-				WC_Facebookcommerce_Utils::logWithDebugModeEnabled( 'Bad response from log_to_meta request' );
+				WC_Facebookcommerce_Utils::logWithDebugModeEnabled( 'Bad response from log_to_meta request', \WC_Log_Levels::ERROR );
 			}
 		} catch ( \Exception $e ) {
-			WC_Facebookcommerce_Utils::logWithDebugModeEnabled( 'Error persisting error logs: ' . $e->getMessage() );
+			WC_Facebookcommerce_Utils::logWithDebugModeEnabled( 'Error persisting error logs: ' . $e->getMessage(), \WC_Log_Levels::ERROR );
 		}
 	}
 

--- a/includes/Framework/Plugin.php
+++ b/includes/Framework/Plugin.php
@@ -536,7 +536,13 @@ abstract class Plugin {
 		if ( ! is_object( $this->logger ) ) {
 			$this->logger = new \WC_Logger();
 		}
-		$this->logger->add( $log_id, $message );
+		$this->logger->log(
+			\WC_Log_Levels::NOTICE,
+			$message,
+			array(
+				'source'  => $log_id,
+			)
+		);
 	}
 
 

--- a/includes/Framework/Plugin.php
+++ b/includes/Framework/Plugin.php
@@ -528,16 +528,20 @@ abstract class Plugin {
 	 * @since 2.0.0
 	 * @param string $message error or message to save to log
 	 * @param string $log_id optional log id to segment the files by, defaults to plugin id
+	 * @param string $level optional log level represents log's tag, defaults to notice
 	 */
-	public function log( $message, $log_id = null ) {
+	public function log( $message, $log_id = null, $level = null ) {
 		if ( is_null( $log_id ) ) {
 			$log_id = $this->get_id();
+		}
+		if ( is_null( $level ) ) {
+			$level = \WC_Log_Levels::NOTICE;
 		}
 		if ( ! is_object( $this->logger ) ) {
 			$this->logger = new \WC_Logger();
 		}
 		$this->logger->log(
-			\WC_Log_Levels::NOTICE,
+			$level,
 			$message,
 			array(
 				'source'  => $log_id,

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -922,8 +922,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		}
 
 		/**
-		 * Saves errors or messages to WordPress debug log (wp-content/debug.log)
-		 * Only logs if debug mode is enabled and WP_DEBUG and WP_DEBUG_LOG are true in wp-config.php.
+		 * Saves errors or messages to WooCommerce (WP admin page:WooCommerce->Status)
+		 * Only logs if debug mode is enabled
 		 */
 		public static function logWithDebugModeEnabled( $message ) {
 
@@ -938,7 +938,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 				$message = sanitize_textarea_field( $message );
 			}
 
-			error_log( $message );
+			facebook_for_woocommerce()->log( $message );
 		}
 
 	}

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -925,7 +925,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		 * Saves errors or messages to WooCommerce (WP admin page:WooCommerce->Status)
 		 * Only logs if debug mode is enabled
 		 */
-		public static function logWithDebugModeEnabled( $message ) {
+		public static function logWithDebugModeEnabled( $message, $level = null ) {
 
 			// if this file is being included outside the plugin, or the plugin setting is disabled
 			if ( ! function_exists( 'facebook_for_woocommerce' ) || ! facebook_for_woocommerce()->get_integration()->is_debug_mode_enabled() ) {
@@ -938,7 +938,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 				$message = sanitize_textarea_field( $message );
 			}
 
-			facebook_for_woocommerce()->log( $message );
+			facebook_for_woocommerce()->log( $message, null, $level );
 		}
 
 	}


### PR DESCRIPTION
## Description

Migrate log function from WC logger deprecated api to WC logger recommended api.
Add new level parameter to config local logs tag.

new local logs can be found in WP admin page:WooCommerce->Status: {F1976773844}

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

Test Plan:
error logs: {F1976774140}
telemetry logs: {F1976774174}