### PR TITLE
[WAUM - Utility] Adding an AJAX cal to disable/remove consent collection on the Utility widget.

### DIFF
--- a/assets/js/admin/whatsapp-consent-remove.js
+++ b/assets/js/admin/whatsapp-consent-remove.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+jQuery( document ).ready( function( $ ) {
+    // handle the whatsapp consent collect button click remove action.
+	$( '#wc-whatsapp-collect-consent-remove' ).click( function( event ) {
+
+        $.post( facebook_for_woocommerce_whatsapp_consent_remove.ajax_url, {
+			action: 'wc_facebook_whatsapp_consent_collection_disable',
+			nonce:  facebook_for_woocommerce_whatsapp_consent_remove.nonce
+		}, function ( response ) {
+
+            if ( response.success ) {
+				console.log( 'success', response ); 
+			}
+		} );
+
+    });
+
+} );

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -63,6 +63,9 @@ class AJAX {
 
 		// search a product's attributes for the given term
 		add_action( 'wp_ajax_' . self::ACTION_SEARCH_PRODUCT_ATTRIBUTES, array( $this, 'admin_search_product_attributes' ) );
+
+		// update the wp_options with wc_facebook_whatsapp_consent_collection_setting_status to disabled
+		add_action( 'wp_ajax_wc_facebook_whatsapp_consent_collection_disable', array( $this, 'whatsapp_consent_collection_disable' ) );
 	}
 
 
@@ -260,6 +263,16 @@ class AJAX {
 		}
 		if ( get_option( 'wc_facebook_whatsapp_consent_collection_setting_status' ) !== 'enabled' ) {
 			update_option( 'wc_facebook_whatsapp_consent_collection_setting_status', 'enabled' );
+		}
+		wp_send_json_success();
+	}
+
+	public function whatsapp_consent_collection_disable() {
+		if ( ! check_ajax_referer( 'facebook-for-wc-whatsapp-consent-disable-nonce', 'nonce', false ) ) {
+			wp_send_json_error( 'Invalid security token sent.' );
+		}
+		if ( get_option( 'wc_facebook_whatsapp_consent_collection_setting_status' ) !== 'disabled' ) {
+			update_option( 'wc_facebook_whatsapp_consent_collection_setting_status', 'disabled' );
 		}
 		wp_send_json_success();
 	}

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -128,6 +128,23 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 					),
 				)
 			);
+			wp_enqueue_script(
+				'facebook-for-woocommerce-whatsapp-consent-remove',
+				facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/whatsapp-consent-remove.js',
+				array( 'jquery', 'jquery-blockui', 'jquery-tiptip', 'wc-enhanced-select' ),
+				\WC_Facebookcommerce::PLUGIN_VERSION
+			);
+			wp_localize_script(
+				'facebook-for-woocommerce-whatsapp-consent-remove',
+				'facebook_for_woocommerce_whatsapp_consent_remove',
+				array(
+					'ajax_url' => admin_url( 'admin-ajax.php' ),
+					'nonce'    => wp_create_nonce( 'facebook-for-wc-whatsapp-consent-disable-nonce' ),
+					'i18n'     => array(
+						'result' => true,
+					),
+				)
+			);
 	}
 
 
@@ -297,8 +314,8 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 					</div>
 					<div class="event-config-manage-button">
 					<a
-						id="remove-button"
-						class="event-config-manage-button button"
+						id="wc-whatsapp-collect-consent-remove"
+						class="button"
 						href="#"><?php esc_html_e( 'Remove', 'facebook-for-woocommerce' ); ?></a>
 					</div>
 				</div>

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -133,36 +133,34 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			array( 'jquery', 'jquery-blockui', 'jquery-tiptip', 'wc-enhanced-select' ),
 			\WC_Facebookcommerce::PLUGIN_VERSION
 		);
-    
-			wp_localize_script(
-				'facebook-for-woocommerce-whatsapp-finish',
-				'facebook_for_woocommerce_whatsapp_finish',
-				array(
-					'ajax_url' => admin_url( 'admin-ajax.php' ),
-					'nonce'    => wp_create_nonce( 'facebook-for-wc-whatsapp-finish-nonce' ),
-					'i18n'     => array(
-						'result' => true,
-					),
-				)
-			);
-			wp_enqueue_script(
-				'facebook-for-woocommerce-whatsapp-consent-remove',
-				facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/whatsapp-consent-remove.js',
-				array( 'jquery', 'jquery-blockui', 'jquery-tiptip', 'wc-enhanced-select' ),
-				\WC_Facebookcommerce::PLUGIN_VERSION
-			);
-			wp_localize_script(
-				'facebook-for-woocommerce-whatsapp-consent-remove',
-				'facebook_for_woocommerce_whatsapp_consent_remove',
-				array(
-					'ajax_url' => admin_url( 'admin-ajax.php' ),
-					'nonce'    => wp_create_nonce( 'facebook-for-wc-whatsapp-consent-disable-nonce' ),
-					'i18n'     => array(
-						'result' => true,
-					),
-				)
-			);
-    
+		wp_localize_script(
+			'facebook-for-woocommerce-whatsapp-finish',
+			'facebook_for_woocommerce_whatsapp_finish',
+			array(
+				'ajax_url' => admin_url( 'admin-ajax.php' ),
+				'nonce'    => wp_create_nonce( 'facebook-for-wc-whatsapp-finish-nonce' ),
+				'i18n'     => array(
+					'result' => true,
+				),
+			)
+		);
+		wp_enqueue_script(
+			'facebook-for-woocommerce-whatsapp-consent-remove',
+			facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/whatsapp-consent-remove.js',
+			array( 'jquery', 'jquery-blockui', 'jquery-tiptip', 'wc-enhanced-select' ),
+			\WC_Facebookcommerce::PLUGIN_VERSION
+		);
+		wp_localize_script(
+			'facebook-for-woocommerce-whatsapp-consent-remove',
+			'facebook_for_woocommerce_whatsapp_consent_remove',
+			array(
+				'ajax_url' => admin_url( 'admin-ajax.php' ),
+				'nonce'    => wp_create_nonce( 'facebook-for-wc-whatsapp-consent-disable-nonce' ),
+				'i18n'     => array(
+					'result' => true,
+				),
+			)
+		);
 		wp_localize_script(
 			'facebook-for-woocommerce-whatsapp-finish',
 			'facebook_for_woocommerce_whatsapp_finish',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,8 @@ const jQueryUIAdminFileNames = [
     'whatsapp-billing',
     'whatsapp-connection',
     'whatsapp-consent',
-    'whatsapp-finish'
+    'whatsapp-finish',
+    'whatsapp-consent-remove'
 ];
 
 const jQueryUIAdminFileEntries = {};


### PR DESCRIPTION
## Description

In this diff, I am adding ability to remove consent of collection whatsapp information from the user. Adding a button to "Remove" consent, for Whatsapp data collection. We would do further enhancements on CSS later.


### Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)


## Changelog entry

New button to remove consent form the user, AJAX call to support the function.


## Test Plan

1. Open Marketing > Facebook tab in wordpress containing facebook-for-woocommerce screens
2. Open Utility Messages tab on the right.
3. After onboarding is completed, user is redirected to Utility Flows. 
4. User clicks on "Remove" button to remove the consent.
5. Checked the consent collection setting is disabled successfully, once the user clicks on the "Remove" button. 

executed the `./vendor `commands 

## Screenshots

### Before
**Remove button doesn't do anything**
![image](https://github.com/user-attachments/assets/91929f86-c1d6-4af0-91bb-8876831a949e)

### After


https://github.com/user-attachments/assets/98d776a8-ae4e-4394-a4ac-943407efcf13


