### PR TITLE
fix: Add parent product material inheritance for variations

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1099,6 +1099,14 @@ class WC_Facebook_Product {
 			true
 		);
 
+		// If empty and this is a variation, get the parent material
+		if ( empty( $fb_material ) && $this->is_type( 'variation' ) ) {
+			$parent_id = $this->get_parent_id();
+			if ( $parent_id ) {
+				$fb_material = get_post_meta( $parent_id, self::FB_MATERIAL, true );
+			}
+		}
+
 		return mb_substr(WC_Facebookcommerce_Utils::clean_string($fb_material), 0, 200);
 	}
 


### PR DESCRIPTION
## Description
This PR fixes an inconsistency in how product material attributes are handled for variable products in the Facebook for WooCommerce sync process. Previously, variations would not inherit their parent product's material attribute, unlike other attributes such as color and size.

### What Changed
- Added parent fallback logic to `get_fb_material()` method
- Variations now check parent product's material value if no variation-specific material is set
- Maintains existing string sanitization and length limits

### Before
```php
// Only checked variation attributes and direct meta
$fb_material = get_post_meta($this->id, self::FB_MATERIAL, true);
```

### After
```php
// Now includes parent fallback like other attributes
if (empty($fb_material) && $this->is_type('variation')) {
    $parent_id = $this->get_parent_id();
    if ($parent_id) {
        $fb_material = get_post_meta($parent_id, self::FB_MATERIAL, true);
    }
}
```
<img width="748" alt="Screenshot 2025-04-09 at 19 47 45" src="https://github.com/user-attachments/assets/9d7a1009-01cd-481f-ae9b-1bae431e0844" />



### Testing
1. Create a variable product with a material set at the parent level
2. Create variations without specific material values
3. Verify variations inherit the parent's material when syncing to Facebook
4. Verify variations with their own material values still use their specific value

### Related Issues
- Fixes inconsistent material attribute syncing for variable products
- Aligns material handling with other product attributes