### PR TITLE
Removing Modal on Do Not Sync 

### DIFF
--- a/assets/js/admin/products-admin.js
+++ b/assets/js/admin/products-admin.js
@@ -394,30 +394,6 @@ jQuery( document ).ready( function( $ ) {
 			$syncModeSelect.val( $syncModeSelect.attr( 'data-original-value') );
 		}
 
-
-		/**
-		 * Determines whether we should show the product removed from sync confirm modal.
-		 *
-		 * @since 2.3.0
-		 *
-		 * @param {jQuery} $syncModeSelect a jQuery object with one or more sync mode select elements
-		 * @return {boolean}
-		 */
-		function shouldShowProductRemovedFromSyncConfirmModal( $syncModeSelect ) {
-
-			let syncValuesStatus = $syncModeSelect.map( function ( index, selectElement ) {
-
-				let $syncMode     	   = $( selectElement );
-				let syncModeValue 	   = $syncMode.val();
-				let isProductPublished = !! facebook_for_woocommerce_products_admin.is_product_published;
-
-				return isProductPublished && 'sync_disabled' === syncModeValue && syncModeValue !== $syncMode.attr( 'data-original-value' );
-			} ).toArray();
-
-			return syncValuesStatus.indexOf( true ) > -1;
-		}
-
-
 		/**
 		 * Gets the target product ID based on the given sync select element.
 		 *
@@ -435,31 +411,6 @@ jQuery( document ).ready( function( $ ) {
 			// variable product
 			return $syncModeSelect.closest( '.woocommerce_variation' ).find( 'input[name^=variable_post_id]' ).val();
 		}
-
-
-		/**
-		 * Shows the product removed from sync confirm modal.
-		 *
-		 * @since 2.3.0
-		 *
-		 * @param {jQuery} $syncModeSelect a jQuery element object
-		 */
-		function showProductRemovedFromSyncConfirmModal( $syncModeSelect ) {
-
-			closeExistingModal();
-
-			$maybeRemoveFromSyncModeSelect = $syncModeSelect;
-			maybeRemoveFromSyncProductID   = getSyncTargetProductID( $syncModeSelect )
-
-			new $.WCBackboneModal.View( {
-				target: 'facebook-for-woocommerce-modal',
-				string: {
-					message: facebook_for_woocommerce_products_admin.product_removed_from_sync_confirm_modal_message,
-					buttons: facebook_for_woocommerce_products_admin.product_removed_from_sync_confirm_modal_buttons
-				}
-			} );
-		}
-
 
 		/**
 		 * Fills in product IDs to remove from Sync.
@@ -488,32 +439,7 @@ jQuery( document ).ready( function( $ ) {
 			populateRemoveFromSyncProductIDsField();
 		}
 
-		let $maybeRemoveFromSyncModeSelect = null;
-		let maybeRemoveFromSyncProductID = null;
 		let removeFromSyncProductIDs = [];
-
-		$( document.body ).on( 'click', 'button.button-product-removed-from-sync-delete', function () {
-
-			if ( maybeRemoveFromSyncProductID ) {
-
-				closeExistingModal();
-
-				removeFromSyncProductIDs.push( maybeRemoveFromSyncProductID );
-
-				populateRemoveFromSyncProductIDsField();
-			}
-		} )
-		.on( 'click', 'button.button-product-removed-from-sync-cancel', function () {
-
-			closeExistingModal();
-
-			if ( $maybeRemoveFromSyncModeSelect ) {
-				revertSyncModeToOriginalValue( $maybeRemoveFromSyncModeSelect );
-				$maybeRemoveFromSyncModeSelect = null;
-			}
-
-			populateRemoveFromSyncProductIDsField();
-		} );
 
 		// handle change events for the Sell on Instagram checkbox field
 		$( '#facebook_options #wc_facebook_commerce_enabled' ).on( 'change', function() {
@@ -556,10 +482,6 @@ jQuery( document ).ready( function( $ ) {
 			}
 
 			simpleProductSyncModeSelect.prop( 'original', simpleProductSyncModeSelect.val() );
-
-			if ( shouldShowProductRemovedFromSyncConfirmModal( simpleProductSyncModeSelect ) ) {
-				showProductRemovedFromSyncConfirmModal( simpleProductSyncModeSelect );
-			}
 
 		} ).trigger( 'change' );
 
@@ -606,10 +528,6 @@ jQuery( document ).ready( function( $ ) {
 			}
 
 			$syncModeSelect.prop( 'original', $syncModeSelect.val() );
-
-			if ( shouldShowProductRemovedFromSyncConfirmModal( $syncModeSelect ) ) {
-				showProductRemovedFromSyncConfirmModal( $syncModeSelect );
-			}
 		} );
 
 		$productData.on( 'woocommerce_variations_loaded', function () {

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -267,8 +267,6 @@ class Admin {
 						'set_product_sync_bulk_action_prompt_nonce' => wp_create_nonce( 'set-product-sync-bulk-action-prompt' ),
 						'product_not_ready_modal_message' => $this->get_product_not_ready_modal_message(),
 						'product_not_ready_modal_buttons' => $this->get_product_not_ready_modal_buttons(),
-						'product_removed_from_sync_confirm_modal_message' => $this->get_product_removed_from_sync_confirm_modal_message(),
-						'product_removed_from_sync_confirm_modal_buttons' => $this->get_product_removed_from_sync_confirm_modal_buttons(),
 						'product_removed_from_sync_field_id' => '#' . \WC_Facebook_Product::FB_REMOVE_FROM_SYNC,
 						'i18n'                            => [
 							'missing_google_product_category_message' => __( 'Please enter a Google product category and at least one sub-category to sell this product on Instagram.', 'facebook-for-woocommerce' ),
@@ -372,60 +370,6 @@ class Admin {
 			id="btn-ok"
 			class="button button-large button-primary"
 		><?php esc_html_e( 'Close', 'facebook-for-woocommerce' ); ?></button>
-		<?php
-		return ob_get_clean();
-	}
-
-	/**
-	 * Gets the markup for the message used in the product removed from sync confirm modal.
-	 *
-	 * @internal
-	 *
-	 * @since 2.3.0
-	 *
-	 * @return string
-	 */
-	private function get_product_removed_from_sync_confirm_modal_message() {
-		ob_start();
-		?>
-		<p>
-		<?php
-		printf(
-			/* translators: Placeholders: %1$s - opening <a> link tag, %2$s - closing </a> link tag */
-			esc_html__( 'You\'re removing a product from the Facebook sync that is currently listed in your %1$sFacebook catalog%2$s. Would you like to delete the product from the Facebook catalog as well?', 'facebook-for-woocommerce' ),
-			'<a href="https://www.facebook.com/products" target="_blank">',
-			'</a>'
-		);
-		?>
-			</p>
-		<?php
-		return ob_get_clean();
-	}
-
-	/**
-	 * Gets the markup for the buttons used in the product removed from sync confirm modal.
-	 *
-	 * @internal
-	 *
-	 * @since 2.3.0
-	 *
-	 * @return string
-	 */
-	private function get_product_removed_from_sync_confirm_modal_buttons() {
-		ob_start();
-		?>
-		<button
-			id="btn-ok"
-			class="button button-large button-primary"
-		><?php esc_html_e( 'Remove from sync only', 'facebook-for-woocommerce' ); ?></button>
-
-		<button
-			class="button button-large button-delete button-product-removed-from-sync-delete"
-		><?php esc_html_e( 'Remove from sync and delete', 'facebook-for-woocommerce' ); ?></button>
-
-		<button
-			class="button button-large button-product-removed-from-sync-cancel"
-		><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></button>
 		<?php
 		return ob_get_clean();
 	}


### PR DESCRIPTION
#Removing Modal on Do Not Sync 

## Description

This PR contains the changes that will remove the modal that shows up when some simple product or variation is marked for **Do not sync**

### Type of change

- Since we have implemented the changes that will remove the product/delete it from facebook catalog on **Don not sync**.
- Having the modal is redundant

## Checklist

- [] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Test Plan

To check the removal of the modal follow the steps:
- Make sure you have some products on the website
- Should have a working catalog linked
- Now edit a product either simple or variable
- Check for sync settings for the variations/facebook tab
- Mark it Do not sync
- Observe no Modal is showing up

## Screenshots

### Before
<img width="1591" alt="Screenshot 2025-04-10 at 3 43 10 pm" src="https://github.com/user-attachments/assets/34592338-028d-4f09-b10e-57c517434bdd" />

### After
No Modal