### PR TITLE
Bugfix: Hide Out Of Stock items

### DIFF
--- a/includes/Products.php
+++ b/includes/Products.php
@@ -288,6 +288,10 @@ class Products {
 	 * @return bool
 	 */
 	public static function is_product_visible( \WC_Product $product ) {
+		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $product->is_in_stock() ) {
+			self::$products_visibility[ $product->get_id() ] = false;
+			return false;
+		}
 		// accounts for a legacy bool value, current should be (string) 'yes' or (string) 'no'
 		if ( ! isset( self::$products_visibility[ $product->get_id() ] ) ) {
 			if ( $product->is_type( 'variable' ) ) {


### PR DESCRIPTION
## Description

When advertiser explicitly enable “Hide out of stock items from the catalog” under WooCommerce > Settings > Products > Inventory, earlier we use to simply delete the out of stock items. After changes introduced in 2952, we started syncing all such items however we missed an edge case to update availability when it goes from in_stock to out_of_stock. 
We are addressing it here and marking visibility as hidden for out_of_stock products in these scenarios.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests and all the new and existing unit tests pass locally with my changes
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.


## Changelog entry

Bugfix: Fix product availability syncing

## Test Plan

npm run test:php