### PR TITLE
Remove UI of a checkbox that controls  enablement of the new style feed generation.

### DIFF
--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -467,15 +467,6 @@ class Connection extends Abstract_Settings_Screen {
 				'default'  => 'no',
 			),
 
-			array(
-				'id'       => \WC_Facebookcommerce_Integration::SETTING_ENABLE_NEW_STYLE_FEED_GENERATOR,
-				'title'    => __( 'Experimental! Enable new style feed generation', 'facebook-for-woocommerce' ),
-				'type'     => 'checkbox',
-				'desc'     => __( 'Use new, memory improved, feed generation process.', 'facebook-for-woocommerce' ),
-				/* translators: %s URL to the documentation page. */
-				'desc_tip' => sprintf( __( 'This is an experimental feature in testing phase. Only enable this if you are experiencing problems with feed generation. <a href="%s" target="_blank">Learn more</a>.', 'facebook-for-woocommerce' ), 'https://woocommerce.com/document/facebook-for-woocommerce/#feed-generation' ),
-				'default'  => 'no',
-			),
 			array( 'type' => 'sectionend' ),
 		);
 	}

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -299,16 +299,6 @@ class Shops extends Abstract_Settings_Screen {
 				'default'  => 'no',
 			),
 
-			array(
-				'id'       => \WC_Facebookcommerce_Integration::SETTING_ENABLE_NEW_STYLE_FEED_GENERATOR,
-				'title'    => __( '[Experimental] Use new, memory improved, feed generation process', 'facebook-for-woocommerce' ),
-				'type'     => 'checkbox',
-				'desc'     => __( 'Enable', 'facebook-for-woocommerce' ),
-				/* translators: %s URL to the documentation page. */
-				'desc_tip' => sprintf( __( 'This is an experimental feature in testing phase. Only enable this if you are experiencing problems with feed generation. <a href="%s" target="_blank">Learn more</a>.', 'facebook-for-woocommerce' ), 'https://woocommerce.com/document/facebook-for-woocommerce/#feed-generation' ),
-				'default'  => 'no',
-			),
-
 			array( 'type' => 'sectionend' ),
 		);
 	}

--- a/tests/Unit/Admin/Settings/ConnectionTest.php
+++ b/tests/Unit/Admin/Settings/ConnectionTest.php
@@ -47,10 +47,5 @@ class ConnectionTest extends \WP_UnitTestCase {
         $debug_setting = $settings[2];
         $this->assertEquals('checkbox', $debug_setting['type']);
         $this->assertEquals('no', $debug_setting['default']);
-
-        // Check feed generator setting
-        $feed_setting = $settings[3];
-        $this->assertEquals('checkbox', $feed_setting['type']);
-        $this->assertEquals('no', $feed_setting['default']);
     }
 }

--- a/tests/Unit/Admin/Settings/ShopsTest.php
+++ b/tests/Unit/Admin/Settings/ShopsTest.php
@@ -61,10 +61,5 @@ class ShopsTest extends \WP_UnitTestCase {
         $debug_setting = $settings[2];
         $this->assertEquals('checkbox', $debug_setting['type']);
         $this->assertEquals('no', $debug_setting['default']);
-
-        // Check feed generator setting
-        $feed_setting = $settings[3];
-        $this->assertEquals('checkbox', $feed_setting['type']);
-        $this->assertEquals('no', $feed_setting['default']);
     }
 }


### PR DESCRIPTION
## Description

As of now there is a switch in UI that controls enablement of the new style feed generation.

The plan is to remove this from the UI, while we will still respect the value that was set.
We are planning for the new style of feed generation to be additionally tested and then rolled out via a Gatekeeper to insure consistent feed generation across all sellers.

We are removing this from the UI since this is exposing an internal infra change and there will be no need for seller to be aware or have a control over it. 
The control was removed from both old and new plugin page UX.

### Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

One liner entry to be surfaced in changelog.txt


## Test Plan
Was manually tested, screenshots provided below.

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before

<img width="1277" alt="Screenshot 2025-04-14 at 15 37 02" src="https://github.com/user-attachments/assets/6f00e56c-1313-432f-9a2e-41adef32a39f" />

### After

The UI control has been removed:
<img width="1481" alt="Screenshot 2025-04-14 at 15 32 03" src="https://github.com/user-attachments/assets/284c138a-dce8-4c8a-95ae-c9b257c1601b" />


