### PR TITLE
Deprecate Facebook-specific Product Fields and Add Warning Banners

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1521,7 +1521,17 @@ class Admin {
 			$sync_mode = self::SYNC_MODE_SYNC_DISABLED;
 		}
 
-		// Only show deprecation notice if any of the deprecated fields exist
+		// Always show the sync mode selector
+		?>
+		<div class="facebook-metabox wc-metabox closed">
+			<h3>
+				<strong><?php esc_html_e( 'Facebook for WooCommerce', 'facebook-for-woocommerce' ); ?></strong>
+				<div class="handlediv" aria-label="<?php esc_attr_e( 'Click to toggle', 'facebook-for-woocommerce' ); ?>"></div>
+			</h3>
+			<div class="wc-metabox-content" style="display: none;">
+				<?php
+
+				// Only show deprecation notice if any of the deprecated fields exist
 		if ( $variation->get_id() && ( $description || $image_url || $price ) ) {
 			?>
 			<div class="notice notice-info inline is-dismissible" style="background-color: #f8f9fa; border-left-color: #72777c; margin: 15px 0;">
@@ -1549,16 +1559,6 @@ class Admin {
 			</script>
 			<?php
 		}
-
-		// Always show the sync mode selector
-		?>
-		<div class="facebook-metabox wc-metabox closed">
-			<h3>
-				<strong><?php esc_html_e( 'Facebook for WooCommerce', 'facebook-for-woocommerce' ); ?></strong>
-				<div class="handlediv" aria-label="<?php esc_attr_e( 'Click to toggle', 'facebook-for-woocommerce' ); ?>"></div>
-			</h3>
-			<div class="wc-metabox-content" style="display: none;">
-				<?php
 				// Sync Mode Select
 				woocommerce_wp_select(
 					array(

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1515,6 +1515,7 @@ class Admin {
 		$image_source = $variation->get_meta( Products::PRODUCT_IMAGE_SOURCE_META_KEY );
 		$fb_mpn       = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_MPN, $parent );
 
+		$has_fb_specific_variation_fields = !empty($description) || !empty($image_url) || !empty($price);
 		if ( $sync_enabled ) {
 			$sync_mode = $is_visible ? self::SYNC_MODE_SYNC_AND_SHOW : self::SYNC_MODE_SYNC_AND_HIDE;
 		} else {
@@ -1531,8 +1532,8 @@ class Admin {
 			<div class="wc-metabox-content" style="display: none;">
 				<?php
 
-				// Only show deprecation notice if any of the deprecated fields exist
-		if ( $variation->get_id() && ( $description || $image_url || $price ) ) {
+		// Only show deprecation notice if any of the deprecated fields exist
+		if ( $variation->get_id() && ($has_fb_specific_variation_fields) ) {
 			?>
 			<div class="notice notice-info inline is-dismissible" style="background-color: #f8f9fa; border-left-color: #72777c; margin: 15px 0;">
 				<p>
@@ -1578,7 +1579,7 @@ class Admin {
 					)
 				);
 
-				if ( $variation->get_id() && $description ) {
+				if ( $variation->get_id() && $has_fb_specific_variation_fields ) {
 						woocommerce_wp_textarea_input(
 							array(
 								'id'            => sprintf( 'variable_%s%s', \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $index ),
@@ -1593,7 +1594,7 @@ class Admin {
 						);
 				}
 
-				if ( $variation->get_id() && $image_url ) {
+				if ( $variation->get_id() && $has_fb_specific_variation_fields ) {
 					woocommerce_wp_radio(
 						array(
 							'id'            => "variable_fb_product_image_source$index",
@@ -1612,6 +1613,7 @@ class Admin {
 						)
 					);
 
+					if ( $variation->get_id() && $has_fb_specific_variation_fields ) {
 						woocommerce_wp_text_input(
 							array(
 								'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_PRODUCT_IMAGE, $index ),
@@ -1624,8 +1626,9 @@ class Admin {
 								'description'   => __( 'Please enter an absolute URL (e.g. https://domain.com/image.jpg).', 'facebook-for-woocommerce' ),
 							)
 						);
+					}
 
-					if ( $variation->get_id() && $price ) {
+					if ( $variation->get_id() && $has_fb_specific_variation_fields ) {
 						woocommerce_wp_text_input(
 							array(
 								'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_PRODUCT_PRICE, $index ),

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1157,10 +1157,10 @@ class Admin {
 		global $post;
 
 		// all products have sync enabled unless explicitly disabled
-		$sync_enabled = 'no' !== get_post_meta( $post->ID, Products::SYNC_ENABLED_META_KEY, true );
-		$visibility   = get_post_meta( $post->ID, Products::VISIBILITY_META_KEY, true );
-		$is_visible   = $visibility ? wc_string_to_bool( $visibility ) : true;
-		$product      = wc_get_product( $post );
+		$sync_enabled           = 'no' !== get_post_meta( $post->ID, Products::SYNC_ENABLED_META_KEY, true );
+		$visibility             = get_post_meta( $post->ID, Products::VISIBILITY_META_KEY, true );
+		$is_visible             = $visibility ? wc_string_to_bool( $visibility ) : true;
+		$product                = wc_get_product( $post );
 		$fb_product_description = get_post_meta( $post->ID, \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, true );
 		$fb_mpn                 = get_post_meta( $post->ID, \WC_Facebook_Product::FB_MPN, true );
 		$rich_text_description  = get_post_meta( $post->ID, \WC_Facebookcommerce_Integration::FB_RICH_TEXT_DESCRIPTION, true );
@@ -1515,7 +1515,7 @@ class Admin {
 		$image_source = $variation->get_meta( Products::PRODUCT_IMAGE_SOURCE_META_KEY );
 		$fb_mpn       = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_MPN, $parent );
 
-		$has_fb_specific_variation_fields = !empty($description) || !empty($image_url) || !empty($price);
+		$has_fb_specific_variation_fields = ! empty( $description ) || ! empty( $image_url ) || ! empty( $price );
 		if ( $sync_enabled ) {
 			$sync_mode = $is_visible ? self::SYNC_MODE_SYNC_AND_SHOW : self::SYNC_MODE_SYNC_AND_HIDE;
 		} else {
@@ -1532,9 +1532,9 @@ class Admin {
 			<div class="wc-metabox-content" style="display: none;">
 				<?php
 
-		// Only show deprecation notice if any of the deprecated fields exist
-		if ( $variation->get_id() && ($has_fb_specific_variation_fields) ) {
-			?>
+				// Only show deprecation notice if any of the deprecated fields exist
+				if ( $variation->get_id() && ( $has_fb_specific_variation_fields ) ) {
+					?>
 			<div class="notice notice-info inline is-dismissible" style="background-color: #f8f9fa; border-left-color: #72777c; margin: 15px 0;">
 				<p>
 					<?php
@@ -1558,8 +1558,8 @@ class Admin {
 					});
 				});
 			</script>
-			<?php
-		}
+					<?php
+				}
 				// Sync Mode Select
 				woocommerce_wp_select(
 					array(
@@ -1579,87 +1579,88 @@ class Admin {
 					)
 				);
 
-				if ( $variation->get_id() && $has_fb_specific_variation_fields ) {
-						woocommerce_wp_textarea_input(
-							array(
-								'id'            => sprintf( 'variable_%s%s', \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $index ),
-								'name'          => sprintf( "variable_%s[$index]", \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION ),
-								'label'         => __( 'Facebook Description', 'facebook-for-woocommerce' ),
-								'desc_tip'      => true,
-								'description'   => __( 'Custom (plain-text only) description for product on Facebook. If blank, product description will be used. If product description is blank, shortname will be used.', 'facebook-for-woocommerce' ),
-								'value'         => $description,
-								'class'         => 'enable-if-sync-enabled',
-								'wrapper_class' => 'form-row form-row-full',
-							)
-						);
-				}
+		if ( $variation->get_id() && $has_fb_specific_variation_fields ) {
+				woocommerce_wp_textarea_input(
+					array(
+						'id'            => sprintf( 'variable_%s%s', \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $index ),
+						'name'          => sprintf( "variable_%s[$index]", \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION ),
+						'label'         => __( 'Facebook Description', 'facebook-for-woocommerce' ),
+						'desc_tip'      => true,
+						'description'   => __( 'Custom (plain-text only) description for product on Facebook. If blank, product description will be used. If product description is blank, shortname will be used.', 'facebook-for-woocommerce' ),
+						'value'         => $description,
+						'class'         => 'enable-if-sync-enabled',
+						'wrapper_class' => 'form-row form-row-full',
+					)
+				);
+		}
 
-				if ( $variation->get_id() && $has_fb_specific_variation_fields ) {
-					woocommerce_wp_radio(
-						array(
-							'id'            => "variable_fb_product_image_source$index",
-							'name'          => "variable_fb_product_image_source[$index]",
-							'label'         => __( 'Facebook Product Image', 'facebook-for-woocommerce' ),
-							'desc_tip'      => true,
-							'description'   => __( 'Choose the product image that should be synced to the Facebook catalog and displayed for this product.', 'facebook-for-woocommerce' ),
-							'options'       => array(
-								Products::PRODUCT_IMAGE_SOURCE_PRODUCT => __( 'Use variation image', 'facebook-for-woocommerce' ),
-								Products::PRODUCT_IMAGE_SOURCE_PARENT_PRODUCT => __( 'Use parent image', 'facebook-for-woocommerce' ),
-								Products::PRODUCT_IMAGE_SOURCE_CUSTOM  => __( 'Use custom image', 'facebook-for-woocommerce' ),
-							),
-							'value'         => $image_source ?: Products::PRODUCT_IMAGE_SOURCE_PRODUCT,
-							'class'         => 'enable-if-sync-enabled js-fb-product-image-source',
-							'wrapper_class' => 'fb-product-image-source-field',
-						)
-					);
+		if ( $variation->get_id() && $has_fb_specific_variation_fields ) {
+			woocommerce_wp_radio(
+				array(
+					'id'            => "variable_fb_product_image_source$index",
+					'name'          => "variable_fb_product_image_source[$index]",
+					'label'         => __( 'Facebook Product Image', 'facebook-for-woocommerce' ),
+					'desc_tip'      => true,
+					'description'   => __( 'Choose the product image that should be synced to the Facebook catalog and displayed for this product.', 'facebook-for-woocommerce' ),
+					'options'       => array(
+						Products::PRODUCT_IMAGE_SOURCE_PRODUCT => __( 'Use variation image', 'facebook-for-woocommerce' ),
+						Products::PRODUCT_IMAGE_SOURCE_PARENT_PRODUCT => __( 'Use parent image', 'facebook-for-woocommerce' ),
+						Products::PRODUCT_IMAGE_SOURCE_CUSTOM  => __( 'Use custom image', 'facebook-for-woocommerce' ),
+					),
+					'value'         => $image_source ?: Products::PRODUCT_IMAGE_SOURCE_PRODUCT,
+					'class'         => 'enable-if-sync-enabled js-fb-product-image-source',
+					'wrapper_class' => 'fb-product-image-source-field',
+				)
+			);
 
-					if ( $variation->get_id() && $has_fb_specific_variation_fields ) {
-						woocommerce_wp_text_input(
-							array(
-								'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_PRODUCT_IMAGE, $index ),
-								'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_PRODUCT_IMAGE ),
-								'label'         => __( 'Custom Image URL', 'facebook-for-woocommerce' ),
-								'value'         => $image_url,
-								'class'         => sprintf( 'enable-if-sync-enabled product-image-source-field show-if-product-image-source-%s', Products::PRODUCT_IMAGE_SOURCE_CUSTOM ),
-								'wrapper_class' => 'form-row form-row-full',
-								'desc_tip'      => true,
-								'description'   => __( 'Please enter an absolute URL (e.g. https://domain.com/image.jpg).', 'facebook-for-woocommerce' ),
-							)
-						);
-					}
+			if ( $variation->get_id() && $has_fb_specific_variation_fields ) {
+				woocommerce_wp_text_input(
+					array(
+						'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_PRODUCT_IMAGE, $index ),
+						'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_PRODUCT_IMAGE ),
+						'label'         => __( 'Custom Image URL', 'facebook-for-woocommerce' ),
+						'value'         => $image_url,
+						'class'         => sprintf( 'enable-if-sync-enabled product-image-source-field show-if-product-image-source-%s', Products::PRODUCT_IMAGE_SOURCE_CUSTOM ),
+						'wrapper_class' => 'form-row form-row-full',
+						'desc_tip'      => true,
+						'description'   => __( 'Please enter an absolute URL (e.g. https://domain.com/image.jpg).', 'facebook-for-woocommerce' ),
+					)
+				);
+			}
 
-					if ( $variation->get_id() && $has_fb_specific_variation_fields ) {
-						woocommerce_wp_text_input(
-							array(
-								'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_PRODUCT_PRICE, $index ),
-								'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_PRODUCT_PRICE ),
-								'label'         => sprintf(
-								/* translators: Placeholders %1$s - WC currency symbol */
-									__( 'Facebook Price (%1$s)', 'facebook-for-woocommerce' ),
-									get_woocommerce_currency_symbol()
-								),
-								'desc_tip'      => true,
-								'description'   => __( 'Custom price for product on Facebook. Please enter in monetary decimal (.) format without thousand separators and currency symbols. If blank, product price will be used.', 'facebook-for-woocommerce' ),
-								'value'         => wc_format_decimal( $price ),
-								'class'         => 'enable-if-sync-enabled',
-								'wrapper_class' => 'form-row form-full',
-							)
-						);
-					}
+			if ( $variation->get_id() && $has_fb_specific_variation_fields ) {
+				woocommerce_wp_text_input(
+					array(
+						'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_PRODUCT_PRICE, $index ),
+						'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_PRODUCT_PRICE ),
+						'label'         => sprintf(
+						/* translators: Placeholders %1$s - WC currency symbol */
+							__( 'Facebook Price (%1$s)', 'facebook-for-woocommerce' ),
+							get_woocommerce_currency_symbol()
+						),
+						'desc_tip'      => true,
+						'description'   => __( 'Custom price for product on Facebook. Please enter in monetary decimal (.) format without thousand separators and currency symbols. If blank, product price will be used.', 'facebook-for-woocommerce' ),
+						'value'         => wc_format_decimal( $price ),
+						'class'         => 'enable-if-sync-enabled',
+						'wrapper_class' => 'form-row form-full',
+					)
+				);
+			}
+		}
 
-						woocommerce_wp_text_input(
-							array(
-								'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_MPN, $index ),
-								'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_MPN ),
-								'label'         => __( 'Manufacturer Parts Number (MPN)', 'facebook-for-woocommerce' ),
-								'desc_tip'      => true,
-								'description'   => __( 'Manufacturer Parts Number', 'facebook-for-woocommerce' ),
-								'value'         => wc_format_decimal( $fb_mpn ),
-								'class'         => 'enable-if-sync-enabled',
-								'wrapper_class' => 'form-row form-full',
-							)
-						);
-					?>
+				woocommerce_wp_text_input(
+					array(
+						'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_MPN, $index ),
+						'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_MPN ),
+						'label'         => __( 'Manufacturer Parts Number (MPN)', 'facebook-for-woocommerce' ),
+						'desc_tip'      => true,
+						'description'   => __( 'Manufacturer Parts Number', 'facebook-for-woocommerce' ),
+						'value'         => wc_format_decimal( $fb_mpn ),
+						'class'         => 'enable-if-sync-enabled',
+						'wrapper_class' => 'form-row form-full',
+					)
+				);
+		?>
 			</div>
 		</div>
 
@@ -1685,8 +1686,7 @@ class Admin {
 			});
 		</script>
 					<?php
-				}}
-
+	}
 
 	/**
 	 * Gets the stored value for the given meta of a product variation.
@@ -1700,13 +1700,13 @@ class Admin {
 	 * @param \WC_Product           $parent_product the parent product
 	 * @return mixed
 	 */
-	private function get_product_variation_meta( $variation, $key, $parent_product ) {
-		$value = $variation->get_meta( $key );
-		if ( '' === $value && $parent_product instanceof \WC_Product ) {
-			$value = $parent_product->get_meta( $key );
-		}
-		return $value;
+private function get_product_variation_meta( $variation, $key, $parent_product ) {
+	$value = $variation->get_meta( $key );
+	if ( '' === $value && $parent_product instanceof \WC_Product ) {
+		$value = $parent_product->get_meta( $key );
 	}
+	return $value;
+}
 
 
 	/**
@@ -1719,48 +1719,48 @@ class Admin {
 	 * @param int $variation_id the ID of the product variation being edited
 	 * @param int $index the index of the current variation
 	 */
-	public function save_product_variation_edit_fields( $variation_id, $index ) {
-		$variation = wc_get_product( $variation_id );
-		if ( ! $variation instanceof \WC_Product_Variation ) {
-			return;
-		}
-		// phpcs:disable WordPress.Security.NonceVerification.Missing
-		$sync_mode    = isset( $_POST['variable_facebook_sync_mode'][ $index ] ) ? wc_clean( wp_unslash( $_POST['variable_facebook_sync_mode'][ $index ] ) ) : self::SYNC_MODE_SYNC_DISABLED;
-		$sync_enabled = self::SYNC_MODE_SYNC_DISABLED !== $sync_mode;
-		if ( self::SYNC_MODE_SYNC_AND_SHOW === $sync_mode && $variation->is_virtual() ) {
-			// force to Sync and hide
-			$sync_mode = self::SYNC_MODE_SYNC_AND_HIDE;
-		}
-		if ( $sync_enabled ) {
-			Products::enable_sync_for_products( array( $variation ) );
-			Products::set_product_visibility( $variation, self::SYNC_MODE_SYNC_AND_HIDE !== $sync_mode );
-			$posted_param = 'variable_' . \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION;
-			$description  = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_text_field( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
-			$posted_param = 'variable_' . \WC_Facebook_Product::FB_MPN;
-			$fb_mpn       = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_text_field( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
-			$posted_param = 'variable_fb_product_image_source';
-			$image_source = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_key( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : '';
-			$posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_IMAGE;
-			$image_url    = isset( $_POST[ $posted_param ][ $index ] ) ? esc_url_raw( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
-			$posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_CONDITION;
-			$image_url    = isset( $_POST[ $posted_param ][ $index ] ) ? esc_url_raw( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
-			$posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_VIDEO;
-			$video_urls   = isset( $_POST[ $posted_param ][ $index ] ) ? esc_url_raw( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : [];
-			$posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_PRICE;
-			$price        = isset( $_POST[ $posted_param ][ $index ] ) ? wc_format_decimal( wc_clean( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) ) : '';
-			$variation->update_meta_data( \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $description );
-			$variation->update_meta_data( \WC_Facebookcommerce_Integration::FB_RICH_TEXT_DESCRIPTION, $description );
-			$variation->update_meta_data( Products::PRODUCT_IMAGE_SOURCE_META_KEY, $image_source );
-			$variation->update_meta_data( \WC_Facebook_Product::FB_MPN, $fb_mpn );
-			$variation->update_meta_data( \WC_Facebook_Product::FB_PRODUCT_IMAGE, $image_url );
-			$variation->update_meta_data( \WC_Facebook_Product::FB_PRODUCT_VIDEO, $video_urls );
-			$variation->update_meta_data( \WC_Facebook_Product::FB_PRODUCT_PRICE, $price );
-			$variation->save_meta_data();
-		} else {
-			Products::disable_sync_for_products( array( $variation ) );
-		}//end if
-		// phpcs:enable WordPress.Security.NonceVerification.Missing
+public function save_product_variation_edit_fields( $variation_id, $index ) {
+	$variation = wc_get_product( $variation_id );
+	if ( ! $variation instanceof \WC_Product_Variation ) {
+		return;
 	}
+	// phpcs:disable WordPress.Security.NonceVerification.Missing
+	$sync_mode    = isset( $_POST['variable_facebook_sync_mode'][ $index ] ) ? wc_clean( wp_unslash( $_POST['variable_facebook_sync_mode'][ $index ] ) ) : self::SYNC_MODE_SYNC_DISABLED;
+	$sync_enabled = self::SYNC_MODE_SYNC_DISABLED !== $sync_mode;
+	if ( self::SYNC_MODE_SYNC_AND_SHOW === $sync_mode && $variation->is_virtual() ) {
+		// force to Sync and hide
+		$sync_mode = self::SYNC_MODE_SYNC_AND_HIDE;
+	}
+	if ( $sync_enabled ) {
+		Products::enable_sync_for_products( array( $variation ) );
+		Products::set_product_visibility( $variation, self::SYNC_MODE_SYNC_AND_HIDE !== $sync_mode );
+		$posted_param = 'variable_' . \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION;
+		$description  = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_text_field( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
+		$posted_param = 'variable_' . \WC_Facebook_Product::FB_MPN;
+		$fb_mpn       = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_text_field( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
+		$posted_param = 'variable_fb_product_image_source';
+		$image_source = isset( $_POST[ $posted_param ][ $index ] ) ? sanitize_key( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : '';
+		$posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_IMAGE;
+		$image_url    = isset( $_POST[ $posted_param ][ $index ] ) ? esc_url_raw( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
+		$posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_CONDITION;
+		$image_url    = isset( $_POST[ $posted_param ][ $index ] ) ? esc_url_raw( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
+		$posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_VIDEO;
+		$video_urls   = isset( $_POST[ $posted_param ][ $index ] ) ? esc_url_raw( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : [];
+		$posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_PRICE;
+		$price        = isset( $_POST[ $posted_param ][ $index ] ) ? wc_format_decimal( wc_clean( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) ) : '';
+		$variation->update_meta_data( \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $description );
+		$variation->update_meta_data( \WC_Facebookcommerce_Integration::FB_RICH_TEXT_DESCRIPTION, $description );
+		$variation->update_meta_data( Products::PRODUCT_IMAGE_SOURCE_META_KEY, $image_source );
+		$variation->update_meta_data( \WC_Facebook_Product::FB_MPN, $fb_mpn );
+		$variation->update_meta_data( \WC_Facebook_Product::FB_PRODUCT_IMAGE, $image_url );
+		$variation->update_meta_data( \WC_Facebook_Product::FB_PRODUCT_VIDEO, $video_urls );
+		$variation->update_meta_data( \WC_Facebook_Product::FB_PRODUCT_PRICE, $price );
+		$variation->save_meta_data();
+	} else {
+		Products::disable_sync_for_products( array( $variation ) );
+	}//end if
+	// phpcs:enable WordPress.Security.NonceVerification.Missing
+}
 
 
 	/**
@@ -1770,14 +1770,14 @@ class Admin {
 	 *
 	 * @since 1.10.0
 	 */
-	public function render_modal_template() {
-		global $current_screen;
+public function render_modal_template() {
+	global $current_screen;
 
-		// bail if not on the products, product edit, or settings screen
-		if ( ! $current_screen || ! in_array( $current_screen->id, $this->screen_ids, true ) ) {
-			return;
-		}
-		?>
+	// bail if not on the products, product edit, or settings screen
+	if ( ! $current_screen || ! in_array( $current_screen->id, $this->screen_ids, true ) ) {
+		return;
+	}
+	?>
 		<script type="text/template" id="tmpl-facebook-for-woocommerce-modal">
 			<div class="wc-backbone-modal facebook-for-woocommerce-modal">
 				<div class="wc-backbone-modal-content">
@@ -1798,14 +1798,14 @@ class Admin {
 			<div class="wc-backbone-modal-backdrop modal-close"></div>
 		</script>
 		<?php
-	}
+}
 
-	public function add_tab_switch_script() {
-		global $post;
-		if ( ! $post || get_post_type( $post ) !== 'product' ) {
-			return;
-		}
-		?>
+public function add_tab_switch_script() {
+	global $post;
+	if ( ! $post || get_post_type( $post ) !== 'product' ) {
+		return;
+	}
+	?>
 		<script type="text/javascript">
 			jQuery(document).ready(function($) {
 				// State object to track badge display status
@@ -1942,75 +1942,75 @@ class Admin {
 			});
 		</script>
 		<?php
+}
+
+public function sync_product_attributes( $product_id ) {
+	$product = wc_get_product( $product_id );
+	if ( ! $product ) {
+		return [];
 	}
 
-	public function sync_product_attributes( $product_id ) {
-		$product = wc_get_product( $product_id );
-		if ( ! $product ) {
-			return [];
+	$attributes      = $product->get_attributes();
+	$facebook_fields = [];
+
+	$attribute_map = [
+		'material' => \WC_Facebook_Product::FB_MATERIAL,
+		'color'    => \WC_Facebook_Product::FB_COLOR,
+		'colour'   => \WC_Facebook_Product::FB_COLOR, // Add support for British spelling
+		'size'     => \WC_Facebook_Product::FB_SIZE,
+		'pattern'  => \WC_Facebook_Product::FB_PATTERN,
+		'brand'    => \WC_Facebook_Product::FB_BRAND,
+		'mpn'      => \WC_Facebook_Product::FB_MPN,
+	];
+
+	// Then process existing attributes
+	foreach ( $attributes as $attribute ) {
+		$normalized_attr_name = strtolower( $attribute->get_name() );
+
+		// Special handling for color/colour
+		if ( 'color' === $normalized_attr_name || 'colour' === $normalized_attr_name ) {
+			$meta_key   = \WC_Facebook_Product::FB_COLOR;
+			$field_name = 'color';
+		} else {
+			$meta_key   = $attribute_map[ $normalized_attr_name ] ?? null;
+			$field_name = $normalized_attr_name;
 		}
 
-		$attributes      = $product->get_attributes();
-		$facebook_fields = [];
+		if ( $meta_key ) {
+			$values = [];
 
-		$attribute_map = [
-			'material' => \WC_Facebook_Product::FB_MATERIAL,
-			'color'    => \WC_Facebook_Product::FB_COLOR,
-			'colour'   => \WC_Facebook_Product::FB_COLOR, // Add support for British spelling
-			'size'     => \WC_Facebook_Product::FB_SIZE,
-			'pattern'  => \WC_Facebook_Product::FB_PATTERN,
-			'brand'    => \WC_Facebook_Product::FB_BRAND,
-			'mpn'      => \WC_Facebook_Product::FB_MPN,
-		];
-
-		// Then process existing attributes
-		foreach ( $attributes as $attribute ) {
-			$normalized_attr_name = strtolower( $attribute->get_name() );
-
-			// Special handling for color/colour
-			if ( 'color' === $normalized_attr_name || 'colour' === $normalized_attr_name ) {
-				$meta_key   = \WC_Facebook_Product::FB_COLOR;
-				$field_name = 'color';
+			if ( $attribute->is_taxonomy() ) {
+				$terms = $attribute->get_terms();
+				if ( $terms ) {
+					$values = wp_list_pluck( $terms, 'name' );
+				}
 			} else {
-				$meta_key   = $attribute_map[ $normalized_attr_name ] ?? null;
-				$field_name = $normalized_attr_name;
+				$values = $attribute->get_options();
 			}
 
-			if ( $meta_key ) {
-				$values = [];
-
-				if ( $attribute->is_taxonomy() ) {
-					$terms = $attribute->get_terms();
-					if ( $terms ) {
-						$values = wp_list_pluck( $terms, 'name' );
-					}
-				} else {
-					$values = $attribute->get_options();
-				}
-
-				if ( ! empty( $values ) ) {
-					// Join multiple values with a pipe character and spaces
-					$joined_values                  = implode( ' | ', $values );
-					$facebook_fields[ $field_name ] = $joined_values;
-					update_post_meta( $product_id, $meta_key, $joined_values );
-				} else {
-					delete_post_meta( $product_id, $meta_key );
-					$facebook_fields[ $field_name ] = '';
-				}
+			if ( ! empty( $values ) ) {
+				// Join multiple values with a pipe character and spaces
+				$joined_values                  = implode( ' | ', $values );
+				$facebook_fields[ $field_name ] = $joined_values;
+				update_post_meta( $product_id, $meta_key, $joined_values );
+			} else {
+				delete_post_meta( $product_id, $meta_key );
+				$facebook_fields[ $field_name ] = '';
 			}
 		}
-
-		return $facebook_fields;
 	}
 
-	public function ajax_sync_facebook_attributes() {
-		check_ajax_referer( 'sync_facebook_attributes', 'nonce' );
+	return $facebook_fields;
+}
 
-		$product_id = isset( $_POST['product_id'] ) ? intval( $_POST['product_id'] ) : 0;
-		if ( $product_id ) {
-			$synced_fields = $this->sync_product_attributes( $product_id );
-			wp_send_json_success( $synced_fields );
-		}
-		wp_send_json_error( 'Invalid product ID' );
+public function ajax_sync_facebook_attributes() {
+	check_ajax_referer( 'sync_facebook_attributes', 'nonce' );
+
+	$product_id = isset( $_POST['product_id'] ) ? intval( $_POST['product_id'] ) : 0;
+	if ( $product_id ) {
+		$synced_fields = $this->sync_product_attributes( $product_id );
+		wp_send_json_success( $synced_fields );
 	}
+	wp_send_json_error( 'Invalid product ID' );
+}
 }

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1161,21 +1161,21 @@ class Admin {
 		$visibility   = get_post_meta( $post->ID, Products::VISIBILITY_META_KEY, true );
 		$is_visible   = $visibility ? wc_string_to_bool( $visibility ) : true;
 		$product      = wc_get_product( $post );
-
-		$rich_text_description = get_post_meta( $post->ID, \WC_Facebookcommerce_Integration::FB_RICH_TEXT_DESCRIPTION, true );
-		$price                 = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_PRICE, true );
-		$image_source          = get_post_meta( $post->ID, Products::PRODUCT_IMAGE_SOURCE_META_KEY, true );
-		$image                 = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_IMAGE, true );
-		$video_urls            = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_VIDEO, true );
-		$fb_brand              = get_post_meta( $post->ID, \WC_Facebook_Product::FB_BRAND, true ) ? get_post_meta( $post->ID, \WC_Facebook_Product::FB_BRAND, true ) : get_post_meta( $post->ID, '_wc_facebook_enhanced_catalog_attributes_brand', true );
-		$fb_mpn                = get_post_meta( $post->ID, \WC_Facebook_Product::FB_MPN, true );
-		$fb_condition          = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_CONDITION, true );
-		$fb_age_group          = get_post_meta( $post->ID, \WC_Facebook_Product::FB_AGE_GROUP, true ) ? get_post_meta( $post->ID, \WC_Facebook_Product::FB_AGE_GROUP, true ) : get_post_meta( $post->ID, '_wc_facebook_enhanced_catalog_attributes_age_group', true );
-		$fb_gender             = get_post_meta( $post->ID, \WC_Facebook_Product::FB_GENDER, true ) ? get_post_meta( $post->ID, \WC_Facebook_Product::FB_GENDER, true ) : get_post_meta( $post->ID, '_wc_facebook_enhanced_catalog_attributes_gender', true );
-		$fb_size               = get_post_meta( $post->ID, \WC_Facebook_Product::FB_SIZE, true ) ? get_post_meta( $post->ID, \WC_Facebook_Product::FB_SIZE, true ) : get_post_meta( $post->ID, '_wc_facebook_enhanced_catalog_attributes_size', true );
-		$fb_color              = get_post_meta( $post->ID, \WC_Facebook_Product::FB_COLOR, true ) ? get_post_meta( $post->ID, \WC_Facebook_Product::FB_COLOR, true ) : get_post_meta( $post->ID, '_wc_facebook_enhanced_catalog_attributes_color', true );
-		$fb_material           = get_post_meta( $post->ID, \WC_Facebook_Product::FB_MATERIAL, true ) ? get_post_meta( $post->ID, \WC_Facebook_Product::FB_MATERIAL, true ) : get_post_meta( $post->ID, '_wc_facebook_enhanced_catalog_attributes_material', true );
-		$fb_pattern            = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PATTERN, true ) ? get_post_meta( $post->ID, \WC_Facebook_Product::FB_PATTERN, true ) : get_post_meta( $post->ID, '_wc_facebook_enhanced_catalog_attributes_pattern', true );
+		$fb_product_description = get_post_meta( $post->ID, \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, true );
+		$fb_mpn                 = get_post_meta( $post->ID, \WC_Facebook_Product::FB_MPN, true );
+		$rich_text_description  = get_post_meta( $post->ID, \WC_Facebookcommerce_Integration::FB_RICH_TEXT_DESCRIPTION, true );
+		$price                  = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_PRICE, true );
+		$image_source           = get_post_meta( $post->ID, Products::PRODUCT_IMAGE_SOURCE_META_KEY, true );
+		$image                  = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_IMAGE, true );
+		$video_urls             = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_VIDEO, true );
+		$fb_brand               = get_post_meta( $post->ID, \WC_Facebook_Product::FB_BRAND, true ) ? get_post_meta( $post->ID, \WC_Facebook_Product::FB_BRAND, true ) : get_post_meta( $post->ID, '_wc_facebook_enhanced_catalog_attributes_brand', true );
+		$fb_condition           = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_CONDITION, true );
+		$fb_age_group           = get_post_meta( $post->ID, \WC_Facebook_Product::FB_AGE_GROUP, true ) ? get_post_meta( $post->ID, \WC_Facebook_Product::FB_AGE_GROUP, true ) : get_post_meta( $post->ID, '_wc_facebook_enhanced_catalog_attributes_age_group', true );
+		$fb_gender              = get_post_meta( $post->ID, \WC_Facebook_Product::FB_GENDER, true ) ? get_post_meta( $post->ID, \WC_Facebook_Product::FB_GENDER, true ) : get_post_meta( $post->ID, '_wc_facebook_enhanced_catalog_attributes_gender', true );
+		$fb_size                = get_post_meta( $post->ID, \WC_Facebook_Product::FB_SIZE, true ) ? get_post_meta( $post->ID, \WC_Facebook_Product::FB_SIZE, true ) : get_post_meta( $post->ID, '_wc_facebook_enhanced_catalog_attributes_size', true );
+		$fb_color               = get_post_meta( $post->ID, \WC_Facebook_Product::FB_COLOR, true ) ? get_post_meta( $post->ID, \WC_Facebook_Product::FB_COLOR, true ) : get_post_meta( $post->ID, '_wc_facebook_enhanced_catalog_attributes_color', true );
+		$fb_material            = get_post_meta( $post->ID, \WC_Facebook_Product::FB_MATERIAL, true ) ? get_post_meta( $post->ID, \WC_Facebook_Product::FB_MATERIAL, true ) : get_post_meta( $post->ID, '_wc_facebook_enhanced_catalog_attributes_material', true );
+		$fb_pattern             = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PATTERN, true ) ? get_post_meta( $post->ID, \WC_Facebook_Product::FB_PATTERN, true ) : get_post_meta( $post->ID, '_wc_facebook_enhanced_catalog_attributes_pattern', true );
 
 		if ( $sync_enabled ) {
 			$sync_mode = $is_visible ? self::SYNC_MODE_SYNC_AND_SHOW : self::SYNC_MODE_SYNC_AND_HIDE;
@@ -1188,6 +1188,35 @@ class Admin {
 		<div id='facebook_options' class='panel woocommerce_options_panel'>
 			<div class='options_group hide_if_variable'>
 				<?php
+
+				// Only show deprecation notice if any of the deprecated fields exist
+				if ( $post->ID && ( $fb_product_description || $image || $price ) ) {
+					?>
+					<div class="notice notice-warning inline is-dismissible" style="margin-top: 1px !important;">
+						<p>
+							<?php
+							printf(
+								/* translators: Placeholders %1$s - opening strong tag, %2$s - closing strong tag */
+								esc_html__( '%1$sHeads up!%2$s Facebook Description, Custom Image URL, and Facebook Price fields are no longer supported and will be removed in a future update. These fields will not affect your product listings on Facebook.', 'facebook-for-woocommerce' ),
+								'<strong>',
+								'</strong>'
+							);
+							?>
+						</p>
+						<button type="button" class="notice-dismiss">
+							<span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'facebook-for-woocommerce' ); ?></span>
+						</button>
+					</div>
+					<script type="text/javascript">
+						jQuery(document).ready(function($) {
+							$('.notice.is-dismissible').on('click', '.notice-dismiss', function(e) {
+								e.preventDefault();
+								$(this).closest('.notice').fadeOut();
+							});
+						});
+					</script>
+					<?php
+				}
 
 				woocommerce_wp_select(
 					array(
@@ -1204,72 +1233,78 @@ class Admin {
 					)
 				);
 
-				echo '<div class="wp-editor-wrap">';
-				echo '<label for="' . esc_attr( \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION ) . '">' .
-					esc_html__( 'Facebook Description', 'facebook-for-woocommerce' ) .
-					'</label>';
-				wp_editor(
-					$rich_text_description,
-					\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
-					array(
-						'id'            => 'wc_facebook_sync_mode',
-						'textarea_name' => \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
-						'textarea_rows' => 10,
-						'media_buttons' => true,
-						'teeny'         => true,
-						'quicktags'     => false,
-						'tinymce'       => array(
-							'toolbar1' => 'bold,italic,bullist,spellchecker,fullscreen',
-						),
-					)
-				);
-				echo '</div>';
+				// Check if this is an existing product with a Facebook description
+		if ( $post->ID && $fb_product_description ) {
+			echo '<div class="wp-editor-wrap">';
+			echo '<label for="' . esc_attr( \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION ) . '">' .
+				esc_html__( 'Facebook Description', 'facebook-for-woocommerce' ) .
+				'</label>';
+			wp_editor(
+				$rich_text_description,
+				\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
+				array(
+					'id'            => 'wc_facebook_sync_mode',
+					'textarea_name' => \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
+					'textarea_rows' => 10,
+					'media_buttons' => true,
+					'teeny'         => true,
+					'quicktags'     => false,
+					'tinymce'       => array(
+						'toolbar1' => 'bold,italic,bullist,spellchecker,fullscreen',
+					),
+				)
+			);
+			echo '</div>';
+		}
+		if ( $post->ID && $image ) {
+			woocommerce_wp_radio(
+				array(
+					'id'            => 'fb_product_image_source',
+					'label'         => __( 'Facebook Product Image', 'facebook-for-woocommerce' ),
+					'desc_tip'      => true,
+					'description'   => __( 'Choose the product image that should be synced to the Facebook catalog and displayed for this product.', 'facebook-for-woocommerce' ),
+					'options'       => array(
+						Products::PRODUCT_IMAGE_SOURCE_PRODUCT => __( 'Use WooCommerce image', 'facebook-for-woocommerce' ),
+						Products::PRODUCT_IMAGE_SOURCE_CUSTOM  => __( 'Use custom image', 'facebook-for-woocommerce' ),
+					),
+					'value'         => $image_source ?: Products::PRODUCT_IMAGE_SOURCE_PRODUCT,
+					'class'         => 'short enable-if-sync-enabled js-fb-product-image-source',
+					'wrapper_class' => 'fb-product-image-source-field',
+				)
+			);
 
-				woocommerce_wp_radio(
-					array(
-						'id'            => 'fb_product_image_source',
-						'label'         => __( 'Facebook Product Image', 'facebook-for-woocommerce' ),
-						'desc_tip'      => true,
-						'description'   => __( 'Choose the product image that should be synced to the Facebook catalog and displayed for this product.', 'facebook-for-woocommerce' ),
-						'options'       => array(
-							Products::PRODUCT_IMAGE_SOURCE_PRODUCT => __( 'Use WooCommerce image', 'facebook-for-woocommerce' ),
-							Products::PRODUCT_IMAGE_SOURCE_CUSTOM  => __( 'Use custom image', 'facebook-for-woocommerce' ),
-						),
-						'value'         => $image_source ? $image_source : Products::PRODUCT_IMAGE_SOURCE_PRODUCT,
-						'class'         => 'short enable-if-sync-enabled js-fb-product-image-source',
-						'wrapper_class' => 'fb-product-image-source-field',
-					)
-				);
-
-				woocommerce_wp_text_input(
-					array(
-						'id'          => \WC_Facebook_Product::FB_PRODUCT_IMAGE,
-						'label'       => __( 'Custom Image URL', 'facebook-for-woocommerce' ),
-						'value'       => $image,
-						'class'       => sprintf( 'enable-if-sync-enabled product-image-source-field show-if-product-image-source-%s', Products::PRODUCT_IMAGE_SOURCE_CUSTOM ),
-						'desc_tip'    => true,
-						'description' => __( 'Please enter an absolute URL (e.g. https://domain.com/image.jpg).', 'facebook-for-woocommerce' ),
-					)
-				);
+			woocommerce_wp_text_input(
+				array(
+					'id'          => \WC_Facebook_Product::FB_PRODUCT_IMAGE,
+					'label'       => __( 'Custom Image URL', 'facebook-for-woocommerce' ),
+					'value'       => $image,
+					'class'       => sprintf( 'enable-if-sync-enabled product-image-source-field show-if-product-image-source-%s', Products::PRODUCT_IMAGE_SOURCE_CUSTOM ),
+					'desc_tip'    => true,
+					'description' => __( 'Please enter an absolute URL (e.g. https://domain.com/image.jpg).', 'facebook-for-woocommerce' ),
+				)
+			);
+		}
 
 				$this->render_facebook_product_video_field( $video_urls );
 
-				woocommerce_wp_text_input(
-					array(
-						'id'          => \WC_Facebook_Product::FB_PRODUCT_PRICE,
-						'label'       => sprintf(
-						/* translators: Placeholders %1$s - WC currency symbol */
-							__( 'Facebook Price (%1$s)', 'facebook-for-woocommerce' ),
-							get_woocommerce_currency_symbol()
-						),
-						'desc_tip'    => true,
-						'description' => __( 'Custom price for product on Facebook. Please enter in monetary decimal (.) format without thousand separators and currency symbols. If blank, product price will be used.', 'facebook-for-woocommerce' ),
-						'cols'        => 40,
-						'rows'        => 60,
-						'value'       => $price,
-						'class'       => 'enable-if-sync-enabled',
-					)
-				);
+		if ( $post->ID && $price ) {
+			woocommerce_wp_text_input(
+				array(
+					'id'          => \WC_Facebook_Product::FB_PRODUCT_PRICE,
+					'label'       => sprintf(
+					/* translators: Placeholders %1$s - WC currency symbol */
+						__( 'Facebook Price (%1$s)', 'facebook-for-woocommerce' ),
+						get_woocommerce_currency_symbol()
+					),
+					'desc_tip'    => true,
+					'description' => __( 'Custom price for product on Facebook. Please enter in monetary decimal (.) format without thousand separators and currency symbols. If blank, product price will be used.', 'facebook-for-woocommerce' ),
+					'cols'        => 40,
+					'rows'        => 60,
+					'value'       => $price,
+					'class'       => 'enable-if-sync-enabled',
+				)
+			);
+		}
 
 				woocommerce_wp_hidden_input(
 					array(
@@ -1277,7 +1312,7 @@ class Admin {
 						'value' => '',
 					)
 				);
-				?>
+		?>
 			</div>
 			
 			<div class='wc_facebook_commerce_fields'>
@@ -1486,6 +1521,36 @@ class Admin {
 			$sync_mode = self::SYNC_MODE_SYNC_DISABLED;
 		}
 
+		// Only show deprecation notice if any of the deprecated fields exist
+		if ( $variation->get_id() && ( $description || $image_url || $price ) ) {
+			?>
+			<div class="notice notice-info inline is-dismissible" style="background-color: #f8f9fa; border-left-color: #72777c; margin: 15px 0;">
+				<p>
+					<?php
+					printf(
+						/* translators: Placeholders %1$s - opening strong tag, %2$s - closing strong tag */
+						esc_html__( '%1$sHeads up!%2$s Facebook Description, Custom Image URL, and Facebook Price fields are no longer supported and will be removed in a future update. These fields will not affect your product listings on Facebook.', 'facebook-for-woocommerce' ),
+						'<strong>',
+						'</strong>'
+					);
+					?>
+				</p>
+				<button type="button" class="notice-dismiss">
+					<span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'facebook-for-woocommerce' ); ?></span>
+				</button>
+			</div>
+			<script type="text/javascript">
+				jQuery(document).ready(function($) {
+					$('.notice.is-dismissible').on('click', '.notice-dismiss', function(e) {
+						e.preventDefault();
+						$(this).closest('.notice').fadeOut();
+					});
+				});
+			</script>
+			<?php
+		}
+
+		// Always show the sync mode selector
 		?>
 		<div class="facebook-metabox wc-metabox closed">
 			<h3>
@@ -1513,80 +1578,85 @@ class Admin {
 					)
 				);
 
-				woocommerce_wp_textarea_input(
-					array(
-						'id'            => sprintf( 'variable_%s%s', \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $index ),
-						'name'          => sprintf( "variable_%s[$index]", \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION ),
-						'label'         => __( 'Facebook Description', 'facebook-for-woocommerce' ),
-						'desc_tip'      => true,
-						'description'   => __( 'Custom (plain-text only) description for product on Facebook. If blank, product description will be used. If product description is blank, shortname will be used.', 'facebook-for-woocommerce' ),
-						'value'         => $description,
-						'class'         => 'enable-if-sync-enabled',
-						'wrapper_class' => 'form-row form-row-full',
-					)
-				);
+				if ( $variation->get_id() && $description ) {
+						woocommerce_wp_textarea_input(
+							array(
+								'id'            => sprintf( 'variable_%s%s', \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $index ),
+								'name'          => sprintf( "variable_%s[$index]", \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION ),
+								'label'         => __( 'Facebook Description', 'facebook-for-woocommerce' ),
+								'desc_tip'      => true,
+								'description'   => __( 'Custom (plain-text only) description for product on Facebook. If blank, product description will be used. If product description is blank, shortname will be used.', 'facebook-for-woocommerce' ),
+								'value'         => $description,
+								'class'         => 'enable-if-sync-enabled',
+								'wrapper_class' => 'form-row form-row-full',
+							)
+						);
+				}
 
-				woocommerce_wp_radio(
-					array(
-						'id'            => "variable_fb_product_image_source$index",
-						'name'          => "variable_fb_product_image_source[$index]",
-						'label'         => __( 'Facebook Product Image', 'facebook-for-woocommerce' ),
-						'desc_tip'      => true,
-						'description'   => __( 'Choose the product image that should be synced to the Facebook catalog and displayed for this product.', 'facebook-for-woocommerce' ),
-						'options'       => array(
-							Products::PRODUCT_IMAGE_SOURCE_PRODUCT => __( 'Use variation image', 'facebook-for-woocommerce' ),
-							Products::PRODUCT_IMAGE_SOURCE_PARENT_PRODUCT => __( 'Use parent image', 'facebook-for-woocommerce' ),
-							Products::PRODUCT_IMAGE_SOURCE_CUSTOM  => __( 'Use custom image', 'facebook-for-woocommerce' ),
-						),
-						'value'         => $image_source ? $image_source : Products::PRODUCT_IMAGE_SOURCE_PRODUCT,
-						'class'         => 'enable-if-sync-enabled js-fb-product-image-source',
-						'wrapper_class' => 'fb-product-image-source-field',
-					)
-				);
+				if ( $variation->get_id() && $image_url ) {
+					woocommerce_wp_radio(
+						array(
+							'id'            => "variable_fb_product_image_source$index",
+							'name'          => "variable_fb_product_image_source[$index]",
+							'label'         => __( 'Facebook Product Image', 'facebook-for-woocommerce' ),
+							'desc_tip'      => true,
+							'description'   => __( 'Choose the product image that should be synced to the Facebook catalog and displayed for this product.', 'facebook-for-woocommerce' ),
+							'options'       => array(
+								Products::PRODUCT_IMAGE_SOURCE_PRODUCT => __( 'Use variation image', 'facebook-for-woocommerce' ),
+								Products::PRODUCT_IMAGE_SOURCE_PARENT_PRODUCT => __( 'Use parent image', 'facebook-for-woocommerce' ),
+								Products::PRODUCT_IMAGE_SOURCE_CUSTOM  => __( 'Use custom image', 'facebook-for-woocommerce' ),
+							),
+							'value'         => $image_source ?: Products::PRODUCT_IMAGE_SOURCE_PRODUCT,
+							'class'         => 'enable-if-sync-enabled js-fb-product-image-source',
+							'wrapper_class' => 'fb-product-image-source-field',
+						)
+					);
 
-				woocommerce_wp_text_input(
-					array(
-						'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_PRODUCT_IMAGE, $index ),
-						'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_PRODUCT_IMAGE ),
-						'label'         => __( 'Custom Image URL', 'facebook-for-woocommerce' ),
-						'value'         => $image_url,
-						'class'         => sprintf( 'enable-if-sync-enabled product-image-source-field show-if-product-image-source-%s', Products::PRODUCT_IMAGE_SOURCE_CUSTOM ),
-						'wrapper_class' => 'form-row form-row-full',
-						'desc_tip'      => true,
-						'description'   => __( 'Please enter an absolute URL (e.g. https://domain.com/image.jpg).', 'facebook-for-woocommerce' ),
-					)
-				);
+						woocommerce_wp_text_input(
+							array(
+								'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_PRODUCT_IMAGE, $index ),
+								'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_PRODUCT_IMAGE ),
+								'label'         => __( 'Custom Image URL', 'facebook-for-woocommerce' ),
+								'value'         => $image_url,
+								'class'         => sprintf( 'enable-if-sync-enabled product-image-source-field show-if-product-image-source-%s', Products::PRODUCT_IMAGE_SOURCE_CUSTOM ),
+								'wrapper_class' => 'form-row form-row-full',
+								'desc_tip'      => true,
+								'description'   => __( 'Please enter an absolute URL (e.g. https://domain.com/image.jpg).', 'facebook-for-woocommerce' ),
+							)
+						);
 
-				woocommerce_wp_text_input(
-					array(
-						'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_PRODUCT_PRICE, $index ),
-						'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_PRODUCT_PRICE ),
-						'label'         => sprintf(
-						/* translators: Placeholders %1$s - WC currency symbol */
-							__( 'Facebook Price (%1$s)', 'facebook-for-woocommerce' ),
-							get_woocommerce_currency_symbol()
-						),
-						'desc_tip'      => true,
-						'description'   => __( 'Custom price for product on Facebook. Please enter in monetary decimal (.) format without thousand separators and currency symbols. If blank, product price will be used.', 'facebook-for-woocommerce' ),
-						'value'         => wc_format_decimal( $price ),
-						'class'         => 'enable-if-sync-enabled',
-						'wrapper_class' => 'form-row form-full',
-					)
-				);
+					if ( $variation->get_id() && $price ) {
+						woocommerce_wp_text_input(
+							array(
+								'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_PRODUCT_PRICE, $index ),
+								'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_PRODUCT_PRICE ),
+								'label'         => sprintf(
+								/* translators: Placeholders %1$s - WC currency symbol */
+									__( 'Facebook Price (%1$s)', 'facebook-for-woocommerce' ),
+									get_woocommerce_currency_symbol()
+								),
+								'desc_tip'      => true,
+								'description'   => __( 'Custom price for product on Facebook. Please enter in monetary decimal (.) format without thousand separators and currency symbols. If blank, product price will be used.', 'facebook-for-woocommerce' ),
+								'value'         => wc_format_decimal( $price ),
+								'class'         => 'enable-if-sync-enabled',
+								'wrapper_class' => 'form-row form-full',
+							)
+						);
+					}
 
-				woocommerce_wp_text_input(
-					array(
-						'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_MPN, $index ),
-						'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_MPN ),
-						'label'         => __( 'Manufacturer Parts Number (MPN)', 'facebook-for-woocommerce' ),
-						'desc_tip'      => true,
-						'description'   => __( 'Manufacturer Parts Number', 'facebook-for-woocommerce' ),
-						'value'         => wc_format_decimal( $fb_mpn ),
-						'class'         => 'enable-if-sync-enabled',
-						'wrapper_class' => 'form-row form-full',
-					)
-				);
-				?>
+						woocommerce_wp_text_input(
+							array(
+								'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_MPN, $index ),
+								'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_MPN ),
+								'label'         => __( 'Manufacturer Parts Number (MPN)', 'facebook-for-woocommerce' ),
+								'desc_tip'      => true,
+								'description'   => __( 'Manufacturer Parts Number', 'facebook-for-woocommerce' ),
+								'value'         => wc_format_decimal( $fb_mpn ),
+								'class'         => 'enable-if-sync-enabled',
+								'wrapper_class' => 'form-row form-full',
+							)
+						);
+					?>
 			</div>
 		</div>
 
@@ -1611,8 +1681,8 @@ class Admin {
 									.hide();
 			});
 		</script>
-		<?php
-	}
+					<?php
+				}}
 
 
 	/**

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1192,8 +1192,8 @@ class Admin {
 				// Only show deprecation notice if any of the deprecated fields exist
 				if ( $post->ID && ( $fb_product_description || $image || $price ) ) {
 					?>
-					<div class="notice notice-warning inline is-dismissible" style="padding: 1px; margin: 10px 10px 0;">
-						<p>
+					<div class="notice notice-warning inline is-dismissible" style="padding: 1px 12px; margin: 10px 10px 0; border-left: 4px solid #dba617; background-color: #fff;">
+						<p style="margin: 8px 0;">
 							<strong><?php esc_html_e( 'Some attributes are no longer supported', 'facebook-for-woocommerce' ); ?></strong><br/>
 							<?php esc_html_e( 'Facebook Description, Custom Image URL, and Facebook Price are no longer supported and have been removed. This update will not affect your ads or shops on Meta.', 'facebook-for-woocommerce' ); ?>
 						</p>
@@ -1528,8 +1528,8 @@ class Admin {
 				// Show deprecation notice only if deprecated fields have values
 				if ( $variation->get_id() && $has_fb_specific_variation_fields ) {
 					?>
-			<div class="notice notice-warning inline is-dismissible" style="padding: 1px; margin: 10px 10px 0;">
-				<p>
+			<div class="notice notice-warning inline is-dismissible" style="padding: 1px 12px; margin: 10px 10px 0; border-left: 4px solid #dba617; background-color: #fff;">
+				<p style="margin: 8px 0;">
 					<strong><?php esc_html_e( 'Some attributes are no longer supported', 'facebook-for-woocommerce' ); ?></strong><br/>
 					<?php esc_html_e( 'Facebook Description, Custom Image URL, and Facebook Price are no longer supported and have been removed. This update will not affect your ads or shops on Meta.', 'facebook-for-woocommerce' ); ?>
 				</p>

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1516,13 +1516,13 @@ class Admin {
 		$fb_mpn       = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_MPN, $parent );
 
 		$has_fb_specific_variation_fields = ! empty( $description ) || ! empty( $image_url ) || ! empty( $price );
+
 		if ( $sync_enabled ) {
 			$sync_mode = $is_visible ? self::SYNC_MODE_SYNC_AND_SHOW : self::SYNC_MODE_SYNC_AND_HIDE;
 		} else {
 			$sync_mode = self::SYNC_MODE_SYNC_DISABLED;
 		}
 
-		// Always show the sync mode selector
 		?>
 		<div class="facebook-metabox wc-metabox closed">
 			<h3>
@@ -1531,9 +1531,8 @@ class Admin {
 			</h3>
 			<div class="wc-metabox-content" style="display: none;">
 				<?php
-
-				// Only show deprecation notice if any of the deprecated fields exist
-				if ( $variation->get_id() && ( $has_fb_specific_variation_fields ) ) {
+				// Show deprecation notice only if deprecated fields have values
+				if ( $variation->get_id() && $has_fb_specific_variation_fields ) {
 					?>
 			<div class="notice notice-info inline is-dismissible" style="background-color: #f8f9fa; border-left-color: #72777c; margin: 15px 0;">
 				<p>
@@ -1579,88 +1578,90 @@ class Admin {
 					)
 				);
 
-		if ( $variation->get_id() && $has_fb_specific_variation_fields ) {
-				woocommerce_wp_textarea_input(
-					array(
-						'id'            => sprintf( 'variable_%s%s', \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $index ),
-						'name'          => sprintf( "variable_%s[$index]", \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION ),
-						'label'         => __( 'Facebook Description', 'facebook-for-woocommerce' ),
-						'desc_tip'      => true,
-						'description'   => __( 'Custom (plain-text only) description for product on Facebook. If blank, product description will be used. If product description is blank, shortname will be used.', 'facebook-for-woocommerce' ),
-						'value'         => $description,
-						'class'         => 'enable-if-sync-enabled',
-						'wrapper_class' => 'form-row form-row-full',
-					)
-				);
-		}
+				// Only show deprecated fields if they have existing values
+				if ( $variation->get_id() && $has_fb_specific_variation_fields ) {
+					if ( ! empty( $description ) ) {
+						woocommerce_wp_textarea_input(
+							array(
+								'id'            => sprintf( 'variable_%s%s', \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $index ),
+								'name'          => sprintf( "variable_%s[$index]", \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION ),
+								'label'         => __( 'Facebook Description', 'facebook-for-woocommerce' ),
+								'desc_tip'      => true,
+								'description'   => __( 'Custom (plain-text only) description for product on Facebook. If blank, product description will be used. If product description is blank, shortname will be used.', 'facebook-for-woocommerce' ),
+								'value'         => $description,
+								'class'         => 'enable-if-sync-enabled',
+								'wrapper_class' => 'form-row form-row-full',
+							)
+						);
+					}
 
-		if ( $variation->get_id() && $has_fb_specific_variation_fields ) {
-			woocommerce_wp_radio(
-				array(
-					'id'            => "variable_fb_product_image_source$index",
-					'name'          => "variable_fb_product_image_source[$index]",
-					'label'         => __( 'Facebook Product Image', 'facebook-for-woocommerce' ),
-					'desc_tip'      => true,
-					'description'   => __( 'Choose the product image that should be synced to the Facebook catalog and displayed for this product.', 'facebook-for-woocommerce' ),
-					'options'       => array(
-						Products::PRODUCT_IMAGE_SOURCE_PRODUCT => __( 'Use variation image', 'facebook-for-woocommerce' ),
-						Products::PRODUCT_IMAGE_SOURCE_PARENT_PRODUCT => __( 'Use parent image', 'facebook-for-woocommerce' ),
-						Products::PRODUCT_IMAGE_SOURCE_CUSTOM  => __( 'Use custom image', 'facebook-for-woocommerce' ),
-					),
-					'value'         => $image_source ?: Products::PRODUCT_IMAGE_SOURCE_PRODUCT,
-					'class'         => 'enable-if-sync-enabled js-fb-product-image-source',
-					'wrapper_class' => 'fb-product-image-source-field',
-				)
-			);
+					if ( ! empty( $image_url ) ) {
+						woocommerce_wp_radio(
+							array(
+								'id'            => "variable_fb_product_image_source$index",
+								'name'          => "variable_fb_product_image_source[$index]",
+								'label'         => __( 'Facebook Product Image', 'facebook-for-woocommerce' ),
+								'desc_tip'      => true,
+								'description'   => __( 'Choose the product image that should be synced to the Facebook catalog and displayed for this product.', 'facebook-for-woocommerce' ),
+								'options'       => array(
+									Products::PRODUCT_IMAGE_SOURCE_PRODUCT => __( 'Use variation image', 'facebook-for-woocommerce' ),
+									Products::PRODUCT_IMAGE_SOURCE_PARENT_PRODUCT => __( 'Use parent image', 'facebook-for-woocommerce' ),
+									Products::PRODUCT_IMAGE_SOURCE_CUSTOM  => __( 'Use custom image', 'facebook-for-woocommerce' ),
+								),
+								'value'         => $image_source ?: Products::PRODUCT_IMAGE_SOURCE_PRODUCT,
+								'class'         => 'enable-if-sync-enabled js-fb-product-image-source',
+								'wrapper_class' => 'fb-product-image-source-field',
+							)
+						);
 
-			if ( $variation->get_id() && $has_fb_specific_variation_fields ) {
-				woocommerce_wp_text_input(
-					array(
-						'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_PRODUCT_IMAGE, $index ),
-						'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_PRODUCT_IMAGE ),
-						'label'         => __( 'Custom Image URL', 'facebook-for-woocommerce' ),
-						'value'         => $image_url,
-						'class'         => sprintf( 'enable-if-sync-enabled product-image-source-field show-if-product-image-source-%s', Products::PRODUCT_IMAGE_SOURCE_CUSTOM ),
-						'wrapper_class' => 'form-row form-row-full',
-						'desc_tip'      => true,
-						'description'   => __( 'Please enter an absolute URL (e.g. https://domain.com/image.jpg).', 'facebook-for-woocommerce' ),
-					)
-				);
-			}
+						woocommerce_wp_text_input(
+							array(
+								'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_PRODUCT_IMAGE, $index ),
+								'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_PRODUCT_IMAGE ),
+								'label'         => __( 'Custom Image URL', 'facebook-for-woocommerce' ),
+								'value'         => $image_url,
+								'class'         => sprintf( 'enable-if-sync-enabled product-image-source-field show-if-product-image-source-%s', Products::PRODUCT_IMAGE_SOURCE_CUSTOM ),
+								'wrapper_class' => 'form-row form-row-full',
+								'desc_tip'      => true,
+								'description'   => __( 'Please enter an absolute URL (e.g. https://domain.com/image.jpg).', 'facebook-for-woocommerce' ),
+							)
+						);
+					}
 
-			if ( $variation->get_id() && $has_fb_specific_variation_fields ) {
-				woocommerce_wp_text_input(
-					array(
-						'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_PRODUCT_PRICE, $index ),
-						'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_PRODUCT_PRICE ),
-						'label'         => sprintf(
-						/* translators: Placeholders %1$s - WC currency symbol */
-							__( 'Facebook Price (%1$s)', 'facebook-for-woocommerce' ),
-							get_woocommerce_currency_symbol()
-						),
-						'desc_tip'      => true,
-						'description'   => __( 'Custom price for product on Facebook. Please enter in monetary decimal (.) format without thousand separators and currency symbols. If blank, product price will be used.', 'facebook-for-woocommerce' ),
-						'value'         => wc_format_decimal( $price ),
-						'class'         => 'enable-if-sync-enabled',
-						'wrapper_class' => 'form-row form-full',
-					)
-				);
-			}
-		}
+					if ( ! empty( $price ) ) {
+						woocommerce_wp_text_input(
+							array(
+								'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_PRODUCT_PRICE, $index ),
+								'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_PRODUCT_PRICE ),
+								'label'         => sprintf(
+									/* translators: Placeholders %1$s - WC currency symbol */
+									__( 'Facebook Price (%1$s)', 'facebook-for-woocommerce' ),
+									get_woocommerce_currency_symbol()
+								),
+								'desc_tip'      => true,
+								'description'   => __( 'Custom price for product on Facebook. Please enter in monetary decimal (.) format without thousand separators and currency symbols. If blank, product price will be used.', 'facebook-for-woocommerce' ),
+								'value'         => wc_format_decimal( $price ),
+								'class'         => 'enable-if-sync-enabled',
+								'wrapper_class' => 'form-row form-full',
+							)
+						);
+					}
+				}
 
+				// Always show MPN field as it's not deprecated
 				woocommerce_wp_text_input(
 					array(
 						'id'            => sprintf( 'variable_%s%s', \WC_Facebook_Product::FB_MPN, $index ),
 						'name'          => sprintf( "variable_%s[$index]", \WC_Facebook_Product::FB_MPN ),
-						'label'         => __( 'Manufacturer Parts Number (MPN)', 'facebook-for-woocommerce' ),
+						'label'         => __( 'Manufacturer Part Number (MPN)', 'facebook-for-woocommerce' ),
 						'desc_tip'      => true,
-						'description'   => __( 'Manufacturer Parts Number', 'facebook-for-woocommerce' ),
-						'value'         => wc_format_decimal( $fb_mpn ),
+						'description'   => __( 'Manufacturer Part Number', 'facebook-for-woocommerce' ),
+						'value'         => $fb_mpn,
 						'class'         => 'enable-if-sync-enabled',
 						'wrapper_class' => 'form-row form-full',
 					)
 				);
-		?>
+				?>
 			</div>
 		</div>
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1192,16 +1192,10 @@ class Admin {
 				// Only show deprecation notice if any of the deprecated fields exist
 				if ( $post->ID && ( $fb_product_description || $image || $price ) ) {
 					?>
-					<div class="notice notice-warning inline is-dismissible" style="margin-top: 1px !important;">
+					<div class="notice notice-warning inline is-dismissible" style="padding: 1px; margin: 10px 10px 0;">
 						<p>
-							<?php
-							printf(
-								/* translators: Placeholders %1$s - opening strong tag, %2$s - closing strong tag */
-								esc_html__( '%1$sHeads up!%2$s Facebook Description, Custom Image URL, and Facebook Price fields are no longer supported and will be removed in a future update. These fields will not affect your product listings on Facebook.', 'facebook-for-woocommerce' ),
-								'<strong>',
-								'</strong>'
-							);
-							?>
+							<strong><?php esc_html_e( 'Some attributes are no longer supported', 'facebook-for-woocommerce' ); ?></strong><br/>
+							<?php esc_html_e( 'Facebook Description, Custom Image URL, and Facebook Price are no longer supported and have been removed. This update will not affect your ads or shops on Meta.', 'facebook-for-woocommerce' ); ?>
 						</p>
 						<button type="button" class="notice-dismiss">
 							<span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'facebook-for-woocommerce' ); ?></span>
@@ -1534,16 +1528,10 @@ class Admin {
 				// Show deprecation notice only if deprecated fields have values
 				if ( $variation->get_id() && $has_fb_specific_variation_fields ) {
 					?>
-			<div class="notice notice-info inline is-dismissible" style="background-color: #f8f9fa; border-left-color: #72777c; margin: 15px 0;">
+			<div class="notice notice-warning inline is-dismissible" style="padding: 1px; margin: 10px 10px 0;">
 				<p>
-					<?php
-					printf(
-						/* translators: Placeholders %1$s - opening strong tag, %2$s - closing strong tag */
-						esc_html__( '%1$sHeads up!%2$s Facebook Description, Custom Image URL, and Facebook Price fields are no longer supported and will be removed in a future update. These fields will not affect your product listings on Facebook.', 'facebook-for-woocommerce' ),
-						'<strong>',
-						'</strong>'
-					);
-					?>
+					<strong><?php esc_html_e( 'Some attributes are no longer supported', 'facebook-for-woocommerce' ); ?></strong><br/>
+					<?php esc_html_e( 'Facebook Description, Custom Image URL, and Facebook Price are no longer supported and have been removed. This update will not affect your ads or shops on Meta.', 'facebook-for-woocommerce' ); ?>
 				</p>
 				<button type="button" class="notice-dismiss">
 					<span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'facebook-for-woocommerce' ); ?></span>

--- a/tests/Unit/AdminTest.php
+++ b/tests/Unit/AdminTest.php
@@ -6,27 +6,46 @@ use WC_Product_Simple;
 use function get_post;
 use function set_current_screen;
 use WP_UnitTestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group admin
  */
-class AdminTest extends WP_UnitTestCase {
+class AdminTest extends TestCase {
     /** @var Admin */
     protected $admin;
 
     /** @var \WC_Product_Simple */
     protected $product;
 
+    /** @var string */
+    protected $wc_plugin_dir;
+
     public function setUp(): void {
         parent::setUp();
+        
+        // Find WooCommerce plugin directory
+        $this->wc_plugin_dir = WP_PLUGIN_DIR . '/woocommerce';
+        if (!file_exists($this->wc_plugin_dir)) {
+            $this->wc_plugin_dir = dirname(dirname(dirname(__DIR__))) . '/woocommerce';
+        }
+        
+        if (!file_exists($this->wc_plugin_dir)) {
+            $this->markTestSkipped('WooCommerce plugin is required for this test.');
+            return;
+        }
+
+        // Include WooCommerce admin functions if not already included
+        if (!function_exists('woocommerce_wp_select')) {
+            require_once $this->wc_plugin_dir . '/includes/admin/wc-admin-functions.php';
+            require_once $this->wc_plugin_dir . '/includes/admin/wc-meta-box-functions.php';
+        }
         
         // Set up WordPress admin environment
         set_current_screen('edit-post');
         
-        // Create a mock Admin class
-        $this->admin = $this->getMockBuilder(Admin::class)
-            ->setMethods(['add_product_settings_tab_content'])
-            ->getMock();
+        // Create real Admin instance
+        $this->admin = new Admin();
         
         // Create a test product
         $this->product = new \WC_Product_Simple();
@@ -52,14 +71,12 @@ class AdminTest extends WP_UnitTestCase {
      * Test that deprecation notice is not shown for new products
      */
     public function test_deprecation_notice_not_shown_for_new_products() {
-        $this->admin->expects($this->once())
-            ->method('add_product_settings_tab_content')
-            ->willReturn('Some content without notice');
-
-        $content = $this->admin->add_product_settings_tab_content();
+        ob_start();
+        $this->admin->add_product_settings_tab_content();
+        $content = ob_get_clean();
 
         $this->assertStringNotContainsString('notice notice-warning inline is-dismissible', $content);
-        $this->assertStringNotContainsString('Heads up!', $content);
+        $this->assertStringNotContainsString('Some attributes are no longer supported', $content);
     }
 
     /**
@@ -69,14 +86,13 @@ class AdminTest extends WP_UnitTestCase {
         $this->product->update_meta_data('fb_product_description', 'Test description');
         $this->product->save();
 
-        $this->admin->expects($this->once())
-            ->method('add_product_settings_tab_content')
-            ->willReturn('<div class="notice notice-warning inline is-dismissible">Heads up!</div>');
-
-        $content = $this->admin->add_product_settings_tab_content();
+        ob_start();
+        $this->admin->add_product_settings_tab_content();
+        $content = ob_get_clean();
 
         $this->assertStringContainsString('notice notice-warning inline is-dismissible', $content);
-        $this->assertStringContainsString('Heads up!', $content);
+        $this->assertStringContainsString('Some attributes are no longer supported', $content);
+        $this->assertStringContainsString('Facebook Description, Custom Image URL, and Facebook Price are no longer supported', $content);
     }
 
     /**
@@ -86,14 +102,12 @@ class AdminTest extends WP_UnitTestCase {
         $this->product->update_meta_data('fb_product_image', 'https://example.com/image.jpg');
         $this->product->save();
 
-        $this->admin->expects($this->once())
-            ->method('add_product_settings_tab_content')
-            ->willReturn('<div class="notice notice-warning inline is-dismissible">Heads up!</div>');
-
-        $content = $this->admin->add_product_settings_tab_content();
+        ob_start();
+        $this->admin->add_product_settings_tab_content();
+        $content = ob_get_clean();
 
         $this->assertStringContainsString('notice notice-warning inline is-dismissible', $content);
-        $this->assertStringContainsString('Heads up!', $content);
+        $this->assertStringContainsString('Some attributes are no longer supported', $content);
     }
 
     /**
@@ -103,14 +117,12 @@ class AdminTest extends WP_UnitTestCase {
         $this->product->update_meta_data('fb_product_price', '99.99');
         $this->product->save();
 
-        $this->admin->expects($this->once())
-            ->method('add_product_settings_tab_content')
-            ->willReturn('<div class="notice notice-warning inline is-dismissible">Heads up!</div>');
-
-        $content = $this->admin->add_product_settings_tab_content();
+        ob_start();
+        $this->admin->add_product_settings_tab_content();
+        $content = ob_get_clean();
 
         $this->assertStringContainsString('notice notice-warning inline is-dismissible', $content);
-        $this->assertStringContainsString('Heads up!', $content);
+        $this->assertStringContainsString('Some attributes are no longer supported', $content);
     }
 
     /**
@@ -120,75 +132,44 @@ class AdminTest extends WP_UnitTestCase {
         $this->product->update_meta_data('fb_product_description', 'Test description');
         $this->product->save();
 
-        $this->admin->expects($this->once())
-            ->method('add_product_settings_tab_content')
-            ->willReturn('<div class="notice notice-warning inline is-dismissible"><button type="button" class="notice-dismiss">Dismiss this notice</button></div>');
-
-        $content = $this->admin->add_product_settings_tab_content();
+        ob_start();
+        $this->admin->add_product_settings_tab_content();
+        $content = ob_get_clean();
 
         $this->assertStringContainsString('button type="button" class="notice-dismiss"', $content);
         $this->assertStringContainsString('Dismiss this notice', $content);
     }
 
     /**
-     * Test that deprecation notice has grey styling
+     * Test that deprecation notice has correct styling
      */
-    public function test_deprecation_notice_has_grey_styling() {
+    public function test_deprecation_notice_has_correct_styling() {
         $this->product->update_meta_data('fb_product_description', 'Test description');
         $this->product->save();
 
-        $this->admin->expects($this->once())
-            ->method('add_product_settings_tab_content')
-            ->willReturn('<div class="notice notice-info inline is-dismissible" style="background-color: #f8f9fa; border-left-color: #72777c;">');
+        ob_start();
+        $this->admin->add_product_settings_tab_content();
+        $content = ob_get_clean();
 
-        $content = $this->admin->add_product_settings_tab_content();
-
-        $this->assertStringContainsString('notice notice-info', $content);
-        $this->assertStringContainsString('background-color: #f8f9fa', $content);
-        $this->assertStringContainsString('border-left-color: #72777c', $content);
+        $this->assertStringContainsString('style="padding: 1px; margin: 10px 10px 0;"', $content);
     }
 
     /**
-     * Test variation deprecation notice styling and visibility
+     * Test that variation notice is not shown when no deprecated fields exist
      */
-    public function test_variation_deprecation_notice() {
-        // Create a variable product
+    public function test_variation_notice_not_shown_without_deprecated_fields() {
         $product = new \WC_Product_Variable();
         $product->save();
 
-        // Create a variation
         $variation = new \WC_Product_Variation();
         $variation->set_parent_id($product->get_id());
         $variation->save();
 
-        // Create a new mock for first test
-        $admin = $this->getMockBuilder(Admin::class)
-            ->setMethods(['add_product_settings_tab_content'])
-            ->getMock();
-
-        $admin->expects($this->once())
-            ->method('add_product_settings_tab_content')
-            ->willReturn('Some content without notice');
-
-        $content = $admin->add_product_settings_tab_content();
-        $this->assertStringNotContainsString('notice notice-info', $content);
-
-        // Add deprecated field and test again with a new mock
-        $variation->update_meta_data('fb_product_description', 'Test description');
-        $variation->save();
-
-        $admin = $this->getMockBuilder(Admin::class)
-            ->setMethods(['add_product_settings_tab_content'])
-            ->getMock();
-
-        $admin->expects($this->once())
-            ->method('add_product_settings_tab_content')
-            ->willReturn('<div class="notice notice-info inline is-dismissible" style="background-color: #f8f9fa; border-left-color: #72777c;">');
-
-        $content = $admin->add_product_settings_tab_content();
-        $this->assertStringContainsString('notice notice-info', $content);
-        $this->assertStringContainsString('background-color: #f8f9fa', $content);
-        $this->assertStringContainsString('border-left-color: #72777c', $content);
+        ob_start();
+        $this->admin->add_product_variation_edit_fields(0, [], get_post($variation->get_id()));
+        $content = ob_get_clean();
+        
+        $this->assertStringNotContainsString('notice notice-warning', $content);
 
         // Clean up
         $variation->delete(true);
@@ -196,9 +177,9 @@ class AdminTest extends WP_UnitTestCase {
     }
 
     /**
-     * Test variation notice dismiss button
+     * Test that variation notice is shown when deprecated fields exist
      */
-    public function test_variation_notice_dismiss_button() {
+    public function test_variation_notice_shown_with_deprecated_fields() {
         $product = new \WC_Product_Variable();
         $product->save();
 
@@ -207,11 +188,56 @@ class AdminTest extends WP_UnitTestCase {
         $variation->update_meta_data('fb_product_description', 'Test description');
         $variation->save();
 
-        $this->admin->expects($this->once())
-            ->method('add_product_settings_tab_content')
-            ->willReturn('<div class="notice notice-info inline is-dismissible"><button type="button" class="notice-dismiss">Dismiss this notice</button></div>');
+        ob_start();
+        $this->admin->add_product_variation_edit_fields(0, [], get_post($variation->get_id()));
+        $content = ob_get_clean();
 
-        $content = $this->admin->add_product_settings_tab_content();
+        $this->assertStringContainsString('notice notice-warning', $content);
+        $this->assertStringContainsString('Some attributes are no longer supported', $content);
+
+        // Clean up
+        $variation->delete(true);
+        $product->delete(true);
+    }
+
+    /**
+     * Test that variation notice has correct styling
+     */
+    public function test_variation_notice_has_correct_styling() {
+        $product = new \WC_Product_Variable();
+        $product->save();
+
+        $variation = new \WC_Product_Variation();
+        $variation->set_parent_id($product->get_id());
+        $variation->update_meta_data('fb_product_description', 'Test description');
+        $variation->save();
+
+        ob_start();
+        $this->admin->add_product_variation_edit_fields(0, [], get_post($variation->get_id()));
+        $content = ob_get_clean();
+
+        $this->assertStringContainsString('style="padding: 1px; margin: 10px 10px 0;"', $content);
+
+        // Clean up
+        $variation->delete(true);
+        $product->delete(true);
+    }
+
+    /**
+     * Test that variation notice has dismiss button
+     */
+    public function test_variation_notice_has_dismiss_button() {
+        $product = new \WC_Product_Variable();
+        $product->save();
+
+        $variation = new \WC_Product_Variation();
+        $variation->set_parent_id($product->get_id());
+        $variation->update_meta_data('fb_product_description', 'Test description');
+        $variation->save();
+
+        ob_start();
+        $this->admin->add_product_variation_edit_fields(0, [], get_post($variation->get_id()));
+        $content = ob_get_clean();
 
         $this->assertStringContainsString('button type="button" class="notice-dismiss"', $content);
         $this->assertStringContainsString('Dismiss this notice', $content);
@@ -222,9 +248,9 @@ class AdminTest extends WP_UnitTestCase {
     }
 
     /**
-     * Test conditional rendering of variation fields
+     * Test that variation fields are not shown when no deprecated fields exist
      */
-    public function test_variation_fields_conditional_render() {
+    public function test_variation_fields_not_shown_without_deprecated_fields() {
         $product = new \WC_Product_Variable();
         $product->save();
 
@@ -232,38 +258,325 @@ class AdminTest extends WP_UnitTestCase {
         $variation->set_parent_id($product->get_id());
         $variation->save();
 
-        // Create a new mock for first test
-        $admin = $this->getMockBuilder(Admin::class)
-            ->setMethods(['add_product_settings_tab_content'])
-            ->getMock();
-
-        $admin->expects($this->once())
-            ->method('add_product_settings_tab_content')
-            ->willReturn('Some content without fields');
-
-        $content = $admin->add_product_settings_tab_content();
+        ob_start();
+        $this->admin->add_product_variation_edit_fields(0, [], get_post($variation->get_id()));
+        $content = ob_get_clean();
+        
         $this->assertStringNotContainsString('Facebook Description', $content);
         $this->assertStringNotContainsString('Custom Image URL', $content);
         $this->assertStringNotContainsString('Facebook Price', $content);
 
-        // Test with deprecated fields using a new mock
+        // Clean up
+        $variation->delete(true);
+        $product->delete(true);
+    }
+
+    /**
+     * Test that variation fields are shown when deprecated fields exist
+     */
+    public function test_variation_fields_shown_with_deprecated_fields() {
+        $product = new \WC_Product_Variable();
+        $product->save();
+
+        $variation = new \WC_Product_Variation();
+        $variation->set_parent_id($product->get_id());
         $variation->update_meta_data('fb_product_description', 'Test description');
         $variation->update_meta_data('fb_product_image', 'https://example.com/image.jpg');
         $variation->update_meta_data('fb_product_price', '99.99');
         $variation->save();
 
-        $admin = $this->getMockBuilder(Admin::class)
-            ->setMethods(['add_product_settings_tab_content'])
-            ->getMock();
+        ob_start();
+        $this->admin->add_product_variation_edit_fields(0, [], get_post($variation->get_id()));
+        $content = ob_get_clean();
 
-        $admin->expects($this->once())
-            ->method('add_product_settings_tab_content')
-            ->willReturn('Facebook Description Custom Image URL Facebook Price');
-
-        $content = $admin->add_product_settings_tab_content();
         $this->assertStringContainsString('Facebook Description', $content);
         $this->assertStringContainsString('Custom Image URL', $content);
         $this->assertStringContainsString('Facebook Price', $content);
+
+        // Clean up
+        $variation->delete(true);
+        $product->delete(true);
+    }
+
+    /**
+     * Test that variation fields show correct values
+     */
+    public function test_variation_fields_show_correct_values() {
+        $product = new \WC_Product_Variable();
+        $product->save();
+
+        $variation = new \WC_Product_Variation();
+        $variation->set_parent_id($product->get_id());
+        $variation->update_meta_data('fb_product_description', 'Test description content');
+        $variation->update_meta_data('fb_product_image', 'https://example.com/test-image.jpg');
+        $variation->update_meta_data('fb_product_price', '99.99');
+        $variation->save();
+
+        ob_start();
+        $this->admin->add_product_variation_edit_fields(0, [], get_post($variation->get_id()));
+        $content = ob_get_clean();
+
+        $this->assertStringContainsString('Test description content', $content);
+        $this->assertStringContainsString('https://example.com/test-image.jpg', $content);
+        $this->assertStringContainsString('99.99', $content);
+
+        // Clean up
+        $variation->delete(true);
+        $product->delete(true);
+    }
+
+    /**
+     * Test that variation fields inherit parent values when not set
+     */
+    public function test_variation_fields_inherit_parent_values() {
+        $product = new \WC_Product_Variable();
+        $product->update_meta_data('fb_product_description', 'Parent description');
+        $product->update_meta_data('fb_product_image', 'https://example.com/parent-image.jpg');
+        $product->update_meta_data('fb_product_price', '199.99');
+        $product->save();
+
+        $variation = new \WC_Product_Variation();
+        $variation->set_parent_id($product->get_id());
+        $variation->save();
+
+        ob_start();
+        $this->admin->add_product_variation_edit_fields(0, [], get_post($variation->get_id()));
+        $content = ob_get_clean();
+
+        $this->assertStringContainsString('Parent description', $content);
+        $this->assertStringContainsString('https://example.com/parent-image.jpg', $content);
+        $this->assertStringContainsString('199.99', $content);
+
+        // Clean up
+        $variation->delete(true);
+        $product->delete(true);
+    }
+
+    /**
+     * Test that variation fields handle empty values correctly
+     */
+    public function test_variation_fields_handle_empty_values() {
+        $product = new \WC_Product_Variable();
+        $product->save();
+
+        $variation = new \WC_Product_Variation();
+        $variation->set_parent_id($product->get_id());
+        $variation->update_meta_data('fb_product_description', '');
+        $variation->update_meta_data('fb_product_image', '');
+        $variation->update_meta_data('fb_product_price', '');
+        $variation->save();
+
+        ob_start();
+        $this->admin->add_product_variation_edit_fields(0, [], get_post($variation->get_id()));
+        $content = ob_get_clean();
+
+        $this->assertStringContainsString('value=""', $content);
+
+        // Clean up
+        $variation->delete(true);
+        $product->delete(true);
+    }
+
+    /**
+     * Test that variation fields handle special characters correctly
+     */
+    public function test_variation_fields_handle_special_characters() {
+        $product = new \WC_Product_Variable();
+        $product->save();
+
+        $variation = new \WC_Product_Variation();
+        $variation->set_parent_id($product->get_id());
+        $variation->update_meta_data('fb_product_description', 'Test & description with <special> "characters"');
+        $variation->update_meta_data('fb_product_image', 'https://example.com/image?param=value&special=true');
+        $variation->save();
+
+        ob_start();
+        $this->admin->add_product_variation_edit_fields(0, [], get_post($variation->get_id()));
+        $content = ob_get_clean();
+
+        $this->assertStringContainsString('Test &amp; description with &lt;special&gt; &quot;characters&quot;', $content);
+        $this->assertStringContainsString('https://example.com/image?param=value&amp;special=true', $content);
+
+        // Clean up
+        $variation->delete(true);
+        $product->delete(true);
+    }
+
+    /**
+     * Test that variation fields handle long text values correctly
+     */
+    public function test_variation_fields_handle_long_text() {
+        $product = new \WC_Product_Variable();
+        $product->save();
+
+        $long_description = str_repeat('This is a very long description. ', 50);
+        $long_image_url = 'https://example.com/image/' . str_repeat('very-long-path-segment-', 10) . '.jpg';
+
+        $variation = new \WC_Product_Variation();
+        $variation->set_parent_id($product->get_id());
+        $variation->update_meta_data('fb_product_description', $long_description);
+        $variation->update_meta_data('fb_product_image', $long_image_url);
+        $variation->save();
+
+        ob_start();
+        $this->admin->add_product_variation_edit_fields(0, [], get_post($variation->get_id()));
+        $content = ob_get_clean();
+
+        $this->assertStringContainsString($long_description, $content);
+        $this->assertStringContainsString($long_image_url, $content);
+
+        // Clean up
+        $variation->delete(true);
+        $product->delete(true);
+    }
+
+    /**
+     * Test that variation fields handle multiple variations correctly
+     */
+    public function test_variation_fields_handle_multiple_variations() {
+        $product = new \WC_Product_Variable();
+        $product->save();
+
+        // Create multiple variations
+        $variations = [];
+        for ($i = 1; $i <= 3; $i++) {
+            $variation = new \WC_Product_Variation();
+            $variation->set_parent_id($product->get_id());
+            $variation->update_meta_data('fb_product_description', "Description {$i}");
+            $variation->update_meta_data('fb_product_image', "https://example.com/image-{$i}.jpg");
+            $variation->update_meta_data('fb_product_price', "99.{$i}9");
+            $variation->save();
+            $variations[] = $variation;
+        }
+
+        // Test each variation
+        foreach ($variations as $index => $variation) {
+            ob_start();
+            $this->admin->add_product_variation_edit_fields($index, [], get_post($variation->get_id()));
+            $content = ob_get_clean();
+
+            $this->assertStringContainsString("Description " . ($index + 1), $content);
+            $this->assertStringContainsString("image-" . ($index + 1), $content);
+            $this->assertStringContainsString("99." . ($index + 1) . "9", $content);
+        }
+
+        // Clean up
+        foreach ($variations as $variation) {
+            $variation->delete(true);
+        }
+        $product->delete(true);
+    }
+
+    /**
+     * Test that variation fields handle HTML content correctly
+     */
+    public function test_variation_fields_handle_html_content() {
+        $product = new \WC_Product_Variable();
+        $product->save();
+
+        $html_description = '<p>This is a <strong>bold</strong> description with <a href="#">link</a></p>';
+        
+        $variation = new \WC_Product_Variation();
+        $variation->set_parent_id($product->get_id());
+        $variation->update_meta_data('fb_product_description', $html_description);
+        $variation->save();
+
+        ob_start();
+        $this->admin->add_product_variation_edit_fields(0, [], get_post($variation->get_id()));
+        $content = ob_get_clean();
+
+        $this->assertStringContainsString(htmlspecialchars($html_description, ENT_QUOTES), $content);
+
+        // Clean up
+        $variation->delete(true);
+        $product->delete(true);
+    }
+
+    /**
+     * Test that variation fields handle Unicode characters correctly
+     */
+    public function test_variation_fields_handle_unicode_characters() {
+        $product = new \WC_Product_Variable();
+        $product->save();
+
+        $unicode_description = 'Description with Unicode: 🚀 emoji, 汉字 Chinese, Español Spanish';
+        
+        $variation = new \WC_Product_Variation();
+        $variation->set_parent_id($product->get_id());
+        $variation->update_meta_data('fb_product_description', $unicode_description);
+        $variation->save();
+
+        ob_start();
+        $this->admin->add_product_variation_edit_fields(0, [], get_post($variation->get_id()));
+        $content = ob_get_clean();
+
+        $this->assertStringContainsString($unicode_description, $content);
+
+        // Clean up
+        $variation->delete(true);
+        $product->delete(true);
+    }
+
+    /**
+     * Test that variation fields handle price formatting correctly
+     */
+    public function test_variation_fields_handle_price_formatting() {
+        $product = new \WC_Product_Variable();
+        $product->save();
+
+        $test_prices = [
+            '99.99',
+            '1234.56',
+            '0.99',
+            '1000000.00',
+            '.99'
+        ];
+
+        foreach ($test_prices as $index => $price) {
+            $variation = new \WC_Product_Variation();
+            $variation->set_parent_id($product->get_id());
+            $variation->update_meta_data('fb_product_price', $price);
+            $variation->save();
+
+            ob_start();
+            $this->admin->add_product_variation_edit_fields($index, [], get_post($variation->get_id()));
+            $content = ob_get_clean();
+
+            $this->assertStringContainsString(wc_format_decimal($price), $content);
+
+            $variation->delete(true);
+        }
+
+        // Clean up
+        $product->delete(true);
+    }
+
+    /**
+     * Test that variation fields handle invalid values correctly
+     */
+    public function test_variation_fields_handle_invalid_values() {
+        $product = new \WC_Product_Variable();
+        $product->save();
+
+        $invalid_values = [
+            'fb_product_image' => 'not-a-valid-url',
+            'fb_product_price' => 'not-a-number',
+            'fb_product_description' => null
+        ];
+
+        $variation = new \WC_Product_Variation();
+        $variation->set_parent_id($product->get_id());
+        foreach ($invalid_values as $key => $value) {
+            $variation->update_meta_data($key, $value);
+        }
+        $variation->save();
+
+        ob_start();
+        $this->admin->add_product_variation_edit_fields(0, [], get_post($variation->get_id()));
+        $content = ob_get_clean();
+
+        // Verify that invalid values are handled gracefully
+        $this->assertStringContainsString('value=""', $content);
 
         // Clean up
         $variation->delete(true);

--- a/tests/Unit/AdminTest.php
+++ b/tests/Unit/AdminTest.php
@@ -1,0 +1,272 @@
+<?php
+namespace WooCommerce\Facebook\Tests\Unit;
+
+use WooCommerce\Facebook\Admin;
+use WC_Product_Simple;
+use function get_post;
+use function set_current_screen;
+use WP_UnitTestCase;
+
+/**
+ * @group admin
+ */
+class AdminTest extends WP_UnitTestCase {
+    /** @var Admin */
+    protected $admin;
+
+    /** @var \WC_Product_Simple */
+    protected $product;
+
+    public function setUp(): void {
+        parent::setUp();
+        
+        // Set up WordPress admin environment
+        set_current_screen('edit-post');
+        
+        // Create a mock Admin class
+        $this->admin = $this->getMockBuilder(Admin::class)
+            ->setMethods(['add_product_settings_tab_content'])
+            ->getMock();
+        
+        // Create a test product
+        $this->product = new \WC_Product_Simple();
+        $this->product->save();
+        
+        // Set up the global post
+        $GLOBALS['post'] = get_post($this->product->get_id());
+    }
+
+    public function tearDown(): void {
+        parent::tearDown();
+        
+        // Clean up WordPress admin environment
+        set_current_screen('front');
+        
+        // Clean up
+        if ($this->product) {
+            $this->product->delete(true);
+        }
+    }
+
+    /**
+     * Test that deprecation notice is not shown for new products
+     */
+    public function test_deprecation_notice_not_shown_for_new_products() {
+        $this->admin->expects($this->once())
+            ->method('add_product_settings_tab_content')
+            ->willReturn('Some content without notice');
+
+        $content = $this->admin->add_product_settings_tab_content();
+
+        $this->assertStringNotContainsString('notice notice-warning inline is-dismissible', $content);
+        $this->assertStringNotContainsString('Heads up!', $content);
+    }
+
+    /**
+     * Test that deprecation notice is shown when product has Facebook description
+     */
+    public function test_deprecation_notice_shown_with_fb_description() {
+        $this->product->update_meta_data('fb_product_description', 'Test description');
+        $this->product->save();
+
+        $this->admin->expects($this->once())
+            ->method('add_product_settings_tab_content')
+            ->willReturn('<div class="notice notice-warning inline is-dismissible">Heads up!</div>');
+
+        $content = $this->admin->add_product_settings_tab_content();
+
+        $this->assertStringContainsString('notice notice-warning inline is-dismissible', $content);
+        $this->assertStringContainsString('Heads up!', $content);
+    }
+
+    /**
+     * Test that deprecation notice is shown when product has custom image URL
+     */
+    public function test_deprecation_notice_shown_with_custom_image() {
+        $this->product->update_meta_data('fb_product_image', 'https://example.com/image.jpg');
+        $this->product->save();
+
+        $this->admin->expects($this->once())
+            ->method('add_product_settings_tab_content')
+            ->willReturn('<div class="notice notice-warning inline is-dismissible">Heads up!</div>');
+
+        $content = $this->admin->add_product_settings_tab_content();
+
+        $this->assertStringContainsString('notice notice-warning inline is-dismissible', $content);
+        $this->assertStringContainsString('Heads up!', $content);
+    }
+
+    /**
+     * Test that deprecation notice is shown when product has custom price
+     */
+    public function test_deprecation_notice_shown_with_custom_price() {
+        $this->product->update_meta_data('fb_product_price', '99.99');
+        $this->product->save();
+
+        $this->admin->expects($this->once())
+            ->method('add_product_settings_tab_content')
+            ->willReturn('<div class="notice notice-warning inline is-dismissible">Heads up!</div>');
+
+        $content = $this->admin->add_product_settings_tab_content();
+
+        $this->assertStringContainsString('notice notice-warning inline is-dismissible', $content);
+        $this->assertStringContainsString('Heads up!', $content);
+    }
+
+    /**
+     * Test that notice dismiss button exists and has correct structure
+     */
+    public function test_deprecation_notice_has_dismiss_button() {
+        $this->product->update_meta_data('fb_product_description', 'Test description');
+        $this->product->save();
+
+        $this->admin->expects($this->once())
+            ->method('add_product_settings_tab_content')
+            ->willReturn('<div class="notice notice-warning inline is-dismissible"><button type="button" class="notice-dismiss">Dismiss this notice</button></div>');
+
+        $content = $this->admin->add_product_settings_tab_content();
+
+        $this->assertStringContainsString('button type="button" class="notice-dismiss"', $content);
+        $this->assertStringContainsString('Dismiss this notice', $content);
+    }
+
+    /**
+     * Test that deprecation notice has grey styling
+     */
+    public function test_deprecation_notice_has_grey_styling() {
+        $this->product->update_meta_data('fb_product_description', 'Test description');
+        $this->product->save();
+
+        $this->admin->expects($this->once())
+            ->method('add_product_settings_tab_content')
+            ->willReturn('<div class="notice notice-info inline is-dismissible" style="background-color: #f8f9fa; border-left-color: #72777c;">');
+
+        $content = $this->admin->add_product_settings_tab_content();
+
+        $this->assertStringContainsString('notice notice-info', $content);
+        $this->assertStringContainsString('background-color: #f8f9fa', $content);
+        $this->assertStringContainsString('border-left-color: #72777c', $content);
+    }
+
+    /**
+     * Test variation deprecation notice styling and visibility
+     */
+    public function test_variation_deprecation_notice() {
+        // Create a variable product
+        $product = new \WC_Product_Variable();
+        $product->save();
+
+        // Create a variation
+        $variation = new \WC_Product_Variation();
+        $variation->set_parent_id($product->get_id());
+        $variation->save();
+
+        // Create a new mock for first test
+        $admin = $this->getMockBuilder(Admin::class)
+            ->setMethods(['add_product_settings_tab_content'])
+            ->getMock();
+
+        $admin->expects($this->once())
+            ->method('add_product_settings_tab_content')
+            ->willReturn('Some content without notice');
+
+        $content = $admin->add_product_settings_tab_content();
+        $this->assertStringNotContainsString('notice notice-info', $content);
+
+        // Add deprecated field and test again with a new mock
+        $variation->update_meta_data('fb_product_description', 'Test description');
+        $variation->save();
+
+        $admin = $this->getMockBuilder(Admin::class)
+            ->setMethods(['add_product_settings_tab_content'])
+            ->getMock();
+
+        $admin->expects($this->once())
+            ->method('add_product_settings_tab_content')
+            ->willReturn('<div class="notice notice-info inline is-dismissible" style="background-color: #f8f9fa; border-left-color: #72777c;">');
+
+        $content = $admin->add_product_settings_tab_content();
+        $this->assertStringContainsString('notice notice-info', $content);
+        $this->assertStringContainsString('background-color: #f8f9fa', $content);
+        $this->assertStringContainsString('border-left-color: #72777c', $content);
+
+        // Clean up
+        $variation->delete(true);
+        $product->delete(true);
+    }
+
+    /**
+     * Test variation notice dismiss button
+     */
+    public function test_variation_notice_dismiss_button() {
+        $product = new \WC_Product_Variable();
+        $product->save();
+
+        $variation = new \WC_Product_Variation();
+        $variation->set_parent_id($product->get_id());
+        $variation->update_meta_data('fb_product_description', 'Test description');
+        $variation->save();
+
+        $this->admin->expects($this->once())
+            ->method('add_product_settings_tab_content')
+            ->willReturn('<div class="notice notice-info inline is-dismissible"><button type="button" class="notice-dismiss">Dismiss this notice</button></div>');
+
+        $content = $this->admin->add_product_settings_tab_content();
+
+        $this->assertStringContainsString('button type="button" class="notice-dismiss"', $content);
+        $this->assertStringContainsString('Dismiss this notice', $content);
+
+        // Clean up
+        $variation->delete(true);
+        $product->delete(true);
+    }
+
+    /**
+     * Test conditional rendering of variation fields
+     */
+    public function test_variation_fields_conditional_render() {
+        $product = new \WC_Product_Variable();
+        $product->save();
+
+        $variation = new \WC_Product_Variation();
+        $variation->set_parent_id($product->get_id());
+        $variation->save();
+
+        // Create a new mock for first test
+        $admin = $this->getMockBuilder(Admin::class)
+            ->setMethods(['add_product_settings_tab_content'])
+            ->getMock();
+
+        $admin->expects($this->once())
+            ->method('add_product_settings_tab_content')
+            ->willReturn('Some content without fields');
+
+        $content = $admin->add_product_settings_tab_content();
+        $this->assertStringNotContainsString('Facebook Description', $content);
+        $this->assertStringNotContainsString('Custom Image URL', $content);
+        $this->assertStringNotContainsString('Facebook Price', $content);
+
+        // Test with deprecated fields using a new mock
+        $variation->update_meta_data('fb_product_description', 'Test description');
+        $variation->update_meta_data('fb_product_image', 'https://example.com/image.jpg');
+        $variation->update_meta_data('fb_product_price', '99.99');
+        $variation->save();
+
+        $admin = $this->getMockBuilder(Admin::class)
+            ->setMethods(['add_product_settings_tab_content'])
+            ->getMock();
+
+        $admin->expects($this->once())
+            ->method('add_product_settings_tab_content')
+            ->willReturn('Facebook Description Custom Image URL Facebook Price');
+
+        $content = $admin->add_product_settings_tab_content();
+        $this->assertStringContainsString('Facebook Description', $content);
+        $this->assertStringContainsString('Custom Image URL', $content);
+        $this->assertStringContainsString('Facebook Price', $content);
+
+        // Clean up
+        $variation->delete(true);
+        $product->delete(true);
+    }
+} 


### PR DESCRIPTION
# Deprecate Facebook-specific Fields and Add Warning Banners

## Description

This PR implements the deprecation of several Facebook-specific fields in the product settings while maintaining backwards compatibility for existing products. It also adds warning banners to notify users about these changes.

### Deprecated Fields
- Facebook Description
- Custom Image URL
- Facebook Price

These fields will now only be visible for products that already have values set for them, ensuring a smooth transition for existing implementations.

### Key Changes

1. **Warning Banner Implementation**
   - Added warning banners for both regular products and variations that have deprecated fields
   - Banners clearly communicate which fields are being deprecated
   - Includes reassurance that existing ads and Meta shops won't be affected

2. **Conditional Field Display**
   - Deprecated fields are now only shown if they contain existing values
   - Prevents new products from using deprecated fields while preserving existing data

3. **User Interface Improvements**
   - Added dismissible notices for better user experience
   - Implemented clear messaging about the deprecation
   - Maintained existing functionality for products with legacy data

### Example Warning Message
<img width="1190" alt="Screenshot 2025-04-08 at 21 01 51" src="https://github.com/user-attachments/assets/47bc0833-0fc9-4859-94cd-7a1a9bc3da6a" />
<img width="1482" alt="Screenshot 2025-04-08 at 21 02 22" src="https://github.com/user-attachments/assets/b8ab5d85-39c7-4ddb-b30f-ad2fb1d2c065" />


## Testing Instructions

1. Check products with existing Facebook-specific fields:
   - Verify warning banner appears
   - Confirm deprecated fields are visible and editable
   - Test banner dismissal functionality

2. Create a new product:
   - Verify deprecated fields are not shown
   - Confirm other Facebook integration features work as expected

3. Test variations:
   - Check warning banner appears for variations with existing Facebook-specific data
   - Verify deprecated fields are only shown for variations with existing values

## Impact

This change provides a graceful deprecation path while:
- Maintaining backwards compatibility
- Preventing confusion for new implementations
- Clearly communicating changes to users