### PR TITLE
Fix Facebook attribute dropdown display and syncing issues

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -775,6 +775,11 @@ class Admin {
 	 * @param string $product_edit the product metadata that is being edited.
 	 */
 	public function handle_products_sync_bulk_actions( $product_edit ) {
+		$products = [];
+		// Add nonce verification
+		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( $_GET['_wpnonce'] ), 'woocommerce-facebook-bulk-sync' ) ) {
+			return;
+		}
 
 		$sync_mode = isset( $_GET['facebook_bulk_sync_options'] ) ? (string) sanitize_text_field( wp_unslash( $_GET['facebook_bulk_sync_options'] ) ) : null;
 
@@ -1248,6 +1253,12 @@ class Admin {
 			<?php
 				woocommerce_wp_text_input(
 					array(
+						'id'          => \WC_Facebook_Product::FB_MPN,
+						'name'        => \WC_Facebook_Product::FB_MPN,
+						'label'       => __( 'Manufacturer Part Number (MPN)', 'facebook-for-woocommerce' ),
+						'value'       => $fb_mpn,
+						'class'       => 'enable-if-sync-enabled',
+						'desc_tip'    => true,
 						'id'          => \WC_Facebook_Product::FB_MPN,
 						'name'        => \WC_Facebook_Product::FB_MPN,
 						'label'       => __( 'Manufacturer Part Number (MPN)', 'facebook-for-woocommerce' ),
@@ -2170,6 +2181,13 @@ class Admin {
 			'pattern'   => \WC_Facebook_Product::FB_PATTERN,
 			'brand'     => \WC_Facebook_Product::FB_BRAND,
 			'mpn'       => \WC_Facebook_Product::FB_MPN,
+			'material'  => \WC_Facebook_Product::FB_MATERIAL,
+			'color'     => \WC_Facebook_Product::FB_COLOR,
+			'colour'    => \WC_Facebook_Product::FB_COLOR, // Add support for British spelling
+			'size'      => \WC_Facebook_Product::FB_SIZE,
+			'pattern'   => \WC_Facebook_Product::FB_PATTERN,
+			'brand'     => \WC_Facebook_Product::FB_BRAND,
+			'mpn'       => \WC_Facebook_Product::FB_MPN,
 			'age_group' => \WC_Facebook_Product::FB_AGE_GROUP,
 			'gender'    => \WC_Facebook_Product::FB_GENDER,
 			'condition' => \WC_Facebook_Product::FB_PRODUCT_CONDITION,
@@ -2187,6 +2205,7 @@ class Admin {
 				\WC_Facebook_Product::AGE_GROUP_NEWBORN,
 			],
 			'gender'    => [
+			'gender'    => [
 				\WC_Facebook_Product::GENDER_MALE,
 				\WC_Facebook_Product::GENDER_FEMALE,
 				\WC_Facebook_Product::GENDER_UNISEX,
@@ -2201,50 +2220,31 @@ class Admin {
 		// Then process existing attributes
 		foreach ( $attributes as $attribute ) {
 			// Remove 'pa_' prefix from taxonomy attributes and convert to lowercase
-			$raw_name = $attribute->get_name();
-			$clean_name = str_replace( 'pa_', '', $raw_name );
-			$normalized_attr_name = strtolower( $clean_name );
-			
-			// Get the actual display name/label of the attribute
-			$attribute_label = wc_attribute_label( $raw_name );
-			$normalized_label = strtolower( $attribute_label );
-			
+			$original_attr_name   = $attribute->get_name();
+			$normalized_attr_name = strtolower( str_replace( 'pa_', '', $original_attr_name ) );
+
 			// Further normalize by removing spaces and underscores for matching
 			$matching_attr_name = str_replace( [ '_', ' ' ], '', $normalized_attr_name );
-	
-			// Find the target Facebook field for this attribute
-			$matched_facebook_field = null;
-			$field_name = null;
-	
+
 			// Special handling for color/colour
 			if ( 'color' === $matching_attr_name || 'colour' === $matching_attr_name ) {
-				$matched_facebook_field = \WC_Facebook_Product::FB_COLOR;
+				$meta_key   = \WC_Facebook_Product::FB_COLOR;
 				$field_name = 'color';
-			} elseif ( 'agegroup' === $matching_attr_name ) { // Special handling for age group
-				$matched_facebook_field = \WC_Facebook_Product::FB_AGE_GROUP;
+			} elseif ( 'agegroup' === $matching_attr_name ) { // Special handling for age group (can be "age_group", "agegroup", "age group")
+				$meta_key   = \WC_Facebook_Product::FB_AGE_GROUP;
 				$field_name = 'age_group';
 			} else {
-				// Try direct matching first
-				if ( isset( $attribute_map[ $normalized_attr_name ] ) ) {
-					$matched_facebook_field = $attribute_map[ $normalized_attr_name ];
-					$field_name = $normalized_attr_name;
-				} else {
-					// Try to match against standard attribute names
-					foreach ( $attribute_map as $fb_attr_name => $fb_meta_key ) {
-						// Check for exact match with the attribute label
-						if ( $normalized_label === $fb_attr_name || 'pa_' . $fb_attr_name === $raw_name ) {
-							$matched_facebook_field = $fb_meta_key;
-							$field_name = $fb_attr_name;
-							break;
-						}
-						
-						// Also check with normalized matching (spaces and underscores removed)
-						$normalized_fb_attr = str_replace( [ '_', ' ' ], '', $fb_attr_name );
-						if ( $matching_attr_name === $normalized_fb_attr ) {
-							$matched_facebook_field = $fb_meta_key;
-							$field_name = $fb_attr_name;
-							break;
-						}
+				// Try to match against standard attribute names
+				$meta_key   = null;
+				$field_name = $normalized_attr_name;
+
+				foreach ( $attribute_map as $fb_attr_name => $fb_meta_key ) {
+					// Replace spaces and underscores in the map keys for matching
+					$normalized_fb_attr = str_replace( [ '_', ' ' ], '', $fb_attr_name );
+					if ( $matching_attr_name === $normalized_fb_attr ) {
+						$meta_key   = $fb_meta_key;
+						$field_name = $fb_attr_name;
+						break;
 					}
 				}
 			}
@@ -2268,35 +2268,36 @@ class Admin {
 					
 					// Check if this attribute is used for variations
 					$used_for_variations = $attribute->get_variation();
-	
+
 					// For dropdown attributes, validate against allowed values
 					if ( array_key_exists( $field_name, $dropdown_attrs ) ) {
 						$valid_values = [];
 						foreach ( $values as $value ) {
 							$normalized_value = strtolower( trim( $value ) );
-	
+
 							// Check if value matches any of the allowed values (case-insensitive)
 							foreach ( $dropdown_attrs[ $field_name ] as $allowed_value ) {
+								if ( strtolower( $allowed_value ) === $normalized_value ) {
 								if ( strtolower( $allowed_value ) === $normalized_value ) {
 									$valid_values[] = $allowed_value; // Use the correctly-cased allowed value
 									break;
 								}
 							}
 						}
-	
+
 						if ( ! empty( $valid_values ) ) {
-							$joined_values = implode( ' | ', $valid_values );
-							$facebook_fields[ $output_field_name ] = $joined_values;
-							update_post_meta( $product_id, $matched_facebook_field, $joined_values );
+							$joined_values                  = implode( ' | ', $valid_values );
+							$facebook_fields[ $field_name ] = $joined_values;
+							update_post_meta( $product_id, $meta_key, $joined_values );
 						} else {
 							delete_post_meta( $product_id, $matched_facebook_field );
 							$facebook_fields[ $output_field_name ] = '';
 						}
 					} else {
 						// Regular attributes - join multiple values with a pipe character and spaces
-						$joined_values = implode( ' | ', $values );
-						$facebook_fields[ $output_field_name ] = $joined_values;
-						update_post_meta( $product_id, $matched_facebook_field, $joined_values );
+						$joined_values                  = implode( ' | ', $values );
+						$facebook_fields[ $field_name ] = $joined_values;
+						update_post_meta( $product_id, $meta_key, $joined_values );
 					}
 				} else {
 					delete_post_meta( $product_id, $matched_facebook_field );

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1691,6 +1691,30 @@ class Admin {
 		?>
 		<script type="text/javascript">
 			jQuery(document).ready(function($) {
+				// Add CSS for synced fields
+				$('head').append(`
+					<style>
+						.multi-value-display,
+						select.synced-attribute,
+						input.synced-attribute {
+							cursor: not-allowed !important;
+							color: rgba(44, 51, 56, .5) !important;
+							background-color: #f0f0f1 !important;
+						}
+						
+						/* Style for Select2 when parent select is synced */
+						select.synced-attribute + .select2-container .select2-selection {
+							cursor: not-allowed !important;
+							background-color: #f0f0f1 !important;
+							color: rgba(44, 51, 56, .5) !important;
+						}
+						
+						select.synced-attribute + .select2-container .select2-selection__rendered {
+							color: rgba(44, 51, 56, .5) !important;
+						}
+					</style>
+				`);
+				
 				// State object to track badge display status
 				var syncedBadgeState = {
 					material: false,
@@ -1856,15 +1880,16 @@ class Admin {
 															'height': '34px',
 															'margin': '0',
 															'padding': '0 8px',
-															'background-color': '#f8f8f8',
+															'background-color': '#f0f0f1',
 															'border': '1px solid #ddd',
 															'border-radius': '4px',
 															'box-sizing': 'border-box',
 															'font-size': '14px',
 															'line-height': '32px',
-															'color': '#555',
+															'color': 'rgba(44, 51, 56, .5)',
 															'display': 'inline-block',
-															'vertical-align': 'middle'
+															'vertical-align': 'middle',
+															'cursor': 'not-allowed'
 														})
 														.insertAfter($field);
 													
@@ -1882,6 +1907,11 @@ class Admin {
 												$field.val(syncedValue)
 													.prop('disabled', true)
 													.addClass('synced-attribute')
+													.css({
+														'cursor': 'not-allowed',
+														'background-color': '#f0f0f1',
+														'color': 'rgba(44, 51, 56, .5)'
+													})
 													.show();
 													
 												// Add the sync badge if it doesn't exist
@@ -1893,6 +1923,11 @@ class Admin {
 												$field.val(syncedValue)
 													.prop('disabled', true)
 													.addClass('synced-attribute')
+													.css({
+														'cursor': 'not-allowed',
+														'background-color': '#f0f0f1',
+														'color': 'rgba(44, 51, 56, .5)'
+													})
 													.show();
 													
 												// Add the sync badge if it doesn't exist
@@ -1905,6 +1940,11 @@ class Admin {
 											$field.val(syncedValue)
 												.prop('disabled', true)
 												.addClass('synced-attribute')
+												.css({
+													'cursor': 'not-allowed', 
+													'background-color': '#f0f0f1',
+													'color': 'rgba(44, 51, 56, .5)'
+												})
 												.show();
 											
 											// Add the sync badge if it doesn't exist

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1253,12 +1253,6 @@ class Admin {
 						'value'       => $fb_mpn,
 						'class'       => 'enable-if-sync-enabled',
 						'desc_tip'    => true,
-						'id'          => \WC_Facebook_Product::FB_MPN,
-						'name'        => \WC_Facebook_Product::FB_MPN,
-						'label'       => __( 'Manufacturer Part Number (MPN)', 'facebook-for-woocommerce' ),
-						'value'       => $fb_mpn,
-						'class'       => 'enable-if-sync-enabled',
-						'desc_tip'    => true,
 						'description' => __( 'Manufacturer Part Number (MPN) of the item', 'facebook-for-woocommerce' ),
 					)
 				);
@@ -2203,10 +2197,10 @@ class Admin {
 		if ( ! $product ) {
 			return [];
 		}
-	
+
 		$attributes      = $product->get_attributes();
 		$facebook_fields = [];
-	
+
 		$attribute_map = [
 			'material'  => \WC_Facebook_Product::FB_MATERIAL,
 			'color'     => \WC_Facebook_Product::FB_COLOR,
@@ -2219,7 +2213,7 @@ class Admin {
 			'gender'    => \WC_Facebook_Product::FB_GENDER,
 			'condition' => \WC_Facebook_Product::FB_PRODUCT_CONDITION,
 		];
-	
+
 		// Dropdown-based attributes that should match specific values
 		$dropdown_attrs = [
 			'age_group' => [
@@ -2242,18 +2236,18 @@ class Admin {
 				\WC_Facebook_Product::CONDITION_REFURBISHED,
 			],
 		];
-	
+
 		// Process all attributes and track which have been processed
 		$processed_fields = [];
-		
+
 		foreach ( $attributes as $attribute ) {
 			// Get all possible variations of the attribute name for matching
-			$raw_name = $attribute->get_name();
-			$clean_name = str_replace( 'pa_', '', $raw_name );
+			$raw_name             = $attribute->get_name();
+			$clean_name           = str_replace( 'pa_', '', $raw_name );
 			$normalized_attr_name = strtolower( $clean_name );
-			$attribute_label = wc_attribute_label( $raw_name );
-			$normalized_label = strtolower( $attribute_label );
-			
+			$attribute_label      = wc_attribute_label( $raw_name );
+			$normalized_label     = strtolower( $attribute_label );
+
 			// Create variations for more flexible matching
 			$name_variations = [
 				$normalized_attr_name,
@@ -2261,45 +2255,45 @@ class Admin {
 				str_replace( [ '_', ' ', '-' ], '', $normalized_attr_name ),
 				str_replace( [ '_', ' ', '-' ], '', $normalized_label ),
 			];
-			
+
 			// Find matching Facebook field
 			$matched_facebook_field = null;
-			$field_name = null;
-			
+			$field_name             = null;
+
 			// Look for matches in attribute map
 			foreach ( $attribute_map as $fb_attr_name => $fb_meta_key ) {
 				$fb_variations = [
 					$fb_attr_name,
 					str_replace( [ '_', ' ', '-' ], '', $fb_attr_name ),
 				];
-				
+
 				// Check for any variation match
 				$matched = false;
 				foreach ( $name_variations as $name_var ) {
 					foreach ( $fb_variations as $fb_var ) {
 						if ( $name_var === $fb_var ) {
-							$matched = true;
+							$matched                = true;
 							$matched_facebook_field = $fb_meta_key;
-							$field_name = $fb_attr_name;
+							$field_name             = $fb_attr_name;
 							break 2;
 						}
 					}
 				}
-				
+
 				if ( $matched ) {
 					break;
 				}
 			}
-			
+
 			// Special case for color/colour conversion
-			if ( $field_name === 'colour' ) {
+			if ( 'colour' === $field_name ) {
 				$field_name = 'color';
 			}
-			
+
 			// If we found a match and haven't processed this field yet
 			if ( $matched_facebook_field && ! in_array( $field_name, $processed_fields ) ) {
 				$values = [];
-				
+
 				if ( $attribute->is_taxonomy() ) {
 					$terms = $attribute->get_terms();
 					if ( $terms && ! is_wp_error( $terms ) ) {
@@ -2308,15 +2302,15 @@ class Admin {
 				} else {
 					$values = $attribute->get_options();
 				}
-				
+
 				if ( ! empty( $values ) ) {
 					// For dropdown attributes, validate against allowed values
 					if ( array_key_exists( $field_name, $dropdown_attrs ) ) {
 						$valid_values = [];
-						
+
 						foreach ( $values as $value ) {
 							$normalized_value = strtolower( trim( $value ) );
-							
+
 							foreach ( $dropdown_attrs[ $field_name ] as $allowed_value ) {
 								if ( strtolower( $allowed_value ) === $normalized_value ) {
 									$valid_values[] = $allowed_value;
@@ -2324,9 +2318,9 @@ class Admin {
 								}
 							}
 						}
-						
+
 						if ( ! empty( $valid_values ) ) {
-							$joined_values = implode( ' | ', $valid_values );
+							$joined_values                  = implode( ' | ', $valid_values );
 							$facebook_fields[ $field_name ] = $joined_values;
 							update_post_meta( $product_id, $matched_facebook_field, $joined_values );
 						} else {
@@ -2335,7 +2329,7 @@ class Admin {
 						}
 					} else {
 						// Regular attributes - join multiple values with a pipe character and spaces
-						$joined_values = implode( ' | ', $values );
+						$joined_values                  = implode( ' | ', $values );
 						$facebook_fields[ $field_name ] = $joined_values;
 						update_post_meta( $product_id, $matched_facebook_field, $joined_values );
 					}
@@ -2343,12 +2337,12 @@ class Admin {
 					delete_post_meta( $product_id, $matched_facebook_field );
 					$facebook_fields[ $field_name ] = '';
 				}
-				
+
 				// Mark this field as processed
 				$processed_fields[] = $field_name;
 			}
 		}
-	
+
 		return $facebook_fields;
 	}
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1687,7 +1687,10 @@ class Admin {
 					size: false,
 					pattern: false,
 					brand: false,
-					mpn: false
+					mpn: false,
+					age_group: false,   // Add dropdown fields
+					gender: false,
+					condition: false
 				};
 
 				// Store manual input values
@@ -1695,9 +1698,92 @@ class Admin {
 
 				// Track which fields are currently synced
 				var syncedFields = {};
+				
+				// Helper function to clean up any previous sync UI elements
+				function cleanupSyncedField(fieldId) {
+					var $field = $(fieldId);
+					
+					// First find all multi-value displays and sync indicators in the parent wrapper
+					var $parent = $field.parent();
+					$parent.find('.multi-value-display').remove();
+					$parent.find('.sync-indicator').remove();
+					
+					// Also remove any elements directly after the field
+					$field.next('.multi-value-display').remove();
+					$field.next('.sync-indicator').remove();
+					
+					// Double check for elements with specific classes anywhere in the row
+					var $row = $parent.closest('.form-field, .form-row');
+					if ($row.length) {
+						$row.find('.multi-value-display').remove();
+						$row.find('.sync-indicator').remove();
+					}
+					
+					// Show the original field if it was hidden
+					$field.show();
+					
+					// Reset the field state
+					$field.prop('disabled', false).removeClass('synced-attribute');
+				}
+
+				// Function to completely reset a field to its default state
+				function resetFieldToDefault(fieldId) {
+					var $field = $(fieldId);
+					
+					// Skip if field doesn't exist
+					if (!$field.length) {
+						return;
+					}
+					
+					// Clean up UI elements
+					cleanupSyncedField(fieldId);
+					
+					// Reset select fields to first option (usually "Select")
+					if ($field.is('select')) {
+						// Check if the select has options
+						if ($field.find('option').length > 0) {
+							$field.val('').trigger('change');
+							$field.find('option:first').prop('selected', true);
+						}
+						
+						// Make sure it's visible and enabled
+						$field.show().prop('disabled', false).removeClass('synced-attribute');
+						
+						// If this is a WooCommerce select2 field, reset the select2 as well
+						if ($field.hasClass('wc-enhanced-select') || $field.hasClass('select2-hidden-accessible')) {
+							try {
+								$field.select2('val', '');
+							} catch (e) {
+								// Ignore select2 errors, it might not be initialized
+							}
+						}
+					} else {
+						// For text fields
+						$field.val('');
+					}
+					
+					// Remove any remaining custom styling
+					$field.css({
+						'background-color': '',
+						'color': '',
+						'border-color': ''
+					});
+				}
 
 				// Function to sync Facebook attributes
 				function syncFacebookAttributes() {
+					// First clean up any stray elements that might exist globally
+					$('.multi-value-display + .sync-indicator').remove();
+					$('.woocommerce_options_panel').find('.multi-value-display, .sync-indicator').each(function() {
+						// Only remove elements that are duplicates (more than one per field)
+						var $parent = $(this).parent();
+						var $siblings = $parent.find('.' + $(this).attr('class'));
+						if ($siblings.length > 1) {
+							// Keep only the first one, remove others
+							$siblings.not(':first').remove();
+						}
+					});
+					
 					$.ajax({
 						url: ajaxurl,
 						type: 'POST',
@@ -1716,6 +1802,9 @@ class Admin {
 									'pattern': '<?php echo esc_js( \WC_Facebook_Product::FB_PATTERN ); ?>',
 									'brand': '<?php echo esc_js( \WC_Facebook_Product::FB_BRAND ); ?>',
 									'mpn': '<?php echo esc_js( \WC_Facebook_Product::FB_MPN ); ?>',
+									'age_group': '<?php echo esc_js( \WC_Facebook_Product::FB_AGE_GROUP ); ?>',
+									'gender': '<?php echo esc_js( \WC_Facebook_Product::FB_GENDER ); ?>',
+									'condition': '<?php echo esc_js( \WC_Facebook_Product::FB_PRODUCT_CONDITION ); ?>'
 								};
 
 								// Loop through each field
@@ -1723,36 +1812,109 @@ class Admin {
 									var fieldId = '#' + fields[key];
 									var $field = $(fieldId);
 									
-									// Always remove existing badges first
-									$field.next('.sync-indicator').remove();
+									// Skip if field doesn't exist
+									if (!$field.length) {
+										return;
+									}
+									
+									// First thoroughly clean up any previous sync UI elements
+									cleanupSyncedField(fieldId);
 									
 									if (response.data && response.data[key]) {
 										// Field has a synced value
-										$field
-											.val(response.data[key])
-											.prop('disabled', true)
-											.addClass('synced-attribute');
+										var syncedValue = response.data[key];
+										var isMultipleValues = syncedValue.includes(' | ');
+										
+										// For fields with multiple values or dropdown fields that need special handling
+										if (isMultipleValues || (key === 'age_group' || key === 'gender' || key === 'condition')) {
+											// First check if this is a standard dropdown or a multi-value field
+											if (isMultipleValues && ($field.is('select') || key === 'age_group' || key === 'gender' || key === 'condition')) {
+												// Check if we already have a multi-value display for this field
+												if ($field.next('.multi-value-display').length === 0) {
+													// For dropdown fields with multiple values (used in variations)
+													// Disable the original dropdown
+													$field.prop('disabled', true).addClass('synced-attribute').hide();
+													
+													// Create a styled disabled field to show multiple values
+													var fieldWidth = $field.outerWidth();
+													var $multiDisplay = $('<input type="text" class="multi-value-display wc-enhanced-select" disabled>')
+														.val(syncedValue)
+														.css({
+															'width': '50%',
+															'max-width': '100%',
+															'height': '34px',
+															'margin': '0',
+															'padding': '0 8px',
+															'background-color': '#f8f8f8',
+															'border': '1px solid #ddd',
+															'border-radius': '4px',
+															'box-sizing': 'border-box',
+															'font-size': '14px',
+															'line-height': '32px',
+															'color': '#555',
+															'display': 'inline-block',
+															'vertical-align': 'middle'
+														})
+														.insertAfter($field);
+													
+													// Always add the sync badge after the multi-value display
+													// Only if it doesn't already exist
+													if ($multiDisplay.next('.sync-indicator').length === 0) {
+														$multiDisplay.after('<span class="sync-indicator wc-attributes-icon" data-tip="Synced from the Attributes tab. Multiple values are used for variations." style="margin-left: 4px;"><span class="sync-tooltip">Synced from the Attributes tab. Multiple values are used for variations.</span></span>');
+													}
+												} else {
+													// Update the existing multi-value display
+													$field.next('.multi-value-display').val(syncedValue);
+												}
+											} else if (isMultipleValues) {
+												// For non-dropdown multi-value fields
+												$field.val(syncedValue)
+													.prop('disabled', true)
+													.addClass('synced-attribute')
+													.show();
+													
+												// Add the sync badge if it doesn't exist
+												if ($field.next('.sync-indicator').length === 0) {
+													$field.after('<span class="sync-indicator wc-attributes-icon" data-tip="Synced from the Attributes tab." style="margin-left: 4px;"><span class="sync-tooltip">Synced from the Attributes tab.</span></span>');
+												}
+											} else {
+												// Single value fields that are dropdowns (age_group, gender, condition)
+												$field.val(syncedValue)
+													.prop('disabled', true)
+													.addClass('synced-attribute')
+													.show();
+													
+												// Add the sync badge if it doesn't exist
+												if ($field.next('.sync-indicator').length === 0) {
+													$field.after('<span class="sync-indicator wc-attributes-icon" data-tip="Synced from the Attributes tab." style="margin-left: 4px;"><span class="sync-tooltip">Synced from the Attributes tab.</span></span>');
+												}
+											}
+										} else {
+											// Standard fields with single values
+											$field.val(syncedValue)
+												.prop('disabled', true)
+												.addClass('synced-attribute')
+												.show();
+											
+											// Add the sync badge if it doesn't exist
+											if ($field.next('.sync-indicator').length === 0) {
+												$field.after('<span class="sync-indicator wc-attributes-icon" data-tip="Synced from the Attributes tab." style="margin-left: 4px;"><span class="sync-tooltip">Synced from the Attributes tab.</span></span>');
+											}
+										}
 										
 										// Mark this field as synced
 										syncedFields[key] = true;
-										
-										// Only add badge if it hasn't been added yet
-										if (!syncedBadgeState[key]) {
-											$field.after('<span class="sync-indicator wc-attributes-icon" data-tip="Synced from the Attributes tab."><span class="sync-tooltip">Synced from the Attributes tab.</span></span>');
-											syncedBadgeState[key] = true;
-										}
+										syncedBadgeState[key] = true;
 									} else {
-										// If field was previously synced but now isn't, clear it
+										// If this field was previously synced but now isn't
 										if (syncedFields[key]) {
-											$field
-												.val('')
-												.prop('disabled', false)
-												.removeClass('synced-attribute');
-											
 											// Reset synced state
 											syncedFields[key] = false;
+											
+											// Completely reset the field value
+											resetFieldToDefault(fieldId);
 										} else if (manualValues[key] && !$field.val()) {
-											// Restore manual value if field is empty (fixed Yoda condition)
+											// Restore manual value if field is empty
 											$field.val(manualValues[key]);
 										}
 										
@@ -1765,33 +1927,198 @@ class Admin {
 					});
 				}
 
-				// Store manual input values
+				// Function to completely reset all fields after attribute removal
+				function resetAllFields() {
+					var fields = {
+						'material': '<?php echo esc_js( \WC_Facebook_Product::FB_MATERIAL ); ?>',
+						'color': '<?php echo esc_js( \WC_Facebook_Product::FB_COLOR ); ?>',
+						'size': '<?php echo esc_js( \WC_Facebook_Product::FB_SIZE ); ?>',
+						'pattern': '<?php echo esc_js( \WC_Facebook_Product::FB_PATTERN ); ?>',
+						'brand': '<?php echo esc_js( \WC_Facebook_Product::FB_BRAND ); ?>',
+						'mpn': '<?php echo esc_js( \WC_Facebook_Product::FB_MPN ); ?>',
+						'age_group': '<?php echo esc_js( \WC_Facebook_Product::FB_AGE_GROUP ); ?>',
+						'gender': '<?php echo esc_js( \WC_Facebook_Product::FB_GENDER ); ?>',
+						'condition': '<?php echo esc_js( \WC_Facebook_Product::FB_PRODUCT_CONDITION ); ?>'
+					};
+					
+					Object.keys(fields).forEach(function(key) {
+						var fieldId = '#' + fields[key];
+						resetFieldToDefault(fieldId);
+						syncedFields[key] = false;
+						syncedBadgeState[key] = false;
+					});
+				}
+
+				// Store manual input values for text fields
 				$('.woocommerce_options_panel input[type="text"]').on('input', function() {
 					var fieldId = $(this).attr('id');
-					Object.keys(syncedBadgeState).forEach(function(key) {
+					for (var key in syncedBadgeState) {
 						if (fieldId.includes(key)) {
 							manualValues[key] = $(this).val();
 							// When manually entering a value, mark as not synced
 							syncedFields[key] = false;
 						}
-					});
+					}
+				});
+
+				// Store manual selection values for select fields
+				$('.woocommerce_options_panel select').on('change', function() {
+					var fieldId = $(this).attr('id');
+					for (var key in syncedBadgeState) {
+						if (fieldId.includes(key)) {
+							manualValues[key] = $(this).val();
+							// When manually selecting a value, mark as not synced
+							syncedFields[key] = false;
+						}
+					}
 				});
 
 				// Listen for attribute removal
 				$('.product_data_tabs').on('click', '.remove_row', function(e) {
+					// Store information about which row was removed
+					var $removedRow = $(this).closest('tr');
+					var attributeName = $removedRow.find('td.attribute_name').text().trim().toLowerCase();
+					
 					// Wait a brief moment for WooCommerce to remove the attribute
 					setTimeout(function() {
+						// Clean up any extra UI elements that might be leftover
+						$('.woocommerce_options_panel').find('.multi-value-display').each(function() {
+							// For each multi-value display, check if there's a corresponding select field
+							var $this = $(this);
+							var $select = $this.prev('select');
+							
+							// If no select exists or the select has no options, remove the multi-value display
+							if ($select.length === 0 || $select.find('option').length <= 1) {
+								$this.next('.sync-indicator').remove();
+								$this.remove();
+							}
+						});
+						
+						// Only trigger if we're on the Facebook tab
+						if ($('.fb_commerce_tab').hasClass('active')) {
+							// First reset all fields to ensure dropdowns are cleared
+							resetAllFields();
+							
+							// Then perform a complete cleanup of all UI elements
+							$('.woocommerce_options_panel').find('.multi-value-display, .sync-indicator').remove();
+							
+							// Re-check all select fields for emptiness
+							$('.woocommerce_options_panel select').each(function() {
+								if ($(this).find('option').length <= 1) {
+									// Reset to first option for empty selects
+									$(this).val('').prop('selected', true);
+									// Make sure it's visible and enabled
+									$(this).show().prop('disabled', false).removeClass('synced-attribute');
+								}
+							});
+							
+							// Then sync to update based on remaining attributes
+							syncFacebookAttributes();
+						}
+					}, 300); // Increased timeout to ensure WooCommerce has fully removed the attribute
+				});
+
+				// Listen for attribute saves
+				$(document).on('click', 'button.save_attributes', function() {
+					// Store reference to the button and attributes panel
+					var $button = $(this);
+					var $attributesPanel = $('#product_attributes');
+					
+					// Wait a brief moment for WooCommerce to save the attributes
+					setTimeout(function() {
+						// Perform cleanup of any stray elements across the entire form
+						$('.woocommerce_options_panel').find('.multi-value-display, .sync-indicator').each(function() {
+							var $element = $(this);
+							var $prevSelect = $element.prev('select');
+							
+							// If this is a multi-value display without a valid select, remove it
+							if ($element.hasClass('multi-value-display') && 
+								(!$prevSelect.length || $prevSelect.find('option').length <= 1 || !$prevSelect.is(':visible'))) {
+								$element.next('.sync-indicator').remove();
+								$element.remove();
+							}
+							
+							// If this is a sync indicator without a valid field before it, remove it
+							if ($element.hasClass('sync-indicator') && 
+								(!$element.prev().length || 
+								($element.prev().is('select') && $element.prev().find('option').length <= 1))) {
+								$element.remove();
+							}
+						});
+						
+						// Re-check all select fields
+						$('.woocommerce_options_panel select').each(function() {
+							var $select = $(this);
+							
+							// Check for empty or nearly empty selects
+							if ($select.find('option').length <= 1) {
+								// Clean up any associated UI elements
+								$select.next('.multi-value-display').next('.sync-indicator').remove();
+								$select.next('.multi-value-display').remove();
+								$select.next('.sync-indicator').remove();
+								
+								// Reset the select
+								$select.val('').prop('selected', true)
+									.show().prop('disabled', false).removeClass('synced-attribute');
+							}
+						});
+						
 						// Only trigger if we're on the Facebook tab
 						if ($('.fb_commerce_tab').hasClass('active')) {
 							syncFacebookAttributes();
 						}
-					}, 100);
+					}, 500);
 				});
+
+				// Function to clean up all UI elements and empty dropdowns
+				function cleanupAllUIElements() {
+					// Remove all multi-value displays and sync indicators
+					$('.woocommerce_options_panel').find('.multi-value-display, .sync-indicator').remove();
+					
+					// Reset all select fields
+					$('.woocommerce_options_panel select').each(function() {
+						var $select = $(this);
+						$select.show().prop('disabled', false).removeClass('synced-attribute');
+						
+						// If the select has no options or just one, ensure it's properly reset
+						if ($select.find('option').length <= 1) {
+							$select.val('').prop('selected', true);
+						}
+						
+						// Reset select2 if applicable
+						if ($select.hasClass('wc-enhanced-select') || $select.hasClass('select2-hidden-accessible')) {
+							try {
+								$select.select2('val', '');
+							} catch (e) {
+								// Ignore select2 errors
+							}
+						}
+					});
+					
+					// Reset all text inputs styling
+					$('.woocommerce_options_panel input[type="text"]').each(function() {
+						var $input = $(this);
+						if ($input.hasClass('multi-value-display')) {
+							$input.remove();
+							return;
+						}
+						$input.show().prop('disabled', false).removeClass('synced-attribute');
+					});
+				}
 
 				// Original tab click handler
 				$('.product_data_tabs li').on('click', function() {
 					var tabClass = $(this).attr('class');
-					if (tabClass.includes('fb_commerce_tab')) {
+					
+					// If we're clicking on a tab that isn't the Facebook tab,
+					// clean up all UI elements first
+					if (!tabClass.includes('fb_commerce_tab')) {
+						cleanupAllUIElements();
+					} else if (tabClass.includes('fb_commerce_tab')) {
+						// If we're clicking on the Facebook tab
+						// First clean up any previous UI elements
+						cleanupAllUIElements();
+						// Then sync to get the latest data
 						syncFacebookAttributes();
 					}
 				});
@@ -1806,11 +2133,21 @@ class Admin {
 				// Initial store of values
 				Object.keys(syncedBadgeState).forEach(function(key) {
 					var fieldId = '#fb_' + key;
-					var value = $(fieldId).val();
-					if (value && !$(fieldId).hasClass('synced-attribute')) {
+					if (key === 'age_group') fieldId = '#' + '<?php echo esc_js( \WC_Facebook_Product::FB_AGE_GROUP ); ?>';
+					if (key === 'gender') fieldId = '#' + '<?php echo esc_js( \WC_Facebook_Product::FB_GENDER ); ?>';
+					if (key === 'condition') fieldId = '#' + '<?php echo esc_js( \WC_Facebook_Product::FB_PRODUCT_CONDITION ); ?>';
+					
+					var $field = $(fieldId);
+					var value = $field.val();
+					if (value && !$field.hasClass('synced-attribute')) {
 						manualValues[key] = value;
 					}
 				});
+
+				// When the page loads, immediately sync if we're on the Facebook tab
+				if ($('.fb_commerce_tab').hasClass('active')) {
+					syncFacebookAttributes();
+				}
 			});
 		</script>
 		<?php
@@ -1821,55 +2158,101 @@ class Admin {
 		if ( ! $product ) {
 			return [];
 		}
-
+	
 		$attributes      = $product->get_attributes();
 		$facebook_fields = [];
-
+	
 		$attribute_map = [
-			'material' => \WC_Facebook_Product::FB_MATERIAL,
-			'color'    => \WC_Facebook_Product::FB_COLOR,
-			'colour'   => \WC_Facebook_Product::FB_COLOR, // Add support for British spelling
-			'size'     => \WC_Facebook_Product::FB_SIZE,
-			'pattern'  => \WC_Facebook_Product::FB_PATTERN,
-			'brand'    => \WC_Facebook_Product::FB_BRAND,
-			'mpn'      => \WC_Facebook_Product::FB_MPN,
+			'material'  => \WC_Facebook_Product::FB_MATERIAL,
+			'color'     => \WC_Facebook_Product::FB_COLOR,
+			'colour'    => \WC_Facebook_Product::FB_COLOR, // Add support for British spelling
+			'size'      => \WC_Facebook_Product::FB_SIZE,
+			'pattern'   => \WC_Facebook_Product::FB_PATTERN,
+			'brand'     => \WC_Facebook_Product::FB_BRAND,
+			'mpn'       => \WC_Facebook_Product::FB_MPN,
+			'age_group' => \WC_Facebook_Product::FB_AGE_GROUP,
+			'gender'    => \WC_Facebook_Product::FB_GENDER,
+			'condition' => \WC_Facebook_Product::FB_PRODUCT_CONDITION,
 		];
-
+	
+		// Dropdown-based attributes that should match specific values
+		$dropdown_attrs = [
+			'age_group' => [
+				\WC_Facebook_Product::AGE_GROUP_ADULT,
+				\WC_Facebook_Product::AGE_GROUP_ALL_AGES,
+				\WC_Facebook_Product::AGE_GROUP_TEEN,
+				\WC_Facebook_Product::AGE_GROUP_KIDS,
+				\WC_Facebook_Product::AGE_GROUP_TODDLER,
+				\WC_Facebook_Product::AGE_GROUP_INFANT,
+				\WC_Facebook_Product::AGE_GROUP_NEWBORN,
+			],
+			'gender'    => [
+				\WC_Facebook_Product::GENDER_MALE,
+				\WC_Facebook_Product::GENDER_FEMALE,
+				\WC_Facebook_Product::GENDER_UNISEX,
+			],
+			'condition' => [
+				\WC_Facebook_Product::CONDITION_NEW,
+				\WC_Facebook_Product::CONDITION_USED,
+				\WC_Facebook_Product::CONDITION_REFURBISHED,
+			],
+		];
+	
 		// Then process existing attributes
 		foreach ( $attributes as $attribute ) {
-			$raw_name             = $attribute->get_name();
-			$clean_name           = str_replace( 'pa_', '', $raw_name );
+			// Remove 'pa_' prefix from taxonomy attributes and convert to lowercase
+			$raw_name = $attribute->get_name();
+			$clean_name = str_replace( 'pa_', '', $raw_name );
 			$normalized_attr_name = strtolower( $clean_name );
-
+			
 			// Get the actual display name/label of the attribute
-			$attribute_label  = wc_attribute_label( $raw_name );
+			$attribute_label = wc_attribute_label( $raw_name );
 			$normalized_label = strtolower( $attribute_label );
-
+			
+			// Further normalize by removing spaces and underscores for matching
+			$matching_attr_name = str_replace( [ '_', ' ' ], '', $normalized_attr_name );
+	
 			// Find the target Facebook field for this attribute
 			$matched_facebook_field = null;
-			$field_name             = null;
-
-			// Try direct matching first
-			if ( isset( $attribute_map[ $normalized_attr_name ] ) ) {
-				$matched_facebook_field = $attribute_map[ $normalized_attr_name ];
-				$field_name             = $normalized_attr_name;
+			$field_name = null;
+	
+			// Special handling for color/colour
+			if ( 'color' === $matching_attr_name || 'colour' === $matching_attr_name ) {
+				$matched_facebook_field = \WC_Facebook_Product::FB_COLOR;
+				$field_name = 'color';
+			} elseif ( 'agegroup' === $matching_attr_name ) { // Special handling for age group
+				$matched_facebook_field = \WC_Facebook_Product::FB_AGE_GROUP;
+				$field_name = 'age_group';
 			} else {
-				// Matching logic: Only match against exact label names, not partial matches
-				// We'll also accept 'pa_size' format for backward compatibility
-				foreach ( $attribute_map as $map_key => $map_value ) {
-					// Check for exact match with the attribute label
-					if ( $normalized_label === $map_key || 'pa_' . $map_key === $raw_name ) {
-						$matched_facebook_field = $map_value;
-						$field_name             = $map_key;
-						break;
+				// Try direct matching first
+				if ( isset( $attribute_map[ $normalized_attr_name ] ) ) {
+					$matched_facebook_field = $attribute_map[ $normalized_attr_name ];
+					$field_name = $normalized_attr_name;
+				} else {
+					// Try to match against standard attribute names
+					foreach ( $attribute_map as $fb_attr_name => $fb_meta_key ) {
+						// Check for exact match with the attribute label
+						if ( $normalized_label === $fb_attr_name || 'pa_' . $fb_attr_name === $raw_name ) {
+							$matched_facebook_field = $fb_meta_key;
+							$field_name = $fb_attr_name;
+							break;
+						}
+						
+						// Also check with normalized matching (spaces and underscores removed)
+						$normalized_fb_attr = str_replace( [ '_', ' ' ], '', $fb_attr_name );
+						if ( $matching_attr_name === $normalized_fb_attr ) {
+							$matched_facebook_field = $fb_meta_key;
+							$field_name = $fb_attr_name;
+							break;
+						}
 					}
 				}
 			}
-
+	
 			// If we found a match, process the attribute values
 			if ( $matched_facebook_field ) {
 				$values = [];
-
+	
 				if ( $attribute->is_taxonomy() ) {
 					$terms = $attribute->get_terms();
 					if ( $terms && ! is_wp_error( $terms ) ) {
@@ -1878,23 +2261,51 @@ class Admin {
 				} else {
 					$values = $attribute->get_options();
 				}
-
+	
 				if ( ! empty( $values ) ) {
-					// Join multiple values with a pipe character and spaces
-					$joined_values = implode( ' | ', $values );
 					// Convert 'colour' to 'color' in the output array's key for consistency
-					$output_field_name                     = ( 'colour' === $field_name ) ? 'color' : $field_name;
-					$facebook_fields[ $output_field_name ] = $joined_values;
-					update_post_meta( $product_id, $matched_facebook_field, $joined_values );
+					$output_field_name = ( 'colour' === $field_name ) ? 'color' : $field_name;
+					
+					// Check if this attribute is used for variations
+					$used_for_variations = $attribute->get_variation();
+	
+					// For dropdown attributes, validate against allowed values
+					if ( array_key_exists( $field_name, $dropdown_attrs ) ) {
+						$valid_values = [];
+						foreach ( $values as $value ) {
+							$normalized_value = strtolower( trim( $value ) );
+	
+							// Check if value matches any of the allowed values (case-insensitive)
+							foreach ( $dropdown_attrs[ $field_name ] as $allowed_value ) {
+								if ( strtolower( $allowed_value ) === $normalized_value ) {
+									$valid_values[] = $allowed_value; // Use the correctly-cased allowed value
+									break;
+								}
+							}
+						}
+	
+						if ( ! empty( $valid_values ) ) {
+							$joined_values = implode( ' | ', $valid_values );
+							$facebook_fields[ $output_field_name ] = $joined_values;
+							update_post_meta( $product_id, $matched_facebook_field, $joined_values );
+						} else {
+							delete_post_meta( $product_id, $matched_facebook_field );
+							$facebook_fields[ $output_field_name ] = '';
+						}
+					} else {
+						// Regular attributes - join multiple values with a pipe character and spaces
+						$joined_values = implode( ' | ', $values );
+						$facebook_fields[ $output_field_name ] = $joined_values;
+						update_post_meta( $product_id, $matched_facebook_field, $joined_values );
+					}
 				} else {
 					delete_post_meta( $product_id, $matched_facebook_field );
-					// Convert 'colour' to 'color' in the output array's key for consistency
-					$output_field_name                     = ( 'colour' === $field_name ) ? 'color' : $field_name;
+					$output_field_name = ( 'colour' === $field_name ) ? 'color' : $field_name;
 					$facebook_fields[ $output_field_name ] = '';
 				}
 			}
 		}
-
+	
 		return $facebook_fields;
 	}
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -775,12 +775,6 @@ class Admin {
 	 * @param string $product_edit the product metadata that is being edited.
 	 */
 	public function handle_products_sync_bulk_actions( $product_edit ) {
-		$products = [];
-		// Add nonce verification
-		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( $_GET['_wpnonce'] ), 'woocommerce-facebook-bulk-sync' ) ) {
-			return;
-		}
-
 		$sync_mode = isset( $_GET['facebook_bulk_sync_options'] ) ? (string) sanitize_text_field( wp_unslash( $_GET['facebook_bulk_sync_options'] ) ) : null;
 
 		if ( $sync_mode ) {


### PR DESCRIPTION
# Fixed Dropdown Attribute Syncing for Facebook Product Integration

## Problem
The WooCommerce Facebook integration had critical issues with product attribute syncing:

1. Attribute dropdowns with multiple values (from simple & variable products) weren't properly displaying in the Facebook tab
2. Sync indicators weren't appearing for variable product attributes
3. Dropdown fields weren't updating correctly when attributes were added, modified, or removed
4. Multiple UI boxes were created when syncing attributes repeatedly
5. Empty dropdowns persisted after attribute removal

## Solution
This PR fixes the attribute dropdown syncing and display functionality:

- **Implemented proper handling of multi-value attributes** (like "adult | teen") from variable products
- **Added sync indicators for variable product attributes** to show when values are inherited from attributes
- **Enhanced cleanup routines** to properly remove UI elements when attributes are removed
- **Fixed tab switching behavior** to ensure clean state when moving between product tabs
- **Prevented duplicate elements** from being created on repeated attribute updates
- **Optimized display of synced multi-value fields** for better readability

## Testing
To test this PR, perform the following:

1. Create a variable product with attributes (particularly Age Group, Gender, Condition)
2. Set values for these attributes in the Attributes tab
3. Verify the values sync correctly to the Facebook tab with proper sync indicators
4. Modify attribute values and verify the changes are reflected in the Facebook tab
5. Remove attributes and confirm no empty fields or dropdowns remain
6. Add new attributes and verify they sync properly to the Facebook tab

