### PR TITLE
Remove the "Advertise" tab

### DIFF
--- a/includes/Admin/Enhanced_Settings.php
+++ b/includes/Admin/Enhanced_Settings.php
@@ -70,7 +70,6 @@ class Enhanced_Settings {
 			// TODO: Remove Product sync and Product sets tab once catalog changes are complete
 			return array(
 				Settings_Screens\Shops::ID        => new Settings_Screens\Shops(),
-				Settings_Screens\Advertise::ID    => new Settings_Screens\Advertise(),
 				Settings_Screens\Product_Sync::ID => new Settings_Screens\Product_Sync(),
 				Settings_Screens\Product_Sets::ID => new Settings_Screens\Product_Sets(),
 			);


### PR DESCRIPTION
## Description
This PR removes the "Advertise" tab from the enhanced settings UI.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Test Plan
1. Set `use_enhanced_onboarding()` in `facebook-for-woocommerce/facebook-commerce.php` to true.
2. Go to `http://test-site-i.local/wp-admin/admin.php?page=wc-facebook`. Make sure you have an existing connection to Meta. The "Advertise" tab should no longer be visible

## Screenshots
### Before
<img width="1728" alt="Screenshot 2025-04-07 at 4 21 50 PM" src="https://github.com/user-attachments/assets/46b4926a-d298-4939-9f3a-7ac7c350b916" />

### After
<img width="1728" alt="Screenshot 2025-04-07 at 4 17 59 PM" src="https://github.com/user-attachments/assets/f2cb5391-7b0c-40c5-8a98-316522f6d66b" />