### PR TITLE
[WAUM][Easy] Fix merge overwrite for Onboarding changes

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
+++ b/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
@@ -29,9 +29,10 @@
     margin-bottom: 10px;
 }
 .add-payment-button {
-    float: right;
+    text-align: right;
+    margin-bottom: 20px;
+    margin-left: 250px;
     margin-top: 20px;
-    margin-left: 400px;
 }
 .whatsapp-onboarding-button {
     text-align: right;

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -41,8 +41,8 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	 */
 	public function initHook(): void {
 		$this->id    = self::ID;
-		$this->label = __( 'WhatsApp Utility', 'facebook-for-woocommerce' );
-		$this->title = __( 'WhatsApp Utility', 'facebook-for-woocommerce' );
+		$this->label = __( 'Utility messages', 'facebook-for-woocommerce' );
+		$this->title = __( 'Utility messages', 'facebook-for-woocommerce' );
 	}
 
 	/**
@@ -123,68 +123,73 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	public function render_utility_message_onboarding() {
 
 		?>
-		<div class="onboarding-card">
-			<div class="card-item">
-				<h1><b><?php esc_html_e( 'Send Updates to customers on WhatsApp', 'facebook-for-woocommerce' ); ?></b></h1>
-				<?php esc_html_e( 'Send important updates and notifications directly to customers through WhatsApp.', 'facebook-for-woocommerce' ); ?>
-			</div>
-			<div class="divider"></div>
-			<div class="card-item">
-				<h2><?php esc_html_e( 'Get started with WhatsApp utility messages', 'facebook-for-woocommerce' ); ?></h2>
-				<p><?php esc_html_e( 'Connect your WhatsApp Business Account to start sending utility messages.', 'facebook-for-woocommerce' ); ?></p>
-				<div class="whatsapp-onboarding-button">
-					<a
-						id="woocommerce-whatsapp-connection"
-						class="button button-primary"
-						href="#"><?php esc_html_e( 'Connect Whatsapp Account', 'facebook-for-woocommerce' ); ?></a>
-				</div>
-			</div>
-			<div class="divider"></div>
-			<div class="card-item">
-				<h2>Collect phone numbers at checkout</h2>
-				<p>To collect phone numbers, a checkbox will be added to your store’s checkout page. This lets customers sign up to receive your messages. You can preview what this looks like in your checkout page preview.</p>
-				<p>This will allow you to send messages to your customers on WhatsApp.</p>
-				<div class="whatsapp-onboarding-button">
-					<a
-						class="button button-primary"
-						id="wc-whatsapp-collect-consent"
-						href="#"><?php esc_html_e( 'Collect', 'facebook-for-woocommerce' ); ?></a>
-				</div>
-			</div>
-			<div class="divider"></div>
-			<div class="card-item">
-				<h2>Add a payment method</h2>
-				<p>Confirm your payment method in Billings & payments.
-					<a
-						href="#"
-						id="wc-whatsapp-about-pricing"><?php esc_html_e( 'About pricing', 'facebook-for-woocommerce' ); ?>
-					</a>
 
-				</p>
-				<div class="add-payment-section">
-					<div class="review-payment-block">
-						<div class="review-payment-content">
-							Add a payment method
-						</div>
+	<div class="onboarding-card">
+	<div class="card-item">
+	<h1><b><?php esc_html_e( 'Send Updates to customers on WhatsApp', 'facebook-for-woocommerce' ); ?></b></h1>
+		<?php esc_html_e( 'Send important updates and notifications directly to customers through WhatsApp.', 'facebook-for-woocommerce' ); ?>
+	</div>
+	<div class="divider"></div>
+	<div class="card-item">
+	<h2><?php esc_html_e( 'Get started with WhatsApp utility messages', 'facebook-for-woocommerce' ); ?></h2>
+	<p><?php esc_html_e( 'Connect your WhatsApp Business Account to start sending utility messages.', 'facebook-for-woocommerce' ); ?></p>
+	<div class="whatsapp-onboarding-button">
+	<a
+			id="woocommerce-whatsapp-connection"
+			class="button"
+			href="#"
+		><?php esc_html_e( 'Connect Whatsapp Account', 'facebook-for-woocommerce' ); ?></a>
+	</div>
+	</div>
+	<div class="divider"></div>
+	<div class="card-item">
+	<h2><?php esc_html_e( 'Collect phone numbers at checkout', 'facebook-for-woocommerce' ); ?></h2>
+	<p><?php esc_html_e( 'To collect phone numbers, a checkbox will be added to your store’s checkout page. This lets customers sign up to receive your messages. You can preview what this looks like in your checkout page preview.', 'facebook-for-woocommerce' ); ?></p>
+		<p><?php esc_html_e( 'This will allow you to send messages to your customers on WhatsApp.', 'facebook-for-woocommerce' ); ?></p>
+		<div class="whatsapp-onboarding-button">
+		<a
+			class="button"
+			id="wc-whatsapp-collect-consent"
+			href="#"
+		><?php esc_html_e( 'Add', 'facebook-for-woocommerce' ); ?></a>
+		</div>
+	</div>
+	<div class="divider"></div>
+	<div class="card-item">
+		<h2><?php esc_html_e( 'Add a payment method', 'facebook-for-woocommerce' ); ?></h2>
+		<p><?php esc_html_e( 'Confirm your payment method in Billings & payments.', 'facebook-for-woocommerce' ); ?>
+				<a
+					href="#"
+					id="wc-whatsapp-about-pricing"
+				><?php esc_html_e( 'About pricing', 'facebook-for-woocommerce' ); ?>
+				</a>
+
+			</p>
+			<div class="add-payment-section">
+				<div class="review-payment-block">
+					<div class="review-payment-content">
+					<?php esc_html_e( 'Add a payment method', 'facebook-for-woocommerce' ); ?>
+					</div>
 						<div class="add-payment-button">
 							<a
-								class="button button-primary"
+								class="button"
 								id="wc-whatsapp-add-payment"
 								href="#"
 								><?php esc_html_e( 'Add', 'facebook-for-woocommerce' ); ?>
 							</a>
 						</div>
-					</div>
-					<div class="whatsapp-onboarding-button">
-						<a
-							class="button button-primary"
-							id="wc-whatsapp-onboarding-finish"
-							href="#"><?php esc_html_e( 'Finish', 'facebook-for-woocommerce' ); ?></a>
-					</div>
 				</div>
-
+				<div class="whatsapp-onboarding-button">
+					<a
+						class="button button-primary"
+						id="wc-whatsapp-onboarding-finish"
+						href="#"
+					><?php esc_html_e( 'Finish', 'facebook-for-woocommerce' ); ?></a>
+				</div>
 			</div>
+
 		</div>
+	</div>
 		<?php
 	}
 


### PR DESCRIPTION
## Description

Fixing the merge overwrite of Whatsapp_Utility.php and facebook-for-woocommerce-whatsapp-utility.css. Closing PR #[3017](https://github.com/facebook/facebook-for-woocommerce/pull/3017) didn't trigger merge conflict resolution and overwrote the changes being introduced in PR [#3026.](https://github.com/facebook/facebook-for-woocommerce/pull/3026)

### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Changelog entry

Code catchup for whatsapp onboarding flow.


## Test Plan

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration.

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before
![Screenshot 2025-04-10 at 11 31 52 AM](https://github.com/user-attachments/assets/aba46dfa-74a4-4015-9fd8-765840c02a9d)

### After
![Screenshot 2025-04-10 at 11 25 47 AM](https://github.com/user-attachments/assets/10fce763-483b-4557-9cf4-2463a40a7669)
After Screenshot matches #[PR 3026](https://github.com/facebook/facebook-for-woocommerce/pull/3026)
