### PR TITLE
Feature: Short Description Fallback

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -753,6 +753,14 @@ class WC_Facebook_Product {
 				}
 			}
 			
+			// If still no short description, check if main description is short enough
+			if (empty($short_description)) {
+				$main_description = WC_Facebookcommerce_Utils::clean_string($this->woo_product->get_description());
+				if (!empty($main_description) && strlen($main_description) < 50) {
+					$short_description = $main_description;
+				}
+			}
+			
 			return apply_filters('facebook_for_woocommerce_fb_product_short_description', $short_description, $this->id);
 		}
 
@@ -762,6 +770,14 @@ class WC_Facebook_Product {
 		
 		if (!empty($post_excerpt)) {
 			$short_description = $post_excerpt;
+		}
+		
+		// If no short description (excerpt) found, check if main description is short enough
+		if (empty($short_description)) {
+			$post_content = WC_Facebookcommerce_Utils::clean_string($post->post_content);
+			if (!empty($post_content) && strlen($post_content) < 50) {
+				$short_description = $post_content;
+			}
 		}
 
 		/**


### PR DESCRIPTION
## Feature: Short Description Fallback

### Summary

This pull request introduces a new feature to the `WC_Facebook_Product` class, specifically enhancing the `get_fb_short_description` method. The method now includes logic to use the main product description as the short description when the main description is less than 50 characters.

### Changes

- **Modified `get_fb_short_description` Method:**
  - For variation products, if no short description is found, the method now checks if the main description is less than 50 characters and uses it as the short description.
  - For regular products, if no short description (excerpt) is found, the method checks if the main description is less than 50 characters and uses it as the short description.

### Benefits

- Ensures that products with very short main descriptions can still have a meaningful short description.
- Improves the consistency and completeness of product data sent to Facebook.

### Testing

- Verified that the short description is correctly populated from the main description when it is less than 50 characters.
- Ensured that existing functionality remains unaffected for products with longer descriptions.

### Notes

- This change does not affect any other parts of the plugin and maintains backward compatibility.