### PR TITLE
[WAUM][22/n] Hide and Show each Whatsapp Onboarding Step based on user progress

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
+++ b/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
@@ -8,7 +8,6 @@
     margin-top: 50px;
 }
 .custom-dashicon-check {
-    margin-top: 30px;
     position: relative;
     display: inline-block;
     width: 26px; /* Set the size of the circle */
@@ -16,6 +15,8 @@
     background-color: #1a805b; /* Fill the circle with green */
     border-radius: 50%; /* Make it a circle */
     margin-right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
 }
 .custom-dashicon-check::before {
     content: '\f147'; /* Unicode for dashicons-yes-alt */
@@ -34,7 +35,6 @@
 }
 
 .custom-dashicon-circle {
-    margin-top: 30px;
     position: relative;
     display: inline-block;
     width: 20px; /* Set the size of the circle */
@@ -42,9 +42,10 @@
     border-radius: 50%; /* Make it a circle */
     margin-right: 10px;
     border: 3px solid #222121ab;
+    top: 50%;
+    transform: translateY(-50%);
 }
 .custom-dashicon-halfcircle {
-    margin-top: 30px;
     position: relative;
     display: inline-block;
     width: 20px; /* Set the size of the circle */
@@ -54,6 +55,8 @@
     border: 3px solid #222121ab;
     background-image: linear-gradient(to left, #222121ab 50%, transparent 50%);
     background-clip: padding-box; /* Add this line */
+    top: 50%;
+    transform: translateY(-50%);
 }
 .card-content-icon {
     display: flex;

--- a/assets/js/admin/whatsapp-billing.js
+++ b/assets/js/admin/whatsapp-billing.js
@@ -10,13 +10,17 @@
 jQuery( document ).ready( function( $ ) {
   	var $billingStepInProgress = $('#wc-fb-whatsapp-billing-inprogress');
   	var $billingStepNotStarted = $('#wc-fb-whatsapp-billing-notstarted');
-		if (facebook_for_woocommerce_whatsapp_consent.consent_collection_enabled) {
-			$billingStepInProgress.show();
-			$billingStepNotStarted.hide();
-		} else {
-			$billingStepInProgress.hide();
-			$billingStepNotStarted.show();
-		}
+	var $billingSubcontent = $('#wc-fb-whatsapp-billing-subcontent');
+	var $billingButtonWrapper = $('#wc-fb-whatsapp-billing-button-wrapper');
+	if (facebook_for_woocommerce_whatsapp_consent.consent_collection_enabled) {
+		$billingStepInProgress.show();
+		$billingStepNotStarted.hide();
+	} else {
+		$billingStepInProgress.hide();
+		$billingStepNotStarted.show();
+		$billingSubcontent.hide();
+		$billingButtonWrapper.hide()
+	}
 
     // handle the whatsapp add payment button click should open billing flow in Meta
     $('#wc-whatsapp-add-payment').click(function(event) {

--- a/assets/js/admin/whatsapp-connection.js
+++ b/assets/js/admin/whatsapp-connection.js
@@ -10,9 +10,13 @@
 jQuery( document ).ready( function( $ ) {
     var $connectSuccess = $('#wc-fb-whatsapp-connect-success');
     var $connectInProgress = $('#wc-fb-whatsapp-connect-inprogress');
+    var $connectSubcontent = $('#wc-fb-whatsapp-onboarding-subcontent');
+    var $connectButtonWrapper = $('#wc-fb-whatsapp-onboarding-button-wrapper');
     if (facebook_for_woocommerce_whatsapp_onboarding_progress.whatsapp_onboarding_complete) {
         $connectSuccess.show();
         $connectInProgress.hide();
+        $connectSubcontent.hide();
+        $connectButtonWrapper.hide();
     } else {
         $connectSuccess.hide();
         $connectInProgress.show();
@@ -39,9 +43,14 @@ jQuery( document ).ready( function( $ ) {
                 // update the progress for connect whatsapp step
                 $connectInProgress.remove();
                 $connectSuccess.show();
-                // update the progress for collect consent step
+                 // collapse whatsapp onboarding step subcontect and button on success
+                $connectSubcontent.hide();
+                $connectButtonWrapper.hide();
+                // update the progress for collect consent step and show button and subcontent
                 $('#wc-fb-whatsapp-consent-collection-inprogress').show();
                 $('#wc-fb-whatsapp-consent-collection-notstarted').hide();
+                $('#whatsapp-consent-subcontent').show();
+	            $('#whatsapp-consent-button-wrapper').show();
 			} else {
                 console.log('Failure. Checking again in 1 second:', response, ', retry attempt:', retryCount, 'pollingTimeout', pollingTimeout);
                 if(retryCount >= pollingTimeout) {

--- a/assets/js/admin/whatsapp-connection.js
+++ b/assets/js/admin/whatsapp-connection.js
@@ -49,8 +49,8 @@ jQuery( document ).ready( function( $ ) {
                 // update the progress for collect consent step and show button and subcontent
                 $('#wc-fb-whatsapp-consent-collection-inprogress').show();
                 $('#wc-fb-whatsapp-consent-collection-notstarted').hide();
-                $('#whatsapp-consent-subcontent').show();
-	            $('#whatsapp-consent-button-wrapper').show();
+                $('#wc-fb-whatsapp-consent-subcontent').show();
+	            $('#wc-fb-whatsapp-consent-button-wrapper').show();
 			} else {
                 console.log('Failure. Checking again in 1 second:', response, ', retry attempt:', retryCount, 'pollingTimeout', pollingTimeout);
                 if(retryCount >= pollingTimeout) {

--- a/assets/js/admin/whatsapp-consent.js
+++ b/assets/js/admin/whatsapp-consent.js
@@ -11,14 +11,20 @@ jQuery( document ).ready( function( $ ) {
 	var $consentCollectSuccess = $('#wc-fb-whatsapp-consent-collection-success');
   	var $consentCollectInProgress = $('#wc-fb-whatsapp-consent-collection-inprogress');
   	var $consentCollectNotStarted = $('#wc-fb-whatsapp-consent-collection-notstarted');
+	var $consentSubcontent = $('#wc-fb-whatsapp-consent-subcontent');
+	var $consentButtonWrapper = $('#wc-fb-whatsapp-consent-button-wrapper');
 	if (facebook_for_woocommerce_whatsapp_consent.whatsapp_onboarding_complete) {
 		if (facebook_for_woocommerce_whatsapp_consent.consent_collection_enabled) {
 			showConsentCollectionProgressIcon(true, false, false);
+			$consentSubcontent.hide();
+			$consentButtonWrapper.hide();
 		} else {
 			showConsentCollectionProgressIcon(false, true, false);
 		}
     } else {
 		showConsentCollectionProgressIcon(false, false, true);
+		$consentSubcontent.hide();
+		$consentButtonWrapper.hide();
     }
 
     // handle the whatsapp consent collect button click should save setting to wp_options table
@@ -30,11 +36,15 @@ jQuery( document ).ready( function( $ ) {
 		}, function ( response ) {
             if ( response.success ) {
 				console.log( 'success', response );
-				// update the progress for collect consent step
+				// update the progress for collect consent step and hide the button and subcontent
 				showConsentCollectionProgressIcon(true, false, false);
-				// update the progress of billing step
+				$consentSubcontent.hide();
+				$consentButtonWrapper.hide();
+				// update the progress of billing step and show the button and subcontent
 				$('#wc-fb-whatsapp-billing-inprogress').show();
                 $('#wc-fb-whatsapp-billing-notstarted').hide();
+				$('#wc-fb-whatsapp-billing-subcontent').show();
+				$('#wc-fb-whatsapp-billing-button-wrapper').show();
 			}
 		} );
 

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -211,10 +211,10 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<div id="wc-fb-whatsapp-connect-inprogress" class="custom-dashicon-halfcircle fbwa-hidden-element"></div>
 				<div class="card-content">
 					<h2><?php esc_html_e( 'Connect your WhatApp Business account', 'facebook-for-woocommerce' ); ?></h2>
-					<p><?php esc_html_e( 'Allows WooCommerce to connect to your WhatsApp account. ', 'facebook-for-woocommerce' ); ?></p>
+					<p id="wc-fb-whatsapp-onboarding-subcontent"><?php esc_html_e( 'Allows WooCommerce to connect to your WhatsApp account. ', 'facebook-for-woocommerce' ); ?></p>
 				</div>
 			</div>
-			<div class="whatsapp-onboarding-button">
+			<div id="wc-fb-whatsapp-onboarding-button-wrapper" class="whatsapp-onboarding-button">
 				<a
 					id="woocommerce-whatsapp-connection"
 					class="button"
@@ -230,10 +230,10 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<div id="wc-fb-whatsapp-consent-collection-inprogress" class="custom-dashicon-halfcircle fbwa-hidden-element"></div>
 				<div class="card-content">
 					<h2><?php esc_html_e( 'Add WhatsApp option at checkout', 'facebook-for-woocommerce' ); ?></h2>
-					<p><?php esc_html_e( 'Adds a checkbox to your store’s checkout page that lets customers request updates about their order on WhatsApp. This allows you to communicate with customers after they make a purchase. You can remove this anytime.', 'facebook-for-woocommerce' ); ?></p>
+					<p id="wc-fb-whatsapp-consent-subcontent"><?php esc_html_e( 'Adds a checkbox to your store’s checkout page that lets customers request updates about their order on WhatsApp. This allows you to communicate with customers after they make a purchase. You can remove this anytime.', 'facebook-for-woocommerce' ); ?></p>
 				</div>
 			</div>
-			<div class="whatsapp-onboarding-button">
+			<div id="wc-fb-whatsapp-consent-button-wrapper" class="whatsapp-onboarding-button">
 			<a
 				class="button"
 				id="wc-whatsapp-collect-consent"
@@ -248,17 +248,19 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<div id="wc-fb-whatsapp-billing-inprogress" class="custom-dashicon-halfcircle fbwa-hidden-element"></div>
 				<div class="card-content">
 					<h2><?php esc_html_e( 'Add a payment method', 'facebook-for-woocommerce' ); ?></h2>
-					<p><?php esc_html_e( 'Review and update your payment method in Billings & payments.', 'facebook-for-woocommerce' ); ?>
-						<a
-							href="https://developers.facebook.com/docs/whatsapp/pricing/#rate-cards"
-							id="wc-whatsapp-about-pricing"
-							target="_blank"
-						><?php esc_html_e( 'About pricing', 'facebook-for-woocommerce' ); ?>
-						</a>
-					</p>
+					<div id="wc-fb-whatsapp-billing-subcontent">
+						<p><?php esc_html_e( 'Review and update your payment method in Billings & payments.', 'facebook-for-woocommerce' ); ?>
+							<a
+								href="https://developers.facebook.com/docs/whatsapp/pricing/#rate-cards"
+								id="wc-whatsapp-about-pricing"
+								target="_blank"
+							><?php esc_html_e( 'About pricing', 'facebook-for-woocommerce' ); ?>
+							</a>
+						</p>
+					</div>
 				</div>
 			</div>
-			<div class="whatsapp-onboarding-button">
+			<div id="wc-fb-whatsapp-billing-button-wrapper" class="whatsapp-onboarding-button">
 				<a
 					class="button"
 					id="wc-whatsapp-add-payment"


### PR DESCRIPTION
## Description
Show only the active steps during whatsapp onboarding, hide all other steps until they become active (i.e) complete the previous step

## Figma
<img width="667" alt="Screenshot 2025-04-27 at 7 21 33 PM" src="https://github.com/user-attachments/assets/2def7afb-14dc-4806-8307-1c4b049d38f4" />
<img width="665" alt="Screenshot 2025-04-27 at 7 21 44 PM" src="https://github.com/user-attachments/assets/6c2849c2-3282-40c9-bab7-d367869a1663" />
<img width="667" alt="Screenshot 2025-04-27 at 7 21 54 PM" src="https://github.com/user-attachments/assets/07822897-6d29-4814-8e7e-6af3ffae738b" />



## Type of change
- New feature (non-breaking change which adds functionality)

## Changelog entry
Hide and Show each Whatsapp Onboarding Step based on user progress


## Test Plan

https://github.com/user-attachments/assets/e7866c14-a9d3-496b-9386-129d3598ba0c


