### PR TITLE
[WAUM][15/n] Redirect to Utility settings page when Finish Button is clicked

### DIFF
--- a/assets/js/admin/whatsapp-finish.js
+++ b/assets/js/admin/whatsapp-finish.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+jQuery( document ).ready( function( $ ) {
+    // handle the whatsapp finish button click
+	$( '#wc-whatsapp-onboarding-finish' ).click( function( event ) {
+        // TODO: call the connect API to create configs and check payment
+        // If error, show banner
+        // If success, redirect to utility settings page
+        let url = window.location.href;
+            if (url.indexOf('?') > -1){
+               url += '&view=utility_settings'
+            } else {
+               url += '?view=utility_settings'
+            }
+            window.location.href = url;
+        });
+
+} );

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -27,8 +27,6 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	/** @var string screen ID */
 	const ID = 'whatsapp_utility';
 
-	/** @var flag to test Utility Messages Overview changes until check for integration config is implemented */
-	const WHATSAPP_UTILITY_MESSAGES_OVERVIEW_FLAG = false;
 
 	/**
 	 * Whatsapp Utility constructor.
@@ -113,6 +111,12 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				),
 			)
 		);
+		wp_enqueue_script(
+			'facebook-for-woocommerce-whatsapp-finish',
+			facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/whatsapp-finish.js',
+			array( 'jquery', 'jquery-blockui', 'jquery-tiptip', 'wc-enhanced-select' ),
+			\WC_Facebookcommerce::PLUGIN_VERSION
+		);
 	}
 
 
@@ -122,13 +126,11 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	 * @since 2.0.0
 	 */
 	public function render() {
-		if ( self::WHATSAPP_UTILITY_MESSAGES_OVERVIEW_FLAG ) {
 			$view = $this->get_current_view();
-			if ( 'manage_event' === $view ) {
-				$this->render_manage_events_view();
-			} else {
-				$this->render_utility_message_overview();
-			}
+		if ( 'utility_settings' === $view ) {
+			$this->render_utility_message_overview();
+		} elseif ( 'manage_event' === $view ) {
+			$this->render_manage_events_view();
 		} else {
 			$this->render_utility_message_onboarding();
 		}
@@ -321,7 +323,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 					<a
 						id="woocommerce-whatsapp-cancel-order-confirmation"
 						class="button"
-						href="<?php echo esc_html( admin_url( 'admin.php?page=' . self::PAGE_ID . '&tab=' . self::ID ) ); ?>"><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></a>
+						href="<?php echo esc_html( admin_url( 'admin.php?page=' . self::PAGE_ID . '&tab=' . self::ID . '&view=utility_settings' ) ); ?>"><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></a>
 				</div>
 
 			</div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ const jQueryUIAdminFileNames = [
     'whatsapp-billing',
     'whatsapp-connection',
     'whatsapp-consent',
+    'whatsapp-finish'
 ];
 
 const jQueryUIAdminFileEntries = {};


### PR DESCRIPTION
## Description
Upon finish button click on the onboarding flow we need to redirect to the Utility Settings Page

### Type of change
- New feature (non-breaking change which adds functionality)

## Changelog entry
WAUM finish button redirect


## Test Plan

https://github.com/user-attachments/assets/164150d6-169d-416f-8bfc-6264bc38529f


