### PR TITLE
[WAUM][26/n]Fix the onclick null property when on onboarding view

### DIFF
--- a/assets/js/admin/whatsapp-consent-remove.js
+++ b/assets/js/admin/whatsapp-consent-remove.js
@@ -22,27 +22,32 @@ jQuery( document ).ready( function( $ ) {
         event.preventDefault();
     });
 
-    // Close modal when clicking the Cancel button
-    cancelButton.onclick = function() {
-        modal.style.display = "none";
-    };
+    if(cancelButton) {
+        // Close modal when clicking the Cancel button
+        cancelButton.onclick = function() {
+            modal.style.display = "none";
+        };
+    }
 
+
+    if(cancelButton) {
     // Handle confirm action
-    confirmButton.onclick = function() {
-        // Send the AJAX request to disable WhatsApp consent collection
-        $.post(facebook_for_woocommerce_whatsapp_consent_remove.ajax_url, {
-            action: 'wc_facebook_whatsapp_consent_collection_disable',
-            nonce: facebook_for_woocommerce_whatsapp_consent_remove.nonce
-        }, function(response) {
-            if (response.success) {
-                console.log('success', response);
-                // You can add a redirect or page refresh here if needed
-            }
-        });
+        confirmButton.onclick = function() {
+            // Send the AJAX request to disable WhatsApp consent collection
+            $.post(facebook_for_woocommerce_whatsapp_consent_remove.ajax_url, {
+                action: 'wc_facebook_whatsapp_consent_collection_disable',
+                nonce: facebook_for_woocommerce_whatsapp_consent_remove.nonce
+            }, function(response) {
+                if (response.success) {
+                    console.log('success', response);
+                    // You can add a redirect or page refresh here if needed
+                }
+            });
 
-        // Close the modal
-        modal.style.display = "none";
-    };
+            // Close the modal
+            modal.style.display = "none";
+        };
+    }
 
     // Close modal when clicking outside of it
     window.onclick = function(event) {

--- a/assets/js/admin/whatsapp-consent-remove.js
+++ b/assets/js/admin/whatsapp-consent-remove.js
@@ -30,7 +30,7 @@ jQuery( document ).ready( function( $ ) {
     }
 
 
-    if(cancelButton) {
+    if(confirmButton) {
     // Handle confirm action
         confirmButton.onclick = function() {
             // Send the AJAX request to disable WhatsApp consent collection


### PR DESCRIPTION
## Description
In the onboarding view, the Confirm and Cancel Button are not available causing null error. Fix the null property issue when on onboarding view by checking for property before manipulating the onclick callback.

### Type of change
- Bug fix (non-breaking change which fixes an issue)


## Changelog entry
Fix the onclick null property when on onboarding view


## Test Plan

https://github.com/user-attachments/assets/810c089c-31f7-4c16-8cce-b05e2f25e3bd


