### PR TITLE
[LINTFIX] Lint fixes for includes/Products/Sync.php

### DIFF
--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\Products;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * The product sync handler.
@@ -102,7 +101,7 @@ class Sync {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param int[] $retailer retailer IDs to delete
+	 * @param int[] $retailer_ids retailer IDs to delete
 	 */
 	public function delete_products( array $retailer_ids ) {
 
@@ -162,8 +161,8 @@ class Sync {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param $product_id
-	 * @return string
+	 * @param int|string $product_id product ID
+	 * @return string prefixed product index
 	 */
 	private function get_product_index( $product_id ) {
 
@@ -188,6 +187,4 @@ class Sync {
 
 		return ! empty( $jobs );
 	}
-
-
 }


### PR DESCRIPTION
## Description
This pull request fixes all PHPCS / linting issues in `includes/Products/Sync.php` without altering runtime behaviour.  

Key fixes:
1. Replaced the prohibited `or` logical operator with `||`.
2. Corrected docblock parameter names and added explicit types / return descriptions.
3. Removed superfluous blank line before the class closing brace.

These updates bring the file into full compliance with the project’s coding‑standards, improving readability and maintainability while keeping functionality intact.

### Type of change
- Syntax change (non‑breaking change which fixes code modularity, linting or phpcs issues)

## Checklist
- [x] I have commented my code, particularly in hard‑to‑understand areas.  
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.  
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.  
- [x] I followed general Pull Request best practices.  
- [ ] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.  
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.  
- [ ] I have updated or requested update to plugin documentation (if necessary).  

## Changelog entry
Fix – Resolve PHPCS / linting issues in the product sync handler (`includes/Products/Sync.php`).

## Test Plan
1. Run `composer phpcs` and verify zero errors / warnings.
2. Activate the plugin in a test WooCommerce site and confirm:
   - Product sync actions still trigger as expected (create, update, delete requests).
   - No new PHP warnings or fatal errors appear in logs.
3. Manually trigger stock updates and verify they are queued for sync correctly.

## Screenshots
N/A
