### PR TITLE
[WAUM][23/n] Add warning modal to whatsapp consent remove button

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
+++ b/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
@@ -94,8 +94,7 @@
 .notice-error p {
     margin: 5px;
 }
-/* Modal styles */
-.custom-modal {
+.warning-custom-modal {
   display: none; /* Hidden by default */
   position: absolute;
   left: 0;
@@ -105,7 +104,7 @@
   background-color: rgba(0,0,0,0.4); /* Black with opacity */
 }
 /* Modal content */
-.modal-content {
+.warning-modal-content {
   background-color: #fefefe;
   margin: 25% auto;
   padding: 20px;
@@ -117,16 +116,16 @@
   box-shadow: 0 4px 8px rgba(0,0,0,0.1);
 }
 /* Modal body */
-.modal-body {
+.warning-modal-body {
   padding: 20px 0;
 }
 /* Modal footer */
-.modal-footer {
+.warning-modal-footer {
   padding: 10px 0;
   text-align: right;
 }
 /* Close button */
-.close {
+.warning-modal-close {
   color: #aaa;
   float: right;
   font-size: 28px;
@@ -136,6 +135,6 @@
   right: 0;
   top: 0;
 }
-.close:hover {
+.warning-modal-close:hover {
   color: #000;
 }

--- a/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
+++ b/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
@@ -94,3 +94,48 @@
 .notice-error p {
     margin: 5px;
 }
+/* Modal styles */
+.custom-modal {
+  display: none; /* Hidden by default */
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0,0,0,0.4); /* Black with opacity */
+}
+/* Modal content */
+.modal-content {
+  background-color: #fefefe;
+  margin: 25% auto;
+  padding: 20px;
+  border: 1px solid #ddd;
+  top: 10%;
+  width: 50%;
+  max-width: 500px;
+  border-radius: 10px;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+/* Modal body */
+.modal-body {
+  padding: 20px 0;
+}
+/* Modal footer */
+.modal-footer {
+  padding: 10px 0;
+  text-align: right;
+}
+/* Close button */
+.close {
+  color: #aaa;
+  float: right;
+  font-size: 28px;
+  font-weight: bold;
+  cursor: pointer;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+.close:hover {
+  color: #000;
+}

--- a/assets/js/admin/whatsapp-consent-remove.js
+++ b/assets/js/admin/whatsapp-consent-remove.js
@@ -8,19 +8,53 @@
  */
 
 jQuery( document ).ready( function( $ ) {
-    // handle the whatsapp consent collect button click remove action.
-	$( '#wc-whatsapp-collect-consent-remove' ).click( function( event ) {
+    // Get the modal and related elements
+    var modal = document.getElementById("warning-modal");
+    var closeBtn = modal.querySelector(".close");
+    var cancelBtn = document.getElementById("modal-cancel");
+    var confirmBtn = document.getElementById("warning-modal-confirm");
 
-        $.post( facebook_for_woocommerce_whatsapp_consent_remove.ajax_url, {
-			action: 'wc_facebook_whatsapp_consent_collection_disable',
-			nonce:  facebook_for_woocommerce_whatsapp_consent_remove.nonce
-		}, function ( response ) {
+    // Handle the whatsapp consent collect button click remove action
+    $("#wc-whatsapp-collect-consent-remove").click(function(event) {
+        // Show the modal
+        modal.style.display = "block";
 
-            if ( response.success ) {
-				console.log( 'success', response ); 
-			}
-		} );
-
+        // Prevent default action
+        event.preventDefault();
     });
+
+    // Close modal when clicking the X
+    closeBtn.onclick = function() {
+        modal.style.display = "none";
+    };
+
+    // Close modal when clicking the Cancel button
+    cancelBtn.onclick = function() {
+        modal.style.display = "none";
+    };
+
+    // Handle confirm action
+    confirmBtn.onclick = function() {
+        // Send the AJAX request to disable WhatsApp consent collection
+        $.post(facebook_for_woocommerce_whatsapp_consent_remove.ajax_url, {
+            action: 'wc_facebook_whatsapp_consent_collection_disable',
+            nonce: facebook_for_woocommerce_whatsapp_consent_remove.nonce
+        }, function(response) {
+            if (response.success) {
+                console.log('success', response);
+                // You can add a redirect or page refresh here if needed
+            }
+        });
+
+        // Close the modal
+        modal.style.display = "none";
+    };
+
+    // Close modal when clicking outside of it
+    window.onclick = function(event) {
+        if (event.target == modal) {
+            modal.style.display = "none";
+        }
+    };
 
 } );

--- a/assets/js/admin/whatsapp-consent-remove.js
+++ b/assets/js/admin/whatsapp-consent-remove.js
@@ -9,12 +9,11 @@
 
 jQuery( document ).ready( function( $ ) {
     // Get the modal and related elements
-    var modal = document.getElementById("warning-modal");
-    var closeBtn = modal.querySelector(".close");
-    var cancelBtn = document.getElementById("modal-cancel");
-    var confirmBtn = document.getElementById("warning-modal-confirm");
+    var modal = document.getElementById("wc-fb-warning-modal");
+    var cancelButton = document.getElementById("wc-fb-warning-modal-cancel");
+    var confirmButton = document.getElementById("wc-fb-warning-modal-confirm");
 
-    // Handle the whatsapp consent collect button click remove action
+    // On click of the remove button, show the warning modal
     $("#wc-whatsapp-collect-consent-remove").click(function(event) {
         // Show the modal
         modal.style.display = "block";
@@ -23,18 +22,13 @@ jQuery( document ).ready( function( $ ) {
         event.preventDefault();
     });
 
-    // Close modal when clicking the X
-    closeBtn.onclick = function() {
-        modal.style.display = "none";
-    };
-
     // Close modal when clicking the Cancel button
-    cancelBtn.onclick = function() {
+    cancelButton.onclick = function() {
         modal.style.display = "none";
     };
 
     // Handle confirm action
-    confirmBtn.onclick = function() {
+    confirmButton.onclick = function() {
         // Send the AJAX request to disable WhatsApp consent collection
         $.post(facebook_for_woocommerce_whatsapp_consent_remove.ajax_url, {
             action: 'wc_facebook_whatsapp_consent_collection_disable',

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -343,8 +343,8 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 							</div>
 						</div>
 						<p><?php esc_html_e( 'Removing this means you won\'t be able to send messages to your customers.', 'facebook-for-woocommerce' ); ?></p>
-					</div>	
-					</div>	
+					</div>
+					</div>
 					<div class="event-config-manage-button">
 						<a
 							id="wc-whatsapp-collect-consent-remove"
@@ -352,6 +352,22 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 							href="#"><?php esc_html_e( 'Remove', 'facebook-for-woocommerce' ); ?></a>
 					</div>
 				</div>
+		<div id="warning-modal" class="custom-modal">
+   		<div class="modal-content">
+   		 <div class="modal-header">
+   		   <span class="close">&times;</span>
+   		   <h2><?php esc_html_e( 'Stop sending messages to customers ?', 'facebook-for-woocommerce' ); ?></h2>
+   		 </div>
+   		 <div class="modal-body">
+   		  	<?php esc_html_e( 'Removing this means customers won\'t be able to receive WhatsApp messages from your business. You\'ll remove the checkbox from your checkout page and stop collecting phone numbers from customers.', 'facebook-for-woocommerce' ); ?>
+   		 </div>
+   		 <div class="modal-footer">
+   		   <button id="modal-cancel" class="button">Cancel</button>
+   		   <button id="warning-modal-confirm" class="button button-primary">Confirm</button>
+   		 </div>
+  		</div>
+		</div>
+		</div>
 		</div>
 		<?php
 	}
@@ -413,8 +429,6 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				</div>
 
 			</div>
-
-
 		</div>
 		<?php
 	}

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -352,22 +352,19 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 							href="#"><?php esc_html_e( 'Remove', 'facebook-for-woocommerce' ); ?></a>
 					</div>
 				</div>
-		<div id="warning-modal" class="custom-modal">
-   		<div class="modal-content">
-   		 <div class="modal-header">
-   		   <span class="close">&times;</span>
-   		   <h2><?php esc_html_e( 'Stop sending messages to customers ?', 'facebook-for-woocommerce' ); ?></h2>
-   		 </div>
-   		 <div class="modal-body">
-   		  	<?php esc_html_e( 'Removing this means customers won\'t be able to receive WhatsApp messages from your business. You\'ll remove the checkbox from your checkout page and stop collecting phone numbers from customers.', 'facebook-for-woocommerce' ); ?>
-   		 </div>
-   		 <div class="modal-footer">
-   		   <button id="modal-cancel" class="button">Cancel</button>
-   		   <button id="warning-modal-confirm" class="button button-primary">Confirm</button>
-   		 </div>
-  		</div>
-		</div>
-		</div>
+			</div>
+			<div id="wc-fb-warning-modal" class="warning-custom-modal">
+   			<div class="warning-modal-content">
+   			   <h2><?php esc_html_e( 'Stop sending messages to customers ?', 'facebook-for-woocommerce' ); ?></h2>
+   			 <div class="warning-modal-body">
+   			  	<?php esc_html_e( 'Removing this means customers won\'t be able to receive WhatsApp messages from your business. You\'ll remove the checkbox from your checkout page and stop collecting phone numbers from customers.', 'facebook-for-woocommerce' ); ?>
+   			 </div>
+   			 <div class="warning-modal-footer">
+   			   <button id="wc-fb-warning-modal-cancel" class="button">Cancel</button>
+   			   <button id="wc-fb-warning-modal-confirm" class="button button-primary">Confirm</button>
+   			 </div>
+  			</div>
+			</div>
 		</div>
 		<?php
 	}
@@ -409,25 +406,22 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 						<input type="radio" name="template-status" value="off" />
 						<label for="template-status"><b><?php esc_html_e( 'Turn off order confirmation', 'facebook-for-woocommerce' ); ?> </b></label>
 					</div>
-
 				</div>
 			</div>
 			<div class="card-item manage-event-template-footer">
 				<div class="manage-event-button">
-
 					<a
 						id="woocommerce-whatsapp-save-order-confirmation"
 						class="button button-primary"
-						href="#"><?php esc_html_e( 'Save', 'facebook-for-woocommerce' ); ?></a>
+						href="#"><?php esc_html_e( 'Save', 'facebook-for-woocommerce' ); ?>
+					</a>
 				</div>
 				<div class="manage-event-button">
-
 					<a
 						id="woocommerce-whatsapp-cancel-order-confirmation"
 						class="button"
 						href="<?php echo esc_html( admin_url( 'admin.php?page=' . self::PAGE_ID . '&tab=' . self::ID . '&view=utility_settings' ) ); ?>"><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></a>
 				</div>
-
 			</div>
 		</div>
 		<?php

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -354,16 +354,16 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				</div>
 			</div>
 			<div id="wc-fb-warning-modal" class="warning-custom-modal">
-   			<div class="warning-modal-content">
-   			   <h2><?php esc_html_e( 'Stop sending messages to customers ?', 'facebook-for-woocommerce' ); ?></h2>
-   			 <div class="warning-modal-body">
-   			  	<?php esc_html_e( 'Removing this means customers won\'t be able to receive WhatsApp messages from your business. You\'ll remove the checkbox from your checkout page and stop collecting phone numbers from customers.', 'facebook-for-woocommerce' ); ?>
-   			 </div>
-   			 <div class="warning-modal-footer">
-   			   <button id="wc-fb-warning-modal-cancel" class="button">Cancel</button>
-   			   <button id="wc-fb-warning-modal-confirm" class="button button-primary">Confirm</button>
-   			 </div>
-  			</div>
+				<div class="warning-modal-content">
+					<h2><?php esc_html_e( 'Stop sending messages to customers ?', 'facebook-for-woocommerce' ); ?></h2>
+				<div class="warning-modal-body">
+				<?php esc_html_e( 'Removing this means customers won\'t be able to receive WhatsApp messages from your business. You\'ll remove the checkbox from your checkout page and stop collecting phone numbers from customers.', 'facebook-for-woocommerce' ); ?>
+				</div>
+				<div class="warning-modal-footer">
+					<button id="wc-fb-warning-modal-cancel" class="button"><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></button>
+					<button id="wc-fb-warning-modal-confirm" class="button button-primary"><?php esc_html_e( 'Remove', 'facebook-for-woocommerce' ); ?></button>
+				</div>
+				</div>
 			</div>
 		</div>
 		<?php


### PR DESCRIPTION
## Description
Add warning modal when whatsapp consent remove button is clicked. Cancel button should disable the setting.

## Figma
<img width="831" alt="Screenshot 2025-04-27 at 11 19 14 PM" src="https://github.com/user-attachments/assets/b8ffb993-a962-4623-a09e-520c315bb302" />


## Type of change
- New feature (non-breaking change which adds functionality)


## Changelog entry
Add warning modal to whatsapp consent remove button


## Test Plan

https://github.com/user-attachments/assets/f39129eb-d86c-415c-80a9-ccc31151df37

Note: The label for confirm button was changed after the recording to "Remove" as per figma


