### PR TITLE
[WAUM][16/n] Call Connect Utility Messages graph api when finish button is clicked

### DIFF
--- a/assets/js/admin/whatsapp-finish.js
+++ b/assets/js/admin/whatsapp-finish.js
@@ -10,14 +10,23 @@
 jQuery( document ).ready( function( $ ) {
     // handle the whatsapp finish button click
 	$( '#wc-whatsapp-onboarding-finish' ).click( function( event ) {
-        // TODO: call the connect API to create configs and check payment
-        // If error, show banner
-        // If success, redirect to utility settings page
-        let url = new URL(window.location.href);
-        let params = new URLSearchParams(url.search);
-        params.set('view', 'utility_settings');
-        url.search = params.toString();
-        window.location.href = url.toString();
+        // call the connect API to create configs and check payment
+        $.post( facebook_for_woocommerce_whatsapp_finish.ajax_url, {
+			action: 'wc_facebook_whatsapp_finish_onboarding',
+			nonce:  facebook_for_woocommerce_whatsapp_finish.nonce
+		}, function ( response ) {
+            if ( response.success ) {
+                // If success, redirect to utility settings page
+                 let url = new URL(window.location.href);
+                 let params = new URLSearchParams(url.search);
+                 params.set('view', 'utility_settings');
+                 url.search = params.toString();
+                 window.location.href = url.toString();
+			} else {
+                // TODO: Handle error show error banner in UI
+                console.log(response);
+            }
+		} );
     });
 
 } );

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -14,6 +14,7 @@ use WooCommerce\Facebook\Framework\Helper;
 use WooCommerce\Facebook\Admin\Settings_Screens\Product_Sync;
 use WooCommerce\Facebook\Admin\Settings_Screens\Shops;
 use WooCommerce\Facebook\Framework\Plugin\Exception as PluginException;
+use WooCommerce\Facebook\Handlers\WhatsAppUtilityConnection;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -209,7 +210,7 @@ class AJAX {
 	}
 
 	/**
-	 * Get data for for finish onboaridng call and make api call.
+	 * Get data for for finish onboarding call and make api call.
 	 *
 	 * @internal
 	 *
@@ -232,45 +233,7 @@ class AJAX {
 			);
 			wp_send_json_error( 'Onboarding is not complete or has failed.' );
 		}
-		$this->wc_facebook_whatsapp_connect_utility_messages_call( $waba_id, $wacs_id, $external_business_id, $bisu_token );
-	}
-
-	private function wc_facebook_whatsapp_connect_utility_messages_call( $waba_id, $wacs_id, $external_business_id, $bisu_token ) {
-		$api_version  = 'v21.0/';
-		$base_url     = array( 'https://graph.facebook.com', $api_version, $waba_id, 'connect_utility_messages' );
-		$base_url     = esc_url( implode( '/', $base_url ) );
-		$query_params = array(
-			'external_integration_id' => $external_business_id,
-			'wacs_id'                 => $wacs_id,
-			'access_token'            => $bisu_token,
-		);
-		$base_url     = add_query_arg( $query_params, $base_url );
-		$options      = array(
-			'headers' => array(
-				'Authorization' => $access_token,
-			),
-			'body'    => array(),
-		);
-		$response     = wp_remote_post( $base_url, $options );
-		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) != 200 ) {
-			$error_data    = explode( "\n", wp_remote_retrieve_body( $response ) );
-			$error_message = $error_data[0];
-			wc_get_logger()->info(
-				sprintf(
-					/* translators: %s $error_message */
-					__( 'Finish Onboarding Button Click Failure %1$s ', 'facebook-for-woocommerce' ),
-					$error_message,
-				)
-			);
-			wp_send_json_error( $response, 'Finish Onboarding Success' );
-		} else {
-				wc_get_logger()->info(
-					sprintf(
-						__( 'Finish Onboarding Button Click Success!!!', 'facebook-for-woocommerce' )
-					)
-				);
-			wp_send_json_success( $response, 'Finish Onboarding Failure' );
-		}
+		WhatsAppUtilityConnection::wc_facebook_whatsapp_connect_utility_messages_call( $waba_id, $wacs_id, $external_business_id, $bisu_token );
 	}
 
 

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -117,6 +117,17 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			array( 'jquery', 'jquery-blockui', 'jquery-tiptip', 'wc-enhanced-select' ),
 			\WC_Facebookcommerce::PLUGIN_VERSION
 		);
+			wp_localize_script(
+				'facebook-for-woocommerce-whatsapp-finish',
+				'facebook_for_woocommerce_whatsapp_finish',
+				array(
+					'ajax_url' => admin_url( 'admin-ajax.php' ),
+					'nonce'    => wp_create_nonce( 'facebook-for-wc-whatsapp-finish-nonce' ),
+					'i18n'     => array(
+						'result' => true,
+					),
+				)
+			);
 	}
 
 

--- a/includes/Handlers/WhatsAppUtilityConnection.php
+++ b/includes/Handlers/WhatsAppUtilityConnection.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace WooCommerce\Facebook\Handlers;
+
+defined( 'ABSPATH' ) || exit;
+
+use WP_Error;
+
+/**
+ * Handles WhatsApp Utility GET and POST APIs Graph API requests.
+ *
+ * @since 2.3.0
+ */
+class WhatsAppUtilityConnection {
+
+	/** @var string API version */
+	const API_VERSION = 'v22.0';
+
+	/** @var string Graph API base URL */
+	const GRAPH_API_BASE_URL = 'https://graph.facebook.com';
+
+
+	/**
+	 * Makes an API call to Whatsapp Utility Message Connect API
+	 *
+	 * @param string $waba_id, string $wacs_id, string $external_business_id, string $bisu_token
+	 */
+	public static function wc_facebook_whatsapp_connect_utility_messages_call( $waba_id, $wacs_id, $external_business_id, $bisu_token ) {
+		$base_url     = array( self::GRAPH_API_BASE_URL, self::API_VERSION, $waba_id, 'connect_utility_messages' );
+		$base_url     = esc_url( implode( '/', $base_url ) );
+		$query_params = array(
+			'external_integration_id' => $external_business_id,
+			'wacs_id'                 => $wacs_id,
+			'access_token'            => $bisu_token,
+		);
+		$base_url     = add_query_arg( $query_params, $base_url );
+		$options      = array(
+			'headers' => array(
+				'Authorization' => $bisu_token,
+			),
+			'body'    => array(),
+		);
+		$response     = wp_remote_post( $base_url, $options );
+		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) != 200 ) {
+			$error_data    = explode( "\n", wp_remote_retrieve_body( $response ) );
+			$error_message = $error_data[0];
+			wc_get_logger()->info(
+				sprintf(
+					/* translators: %s $error_message */
+					__( 'Finish Onboarding Button Click Failure %1$s ', 'facebook-for-woocommerce' ),
+					$error_message,
+				)
+			);
+			wp_send_json_error( $response, 'Finish Onboarding Failure' );
+		} else {
+				wc_get_logger()->info(
+					sprintf(
+						__( 'Finish Onboarding Button Click Success!!!', 'facebook-for-woocommerce' )
+					)
+				);
+			wp_send_json_success( $response, 'Finish Onboarding Success' );
+		}
+	}
+}

--- a/includes/Handlers/WhatsAppUtilityConnection.php
+++ b/includes/Handlers/WhatsAppUtilityConnection.php
@@ -31,7 +31,10 @@ class WhatsAppUtilityConnection {
 	/**
 	 * Makes an API call to Whatsapp Utility Message Connect API
 	 *
-	 * @param string $waba_id, string $wacs_id, string $external_business_id, string $bisu_token
+	 * @param string $waba_id WABA ID
+	 * @param string $wacs_id WACS ID
+	 * @param string $external_business_id external business ID
+	 * @param string $bisu_token BISU token
 	 */
 	public static function wc_facebook_whatsapp_connect_utility_messages_call( $waba_id, $wacs_id, $external_business_id, $bisu_token ) {
 		$base_url     = array( self::GRAPH_API_BASE_URL, self::API_VERSION, $waba_id, 'connect_utility_messages' );


### PR DESCRIPTION
## Description
When the finish onboarding button is clicked in the whatsapp utility message onboarding flow in woocommerce fetch the required info and make the graph api call to connect utility message configs. This PR fetched info and makes graph api call, the next PR will handle errors during the button click to show a error banner.

### Type of change
- New feature (non-breaking change which adds functionality)


## Changelog entry
Call Connect Utility Messages graph api when finish button is clicked


## Test Plan

UI changes:


https://github.com/user-attachments/assets/b433caed-a767-4d3a-97a4-4e64c290a131

<img width="1064" alt="Screenshot 2025-04-21 at 1 10 02 PM" src="https://github.com/user-attachments/assets/f22ea43d-5992-4e24-a01d-a58f7a85e1ac" />


Config created as expected:

<img width="1728" alt="Screenshot 2025-04-21 at 1 11 21 PM" src="https://github.com/user-attachments/assets/d54da077-e797-4c43-8e89-25c629d1f5fc" />

https://www.internalfb.com/id3/id/509734938880662?test_vc_id&viewer_context

