### PR TITLE
[WAUM][11/n]Update the Rest API to receive all onboarding info and perform authentication using auth key

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -889,7 +889,6 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 		}
 		return $fields;
 	}
-}
 
 	/**
 	 * Determines if the enhanced onboarding (iframe) should be used.

--- a/includes/Handlers/Whatsapp_Webhook.php
+++ b/includes/Handlers/Whatsapp_Webhook.php
@@ -81,7 +81,7 @@ class Whatsapp_Webhook {
 	private static function authenticate_request( $auth_key, $bisu_token ) {
 		$external_business_id = get_option( 'wc_facebook_external_business_id' );
 
-		$expected_auth_key = hash_hmac( 'sha1', $bisu_token, $external_business_id );
+		$expected_auth_key = 'sha1=' . (string) hash_hmac( 'sha1', $bisu_token, $external_business_id );
 
 		return hash_equals( $expected_auth_key, $auth_key );
 	}

--- a/includes/Handlers/Whatsapp_Webhook.php
+++ b/includes/Handlers/Whatsapp_Webhook.php
@@ -70,9 +70,10 @@ class Whatsapp_Webhook {
 	}
 
 	/**
-	 * Authenticates Whatsapp Webhook using the SHA1 pf the external business ID and BISU token
+	 * Authenticates Whatsapp Webhook using the SHA1 of the external business ID and BISU token
 	 *
-	 * @param string $auth_key, string $bisu_token
+	 * @param string $auth_key the auth key received in the webhook
+	 * @param string $bisu_token the BISU token received in the webhook
 	 *
 	 * @return bool
 	 * @internal
@@ -110,7 +111,7 @@ class Whatsapp_Webhook {
 		// authentication is done via auth_key using sha_1 hash mac of BISU token and external business ID stored in woo DB
 		$authentication_result = self::authenticate_request( $auth_key, $bisu_token );
 
-		if ( $authentication_result === false ) {
+		if ( false === $authentication_result ) {
 			wc_get_logger()->info(
 				sprintf(
 					__( 'Authentication Failure on received Whatsapp Webhook', 'facebook-for-woocommerce' ),
@@ -150,7 +151,7 @@ class Whatsapp_Webhook {
 
 		$result = self::update_settings( $options_setting_fields );
 
-		if ( $result === false ) {
+		if ( false === $result ) {
 			wc_get_logger()->info(
 				sprintf(
 						/* translators: %d $waba_id, %d $business_id. */

--- a/includes/Handlers/Whatsapp_Webhook.php
+++ b/includes/Handlers/Whatsapp_Webhook.php
@@ -69,6 +69,22 @@ class Whatsapp_Webhook {
 		return ! in_array( false, $updated, true );
 	}
 
+	/**
+	 * Authenticates Whatsapp Webhook using the SHA1 pf the external business ID and BISU token
+	 *
+	 * @param string $auth_key, string $bisu_token
+	 *
+	 * @return bool
+	 * @internal
+	 */
+	private static function authenticate_request( $auth_key, $bisu_token ) {
+		$external_business_id = get_option( 'wc_facebook_external_business_id' );
+
+		$expected_auth_key = hash_hmac( 'sha1', $bisu_token, $external_business_id );
+
+		return hash_equals( $expected_auth_key, $auth_key );
+	}
+
 
 
 	/**
@@ -81,19 +97,40 @@ class Whatsapp_Webhook {
 	 * @return \WP_REST_Response
 	 */
 	public function whatsapp_webhook_callback( \WP_REST_Request $request ) {
-		$request_params = $request->get_query_params();
-		$waba_id        = sanitize_text_field( $request_params['waba_id'] );
-		$access_token   = sanitize_text_field( $request_params['access_token'] );
-		$business_id    = sanitize_text_field( $request_params['business_id'] );
-		// TODO: Request authentication
+		$request_params           = $request->get_params();
+		$waba_id                  = sanitize_text_field( $request_params['waba_id'] );
+		$wacs_id                  = sanitize_text_field( $request_params['wacs_id'] );
+		$is_waba_payment_setup    = sanitize_text_field( $request_params['is_waba_payment_setup'] );
+		$waba_profile_picture_url = sanitize_text_field( $request_params['waba_profile_picture_url'] );
+		$bisu_token               = sanitize_text_field( $request_params['client_bisu_token'] );
+		$business_id              = sanitize_text_field( $request_params['client_business_id'] );
+		$wacs_phone_number        = sanitize_text_field( $request_params['wacs_phone_number'] );
+		$auth_key                 = sanitize_text_field( $request_params['auth_key'] );
 
-		if ( empty( $waba_id ) || empty( $access_token ) || empty( $business_id ) ) {
+		// authentication is done via auth_key using sha_1 hash mac of BISU token and external business ID stored in woo DB
+		$authentication_result = self::authenticate_request( $auth_key, $bisu_token );
+
+		if ( $authentication_result === false ) {
+			wc_get_logger()->info(
+				sprintf(
+					__( 'Authentication Failure on received Whatsapp Webhook', 'facebook-for-woocommerce' ),
+				)
+			);
+			return new \WP_REST_Response( null, 400 );
+		}
+
+		if ( empty( $waba_id ) || empty( $bisu_token ) || empty( $business_id ) || empty( $wacs_phone_number ) || empty( $wacs_id ) ) {
+				wc_get_logger()->info(
+					sprintf(
+						__( 'All required onboarding info not received in Whatsapp Webhook', 'facebook-for-woocommerce' ),
+					)
+				);
 			return new \WP_REST_Response( null, 400 );
 		}
 
 		wc_get_logger()->info(
 			sprintf(
-						/* translators: %d user ID. */
+						/* translators: %s waba ID %s business ID */
 				__( 'Whatsapp Account WebHook Event received. WABA ID: %1$s, Business ID: %2$s ', 'facebook-for-woocommerce' ),
 				$waba_id,
 				$business_id
@@ -102,19 +139,37 @@ class Whatsapp_Webhook {
 
 		$options_setting_fields = array(
 			'wc_facebook_wa_integration_waba_id'           => $waba_id,
-			'wc_facebook_wa_integration_bisu_access_token' => $access_token,
+			'wc_facebook_wa_integration_bisu_access_token' => $bisu_token,
 			'wc_facebook_wa_integration_business_id'       => $business_id,
+			'wc_facebook_wa_integration_wacs_phone_number' => $wacs_phone_number,
+			'wc_facebook_wa_integration_is_payment_setup'  => $is_waba_payment_setup,
+			'wc_facebook_wa_integration_wacs_id'           => $wacs_id,
+			'wc_facebook_wa_integration_waba_profile_picture_url' => $waba_profile_picture_url,
+
 		);
 
 		$result = self::update_settings( $options_setting_fields );
 
-		// TODO: add validation for wp_options table update
+		if ( $result === false ) {
+			wc_get_logger()->info(
+				sprintf(
+						/* translators: %d $waba_id, %d $business_id. */
+					__( 'Whatsapp Integration Setting Fields Update Failure waba_id: %1$s, business_id: %2$s', 'facebook-for-woocommerce' ),
+					$waba_id,
+					$business_id,
+				)
+			);
+
+			return new \WP_REST_Response( null, 400 );
+
+		}
+
 		wc_get_logger()->info(
 			sprintf(
 						/* translators: %d $waba_id, %d $business_id. */
 				__( 'Whatsapp Integration Setting Fields stored successfully in wp_options. wc_facebook_wa_integration_waba_id: %1$s, wc_facebook_wa_integration_business_id: %2$s ', 'facebook-for-woocommerce' ),
 				$waba_id,
-				$business_id
+				$business_id,
 			)
 		);
 


### PR DESCRIPTION

## Description
Update the Rest Whatsapp POST API to receive all onboarding info and perform authentication using auth key and store it in DB

### Type of change
- New feature (non-breaking change which adds functionality)


## Changelog entry
Update the Rest Whatsapp POST API to receive all onboarding info 


## Test Plan
Tested the flow with right and wrong auth keys to check if request is success and failure

## Screenshots
Request with correct auth key stores the right data as expected.
![Screenshot 2025-04-07 at 4 09 50 PM](https://github.com/user-attachments/assets/26b05dfe-4fcd-41ae-9a38-a6fbeee59016)
<img width="1728" alt="Screenshot 2025-04-07 at 4 09 59 PM" src="https://github.com/user-attachments/assets/682ceb49-16e5-4ae9-9f37-bcfb1a71237b" />

