### PR TITLE
Fix cursor style not resetting after attribute removal

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1770,28 +1770,43 @@ class Admin {
 							$field.find('option:first').prop('selected', true);
 						}
 						
-						// Make sure it's visible and enabled
-						$field.show().prop('disabled', false).removeClass('synced-attribute');
-						
-						// If this is a WooCommerce select2 field, reset the select2 as well
+						// Reset select2 if it's initialized
 						if ($field.hasClass('wc-enhanced-select') || $field.hasClass('select2-hidden-accessible')) {
 							try {
 								$field.select2('val', '');
+								// Also reset the select2 container styles
+								$field.next('.select2-container').find('.select2-selection').css({
+									'cursor': '',
+									'background-color': '',
+									'color': ''
+								});
 							} catch (e) {
-								// Ignore select2 errors, it might not be initialized
+								// Ignore select2 errors
 							}
 						}
-					} else {
-						// For text fields
-						$field.val('');
 					}
-					
-					// Remove any remaining custom styling
-					$field.css({
-						'background-color': '',
-						'color': '',
-						'border-color': ''
-					});
+
+					// Reset all styles and classes
+					$field
+						.val('')
+						.prop('disabled', false)
+						.removeClass('synced-attribute')
+						.css({
+							'cursor': '',
+							'background-color': '',
+							'color': '',
+							'border-color': '',
+							'opacity': ''
+						})
+						.show();
+
+					// Also reset any select2 container if it exists
+					if ($field.next('.select2-container').length) {
+						$field.next('.select2-container').css({
+							'cursor': '',
+							'opacity': ''
+						});
+					}
 				}
 
 				// Function to sync Facebook attributes

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -449,7 +449,6 @@ class Admin {
 	public function add_products_by_sync_enabled_input_filter() {
 		global $typenow;
 
-		
 		if ( 'product' !== $typenow ) {
 			return;
 		}

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -449,6 +449,7 @@ class Admin {
 	public function add_products_by_sync_enabled_input_filter() {
 		global $typenow;
 
+		
 		if ( 'product' !== $typenow ) {
 			return;
 		}


### PR DESCRIPTION
## Description

This PR fixes an issue where the cursor style remains in a "not-allowed" state after removing a dropdown attribute in the Facebook for WooCommerce tab. Previously, when removing an attribute, the cursor would incorrectly remain in a disabled state even though the field was re-enabled.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki](https://fburl.com/wiki/2cgfduwc).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki](https://fburl.com/wiki/nhx73tgs).

## Changelog entry

Fixed: Cursor style not resetting properly after removing product attributes in Facebook catalog settings

## Test Plan

1. Navigate to a product's edit page in WooCommerce
2. Go to the Attributes tab and add a new attribute (e.g., "Age group")
3. Switch to the Facebook tab and verify the attribute is synced
4. Return to Attributes tab and remove the attribute
5. Switch back to Facebook tab and verify:
   - The field is properly reset
   - The cursor style is back to default
   - All synced state indicators are removed
   - Select2 dropdowns (if present) are properly reset



## Screenshots
### Before
The cursor remained in "not-allowed" state after attribute removal:

### After
Cursor and all styles properly reset after attribute removal:
