### PR TITLE
[WAUM][25/n] Add checkout preview url to whatsapp consent settings update section

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
+++ b/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
@@ -150,46 +150,46 @@
     margin: 5px;
 }
 .warning-custom-modal {
-  display: none; /* Hidden by default */
-  position: absolute;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0,0,0,0.4); /* Black with opacity */
+    display: none; /* Hidden by default */
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0,0,0,0.4); /* Black with opacity */
 }
 /* Modal content */
 .warning-modal-content {
-  background-color: #fefefe;
-  margin: 25% auto;
-  padding: 20px;
-  border: 1px solid #ddd;
-  top: 10%;
-  width: 50%;
-  max-width: 500px;
-  border-radius: 10px;
-  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    background-color: #fefefe;
+    margin: 25% auto;
+    padding: 20px;
+    border: 1px solid #ddd;
+    top: 10%;
+    width: 50%;
+    max-width: 500px;
+    border-radius: 10px;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
 }
 /* Modal body */
 .warning-modal-body {
-  padding: 20px 0;
+    padding: 20px 0;
 }
 /* Modal footer */
 .warning-modal-footer {
-  padding: 10px 0;
-  text-align: right;
+    padding: 10px 0;
+    text-align: right;
 }
 /* Close button */
 .warning-modal-close {
-  color: #aaa;
-  float: right;
-  font-size: 28px;
-  font-weight: bold;
-  cursor: pointer;
-  position: absolute;
-  right: 0;
-  top: 0;
+    color: #aaa;
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+    cursor: pointer;
+    position: absolute;
+    right: 0;
+    top: 0;
 }
 .warning-modal-close:hover {
-  color: #000;
+    color: #000;
 }

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -388,10 +388,10 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 					<div class="warning-modal-body">
 						<?php esc_html_e( 'Removing this means customers won\'t be able to receive WhatsApp messages from your business. You\'ll remove the checkbox from your checkout page and stop collecting phone numbers from customers.', 'facebook-for-woocommerce' ); ?>
 					</div>
-				</div>
-				<div class="warning-modal-footer">
-					<button id="wc-fb-warning-modal-cancel" class="button"><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></button>
-					<button id="wc-fb-warning-modal-confirm" class="button button-primary"><?php esc_html_e( 'Remove', 'facebook-for-woocommerce' ); ?></button>
+					<div class="warning-modal-footer">
+						<button id="wc-fb-warning-modal-cancel" class="button"><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></button>
+						<button id="wc-fb-warning-modal-confirm" class="button button-primary"><?php esc_html_e( 'Remove', 'facebook-for-woocommerce' ); ?></button>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -359,14 +359,20 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			<div class="card-item event-config">
 					<div>
 						<div class="event-config-heading-container">
-							<h3><?php esc_html_e( 'Checkbox', 'facebook-for-woocommerce' ); ?></h3>
+							<h3><?php esc_html_e( 'Add WhatsApp option at checkout', 'facebook-for-woocommerce' ); ?></h3>
 							<div class="event-config-status on-status">
 								<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
-							</div>
 						</div>
-						<p><?php esc_html_e( 'Removing this means you won\'t be able to send messages to your customers.', 'facebook-for-woocommerce' ); ?></p>
 					</div>
-					</div>
+					<span class="consent-update-card-subcontent">
+						<?php esc_html_e( 'Adds a checkbox to your store\'s checkout page that lets customers request updates about their order on WhatsApp. This allows you to communicate with customers after they make a purchase. You can preview what this looks like ', 'facebook-for-woocommerce' ); ?>
+						<a
+							href="<?php echo admin_url( 'post.php?post=' . get_option( 'woocommerce_checkout_page_id' ) . '&action=edit' ); ?>"
+							id="wc-whatsapp-checkout-preview"
+							target="_blank"
+						><?php esc_html_e( 'checkout preview.', 'facebook-for-woocommerce' ); ?>
+						</a>
+					</span>
 					<div class="event-config-manage-button">
 						<a
 							id="wc-whatsapp-collect-consent-remove"

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -367,7 +367,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 					<span class="consent-update-card-subcontent">
 						<?php esc_html_e( 'Adds a checkbox to your store\'s checkout page that lets customers request updates about their order on WhatsApp. This allows you to communicate with customers after they make a purchase. You can preview what this looks like ', 'facebook-for-woocommerce' ); ?>
 						<a
-							href="<?php echo admin_url( 'post.php?post=' . get_option( 'woocommerce_checkout_page_id' ) . '&action=edit' ); ?>"
+							href="<?php echo esc_url( admin_url( 'post.php?post=' . get_option( 'woocommerce_checkout_page_id' ) . '&action=edit' ) ); ?>"
 							id="wc-whatsapp-checkout-preview"
 							target="_blank"
 						><?php esc_html_e( 'checkout preview.', 'facebook-for-woocommerce' ); ?>

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -357,11 +357,11 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 		</div>
 		<div class="onboarding-card">
 			<div class="card-item event-config">
-					<div>
-						<div class="event-config-heading-container">
-							<h3><?php esc_html_e( 'Add WhatsApp option at checkout', 'facebook-for-woocommerce' ); ?></h3>
-							<div class="event-config-status on-status">
-								<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
+				<div class="card-content">
+					<div class="event-config-heading-container">
+						<h1><?php esc_html_e( 'Add WhatsApp option at checkout', 'facebook-for-woocommerce' ); ?></h1>
+						<div class="event-config-status on-status">
+							<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
 						</div>
 					</div>
 					<span class="consent-update-card-subcontent">
@@ -373,24 +373,25 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 						><?php esc_html_e( 'checkout preview.', 'facebook-for-woocommerce' ); ?>
 						</a>
 					</span>
-					<div class="event-config-manage-button">
-						<a
-							id="wc-whatsapp-collect-consent-remove"
-							class="event-config-manage-button button"
-							href="#"><?php esc_html_e( 'Remove', 'facebook-for-woocommerce' ); ?></a>
-					</div>
+				</div>
+				<div class="event-config-manage-button">
+					<a
+						id="wc-whatsapp-collect-consent-remove"
+						class="event-config-manage-button button"
+						href="#"><?php esc_html_e( 'Remove', 'facebook-for-woocommerce' ); ?>
+					</a>
 				</div>
 			</div>
 			<div id="wc-fb-warning-modal" class="warning-custom-modal">
 				<div class="warning-modal-content">
 					<h2><?php esc_html_e( 'Stop sending messages to customers ?', 'facebook-for-woocommerce' ); ?></h2>
-				<div class="warning-modal-body">
-				<?php esc_html_e( 'Removing this means customers won\'t be able to receive WhatsApp messages from your business. You\'ll remove the checkbox from your checkout page and stop collecting phone numbers from customers.', 'facebook-for-woocommerce' ); ?>
+					<div class="warning-modal-body">
+						<?php esc_html_e( 'Removing this means customers won\'t be able to receive WhatsApp messages from your business. You\'ll remove the checkbox from your checkout page and stop collecting phone numbers from customers.', 'facebook-for-woocommerce' ); ?>
+					</div>
 				</div>
 				<div class="warning-modal-footer">
 					<button id="wc-fb-warning-modal-cancel" class="button"><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></button>
 					<button id="wc-fb-warning-modal-confirm" class="button button-primary"><?php esc_html_e( 'Remove', 'facebook-for-woocommerce' ); ?></button>
-				</div>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
## Description
Add checkout preview url to whatsapp consent settings update section. Also, format files to remove unnecessary divs and align css.

## Figma
<img width="709" alt="Screenshot 2025-04-28 at 5 34 42 PM" src="https://github.com/user-attachments/assets/2b58e2ed-e3bd-4417-9103-cc10bbb538d8" />

## Type of change
- New feature (non-breaking change which adds functionality)


## Changelog entry
Add checkout preview url to whatsapp consent settings update section


## Test Plan

https://github.com/user-attachments/assets/dfe3f351-ff03-469e-a252-f989da91ad48


