### PR TITLE
Fix product attribute sort error

### DIFF
--- a/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
+++ b/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
@@ -135,6 +135,7 @@ class Enhanced_Catalog_Attribute_Fields {
 			'default'        => 100,
 		);
 
+		$priority = array(); // Initialize priority array.
 		foreach ( $recommended_attributes as $key => $attribute ) {
 			$recommended_attributes[ $key ]['priority'] = 5; // Assign 5 initially to each attribute
 			if ( 'measurement' === $attribute['type'] ) {
@@ -145,7 +146,10 @@ class Enhanced_Catalog_Attribute_Fields {
 
 		$should_render_checkbox = ! empty( $recommended_attributes );
 
-		array_multisort( $priority, SORT_DESC, $recommended_attributes );
+		// Only sort if we have recommended attributes.
+		if ( ! empty( $priority ) ) {
+			array_multisort( $priority, SORT_DESC, $recommended_attributes );
+		}
 		$selector_value      = $this->get_value( self::OPTIONAL_SELECTOR_KEY, $category_id );
 		$is_showing_optional = 'on' === $selector_value;
 


### PR DESCRIPTION
## Description

This changeset fixes an attribute sort fatal error which prevents users from editing products.

We now check if there are elements in the attribute array that can be sorted.

This is outlined in issue #3008.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests and all the new and existing unit tests pass locally with my changes
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.


## Changelog entry

Fix product attribute sort error which prevented product edits in certain scenarios.


## Test Plan

Install the artifact built from this version. The error can manifest in two places:
- In the WooCommerce logs for the plugin after installing.
- It will not let you edit a product's status (published/draft). In this test, the browser console will show a 500 Internal Server Error for the Ajax request.

With this version, you should not see the error.