### PR TITLE
Fix product variation fields not saving correctly

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1515,7 +1515,7 @@ class Admin {
 						'value'         => wc_format_decimal( $price ),
 						'class'         => 'enable-if-sync-enabled',
 						'wrapper_class' => 'form-row form-full',
-					) 
+					)
 				);
 
 				woocommerce_wp_text_input(

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1515,7 +1515,7 @@ class Admin {
 						'value'         => wc_format_decimal( $price ),
 						'class'         => 'enable-if-sync-enabled',
 						'wrapper_class' => 'form-row form-full',
-					)
+					) 
 				);
 
 				woocommerce_wp_text_input(

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1525,7 +1525,7 @@ class Admin {
 						'label'         => __( 'Manufacturer Parts Number (MPN)', 'facebook-for-woocommerce' ),
 						'desc_tip'      => true,
 						'description'   => __( 'Manufacturer Parts Number', 'facebook-for-woocommerce' ),
-						'value'         => wc_format_decimal( $fb_mpn ),
+						'value'         => $fb_mpn,
 						'class'         => 'enable-if-sync-enabled',
 						'wrapper_class' => 'form-row form-full',
 					)
@@ -1614,7 +1614,7 @@ class Admin {
 			$posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_IMAGE;
 			$image_url    = isset( $_POST[ $posted_param ][ $index ] ) ? esc_url_raw( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
 			$posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_CONDITION;
-			$image_url    = isset( $_POST[ $posted_param ][ $index ] ) ? esc_url_raw( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
+			$condition    = isset( $_POST[ $posted_param ][ $index ] ) ? esc_url_raw( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : null;
 			$posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_VIDEO;
 			$video_urls   = isset( $_POST[ $posted_param ][ $index ] ) ? esc_url_raw( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) : [];
 			$posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_PRICE;
@@ -1624,6 +1624,7 @@ class Admin {
 			$variation->update_meta_data( Products::PRODUCT_IMAGE_SOURCE_META_KEY, $image_source );
 			$variation->update_meta_data( \WC_Facebook_Product::FB_MPN, $fb_mpn );
 			$variation->update_meta_data( \WC_Facebook_Product::FB_PRODUCT_IMAGE, $image_url );
+			$variation->update_meta_data( \WC_Facebook_Product::FB_PRODUCT_CONDITION, $condition );
 			$variation->update_meta_data( \WC_Facebook_Product::FB_PRODUCT_VIDEO, $video_urls );
 			$variation->update_meta_data( \WC_Facebook_Product::FB_PRODUCT_PRICE, $price );
 			$variation->save_meta_data();


### PR DESCRIPTION
# Fix Product Variation Fields Not Saving Correctly

## Description

This PR fixes an issue where product variation custom fields for Facebook for WooCommerce were not being properly saved and displayed. Specifically, the MPN (Manufacturer Part Number) and custom image URL values weren't being preserved when saving product variations.

The issue was caused by two main problems:
1. The MPN field was being incorrectly formatted as a decimal number with `wc_format_decimal()` when rendered, which is inappropriate for an alphanumeric identifier
2. The custom image URL was potentially being overwritten due to variable reuse in the save logic

These bugs prevented merchants from properly configuring their product variations for Facebook Catalog sync.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki](https://fburl.com/wiki/2cgfduwc).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki](https://fburl.com/wiki/nhx73tgs).

## Changelog entry

Fix issue where product variation MPN and custom image URL fields weren't being properly saved and displayed.

## Test Plan

1. Create a variable product with at least one variation
2. Enable Facebook sync for the variation
3. Set a custom MPN value (e.g., "ABC12345") and a custom image URL
4. Save the product
5. Reload the product edit page
6. Verify that the MPN and custom image URL values have been preserved

## Screenshots
### Before

When saving product variations, the MPN field and custom image URL would not persist after saving.

### After

The MPN field and custom image URL now correctly display and save the values entered by users.