### PR TITLE
Clean up unused code from Connection.php

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-connection.css
+++ b/assets/css/admin/facebook-for-woocommerce-connection.css
@@ -76,12 +76,3 @@
 #wc-facebook-connection-box .uninstall {
 	vertical-align: middle;
 }
-
-#facebook-commerce-iframe {
-	width: 100%;
-	min-height: calc(100vh - 200px);
-}
-
-.woocommerce-embed-page #wpbody-content {
-	padding-bottom: 0;
-}

--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -31,23 +31,8 @@ class Connection extends Abstract_Settings_Screen {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 
 		add_action( 'admin_notices', array( $this, 'add_notices' ) );
-
-		// Add action to enqueue the message handler script
-		add_action( 'admin_footer', array( $this, 'render_message_handler' ) );
-
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
 	}
 
-	/**
-	 * Enqueues the wp-api script and the Facebook REST API JavaScript client.
-	 *
-	 * @internal
-	 */
-	public function enqueue_admin_scripts() {
-		if ( $this->is_current_screen_page() ) {
-			wp_enqueue_script( 'wp-api' );
-		}
-	}
 	/**
 	 * Initializes this settings page's properties.
 	 */
@@ -114,19 +99,12 @@ class Connection extends Abstract_Settings_Screen {
 	 * @since 3.5.0
 	 */
 	public function render() {
-		// Check if we should render iframe
-		if ( facebook_for_woocommerce()->use_enhanced_onboarding() ) {
-			$this->render_facebook_iframe();
-
-			return;
-		}
-
 		$is_connected = facebook_for_woocommerce()->get_connection_handler()->is_connected();
 
-		// always render the CTA box
+		// Always render the CTA box
 		$this->render_facebook_box( $is_connected );
 
-		// don't proceed further if not connected
+		// Don't proceed further if not connected
 		if ( ! $is_connected ) {
 			return;
 		}
@@ -267,43 +245,6 @@ class Connection extends Abstract_Settings_Screen {
 	}
 
 	/**
-	 * Renders the appropriate Facebook iframe based on connection status.
-	 */
-	private function render_facebook_iframe() {
-		$connection            = facebook_for_woocommerce()->get_connection_handler();
-		$is_connected          = $connection->is_connected();
-		$merchant_access_token = get_option( 'wc_facebook_merchant_access_token', '' );
-
-		if ( ! empty( $merchant_access_token ) && $is_connected ) {
-			// Get management iframe URL for connected merchants
-			$iframe_url = \WooCommerce\Facebook\Handlers\MetaExtension::generate_iframe_management_url(
-				$connection->get_external_business_id()
-			);
-		} else {
-			// Get onboarding iframe URL for new connections
-			$iframe_url = \WooCommerce\Facebook\Handlers\MetaExtension::generate_iframe_splash_url(
-				$is_connected,
-				$connection->get_plugin(),
-				$connection->get_external_business_id()
-			);
-		}
-
-		if ( empty( $iframe_url ) ) {
-			return;
-		}
-
-		?>
-		<iframe
-			src="<?php echo esc_url( $iframe_url ); ?>"
-			width="100%"
-			height="800"
-			frameborder="0"
-			style="background: transparent;"
-			id="facebook-commerce-iframe"></iframe>
-		<?php
-	}
-
-	/**
 	 * Renders the legacy Facebook CTA box.
 	 *
 	 * @param bool $is_connected whether the plugin is connected
@@ -355,83 +296,6 @@ class Connection extends Abstract_Settings_Screen {
 		</div>
 		<?php
 	}
-
-	/**
-	 * Renders the message handler script in the footer.
-	 *
-	 * @since 3.5.0
-	 */
-	public function render_message_handler() {
-		if ( ! $this->is_current_screen_page() || ! facebook_for_woocommerce()->use_enhanced_onboarding() ) {
-			return;
-		}
-		// Add the inline script as a dependent script
-		wp_add_inline_script( 'plugin-api-client', $this->generate_inline_enhanced_onboarding_script(), 'after' );
-	}
-
-	public function generate_inline_enhanced_onboarding_script() {
-		// Generate a fresh nonce for this request
-		$nonce = wp_json_encode( wp_create_nonce( 'wp_rest' ) );
-
-		// Create the inline script with HEREDOC syntax for better JS readability
-		return <<<JAVASCRIPT
-			const fbAPI = GeneratePluginAPIClient({$nonce});
-			window.addEventListener('message', function(event) {
-				const message = event.data;
-				const messageEvent = message.event;
-
-				if (messageEvent === 'CommerceExtension::INSTALL' && message.success) {
-					const requestBody = {
-						access_token: message.access_token,
-						merchant_access_token: message.access_token,
-						page_access_token: message.access_token,
-						product_catalog_id: message.catalog_id,
-						pixel_id: message.pixel_id,
-						page_id: message.page_id,
-						business_manager_id: message.business_manager_id,
-						commerce_merchant_settings_id: message.installed_features.find(f => f.feature_type === 'fb_shop')?.connected_assets?.commerce_merchant_settings_id || '',
-						ad_account_id: message.installed_features.find(f => f.feature_type === 'ads')?.connected_assets?.ad_account_id || '',
-						commerce_partner_integration_id: message.commerce_partner_integration_id || '',
-						profiles: message.profiles,
-						installed_features: message.installed_features
-					};
-
-					fbAPI.updateSettings(requestBody)
-						.then(function(response) {
-							if (response.success) {
-								window.location.reload();
-							} else {
-								console.error('Error updating Facebook settings:', response);
-							}
-						})
-						.catch(function(error) {
-							console.error('Error during settings update:', error);
-						});
-				}
-
-				if (messageEvent === 'CommerceExtension::RESIZE') {
-					const iframe = document.getElementById('facebook-commerce-iframe');
-					if (iframe && message.height) {
-						iframe.height = message.height;
-					}
-				}
-
-				if (messageEvent === 'CommerceExtension::UNINSTALL') {
-					fbAPI.uninstallSettings()
-						.then(function(response) {
-							if (response.success) {
-								window.location.reload();
-							}
-						})
-						.catch(function(error) {
-							console.error('Error during uninstall:', error);
-							window.location.reload();
-						});
-				}
-			});
-		JAVASCRIPT;
-	}
-
 
 	/**
 	 * Gets the screen settings.

--- a/tests/Unit/Admin/Settings_Screens/ConnectionTest.php
+++ b/tests/Unit/Admin/Settings_Screens/ConnectionTest.php
@@ -30,18 +30,9 @@ class ConnectionTest extends TestCase {
     }
 
 	/**
-	 * Test that render method calls render_facebook_iframe when enhanced onboarding is disabled
+	 * Test the rendering of the Facebook connection box
 	 */
 	public function test_render_facebook_box() {
-		// Create a partial mock of the facebook_for_woocommerce() class
-		$fb_for_wc = $this->getMockBuilder(WC_Facebookcommerce::class)
-		                  ->getMock();
-
-		// Override the facebook_for_woocommerce method to return the mock
-		add_filter('wc_facebook_instance', function() use ( $fb_for_wc ) {
-			return $fb_for_wc;
-		});
-
 		// Start output buffering to capture the render output
 		$connection = new Connection();
 		ob_start();

--- a/tests/Unit/Admin/Settings_Screens/ConnectionTest.php
+++ b/tests/Unit/Admin/Settings_Screens/ConnectionTest.php
@@ -29,50 +29,13 @@ class ConnectionTest extends TestCase {
         return $method->invokeArgs($object, $parameters);
     }
 
-    /**
-     * Test that render method calls render_facebook_iframe when enhanced onboarding is enabled
-     */
-    public function test_render_facebook_box_iframe() {
-        // Create a partial mock of the facebook_for_woocommerce() class
-        $fb_for_wc = $this->getMockBuilder(WC_Facebookcommerce::class)
-            ->onlyMethods(['use_enhanced_onboarding'])
-            ->getMock();
-
-        // Configure the mock to return true for use_enhanced_onboarding
-	    $fb_for_wc->expects($this->once())
-            ->method('use_enhanced_onboarding')
-            ->willReturn(true);
-
-        // Override the facebook_for_woocommerce method to return the mock
-	    add_filter('wc_facebook_instance', function() use ( $fb_for_wc ) {
-	        return $fb_for_wc;
-	    });
-
-        // Start output buffering to capture the render output
-	    $connection = new Connection();
-        ob_start();
-        $connection->render();
-        $output = ob_get_clean();
-
-        // Since we can't directly test the private render_facebook_iframe method,
-        // we'll verify that the render method doesn't output the legacy Facebook box
-        // when enhanced onboarding is enabled
-        $this->assertStringNotContainsString('wc-facebook-connection-box', $output);
-    }
-
 	/**
 	 * Test that render method calls render_facebook_iframe when enhanced onboarding is disabled
 	 */
-	public function test_render_facebook_box_legacy() {
+	public function test_render_facebook_box() {
 		// Create a partial mock of the facebook_for_woocommerce() class
 		$fb_for_wc = $this->getMockBuilder(WC_Facebookcommerce::class)
-		                  ->onlyMethods(['use_enhanced_onboarding'])
 		                  ->getMock();
-
-		// Configure the mock to return false for use_enhanced_onboarding
-		$fb_for_wc->expects($this->once())
-		          ->method('use_enhanced_onboarding')
-		          ->willReturn(false);
 
 		// Override the facebook_for_woocommerce method to return the mock
 		add_filter('wc_facebook_instance', function() use ( $fb_for_wc ) {
@@ -85,74 +48,6 @@ class ConnectionTest extends TestCase {
 		$connection->render();
 		$output = ob_get_clean();
 
-		// Since we can't directly test the private render_facebook_iframe method,
-		// we'll verify that the render method doesn't output the legacy Facebook box
-		// when enhanced onboarding is enabled
 		$this->assertStringContainsString('wc-facebook-connection-box', $output);
 	}
-
-    /**
-     * Test that render_message_handler outputs the expected JavaScript
-     */
-    public function test_render_message_handler() {
-        // Create a mock of the Connection class
-        $connection_mock = $this->getMockBuilder(Connection::class)
-            ->onlyMethods(['is_current_screen_page'])
-            ->getMock();
-
-        // Configure the mock to return true for is_current_screen_page
-        $connection_mock->method('is_current_screen_page')
-            ->willReturn(true);
-
-        // Call the method
-        $output = $connection_mock->generate_inline_enhanced_onboarding_script();
-
-        // Assert JavaScript event listeners and handlers
-        $this->assertStringContainsString('window.addEventListener(\'message\'', $output);
-        $this->assertStringContainsString('CommerceExtension::INSTALL', $output);
-        $this->assertStringContainsString('CommerceExtension::RESIZE', $output);
-        $this->assertStringContainsString('CommerceExtension::UNINSTALL', $output);
-
-        // Assert fetch request setup - check for wpApiSettings.root instead of hardcoded path
-        $this->assertStringContainsString('GeneratePluginAPIClient', $output);
-        $this->assertStringContainsString('fbAPI.updateSettings', $output);
-    }
-
-    /**
-     * Test that render_message_handler doesn't output when not on current screen
-     */
-    public function test_render_message_handler_not_current_screen() {
-        $connection_mock = $this->getMockBuilder(Connection::class)
-	        ->onlyMethods(['is_current_screen_page'])
-            ->getMock();
-
-        $connection_mock->method('is_current_screen_page')
-            ->willReturn(false);
-
-        ob_start();
-        $connection_mock->render_message_handler();
-        $output = ob_get_clean();
-
-        $this->assertEmpty($output);
-    }
-
-    /**
-     * Test that the management URL is used when merchant token exists
-     */
-    public function test_renders_management_url_based_on_merchant_token() {
-		$connection = new Connection();
-
-        // Set up the merchant token
-        update_option('wc_facebook_merchant_access_token', 'test_token');
-
-        // Use output buffering to capture the iframe HTML
-        ob_start();
-        $this->invoke_method($connection, 'render_facebook_iframe');
-        $output = ob_get_clean();
-
-        // Check that the iframe is rendered
-        $this->assertStringContainsString('<iframe', $output);
-        $this->assertStringContainsString('frameborder="0"', $output);
-        $this->assertStringContainsString('id="facebook-commerce-iframe"', $output);
-    }
 }


### PR DESCRIPTION
## Description
This PR removes unused code in `Connection.php` that related to enhanced onboarding. In https://github.com/facebook/facebook-for-woocommerce/pull/2968, we introduced the enhanced settings UI, which completely revamped all extension settings using `Enhanced_Settings.php`. The logic that was deleted here is available in `Shops.php`.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Test Plan
1. Go to `http://test-site-i.local/wp-admin/admin.php?page=wc-facebook`. Make sure you are seeing the legacy setting UI. 
2. Go to the "Connection" tab and test the functionality. Make sure to test the UI in both the connected state and non-connected state.