### PR TITLE
[WAUM][1/n] Scaffold for utility message overview UI

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
+++ b/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
@@ -37,3 +37,12 @@
 .whatsapp-onboarding-button {
     text-align: right;
 }
+.event-config {
+    padding: 20px;
+    display: flex;
+    flex-direction: row;
+}
+.event-config-manage-button {
+    padding: 20px;
+    margin-left: auto;
+}

--- a/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
+++ b/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
@@ -29,9 +29,10 @@
     margin-bottom: 10px;
 }
 .add-payment-button {
-    float: right;
+    text-align: right;
+    margin-bottom: 20px;
+    margin-left: 250px;
     margin-top: 20px;
-    margin-left: 400px;
 }
 .whatsapp-onboarding-button {
     text-align: right;

--- a/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
+++ b/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
@@ -29,10 +29,9 @@
     margin-bottom: 10px;
 }
 .add-payment-button {
-    text-align: right;
-    margin-bottom: 20px;
-    margin-left: 250px;
+    float: right;
     margin-top: 20px;
+    margin-left: 400px;
 }
 .whatsapp-onboarding-button {
     text-align: right;

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -889,6 +889,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 		}
 		return $fields;
 	}
+}
 
 	/**
 	 * Determines if the enhanced onboarding (iframe) should be used.

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -889,7 +889,6 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 		}
 		return $fields;
 	}
-}
 
 	/**
 	 * Determines if the enhanced onboarding (iframe) should be used.

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -20,6 +20,10 @@ use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
  */
 class Whatsapp_Utility extends Abstract_Settings_Screen {
 
+
+	/** @var string screen ID */
+	const ID = 'whatsapp_utility';
+
 	/** @var flag to test Utility Messages Overview changes until check for integration config is implemented */
 	const WHATSAPP_UTILITY_MESSAGES_OVERVIEW_FLAG = false;
 
@@ -102,67 +106,73 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	public function render_utility_message_onboarding() {
 
 		?>
-		<div class="onboarding-card">
-			<div class="card-item">
-				<h1><b><?php esc_html_e( 'Send Updates to customers on WhatsApp', 'facebook-for-woocommerce' ); ?></b></h1>
-				<?php esc_html_e( 'Send important updates and notifications directly to customers through WhatsApp.', 'facebook-for-woocommerce' ); ?>
-			</div>
-			<div class="divider"></div>
-			<div class="card-item">
-				<h2><?php esc_html_e( 'Get started with WhatsApp utility messages', 'facebook-for-woocommerce' ); ?></h2>
-				<p><?php esc_html_e( 'Connect your WhatsApp Business Account to start sending utility messages.', 'facebook-for-woocommerce' ); ?></p>
-				<div class="whatsapp-onboarding-button">
-					<a
-						id="woocommerce-whatsapp-connection"
-						class="button button-primary"
-						href="#"><?php esc_html_e( 'Connect Whatsapp Account', 'facebook-for-woocommerce' ); ?></a>
-				</div>
-			</div>
-			<div class="divider"></div>
-			<div class="card-item">
-				<h2>Collect phone numbers at checkout</h2>
-				<p>To collect phone numbers, a checkbox will be added to your store’s checkout page. This lets customers sign up to receive your messages. You can preview what this looks like in your checkout page preview.</p>
-				<p>This will allow you to send messages to your customers on WhatsApp.</p>
-				<div class="whatsapp-onboarding-button">
-					<a
-						class="button button-primary"
-						id="wc-whatsapp-collect-consent"
-						href="#"><?php esc_html_e( 'Collect', 'facebook-for-woocommerce' ); ?></a>
-				</div>
-			</div>
-			<div class="divider"></div>
-			<div class="card-item">
-				<h2>Add a payment method</h2>
-				<p>Confirm your payment method in Billings & payments.
-					<a
-						href="#"
-						id="wc-whatsapp-about-pricing"><?php esc_html_e( 'About pricing', 'facebook-for-woocommerce' ); ?>
-					</a>
 
-				</p>
-				<div class="add-payment-section">
-					<div class="review-payment-block">
-						<div class="review-payment-content">
-							Add a payment method
-						</div>
+	<div class="onboarding-card">
+	<div class="card-item">
+	<h1><b><?php esc_html_e( 'Send Updates to customers on WhatsApp', 'facebook-for-woocommerce' ); ?></b></h1>
+		<?php esc_html_e( 'Send important updates and notifications directly to customers through WhatsApp.', 'facebook-for-woocommerce' ); ?>
+	</div>
+	<div class="divider"></div>
+	<div class="card-item">
+	<h2><?php esc_html_e( 'Get started with WhatsApp utility messages', 'facebook-for-woocommerce' ); ?></h2>
+	<p><?php esc_html_e( 'Connect your WhatsApp Business Account to start sending utility messages.', 'facebook-for-woocommerce' ); ?></p>
+	<div class="whatsapp-onboarding-button">
+	<a
+			id="woocommerce-whatsapp-connection"
+			class="button"
+			href="#"
+		><?php esc_html_e( 'Connect Whatsapp Account', 'facebook-for-woocommerce' ); ?></a>
+	</div>
+	</div>
+	<div class="divider"></div>
+	<div class="card-item">
+	<h2><?php esc_html_e( 'Collect phone numbers at checkout', 'facebook-for-woocommerce' ); ?></h2>
+	<p><?php esc_html_e( 'To collect phone numbers, a checkbox will be added to your store’s checkout page. This lets customers sign up to receive your messages. You can preview what this looks like in your checkout page preview.', 'facebook-for-woocommerce' ); ?></p>
+		<p><?php esc_html_e( 'This will allow you to send messages to your customers on WhatsApp.', 'facebook-for-woocommerce' ); ?></p>
+		<div class="whatsapp-onboarding-button">
+		<a
+			class="button"
+			id="wc-whatsapp-collect-consent"
+			href="#"
+		><?php esc_html_e( 'Add', 'facebook-for-woocommerce' ); ?></a>
+		</div>
+	</div>
+	<div class="divider"></div>
+	<div class="card-item">
+		<h2><?php esc_html_e( 'Add a payment method', 'facebook-for-woocommerce' ); ?></h2>
+		<p><?php esc_html_e( 'Confirm your payment method in Billings & payments.', 'facebook-for-woocommerce' ); ?>
+				<a
+					href="#"
+					id="wc-whatsapp-about-pricing"
+				><?php esc_html_e( 'About pricing', 'facebook-for-woocommerce' ); ?>
+				</a>
+
+			</p>
+			<div class="add-payment-section">
+				<div class="review-payment-block">
+					<div class="review-payment-content">
+					<?php esc_html_e( 'Add a payment method', 'facebook-for-woocommerce' ); ?>
+					</div>
 						<div class="add-payment-button">
 							<a
 								class="button"
 								id="wc-whatsapp-add-payment"
-								href="#"><?php esc_html_e( 'Add', 'facebook-for-woocommerce' ); ?>
+								href="#"
+								><?php esc_html_e( 'Add', 'facebook-for-woocommerce' ); ?>
 							</a>
 						</div>
-					</div>
-					<div class="whatsapp-onboarding-button">
-						<a
-							class="button button-primary"
-							id="wc-whatsapp-onboarding-finish"
-							href="#"><?php esc_html_e( 'Finish', 'facebook-for-woocommerce' ); ?></a>
-					</div>
 				</div>
-
+				<div class="whatsapp-onboarding-button">
+					<a
+						class="button button-primary"
+						id="wc-whatsapp-onboarding-finish"
+						href="#"
+					><?php esc_html_e( 'Finish', 'facebook-for-woocommerce' ); ?></a>
+				</div>
 			</div>
+
 		</div>
+	</div>
 		<?php
 	}
 
@@ -184,7 +194,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			<div class="card-item event-config">
 				<div>
 					<h3><b><?php esc_html_e( 'Order confirmation', 'facebook-for-woocommerce' ); ?></b></h3>
-					<p><?php esc_html_e( 'Send a confirmation to customers after they\'ve placed an order.' ); ?></p>
+					<p><?php esc_html_e( 'Send a confirmation to customers after they\'ve placed an order.', 'facebook-for-woocommerce' ); ?></p>
 				</div>
 				<div class="event-config-manage-button">
 					<a
@@ -197,7 +207,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			<div class="card-item event-config">
 				<div>
 					<h3><b><?php esc_html_e( 'Order shipped', 'facebook-for-woocommerce' ); ?></b></h3>
-					<p><?php esc_html_e( 'Send a confirmation to customers when their order is shipped.' ); ?></p>
+					<p><?php esc_html_e( 'Send a confirmation to customers when their order is shipped.', 'facebook-for-woocommerce' ); ?></p>
 				</div>
 				<div class="event-config-manage-button">
 					<a
@@ -210,7 +220,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			<div class="card-item event-config">
 				<div>
 					<h3><b><?php esc_html_e( 'Order refunded', 'facebook-for-woocommerce' ); ?></b></h3>
-					<p><?php esc_html_e( 'Send a confirmation to customers when an order is refunded.' ); ?></p>
+					<p><?php esc_html_e( 'Send a confirmation to customers when an order is refunded.', 'facebook-for-woocommerce' ); ?></p>
 				</div>
 				<div class="event-config-manage-button">
 					<a

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -20,6 +20,10 @@ use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
  */
 class Whatsapp_Utility extends Abstract_Settings_Screen {
 
+
+	/** @var string screen ID */
+	const ID = 'whatsapp_utility';
+
 	/** @var flag to test Utility Messages Overview changes until check for integration config is implemented */
 	const WHATSAPP_UTILITY_MESSAGES_OVERVIEW_FLAG = false;
 
@@ -37,8 +41,8 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	 */
 	public function initHook(): void {
 		$this->id    = self::ID;
-		$this->label = __( 'Utility messages', 'facebook-for-woocommerce' );
-		$this->title = __( 'Utility messages', 'facebook-for-woocommerce' );
+		$this->label = __( 'WhatsApp Utility', 'facebook-for-woocommerce' );
+		$this->title = __( 'WhatsApp Utility', 'facebook-for-woocommerce' );
 	}
 
 	/**
@@ -147,9 +151,10 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 						</div>
 						<div class="add-payment-button">
 							<a
-								class="button"
+								class="button button-primary"
 								id="wc-whatsapp-add-payment"
-								href="#"><?php esc_html_e( 'Add', 'facebook-for-woocommerce' ); ?>
+								href="#"
+								><?php esc_html_e( 'Add', 'facebook-for-woocommerce' ); ?>
 							</a>
 						</div>
 					</div>
@@ -184,7 +189,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			<div class="card-item event-config">
 				<div>
 					<h3><b><?php esc_html_e( 'Order confirmation', 'facebook-for-woocommerce' ); ?></b></h3>
-					<p><?php esc_html_e( 'Send a confirmation to customers after they\'ve placed an order.' ); ?></p>
+					<p><?php esc_html_e( 'Send a confirmation to customers after they\'ve placed an order.', 'facebook-for-woocommerce' ); ?></p>
 				</div>
 				<div class="event-config-manage-button">
 					<a
@@ -197,7 +202,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			<div class="card-item event-config">
 				<div>
 					<h3><b><?php esc_html_e( 'Order shipped', 'facebook-for-woocommerce' ); ?></b></h3>
-					<p><?php esc_html_e( 'Send a confirmation to customers when their order is shipped.' ); ?></p>
+					<p><?php esc_html_e( 'Send a confirmation to customers when their order is shipped.', 'facebook-for-woocommerce' ); ?></p>
 				</div>
 				<div class="event-config-manage-button">
 					<a
@@ -210,7 +215,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			<div class="card-item event-config">
 				<div>
 					<h3><b><?php esc_html_e( 'Order refunded', 'facebook-for-woocommerce' ); ?></b></h3>
-					<p><?php esc_html_e( 'Send a confirmation to customers when an order is refunded.' ); ?></p>
+					<p><?php esc_html_e( 'Send a confirmation to customers when an order is refunded.', 'facebook-for-woocommerce' ); ?></p>
 				</div>
 				<div class="event-config-manage-button">
 					<a

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -24,6 +25,8 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	/** @var string screen ID */
 	const ID = 'whatsapp_utility';
 
+	/** @var flag to test Utility Messages Overview changes until check for integration config is implemented */
+	const WHATSAPP_UTILITY_MESSAGES_OVERVIEW_FLAG = false;
 
 	/**
 	 * Whatsapp Utility constructor.
@@ -89,79 +92,142 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	 * @since 2.0.0
 	 */
 	public function render() {
+		if ( self::WHATSAPP_UTILITY_MESSAGES_OVERVIEW_FLAG ) {
+			$this->render_utility_message_overview();
+		} else {
+			$this->render_utility_message_onboarding();
+		}
+
+		parent::render();
+	}
+
+	/**
+	 * Renders the WhatsApp Utility Onboarding screen.
+	 */
+	public function render_utility_message_onboarding() {
 
 		?>
+		<div class="onboarding-card">
+			<div class="card-item">
+				<h1><b><?php esc_html_e( 'Send Updates to customers on WhatsApp', 'facebook-for-woocommerce' ); ?></b></h1>
+				<?php esc_html_e( 'Send important updates and notifications directly to customers through WhatsApp.', 'facebook-for-woocommerce' ); ?>
+			</div>
+			<div class="divider"></div>
+			<div class="card-item">
+				<h2><?php esc_html_e( 'Get started with WhatsApp utility messages', 'facebook-for-woocommerce' ); ?></h2>
+				<p><?php esc_html_e( 'Connect your WhatsApp Business Account to start sending utility messages.', 'facebook-for-woocommerce' ); ?></p>
+				<div class="whatsapp-onboarding-button">
+					<a
+						id="woocommerce-whatsapp-connection"
+						class="button button-primary"
+						href="#"><?php esc_html_e( 'Connect Whatsapp Account', 'facebook-for-woocommerce' ); ?></a>
+				</div>
+			</div>
+			<div class="divider"></div>
+			<div class="card-item">
+				<h2>Collect phone numbers at checkout</h2>
+				<p>To collect phone numbers, a checkbox will be added to your store’s checkout page. This lets customers sign up to receive your messages. You can preview what this looks like in your checkout page preview.</p>
+				<p>This will allow you to send messages to your customers on WhatsApp.</p>
+				<div class="whatsapp-onboarding-button">
+					<a
+						class="button button-primary"
+						id="wc-whatsapp-collect-consent"
+						href="#"><?php esc_html_e( 'Collect', 'facebook-for-woocommerce' ); ?></a>
+				</div>
+			</div>
+			<div class="divider"></div>
+			<div class="card-item">
+				<h2>Add a payment method</h2>
+				<p>Confirm your payment method in Billings & payments.
+					<a
+						href="#"
+						id="wc-whatsapp-about-pricing"><?php esc_html_e( 'About pricing', 'facebook-for-woocommerce' ); ?>
+					</a>
 
-	<div class="onboarding-card">
-	<div class="card-item">
-	<h1><b><?php esc_html_e( 'Send Updates to customers on WhatsApp', 'facebook-for-woocommerce' ); ?></b></h1>
-		<?php esc_html_e( 'Send important updates and notifications directly to customers through WhatsApp.', 'facebook-for-woocommerce' ); ?>
-	</div>
-	<div class="divider"></div>
-	<div class="card-item">
-	<h2><?php esc_html_e( 'Get started with WhatsApp utility messages', 'facebook-for-woocommerce' ); ?></h2>
-	<p><?php esc_html_e( 'Connect your WhatsApp Business Account to start sending utility messages.', 'facebook-for-woocommerce' ); ?></p>
-	<div class="whatsapp-onboarding-button">
-	<a
-			id="woocommerce-whatsapp-connection"
-			class="button"
-			href="#"
-		><?php esc_html_e( 'Connect Whatsapp Account', 'facebook-for-woocommerce' ); ?></a>
-	</div>
-	</div>
-	<div class="divider"></div>
-	<div class="card-item">
-	<h2><?php esc_html_e( 'Collect phone numbers at checkout', 'facebook-for-woocommerce' ); ?></h2>
-	<p><?php esc_html_e( 'To collect phone numbers, a checkbox will be added to your store’s checkout page. This lets customers sign up to receive your messages. You can preview what this looks like in your checkout page preview.', 'facebook-for-woocommerce' ); ?></p>
-		<p><?php esc_html_e( 'This will allow you to send messages to your customers on WhatsApp.', 'facebook-for-woocommerce' ); ?></p>
-		<div class="whatsapp-onboarding-button">
-		<a
-			class="button"
-			id="wc-whatsapp-collect-consent"
-			href="#"
-		><?php esc_html_e( 'Add', 'facebook-for-woocommerce' ); ?></a>
-		</div>
-	</div>
-	<div class="divider"></div>
-	<div class="card-item">
-		<h2><?php esc_html_e( 'Add a payment method', 'facebook-for-woocommerce' ); ?></h2>
-		<p><?php esc_html_e( 'Confirm your payment method in Billings & payments.', 'facebook-for-woocommerce' ); ?>
-				<a
-					href="#"
-					id="wc-whatsapp-about-pricing"
-				><?php esc_html_e( 'About pricing', 'facebook-for-woocommerce' ); ?>
-				</a>
-
-			</p>
-			<div class="add-payment-section">
-				<div class="review-payment-block">
-					<div class="review-payment-content">
-					<?php esc_html_e( 'Add a payment method', 'facebook-for-woocommerce' ); ?>
-					</div>
+				</p>
+				<div class="add-payment-section">
+					<div class="review-payment-block">
+						<div class="review-payment-content">
+							Add a payment method
+						</div>
 						<div class="add-payment-button">
 							<a
 								class="button"
 								id="wc-whatsapp-add-payment"
-								href="#"
-								><?php esc_html_e( 'Add', 'facebook-for-woocommerce' ); ?>
+								href="#"><?php esc_html_e( 'Add', 'facebook-for-woocommerce' ); ?>
 							</a>
 						</div>
+					</div>
+					<div class="whatsapp-onboarding-button">
+						<a
+							class="button button-primary"
+							id="wc-whatsapp-onboarding-finish"
+							href="#"><?php esc_html_e( 'Finish', 'facebook-for-woocommerce' ); ?></a>
+					</div>
 				</div>
-				<div class="whatsapp-onboarding-button">
+
+			</div>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Renders the WhatsApp Utility Overview screen.
+	 */
+	public function render_utility_message_overview() {
+		?>
+		<div class="onboarding-card">
+			<div class="card-item">
+				<h1><b><?php esc_html_e( 'Utility Messages', 'facebook-for-woocommerce' ); ?></b></h2>
+					<p><?php esc_html_e( 'Manage which utility messages you want to send to customers. You can check performance of these messages in Whatsapp Manager.', 'facebook-for-woocommerce' ); ?>
+						<a
+							id="woocommerce-whatsapp-manager-insights"
+							href="#"><?php esc_html_e( 'View insights', 'facebook-for-woocommerce' ); ?></a>
+					</p>
+			</div>
+			<div class="divider"></div>
+			<div class="card-item event-config">
+				<div>
+					<h3><b><?php esc_html_e( 'Order confirmation', 'facebook-for-woocommerce' ); ?></b></h3>
+					<p><?php esc_html_e( 'Send a confirmation to customers after they\'ve placed an order.' ); ?></p>
+				</div>
+				<div class="event-config-manage-button">
 					<a
-						class="button button-primary"
-						id="wc-whatsapp-onboarding-finish"
-						href="#"
-					><?php esc_html_e( 'Finish', 'facebook-for-woocommerce' ); ?></a>
+						id="woocommerce-whatsapp-manage-order-confirmation"
+						class="event-config-manage-button button"
+						href="#"><?php esc_html_e( 'Manage', 'facebook-for-woocommerce' ); ?></a>
 				</div>
 			</div>
-
+			<div class="divider"></div>
+			<div class="card-item event-config">
+				<div>
+					<h3><b><?php esc_html_e( 'Order shipped', 'facebook-for-woocommerce' ); ?></b></h3>
+					<p><?php esc_html_e( 'Send a confirmation to customers when their order is shipped.' ); ?></p>
+				</div>
+				<div class="event-config-manage-button">
+					<a
+						id="woocommerce-whatsapp-manage-order-shipped"
+						class="button"
+						href="#"><?php esc_html_e( 'Manage', 'facebook-for-woocommerce' ); ?></a>
+				</div>
+			</div>
+			<div class="divider"></div>
+			<div class="card-item event-config">
+				<div>
+					<h3><b><?php esc_html_e( 'Order refunded', 'facebook-for-woocommerce' ); ?></b></h3>
+					<p><?php esc_html_e( 'Send a confirmation to customers when an order is refunded.' ); ?></p>
+				</div>
+				<div class="event-config-manage-button">
+					<a
+						id="woocommerce-whatsapp-manage-order-refunded"
+						class="event-config-manage-button button"
+						href="#"><?php esc_html_e( 'Manage', 'facebook-for-woocommerce' ); ?></a>
+				</div>
+			</div>
 		</div>
-	</div>
 		<?php
-
-		parent::render();
 	}
+
 
 	/**
 	 * Gets the screen settings.

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -223,7 +222,6 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 		</div>
 		<?php
 	}
-
 
 	/**
 	 * Gets the screen settings.

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -39,8 +39,8 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	 */
 	public function initHook(): void {
 		$this->id    = self::ID;
-		$this->label = __( 'WhatsApp Utility', 'facebook-for-woocommerce' );
-		$this->title = __( 'Whatsapp Utility', 'facebook-for-woocommerce' );
+		$this->label = __( 'Utility messages', 'facebook-for-woocommerce' );
+		$this->title = __( 'Utility messages', 'facebook-for-woocommerce' );
 	}
 
 	/**
@@ -104,28 +104,28 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	<div class="whatsapp-onboarding-button">
 	<a
 			id="woocommerce-whatsapp-connection"
-			class="button button-primary"
+			class="button"
 			href="#"
 		><?php esc_html_e( 'Connect Whatsapp Account', 'facebook-for-woocommerce' ); ?></a>
 	</div>
 	</div>
 	<div class="divider"></div>
 	<div class="card-item">
-	<h2>Collect phone numbers at checkout</h2>
-	<p>To collect phone numbers, a checkbox will be added to your store’s checkout page. This lets customers sign up to receive your messages. You can preview what this looks like in your checkout page preview.</p>
-		<p>This will allow you to send messages to your customers on WhatsApp.</p>
+	<h2><?php esc_html_e( 'Collect phone numbers at checkout', 'facebook-for-woocommerce' ); ?></h2>
+	<p><?php esc_html_e( 'To collect phone numbers, a checkbox will be added to your store’s checkout page. This lets customers sign up to receive your messages. You can preview what this looks like in your checkout page preview.', 'facebook-for-woocommerce' ); ?></p>
+		<p><?php esc_html_e( 'This will allow you to send messages to your customers on WhatsApp.', 'facebook-for-woocommerce' ); ?></p>
 		<div class="whatsapp-onboarding-button">
 		<a
-			class="button button-primary"
+			class="button"
 			id="wc-whatsapp-collect-consent"
 			href="#"
-		><?php esc_html_e( 'Collect', 'facebook-for-woocommerce' ); ?></a>
+		><?php esc_html_e( 'Add', 'facebook-for-woocommerce' ); ?></a>
 		</div>
 	</div>
 	<div class="divider"></div>
 	<div class="card-item">
-		<h2>Add a payment method</h2>
-		<p>Confirm your payment method in Billings & payments.
+		<h2><?php esc_html_e( 'Add a payment method', 'facebook-for-woocommerce' ); ?></h2>
+		<p><?php esc_html_e( 'Confirm your payment method in Billings & payments.', 'facebook-for-woocommerce' ); ?>
 				<a
 					href="#"
 					id="wc-whatsapp-about-pricing"
@@ -136,11 +136,11 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			<div class="add-payment-section">
 				<div class="review-payment-block">
 					<div class="review-payment-content">
-					Add a payment method
+					<?php esc_html_e( 'Add a payment method', 'facebook-for-woocommerce' ); ?>
 					</div>
 						<div class="add-payment-button">
 							<a
-								class="button button-primary"
+								class="button"
 								id="wc-whatsapp-add-payment"
 								href="#"
 								><?php esc_html_e( 'Add', 'facebook-for-woocommerce' ); ?>

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -21,10 +21,6 @@ use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
  */
 class Whatsapp_Utility extends Abstract_Settings_Screen {
 
-
-	/** @var string screen ID */
-	const ID = 'whatsapp_utility';
-
 	/** @var flag to test Utility Messages Overview changes until check for integration config is implemented */
 	const WHATSAPP_UTILITY_MESSAGES_OVERVIEW_FLAG = false;
 

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -20,10 +20,6 @@ use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
  */
 class Whatsapp_Utility extends Abstract_Settings_Screen {
 
-
-	/** @var string screen ID */
-	const ID = 'whatsapp_utility';
-
 	/** @var flag to test Utility Messages Overview changes until check for integration config is implemented */
 	const WHATSAPP_UTILITY_MESSAGES_OVERVIEW_FLAG = false;
 
@@ -106,73 +102,67 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	public function render_utility_message_onboarding() {
 
 		?>
+		<div class="onboarding-card">
+			<div class="card-item">
+				<h1><b><?php esc_html_e( 'Send Updates to customers on WhatsApp', 'facebook-for-woocommerce' ); ?></b></h1>
+				<?php esc_html_e( 'Send important updates and notifications directly to customers through WhatsApp.', 'facebook-for-woocommerce' ); ?>
+			</div>
+			<div class="divider"></div>
+			<div class="card-item">
+				<h2><?php esc_html_e( 'Get started with WhatsApp utility messages', 'facebook-for-woocommerce' ); ?></h2>
+				<p><?php esc_html_e( 'Connect your WhatsApp Business Account to start sending utility messages.', 'facebook-for-woocommerce' ); ?></p>
+				<div class="whatsapp-onboarding-button">
+					<a
+						id="woocommerce-whatsapp-connection"
+						class="button button-primary"
+						href="#"><?php esc_html_e( 'Connect Whatsapp Account', 'facebook-for-woocommerce' ); ?></a>
+				</div>
+			</div>
+			<div class="divider"></div>
+			<div class="card-item">
+				<h2>Collect phone numbers at checkout</h2>
+				<p>To collect phone numbers, a checkbox will be added to your store’s checkout page. This lets customers sign up to receive your messages. You can preview what this looks like in your checkout page preview.</p>
+				<p>This will allow you to send messages to your customers on WhatsApp.</p>
+				<div class="whatsapp-onboarding-button">
+					<a
+						class="button button-primary"
+						id="wc-whatsapp-collect-consent"
+						href="#"><?php esc_html_e( 'Collect', 'facebook-for-woocommerce' ); ?></a>
+				</div>
+			</div>
+			<div class="divider"></div>
+			<div class="card-item">
+				<h2>Add a payment method</h2>
+				<p>Confirm your payment method in Billings & payments.
+					<a
+						href="#"
+						id="wc-whatsapp-about-pricing"><?php esc_html_e( 'About pricing', 'facebook-for-woocommerce' ); ?>
+					</a>
 
-	<div class="onboarding-card">
-	<div class="card-item">
-	<h1><b><?php esc_html_e( 'Send Updates to customers on WhatsApp', 'facebook-for-woocommerce' ); ?></b></h1>
-		<?php esc_html_e( 'Send important updates and notifications directly to customers through WhatsApp.', 'facebook-for-woocommerce' ); ?>
-	</div>
-	<div class="divider"></div>
-	<div class="card-item">
-	<h2><?php esc_html_e( 'Get started with WhatsApp utility messages', 'facebook-for-woocommerce' ); ?></h2>
-	<p><?php esc_html_e( 'Connect your WhatsApp Business Account to start sending utility messages.', 'facebook-for-woocommerce' ); ?></p>
-	<div class="whatsapp-onboarding-button">
-	<a
-			id="woocommerce-whatsapp-connection"
-			class="button"
-			href="#"
-		><?php esc_html_e( 'Connect Whatsapp Account', 'facebook-for-woocommerce' ); ?></a>
-	</div>
-	</div>
-	<div class="divider"></div>
-	<div class="card-item">
-	<h2><?php esc_html_e( 'Collect phone numbers at checkout', 'facebook-for-woocommerce' ); ?></h2>
-	<p><?php esc_html_e( 'To collect phone numbers, a checkbox will be added to your store’s checkout page. This lets customers sign up to receive your messages. You can preview what this looks like in your checkout page preview.', 'facebook-for-woocommerce' ); ?></p>
-		<p><?php esc_html_e( 'This will allow you to send messages to your customers on WhatsApp.', 'facebook-for-woocommerce' ); ?></p>
-		<div class="whatsapp-onboarding-button">
-		<a
-			class="button"
-			id="wc-whatsapp-collect-consent"
-			href="#"
-		><?php esc_html_e( 'Add', 'facebook-for-woocommerce' ); ?></a>
-		</div>
-	</div>
-	<div class="divider"></div>
-	<div class="card-item">
-		<h2><?php esc_html_e( 'Add a payment method', 'facebook-for-woocommerce' ); ?></h2>
-		<p><?php esc_html_e( 'Confirm your payment method in Billings & payments.', 'facebook-for-woocommerce' ); ?>
-				<a
-					href="#"
-					id="wc-whatsapp-about-pricing"
-				><?php esc_html_e( 'About pricing', 'facebook-for-woocommerce' ); ?>
-				</a>
-
-			</p>
-			<div class="add-payment-section">
-				<div class="review-payment-block">
-					<div class="review-payment-content">
-					<?php esc_html_e( 'Add a payment method', 'facebook-for-woocommerce' ); ?>
-					</div>
+				</p>
+				<div class="add-payment-section">
+					<div class="review-payment-block">
+						<div class="review-payment-content">
+							Add a payment method
+						</div>
 						<div class="add-payment-button">
 							<a
 								class="button"
 								id="wc-whatsapp-add-payment"
-								href="#"
-								><?php esc_html_e( 'Add', 'facebook-for-woocommerce' ); ?>
+								href="#"><?php esc_html_e( 'Add', 'facebook-for-woocommerce' ); ?>
 							</a>
 						</div>
+					</div>
+					<div class="whatsapp-onboarding-button">
+						<a
+							class="button button-primary"
+							id="wc-whatsapp-onboarding-finish"
+							href="#"><?php esc_html_e( 'Finish', 'facebook-for-woocommerce' ); ?></a>
+					</div>
 				</div>
-				<div class="whatsapp-onboarding-button">
-					<a
-						class="button button-primary"
-						id="wc-whatsapp-onboarding-finish"
-						href="#"
-					><?php esc_html_e( 'Finish', 'facebook-for-woocommerce' ); ?></a>
-				</div>
-			</div>
 
+			</div>
 		</div>
-	</div>
 		<?php
 	}
 
@@ -194,7 +184,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			<div class="card-item event-config">
 				<div>
 					<h3><b><?php esc_html_e( 'Order confirmation', 'facebook-for-woocommerce' ); ?></b></h3>
-					<p><?php esc_html_e( 'Send a confirmation to customers after they\'ve placed an order.', 'facebook-for-woocommerce' ); ?></p>
+					<p><?php esc_html_e( 'Send a confirmation to customers after they\'ve placed an order.' ); ?></p>
 				</div>
 				<div class="event-config-manage-button">
 					<a
@@ -207,7 +197,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			<div class="card-item event-config">
 				<div>
 					<h3><b><?php esc_html_e( 'Order shipped', 'facebook-for-woocommerce' ); ?></b></h3>
-					<p><?php esc_html_e( 'Send a confirmation to customers when their order is shipped.', 'facebook-for-woocommerce' ); ?></p>
+					<p><?php esc_html_e( 'Send a confirmation to customers when their order is shipped.' ); ?></p>
 				</div>
 				<div class="event-config-manage-button">
 					<a
@@ -220,7 +210,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			<div class="card-item event-config">
 				<div>
 					<h3><b><?php esc_html_e( 'Order refunded', 'facebook-for-woocommerce' ); ?></b></h3>
-					<p><?php esc_html_e( 'Send a confirmation to customers when an order is refunded.', 'facebook-for-woocommerce' ); ?></p>
+					<p><?php esc_html_e( 'Send a confirmation to customers when an order is refunded.' ); ?></p>
 				</div>
 				<div class="event-config-manage-button">
 					<a


### PR DESCRIPTION
This current PR is a scaffold for the UI elements in the utility message overview viwq once onboarding has successfully completed. In this change, we are using a feature to control the switch between the utility message overview view and the onboarding view. I will add the changes for the other cards in upcoming diffs a

Figma Screenshot for Utility Message overview UI
<img width="1160" alt="Screenshot 2025-04-04 at 9 00 43 PM" src="https://github.com/user-attachments/assets/fef750b5-eef0-44d1-b812-8ac8cbff6eb5" />

## Additional details
I am currently using a feature flag to determine if the whatsapp utility message onboarding has been completed. I will update this to use the integration config information instead in later code changes.

### Type of change
- [ ] New feature (non-breaking change which adds functionality)

## Changelog entry

Scaffold for Manage Utility Message Events UI

## Test Plan
1. Open Marketing > Facebook tab in wordpress containing facebook-for-woocommerce screens
2. Check if new Whatsapp utility tab is visible
3. Clicking on the tab shows connect to whatsapp button when flag is set to true
4. Clicking on the tab shows connect to whatsapp button when flag is set to false

## Screenshots
### Flag set true shows the "Utility Message overview" view
<img width="1727" alt="Screenshot 2025-04-09 at 9 19 11 AM" src="https://github.com/user-attachments/assets/db3dec29-e622-4991-9b94-9b90a9c0d879" />

### Flag set false shows the "Utility Message onboarding" view
<img width="1722" alt="Screenshot 2025-04-09 at 9 14 04 AM" src="https://github.com/user-attachments/assets/c21b0f9b-eaec-4a51-9093-db08a70af210" />


