### PR TITLE
fix skipped tests2

### DIFF
--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -69,6 +69,8 @@ class WCFacebookCommerceIntegrationTest extends \WooCommerce\Facebook\Tests\Abst
 		/* Making sure no options are set before the test. */
 		delete_option( WC_Facebookcommerce_Pixel::SETTINGS_KEY );
 		delete_option( WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID );
+		// Needed to prevent error logs in tests.
+		WC_Facebookcommerce_Utils::$ems = 'dummy_ems_id';
 	}
 
 	/**

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -417,29 +417,6 @@ class WCFacebookCommerceIntegrationTest extends \WooCommerce\Facebook\Tests\Abst
 	}
 
 	/**
-	 * Tests default allow full batch api sync uses facebook_for_woocommerce_allow_full_batch_api_sync filter
-	 * to overwrite allowance status.
-	 *
-	 * @return void
-	 */
-	public function test_allow_full_batch_api_sync_uses_allow_full_batch_api_sync_filter() {
-		$this->markTestSkipped( 'Some problems with phpunit polyfills notices handling.' );
-
-		$this->add_filter_with_safe_teardown(
-			'facebook_for_woocommerce_allow_full_batch_api_sync',
-			function ( bool $status ) {
-				return false;
-			}
-		);
-
-		$status = $this->integration->allow_full_batch_api_sync();
-
-		$this->assertFalse( $status );
-		$this->assertFalse( has_filter( 'facebook_for_woocommerce_block_full_batch_api_sync' ) );
-		$this->assertTrue( has_filter( 'facebook_for_woocommerce_allow_full_batch_api_sync' ) );
-	}
-
-	/**
 	 * Tests plugin enqueues scripts and styles for non admin user for non plugin settings screens.
 	 *
 	 * @return void
@@ -2176,8 +2153,6 @@ class WCFacebookCommerceIntegrationTest extends \WooCommerce\Facebook\Tests\Abst
 	 * @return void
 	 */
 	public function test_get_js_sdk_version_returns_id_from_options_using_no_filter() {
-		$this->markTestSkipped( 'get_js_sdk_version method is called in constructor which makes it impossible to test it in isolation w/o refactoring the constructor.' );
-
 		add_option( WC_Facebookcommerce_Integration::OPTION_JS_SDK_VERSION, 'v1.0.0' );
 		$this->teardown_callback_category_safely( 'wc_facebook_js_sdk_version' );
 
@@ -2192,8 +2167,6 @@ class WCFacebookCommerceIntegrationTest extends \WooCommerce\Facebook\Tests\Abst
 	 * @return void
 	 */
 	public function test_get_js_sdk_version_returns_id_with_filter() {
-		$this->markTestSkipped( 'get_js_sdk_version method is called in constructor which makes it impossible to test it in isolation w/o refactoring the constructor.' );
-
 		$this->add_filter_with_safe_teardown(
 			'wc_facebook_js_sdk_version',
 			function ( $js_sdk_version ) {


### PR DESCRIPTION
## Description

This PR addresses noisy error logs originating from `WC_Facebookcommerce_Utils::fblog` during PHPUnit tests in `WCFacebookCommerceIntegrationTest`. These errors occurred because the `wc_facebook_external_merchant_settings_id` option (External Merchant Settings ID) was not set during test execution, leading to false positive error messages like "external merchant setting is null".

The fix involves initializing this option with a dummy value (`'dummy_ems_id'`) within the `setUp()` method of the `WCFacebookCommerceIntegrationTest` class. This ensures the setting is present before relevant tests run, preventing the erroneous `fblog` calls.

Additionally, this PR includes the following test cleanup:
- Deleted the test `test_allow_full_batch_api_sync_uses_allow_full_batch_api_sync_filter` as it was testing a deprecated option (`allow_full_batch_api_sync`) and was already marked as skipped.
- Removed `markTestSkipped` annotations from `test_get_js_sdk_version_returns_id_from_options_using_no_filter` and `test_get_js_sdk_version_returns_id_with_filter` as they now pass successfully.

### Type of change

- Bug fix (non-breaking change which fixes an issue)
- Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)

## Checklist

- [] I have commented my code, particularly in hard-to-understand areas.
- [] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
- [] I followed general Pull Request best practices. Meta employees to follow this [wiki](https://fburl.com/wiki/2cgfduwc).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki](https://fburl.com/wiki/nhx73tgs).


## Changelog entry

Fix - Prevent spurious error logs during unit tests by initializing external merchant settings ID.
Fix - Remove obsolete/skipped unit tests and enable previously skipped tests that now pass.

Pull Request resolved: https://github.com/facebook/facebook-for-woocommerce/pull/3058
GitHub Author: Paul Kang <sollipse@meta.com>