### PR TITLE
[WAUM][18/n] Error Handling on Onboarding Flow Completion

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
+++ b/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
@@ -57,3 +57,20 @@
 .manage-event-button {
     margin-left: 20px;
 }
+.error-notice-wrapper {
+    justify-content: left;
+    padding-left: 20px;
+    padding-bottom: 10px;
+    margin-right: 20px; /* Add the right margin */
+}
+.notice-error {
+  background-color: #f7f7f7;
+  border: 1px solid #EF0000; /* Red border */
+  border-radius: 0; /* No curvature */
+  border-left-width: 5px; /* Thicker left border */
+  width: 100%; /* Take up full width */
+}
+.notice-error p {
+  margin: 5px;
+
+}

--- a/assets/js/admin/whatsapp-finish.js
+++ b/assets/js/admin/whatsapp-finish.js
@@ -23,8 +23,27 @@ jQuery( document ).ready( function( $ ) {
                  url.search = params.toString();
                  window.location.href = url.toString();
 			} else {
-                // TODO: Handle error show error banner in UI
-                console.log(response);
+                var message;
+                const error = response.data;
+
+                switch (error) {
+                    case "Incorrect payment setup":
+                        message = facebook_for_woocommerce_whatsapp_finish.i18n.payment_setup_error;
+                        break;
+                    case "Onboarding is not complete or has failed.":
+                        message = facebook_for_woocommerce_whatsapp_finish.i18n.onboarding_incomplete_error;
+                        break;
+                    default:
+                        message = facebook_for_woocommerce_whatsapp_finish.i18n.generic_error;
+                }
+
+
+                const errorNoticeHtml = `
+                      <div class="notice-error">
+                        <p>${message}</p>
+                      </div>
+                    `;
+                $( '#payment-method-error-notice' ).html( errorNoticeHtml ).show();
             }
 		} );
     });

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -123,8 +123,10 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				array(
 					'ajax_url' => admin_url( 'admin-ajax.php' ),
 					'nonce'    => wp_create_nonce( 'facebook-for-wc-whatsapp-finish-nonce' ),
-					'i18n'     => array(
-						'result' => true,
+					'i18n'     => array( // will generate i18 pot translation
+						'payment_setup_error'         => __( 'To proceed, add a payment method to make future purchases on your accounts.', 'facebook-for-woocommerce' ),
+						'onboarding_incomplete_error' => __( 'Whatsapp Business Account Onboarding is not complete or has failed.', 'facebook-for-woocommerce' ),
+						'generic_error'               => __( 'Something went wrong. Please try again.', 'facebook-for-woocommerce' ),
 					),
 				)
 			);
@@ -211,6 +213,9 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 					href="#"
 				><?php esc_html_e( 'Review', 'facebook-for-woocommerce' ); ?></a>
 			</div>
+		</div>
+		<div class="error-notice-wrapper">
+			<div id="payment-method-error-notice" style="display: none;"></div>
 		</div>
 		<div class="divider"></div>
 		<div class="card-item">

--- a/includes/Handlers/WhatsAppUtilityConnection.php
+++ b/includes/Handlers/WhatsAppUtilityConnection.php
@@ -54,7 +54,9 @@ class WhatsAppUtilityConnection {
 		$response     = wp_remote_post( $base_url, $options );
 		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) != 200 ) {
 			$error_data    = explode( "\n", wp_remote_retrieve_body( $response ) );
-			$error_message = $error_data[0];
+			$error_object  = json_decode( $error_data[0] );
+			$error_message = $error_object->error->error_user_title;
+
 			wc_get_logger()->info(
 				sprintf(
 					/* translators: %s $error_message */
@@ -62,7 +64,7 @@ class WhatsAppUtilityConnection {
 					$error_message,
 				)
 			);
-			wp_send_json_error( $response, 'Finish Onboarding Failure' );
+			wp_send_json_error( $error_message, 'Finish Onboarding Failure' );
 		} else {
 				wc_get_logger()->info(
 					sprintf(


### PR DESCRIPTION
## Description
Handle errors when onboarding flow is complete when user clicks the Done button. Error can be from PHP checks or meta api calls.

### Type of change
- New feature (non-breaking change which adds functionality)



## Changelog entry
Error Handling on Onboarding Flow Completion


## Test Plan
Various errors are handled as expected:

https://github.com/user-attachments/assets/60036b3a-de05-4421-af7a-750d03be623d



<img width="1728" alt="Screenshot 2025-04-23 at 5 24 23 PM" src="https://github.com/user-attachments/assets/23d7789b-3107-42dd-9e65-2ce84aaafd48" />
<img width="1728" alt="Screenshot 2025-04-23 at 5 24 43 PM" src="https://github.com/user-attachments/assets/293efbb2-ad9c-4a1f-ab7c-1ca084658bfd" />

