### PR TITLE
[WAUM][24/n] Gracefully handle errors during Whatsapp connect API call

### DIFF
--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -359,14 +359,20 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			<div class="card-item event-config">
 					<div>
 						<div class="event-config-heading-container">
-							<h3><?php esc_html_e( 'Checkbox', 'facebook-for-woocommerce' ); ?></h3>
+							<h3><?php esc_html_e( 'Add WhatsApp option at checkout', 'facebook-for-woocommerce' ); ?></h3>
 							<div class="event-config-status on-status">
 								<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
-							</div>
 						</div>
-						<p><?php esc_html_e( 'Removing this means you won\'t be able to send messages to your customers.', 'facebook-for-woocommerce' ); ?></p>
 					</div>
-					</div>
+					<span class="consent-update-card-subcontent">
+						<?php esc_html_e( 'Adds a checkbox to your store\'s checkout page that lets customers request updates about their order on WhatsApp. This allows you to communicate with customers after they make a purchase. You can preview what this looks like ', 'facebook-for-woocommerce' ); ?>
+						<a
+							href="<?php echo admin_url( 'post.php?post=' . get_option( 'woocommerce_checkout_page_id' ) . '&action=edit' ); ?>"
+							id="wc-whatsapp-checkout-preview"
+							target="_blank"
+						><?php esc_html_e( 'checkout preview.', 'facebook-for-woocommerce' ); ?>
+						</a>
+					</span>
 					<div class="event-config-manage-button">
 						<a
 							id="wc-whatsapp-collect-consent-remove"

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -357,11 +357,11 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 		</div>
 		<div class="onboarding-card">
 			<div class="card-item event-config">
-					<div>
-						<div class="event-config-heading-container">
-							<h3><?php esc_html_e( 'Add WhatsApp option at checkout', 'facebook-for-woocommerce' ); ?></h3>
-							<div class="event-config-status on-status">
-								<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
+				<div class="card-content">
+					<div class="event-config-heading-container">
+						<h1><?php esc_html_e( 'Add WhatsApp option at checkout', 'facebook-for-woocommerce' ); ?></h1>
+						<div class="event-config-status on-status">
+							<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
 						</div>
 					</div>
 					<span class="consent-update-card-subcontent">
@@ -373,24 +373,25 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 						><?php esc_html_e( 'checkout preview.', 'facebook-for-woocommerce' ); ?>
 						</a>
 					</span>
-					<div class="event-config-manage-button">
-						<a
-							id="wc-whatsapp-collect-consent-remove"
-							class="event-config-manage-button button"
-							href="#"><?php esc_html_e( 'Remove', 'facebook-for-woocommerce' ); ?></a>
-					</div>
+				</div>
+				<div class="event-config-manage-button">
+					<a
+						id="wc-whatsapp-collect-consent-remove"
+						class="event-config-manage-button button"
+						href="#"><?php esc_html_e( 'Remove', 'facebook-for-woocommerce' ); ?>
+					</a>
 				</div>
 			</div>
 			<div id="wc-fb-warning-modal" class="warning-custom-modal">
 				<div class="warning-modal-content">
 					<h2><?php esc_html_e( 'Stop sending messages to customers ?', 'facebook-for-woocommerce' ); ?></h2>
-				<div class="warning-modal-body">
-				<?php esc_html_e( 'Removing this means customers won\'t be able to receive WhatsApp messages from your business. You\'ll remove the checkbox from your checkout page and stop collecting phone numbers from customers.', 'facebook-for-woocommerce' ); ?>
+					<div class="warning-modal-body">
+						<?php esc_html_e( 'Removing this means customers won\'t be able to receive WhatsApp messages from your business. You\'ll remove the checkbox from your checkout page and stop collecting phone numbers from customers.', 'facebook-for-woocommerce' ); ?>
+					</div>
 				</div>
 				<div class="warning-modal-footer">
 					<button id="wc-fb-warning-modal-cancel" class="button"><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></button>
 					<button id="wc-fb-warning-modal-confirm" class="button button-primary"><?php esc_html_e( 'Remove', 'facebook-for-woocommerce' ); ?></button>
-				</div>
 				</div>
 			</div>
 		</div>

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -269,7 +269,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			</div>
 		</div>
 		<div class="error-notice-wrapper">
-			<div id="payment-method-error-notice fbwa-hidden-element"></div>
+			<div id="payment-method-error-notice"></div>
 		</div>
 		<div class="divider"></div>
 		<div class="card-item">

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -357,11 +357,11 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 		</div>
 		<div class="onboarding-card">
 			<div class="card-item event-config">
-				<div class="card-content">
-					<div class="event-config-heading-container">
-						<h1><?php esc_html_e( 'Add WhatsApp option at checkout', 'facebook-for-woocommerce' ); ?></h1>
-						<div class="event-config-status on-status">
-							<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
+					<div>
+						<div class="event-config-heading-container">
+							<h3><?php esc_html_e( 'Add WhatsApp option at checkout', 'facebook-for-woocommerce' ); ?></h3>
+							<div class="event-config-status on-status">
+								<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
 						</div>
 					</div>
 					<span class="consent-update-card-subcontent">
@@ -373,25 +373,24 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 						><?php esc_html_e( 'checkout preview.', 'facebook-for-woocommerce' ); ?>
 						</a>
 					</span>
-				</div>
-				<div class="event-config-manage-button">
-					<a
-						id="wc-whatsapp-collect-consent-remove"
-						class="event-config-manage-button button"
-						href="#"><?php esc_html_e( 'Remove', 'facebook-for-woocommerce' ); ?>
-					</a>
+					<div class="event-config-manage-button">
+						<a
+							id="wc-whatsapp-collect-consent-remove"
+							class="event-config-manage-button button"
+							href="#"><?php esc_html_e( 'Remove', 'facebook-for-woocommerce' ); ?></a>
+					</div>
 				</div>
 			</div>
 			<div id="wc-fb-warning-modal" class="warning-custom-modal">
 				<div class="warning-modal-content">
 					<h2><?php esc_html_e( 'Stop sending messages to customers ?', 'facebook-for-woocommerce' ); ?></h2>
-					<div class="warning-modal-body">
-						<?php esc_html_e( 'Removing this means customers won\'t be able to receive WhatsApp messages from your business. You\'ll remove the checkbox from your checkout page and stop collecting phone numbers from customers.', 'facebook-for-woocommerce' ); ?>
-					</div>
+				<div class="warning-modal-body">
+				<?php esc_html_e( 'Removing this means customers won\'t be able to receive WhatsApp messages from your business. You\'ll remove the checkbox from your checkout page and stop collecting phone numbers from customers.', 'facebook-for-woocommerce' ); ?>
 				</div>
 				<div class="warning-modal-footer">
 					<button id="wc-fb-warning-modal-cancel" class="button"><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></button>
 					<button id="wc-fb-warning-modal-confirm" class="button button-primary"><?php esc_html_e( 'Remove', 'facebook-for-woocommerce' ); ?></button>
+				</div>
 				</div>
 			</div>
 		</div>

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -359,20 +359,14 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			<div class="card-item event-config">
 					<div>
 						<div class="event-config-heading-container">
-							<h3><?php esc_html_e( 'Add WhatsApp option at checkout', 'facebook-for-woocommerce' ); ?></h3>
+							<h3><?php esc_html_e( 'Checkbox', 'facebook-for-woocommerce' ); ?></h3>
 							<div class="event-config-status on-status">
 								<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
+							</div>
 						</div>
+						<p><?php esc_html_e( 'Removing this means you won\'t be able to send messages to your customers.', 'facebook-for-woocommerce' ); ?></p>
 					</div>
-					<span class="consent-update-card-subcontent">
-						<?php esc_html_e( 'Adds a checkbox to your store\'s checkout page that lets customers request updates about their order on WhatsApp. This allows you to communicate with customers after they make a purchase. You can preview what this looks like ', 'facebook-for-woocommerce' ); ?>
-						<a
-							href="<?php echo admin_url( 'post.php?post=' . get_option( 'woocommerce_checkout_page_id' ) . '&action=edit' ); ?>"
-							id="wc-whatsapp-checkout-preview"
-							target="_blank"
-						><?php esc_html_e( 'checkout preview.', 'facebook-for-woocommerce' ); ?>
-						</a>
-					</span>
+					</div>
 					<div class="event-config-manage-button">
 						<a
 							id="wc-whatsapp-collect-consent-remove"

--- a/includes/Handlers/WhatsAppUtilityConnection.php
+++ b/includes/Handlers/WhatsAppUtilityConnection.php
@@ -103,7 +103,7 @@ class WhatsAppUtilityConnection {
 		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			$error_data    = explode( "\n", wp_remote_retrieve_body( $response ) );
 			$error_object  = json_decode( $error_data[0] );
-			$error_message = $error_object->error->error_user_title;
+			$error_message = $error_object->error->error_user_title ?? $error_object->error->message ?? "Something went wrong. Please try again later!";
 
 			wc_get_logger()->info(
 				sprintf(

--- a/includes/Handlers/WhatsAppUtilityConnection.php
+++ b/includes/Handlers/WhatsAppUtilityConnection.php
@@ -103,7 +103,7 @@ class WhatsAppUtilityConnection {
 		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			$error_data    = explode( "\n", wp_remote_retrieve_body( $response ) );
 			$error_object  = json_decode( $error_data[0] );
-			$error_message = $error_object->error->error_user_title ?? $error_object->error->message ?? "Something went wrong. Please try again later!";
+			$error_message = $error_object->error->error_user_title ?? $error_object->error->message ?? 'Something went wrong. Please try again later!';
 
 			wc_get_logger()->info(
 				sprintf(


### PR DESCRIPTION
## Description
When we call connect API if an unknown error occurs then the notice was not show since $error_object->error was empty and exception was thrown. Fetch the error->message on API call for unknown errors or fallback to a default error message.

### Type of change
- New feature (non-breaking change which adds functionality)


## Changelog entry
Gracefully handle errors during Whatsapp connect API call


## Test Plan
<img width="1718" alt="Screenshot 2025-04-28 at 2 26 44 PM" src="https://github.com/user-attachments/assets/dd1cb28b-b9c6-48a4-8981-3c5325131496" />

