### PR TITLE
[WAUM][8/n] Polling back-end to check if whatsapp onboarding info Received

### DIFF
--- a/assets/js/admin/whatsapp-connection.js
+++ b/assets/js/admin/whatsapp-connection.js
@@ -10,11 +10,29 @@
 jQuery( document ).ready( function( $ ) {
     // handle the whatsapp connect button click should open hosted ES flow
 	$( '#woocommerce-whatsapp-connection' ).click( function( event ) {
-        // dummy values for app id and config id, will be replaced in upcoming diffs
-        const APP_ID = '18402284156271';
-        const CONFIG_ID = '17502287264684';
+        const APP_ID = '474166926521348'; // WOO_COMMERCE_APP_ID
+        const CONFIG_ID = '1237758981048330'; // WOO_COMMERCE_WHATSAPP_CONFIG_ID
         const HOSTED_ES_URL = `https://business.facebook.com/messaging/whatsapp/onboard/?app_id=${APP_ID}&config_id=${CONFIG_ID}`;
         window.open( HOSTED_ES_URL);
+        updateProgress();
     });
+
+    function updateProgress() {
+        $.post( facebook_for_woocommerce_whatsapp_onboarding_progress.ajax_url, {
+			action: 'wc_facebook_whatsapp_onboarding_progress_check',
+			nonce:  facebook_for_woocommerce_whatsapp_onboarding_progress.nonce
+		}, function ( response ) {
+
+            // check if the response is success (i.e. onboarding is completed)
+            if ( response.success ) {
+                // TODO: if success, update the UI with the onboarding succeeded
+				console.log( 'success', response );
+			} else {
+                console.log('Failure. Checking again in 1 second', response);
+                setTimeout( updateProgress, 1000 );
+            }
+		} );
+
+    }
 
 } );

--- a/assets/js/admin/whatsapp-connection.js
+++ b/assets/js/admin/whatsapp-connection.js
@@ -17,7 +17,7 @@ jQuery( document ).ready( function( $ ) {
         updateProgress(0,1800000); // retry for 30 minutes
     });
 
-    function updateProgress(retryCount = 0, maxRetries = 1800000) {
+    function updateProgress(retryCount = 0, pollingTimeout = 1800000) {
         $.post( facebook_for_woocommerce_whatsapp_onboarding_progress.ajax_url, {
 			action: 'wc_facebook_whatsapp_onboarding_progress_check',
 			nonce:  facebook_for_woocommerce_whatsapp_onboarding_progress.nonce
@@ -28,12 +28,12 @@ jQuery( document ).ready( function( $ ) {
                 // TODO: if success, update the UI with the onboarding succeeded
 				console.log( 'success', response );
 			} else {
-                console.log('Failure. Checking again in 1 second:', response, ', retry attempt:', retryCount, 'maxRetries', maxRetries);
-                if(retryCount >= maxRetries) {
+                console.log('Failure. Checking again in 1 second:', response, ', retry attempt:', retryCount, 'pollingTimeout', pollingTimeout);
+                if(retryCount >= pollingTimeout) {
                     console.log('Max retries reached. Aborting.');
                     return;
                 }
-                setTimeout( updateProgress(retryCount+1, maxRetries), 1000 );
+                setTimeout( function() { updateProgress(retryCount + 1, pollingTimeout); }, 5000 );
             }
 		} );
 

--- a/assets/js/admin/whatsapp-connection.js
+++ b/assets/js/admin/whatsapp-connection.js
@@ -14,10 +14,10 @@ jQuery( document ).ready( function( $ ) {
         const CONFIG_ID = '1237758981048330'; // WOO_COMMERCE_WHATSAPP_CONFIG_ID
         const HOSTED_ES_URL = `https://business.facebook.com/messaging/whatsapp/onboard/?app_id=${APP_ID}&config_id=${CONFIG_ID}`;
         window.open( HOSTED_ES_URL);
-        updateProgress();
+        updateProgress(0,1800000); // retry for 30 minutes
     });
 
-    function updateProgress() {
+    function updateProgress(retryCount = 0, maxRetries = 1800000) {
         $.post( facebook_for_woocommerce_whatsapp_onboarding_progress.ajax_url, {
 			action: 'wc_facebook_whatsapp_onboarding_progress_check',
 			nonce:  facebook_for_woocommerce_whatsapp_onboarding_progress.nonce
@@ -28,8 +28,12 @@ jQuery( document ).ready( function( $ ) {
                 // TODO: if success, update the UI with the onboarding succeeded
 				console.log( 'success', response );
 			} else {
-                console.log('Failure. Checking again in 1 second', response);
-                setTimeout( updateProgress, 1000 );
+                console.log('Failure. Checking again in 1 second:', response, ', retry attempt:', retryCount, 'maxRetries', maxRetries);
+                if(retryCount >= maxRetries) {
+                    console.log('Max retries reached. Aborting.');
+                    return;
+                }
+                setTimeout( updateProgress(retryCount+1, maxRetries), 1000 );
             }
 		} );
 

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -889,7 +889,6 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 		}
 		return $fields;
 	}
-}
 
 	/**
 	 * Determines if the enhanced onboarding (iframe) should be used.

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -48,6 +48,9 @@ class AJAX {
 		// get the current sync status
 		add_action( 'wp_ajax_wc_facebook_get_sync_status', array( $this, 'get_sync_status' ) );
 
+		// check the status of whatsapp onboarding and update the progress
+		add_action( 'wp_ajax_wc_facebook_whatsapp_onboarding_progress_check', array( $this, 'whatsapp_onboarding_progress_check' ) );
+
 		// search a product's attributes for the given term
 		add_action( 'wp_ajax_' . self::ACTION_SEARCH_PRODUCT_ATTRIBUTES, array( $this, 'admin_search_product_attributes' ) );
 	}
@@ -166,6 +169,23 @@ class AJAX {
 		}
 
 		wp_send_json_success( $remaining_products );
+	}
+
+	/**
+	 * Checks if the onboarding for whatsapp is complete once business has initiated onboarding.
+	 *
+	 * @internal
+	 *
+	 * @since 1.10.0
+	 */
+	public function whatsapp_onboarding_progress_check() {
+		if ( ! check_ajax_referer( 'facebook-for-wc-whatsapp-onboarding-progress-nonce', 'nonce', false ) ) {
+			wp_send_json_error( 'Invalid security token sent.' );
+		}
+		if ( get_option( 'wc_facebook_wa_integration_waba_id', '' ) !== '' ) { // TODO: Do a detailed check of all the required fields
+			wp_send_json_success();
+		}
+		wp_send_json_error( 'WhatsApp onboarding is not complete' );
 	}
 
 

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -69,7 +69,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			array(
 				'ajax_url' => admin_url( 'admin-ajax.php' ),
 				'nonce'    => wp_create_nonce( 'facebook-for-wc-whatsapp-onboarding-progress-nonce' ),
-        'i18n'     => array(
+				'i18n'     => array(
 					'result' => true,
 				),
 			)

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -63,6 +63,17 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			array( 'jquery', 'jquery-blockui', 'jquery-tiptip', 'wc-enhanced-select' ),
 			\WC_Facebookcommerce::PLUGIN_VERSION
 		);
+		wp_localize_script(
+			'facebook-for-woocommerce-connect-whatsapp',
+			'facebook_for_woocommerce_whatsapp_onboarding_progress',
+			array(
+				'ajax_url' => admin_url( 'admin-ajax.php' ),
+				'nonce'    => wp_create_nonce( 'facebook-for-wc-whatsapp-onboarding-progress-nonce' ),
+				'i18n'     => array(
+					'result' => true,
+				),
+			)
+		);
 	}
 
 


### PR DESCRIPTION
## Description
When business completes whatsapp onboarding, meta will send the onboarding info to woocommerce with the whatsapp onboarding details. Once these details are received we have to update the front-end with progress on their onboarding (i.e) let end business know that their onboarding was successful. We do this by initiating a polling session when business click on connect whatsapp button in woocommerce and continuously check if info is received at the back-end. We stop polling when info is received.

Note: The diff to do this via E2E(onboarding and receiving the webhook is not in production yet), for now we send data via postman emulating the data sent by meta.

### Type of change
- [ ] New feature (non-breaking change which adds functionality)


## Changelog entry
Add polling to check progress update of whatsapp onboarding


## Test Plan
- Initiating onboarding flow kickstarts the polling session
- When info is received polling session stops and response is success.

## Screenshots
https://github.com/user-attachments/assets/8ca00288-e365-4b94-8d81-425eaa6abc0e


