### PR TITLE
fix: Update descriptive tooltip for MPN text input

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1310,6 +1310,7 @@ class Admin {
 						'value'    => $fb_mpn,
 						'class'    => 'enable-if-sync-enabled',
 						'desc_tip' => true,
+						'description' => __( 'Manufacturer Part Number (MPN) of the item', 'facebook-for-woocommerce' ),
 					)
 				);
 


### PR DESCRIPTION
## Description
Fixed bug where MPN input box had no tooltip

#Before
<img width="830" alt="Screenshot 2025-04-09 at 16 48 51" src="https://github.com/user-attachments/assets/cc76ed53-3256-480a-9ffd-5ae16870b67e" />


#After 
<img width="992" alt="Screenshot 2025-04-09 at 16 49 06" src="https://github.com/user-attachments/assets/fc8aac34-0989-4bfd-b3a6-55a0b5ca5d70" />

