### PR TITLE
[WAUM] Consent Collection - Adding logic to the "remove" button, toggling 'On' to 'Off' status. 

### DIFF
--- a/assets/js/admin/whatsapp-consent-remove.js
+++ b/assets/js/admin/whatsapp-consent-remove.js
@@ -7,20 +7,27 @@
  * @package FacebookCommerce
  */
 
-jQuery( document ).ready( function( $ ) {
-    // handle the whatsapp consent collect button click remove action.
-	$( '#wc-whatsapp-collect-consent-remove' ).click( function( event ) {
+jQuery(document).ready(function($) {
+    // Handle the WhatsApp consent collect button click remove action.
+    $('#wc-whatsapp-collect-consent-remove').click(function(event) {
+        event.preventDefault(); // Prevent the default action of the link.
 
-        $.post( facebook_for_woocommerce_whatsapp_consent_remove.ajax_url, {
-			action: 'wc_facebook_whatsapp_consent_collection_disable',
-			nonce:  facebook_for_woocommerce_whatsapp_consent_remove.nonce
-		}, function ( response ) {
+        var $button = $(this); // The clicked button
+        var $statusElement = $button.closest('.event-config').find('.event-config-status');
 
-            if ( response.success ) {
-				console.log( 'success', response ); 
-			}
-		} );
-
+        $.post(facebook_for_woocommerce_whatsapp_consent_remove.ajax_url, {
+            action: 'wc_facebook_whatsapp_consent_collection_disable',
+            nonce: facebook_for_woocommerce_whatsapp_consent_remove.nonce
+        }, function(response) {
+            if (response.success) {
+                // Change the status from "on-status" to "off-status" for the specific element.
+                $statusElement.removeClass('on-status').addClass('off-status');
+                // Update the text to "Off".
+                $statusElement.text('Off');
+				// Update button text to "Add".
+				$button.text('Add');
+				console.log('success', response);
+            }
+        });
     });
-
-} );
+});

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -182,7 +182,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	 */
 	public function render() {
 		$view = $this->get_current_view();
-		if ( true ) {
+		if ( 'utility_settings' === $view ) {
 			$this->render_utility_message_overview();
 		} elseif ( 'manage_event' === $view ) {
 			$this->render_manage_events_view();

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -342,13 +342,12 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			<div class="card-item event-config">
 					<div>
 						<div class="event-config-heading-container">
-							<h3><?php esc_html_e( 'Checkbox', 'facebook-for-woocommerce' ); ?></h3>
+							<h3><?php esc_html_e( 'Add WhatsApp option at checkout', 'facebook-for-woocommerce' ); ?></h3>
 							<div class="event-config-status on-status">
 								<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
 							</div>
 						</div>
 						<p><?php esc_html_e( 'Removing this means you won\'t be able to send messages to your customers.', 'facebook-for-woocommerce' ); ?></p>
-					</div>	
 					</div>	
 					<div class="event-config-manage-button">
 						<a


### PR DESCRIPTION
## Description

Adding UI changes to handle "Remove" button logic, now when the user clicks on "Remove" button we would disable the consent collection feature and also turn the "On" button to "Off", we will also change the "Remove" button to "Add", logic for enabling consent collection back again is remaining.

### Type of change

- New feature (non-breaking change which adds functionality)


## Changelog entry
Handle logic for "Remove" button click, for consent collection widget.


## Test Plan
1. Open Marketing > Facebook tab in wordpress containing facebook-for-woocommerce screens
2. Open Utility Messages tab on the right.
3. After onboarding is completed, user is redirected to Utility Flows.
4. User clicks on "Remove" button to remove the consent.
5. Checked the Remove button turns to "Add" button.
6. Checked the green "On" button turns to grey "Off".

## Screenshots
### Before
Nothing happens on UI, after clicking remove button.

### After

https://github.com/user-attachments/assets/3ab9f057-ea2e-4f45-a01c-4e653da07ebd

