### PR TITLE
Feature/truncate title description

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -102,6 +102,20 @@ class WC_Facebook_Product {
 	const MAX_TIME   = 'T23:59+00:00';
 	const MIN_TIME   = 'T00:00+00:00';
 
+  /**
+	 * Maximum length of product description.
+	 *
+	 * @var int
+	 */
+	public const MAX_DESCRIPTION_LENGTH = 5000;
+
+	/**
+	 * Maximum length of product title.
+	 *
+	 * @var int
+	 */
+	public const MAX_TITLE_LENGTH = 150;
+
 	static $use_checkout_url = array(
 		'simple'    => 1,
 		'variable'  => 1,
@@ -1169,7 +1183,7 @@ class WC_Facebook_Product {
 		$categories = WC_Facebookcommerce_Utils::get_product_categories( $id );
 		
 		$product_data = array();
-		$product_data[ 'description' ] = $this->get_fb_description();
+		$product_data[ 'description' ] = Helper::str_truncate( $this->get_fb_description(), self::MAX_DESCRIPTION_LENGTH );
 		$product_data[ 'rich_text_description' ] = $this->get_rich_text_description();
 		$product_data[ 'product_type' ] = $categories['categories'];
 		$product_data[ 'brand' ] = Helper::str_truncate( $this->get_fb_brand(), 100 );
@@ -1190,7 +1204,7 @@ class WC_Facebook_Product {
 		$product_data[ 'woo_product_type' ] = $this->get_type();
 
 		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
-			$product_data['title'] = WC_Facebookcommerce_Utils::clean_string( $this->get_title() );
+			$product_data['title'] = Helper::str_truncate( WC_Facebookcommerce_Utils::clean_string( $this->get_title() ), self::MAX_TITLE_LENGTH );
 			$product_data['image_link'] = $image_urls[0];
 			$product_data['additional_image_link'] = $this->get_additional_image_urls( $image_urls );
 			$product_data['link'] = $product_url;


### PR DESCRIPTION
## Description

in #2969 the validations were relaxed, this might cause some backend issues. In this diff, in order to sync products, we are truncating any extra characters form the title and description

### Type of change
- New feature (non-breaking change which adds functionality)

## Checklist

- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [X] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [X] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [X] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [X] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Truncates extra characters from title and description 


## Test Plan
Create item with more than the limits of 150 character for title and more than 5000 for description
Before:
The title/description will be missing
if both title and description are above limit, the item won't be synced


After:
Truncates (title/description)
<img width="2056" alt="image" src="https://github.com/user-attachments/assets/4eb494c7-d070-485a-8b6d-e9ff187fedfb" />
synced
<img width="2056" alt="image" src="https://github.com/user-attachments/assets/01b0a61d-3fe2-4a92-9a01-e2e263ad76a5" />


## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before

### After
