### PR TITLE
[Easy] Revert committed change on utility settings view

### DIFF
--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -182,7 +182,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	 */
 	public function render() {
 		$view = $this->get_current_view();
-		if ( true ) {
+		if ( 'utility_settings' === $view ) {
 			$this->render_utility_message_overview();
 		} elseif ( 'manage_event' === $view ) {
 			$this->render_manage_events_view();


### PR DESCRIPTION
## Description
Reverted change that always defaulted the Utility Messages view to the Settings Page

### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Changelog entry
Fix bug introduced defaulting Utility Messages Settings Page

## Test Plan
1. Load Utility Messages Tab
2. Validate the Onboarding Page is shown
3. Append &view=utility_settings
4. Validate the Settings Page is shown
## Screen Recording
https://github.com/user-attachments/assets/16538818-2815-4e39-9433-c5843f9dae5d


