### PR TITLE
[WAUM][12/n]Link the Add payment button to the correct billing url

### DIFF
--- a/assets/js/admin/whatsapp-billing.js
+++ b/assets/js/admin/whatsapp-billing.js
@@ -15,9 +15,7 @@ jQuery( document ).ready( function( $ ) {
 			action: 'wc_facebook_whatsapp_fetch_billing_url_info',
 			nonce:  facebook_for_woocommerce_whatsapp_billing.nonce
 		}, function ( response ) {
-            console.log("response 1", response);
             if ( response.success ) {
-                console.log("response 2", response);
                 var  business_id = response.data.business_id;
                 var asset_id = response.data.waba_id;
 				const BILLING_URL = `https://business.facebook.com/billing_hub/accounts/details/?business_id=${business_id}&asset_id=${asset_id}&account_type=whatsapp-business-account`;

--- a/assets/js/admin/whatsapp-billing.js
+++ b/assets/js/admin/whatsapp-billing.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+jQuery( document ).ready( function( $ ) {
+    // handle the whatsapp add payment button click should open billing flow in Meta
+    $('#wc-whatsapp-add-payment').click(function(event) {
+
+        $.post( facebook_for_woocommerce_whatsapp_billing.ajax_url, {
+			action: 'wc_facebook_whatsapp_fetch_billing_url_info',
+			nonce:  facebook_for_woocommerce_whatsapp_billing.nonce
+		}, function ( response ) {
+            console.log("response 1", response);
+            if ( response.success ) {
+                console.log("response 2", response);
+                var  business_id = response.data.business_id;
+                var asset_id = response.data.waba_id;
+				const BILLING_URL = `https://business.facebook.com/billing_hub/accounts/details/?business_id=${business_id}&asset_id=${asset_id}&account_type=whatsapp-business-account`;
+                window.open( BILLING_URL);
+			}
+		} );
+
+
+    });
+
+} );

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -51,6 +51,9 @@ class AJAX {
 		// update the wp_options with wc_facebook_whatsapp_consent_collection_setting_status to enabled
 		add_action( 'wp_ajax_wc_facebook_whatsapp_consent_collection_enable', array( $this, 'whatsapp_consent_collection_enable' ) );
 
+		// fetch billing url info - waba id and business id
+		add_action( 'wp_ajax_wc_facebook_whatsapp_fetch_billing_url_info', array( $this, 'wc_facebook_whatsapp_fetch_billing_url_info') );
+
 		// search a product's attributes for the given term
 		add_action( 'wp_ajax_' . self::ACTION_SEARCH_PRODUCT_ATTRIBUTES, array( $this, 'admin_search_product_attributes' ) );
 	}
@@ -171,6 +174,33 @@ class AJAX {
 		wp_send_json_success( $remaining_products );
 	}
 
+	public function whatsapp_consent_collection_enable() {
+		if ( ! check_ajax_referer( 'facebook-for-wc-whatsapp-consent-nonce', 'nonce', false ) ) {
+			wp_send_json_error( 'Invalid security token sent.' );
+		}
+		if ( get_option( 'wc_facebook_whatsapp_consent_collection_setting_status' ) !== 'enabled' ) {
+			update_option( 'wc_facebook_whatsapp_consent_collection_setting_status', 'enabled' );
+		}
+		wp_send_json_success();
+	}
+
+	public function wc_facebook_whatsapp_fetch_billing_url_info() {
+		facebook_for_woocommerce()->log( 'Fetching billing url info' );
+		if ( ! check_ajax_referer( 'facebook-for-wc-whatsapp-billing-nonce', 'nonce', false ) ) {
+			wp_send_json_error( 'Invalid security token sent.' );
+		}
+
+		$waba_id     = get_option( 'wc_facebook_wa_integration_waba_id', null );
+		$business_id = get_option( 'wc_facebook_wa_integration_business_id', null );
+
+		if ( empty( $waba_id ) || empty( $business_id ) ) {
+			wp_send_json_error( 'Onboarding is not complete or has failed.' );
+		}
+
+		$response = array ( 'waba_id' => $waba_id, 'business_id' => $business_id, );
+
+		wp_send_json_success($response);
+	}
 
 	public function whatsapp_consent_collection_enable() {
 		if ( ! check_ajax_referer( 'facebook-for-wc-whatsapp-consent-nonce', 'nonce', false ) ) {

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -174,16 +174,6 @@ class AJAX {
 		wp_send_json_success( $remaining_products );
 	}
 
-	public function whatsapp_consent_collection_enable() {
-		if ( ! check_ajax_referer( 'facebook-for-wc-whatsapp-consent-nonce', 'nonce', false ) ) {
-			wp_send_json_error( 'Invalid security token sent.' );
-		}
-		if ( get_option( 'wc_facebook_whatsapp_consent_collection_setting_status' ) !== 'enabled' ) {
-			update_option( 'wc_facebook_whatsapp_consent_collection_setting_status', 'enabled' );
-		}
-		wp_send_json_success();
-	}
-
 	public function wc_facebook_whatsapp_fetch_billing_url_info() {
 		facebook_for_woocommerce()->log( 'Fetching billing url info' );
 		if ( ! check_ajax_referer( 'facebook-for-wc-whatsapp-billing-nonce', 'nonce', false ) ) {

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -52,7 +52,7 @@ class AJAX {
 		add_action( 'wp_ajax_wc_facebook_whatsapp_consent_collection_enable', array( $this, 'whatsapp_consent_collection_enable' ) );
 
 		// fetch billing url info - waba id and business id
-		add_action( 'wp_ajax_wc_facebook_whatsapp_fetch_billing_url_info', array( $this, 'wc_facebook_whatsapp_fetch_billing_url_info') );
+		add_action( 'wp_ajax_wc_facebook_whatsapp_fetch_billing_url_info', array( $this, 'wc_facebook_whatsapp_fetch_billing_url_info' ) );
 
 		// search a product's attributes for the given term
 		add_action( 'wp_ajax_' . self::ACTION_SEARCH_PRODUCT_ATTRIBUTES, array( $this, 'admin_search_product_attributes' ) );
@@ -197,9 +197,12 @@ class AJAX {
 			wp_send_json_error( 'Onboarding is not complete or has failed.' );
 		}
 
-		$response = array ( 'waba_id' => $waba_id, 'business_id' => $business_id, );
+		$response = array(
+			'waba_id'     => $waba_id,
+			'business_id' => $business_id,
+		);
 
-		wp_send_json_success($response);
+		wp_send_json_success( $response );
 	}
 
 	public function whatsapp_consent_collection_enable() {

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -80,6 +80,23 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				),
 			)
 		);
+		wp_enqueue_script(
+			'facebook-for-woocommerce-whatsapp-billing',
+			facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/whatsapp-billing.js',
+			array( 'jquery', 'jquery-blockui', 'jquery-tiptip', 'wc-enhanced-select' ),
+			\WC_Facebookcommerce::PLUGIN_VERSION
+		);
+		wp_localize_script(
+			'facebook-for-woocommerce-whatsapp-billing',
+			'facebook_for_woocommerce_whatsapp_billing',
+			array(
+				'ajax_url' => admin_url( 'admin-ajax.php' ),
+				'nonce'    => wp_create_nonce( 'facebook-for-wc-whatsapp-billing-nonce' ),
+				'i18n'     => array(
+					'result' => true,
+				),
+			)
+		);
 	}
 
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ const jQueryUIAdminFileNames = [
 	'settings-commerce',
 	'settings-sync',
 	'enhanced-settings-sync',
+    'whatsapp-billing',
     'whatsapp-connection',
     'whatsapp-consent',
 ];


### PR DESCRIPTION
## Description
After embedded sign up is completed the waba/business ID will be stored in DB. Use this stored info to form the billing url to take the user to the billing hub for the whatsapp business account.

### Type of change
- New feature (non-breaking change which adds functionality)


## Changelog entry
Update add payment method to link to the whatsapp billing hub url


## Test Plan
Clicking on the add payment button opens the billing hub for the whatsapp business account

## Screenshots

https://github.com/user-attachments/assets/82943786-5ee4-4e6a-8e47-492159712a4a


