### PR TITLE
[WAUM] Fix broken UI 

### DIFF
--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -276,11 +276,11 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 		<div class="onboarding-card">
 			<div class="card-item">
 				<h1><?php esc_html_e( 'Utility Messages', 'facebook-for-woocommerce' ); ?></h1>
-					<p><?php esc_html_e( 'Manage which utility messages you want to send to customers. You can check performance of these messages in Whatsapp Manager.', 'facebook-for-woocommerce' ); ?>
-						<a
-							id="woocommerce-whatsapp-manager-insights"
-							href="#"><?php esc_html_e( 'View insights', 'facebook-for-woocommerce' ); ?></a>
-					</p>
+				<p><?php esc_html_e( 'Manage which utility messages you want to send to customers. You can check performance of these messages in Whatsapp Manager.', 'facebook-for-woocommerce' ); ?>
+					<a
+						id="woocommerce-whatsapp-manager-insights"
+						href="#"><?php esc_html_e( 'View insights', 'facebook-for-woocommerce' ); ?></a>
+				</p>
 			</div>
 			<div class="divider"></div>
 			<div class="card-item event-config">
@@ -291,15 +291,8 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 							<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
 						</div>
 					</div>
-					<div class="event-config-heading-container">
-						<h3><?php esc_html_e( 'Order confirmation', 'facebook-for-woocommerce' ); ?></h3>
-						<div class="event-config-status on-status">
-							<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
-						</div>
-					</div>
 					<p><?php esc_html_e( 'Send a confirmation to customers after they\'ve placed an order.', 'facebook-for-woocommerce' ); ?></p>
-				</div>	
-				</div>	
+				</div>
 				<div class="event-config-manage-button">
 					<a
 						id="woocommerce-whatsapp-manage-order-confirmation"
@@ -316,30 +309,18 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 							<?php esc_html_e( 'Off', 'facebook-for-woocommerce' ); ?>
 						</div>
 					</div>
-					<div class="event-config-heading-container">
-						<h3><?php esc_html_e( 'Order shipped', 'facebook-for-woocommerce' ); ?></h3>
-						<div class="event-config-status">
-							<?php esc_html_e( 'Off', 'facebook-for-woocommerce' ); ?>
-						</div>
-					</div>
 					<p><?php esc_html_e( 'Send a confirmation to customers when their order is shipped.', 'facebook-for-woocommerce' ); ?></p>
 				</div>
 				<div class="event-config-manage-button">
 					<a
 						id="woocommerce-whatsapp-manage-order-shipped"
-						class="button"
+						class="event-config-manage-button button"
 						href="#"><?php esc_html_e( 'Manage', 'facebook-for-woocommerce' ); ?></a>
 				</div>
 			</div>
 			<div class="divider"></div>
 			<div class="card-item event-config">
 				<div>
-					<div class="event-config-heading-container">
-						<h3><?php esc_html_e( 'Order refunded', 'facebook-for-woocommerce' ); ?></h3>
-						<div class="event-config-status">
-							<?php esc_html_e( 'Off', 'facebook-for-woocommerce' ); ?>
-						</div>
-					</div>
 					<div class="event-config-heading-container">
 						<h3><?php esc_html_e( 'Order refunded', 'facebook-for-woocommerce' ); ?></h3>
 						<div class="event-config-status">
@@ -356,7 +337,6 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				</div>
 			</div>
 			<div class="divider"></div>
-
 		</div>
 		<div class="onboarding-card">
 			<div class="card-item event-config">


### PR DESCRIPTION
## Description

Fixing the UI for Utility Card

### Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


## Changelog entry

Fixing UI for Utility Card. 


## Test Plan
1. Open Marketing > Facebook tab in wordpress containing facebook-for-woocommerce screens
2. Open Utility Messages tab on the right.
3. After onboarding is completed, user is redirected to Utility Flows.

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before
![image](https://github.com/user-attachments/assets/3a057d49-6cc8-4fbf-9de5-71f802759588)

### After
![image](https://github.com/user-attachments/assets/ecd3b8c4-2265-46e2-8b2d-a8cf51645962)

