### PR TITLE
[WAUM] Consent Collection - Adding logic to the "remove" button, toggling 'On' to 'Off' status. 

### DIFF
--- a/assets/js/admin/whatsapp-consent-remove.js
+++ b/assets/js/admin/whatsapp-consent-remove.js
@@ -12,6 +12,7 @@ jQuery( document ).ready( function( $ ) {
     var modal = document.getElementById("wc-fb-warning-modal");
     var cancelButton = document.getElementById("wc-fb-warning-modal-cancel");
     var confirmButton = document.getElementById("wc-fb-warning-modal-confirm");
+    var $statusElement = $('#wc-whatsapp-collect-consent-status');
 
     // On click of the remove button, show the warning modal
     $("#wc-whatsapp-collect-consent-remove").click(function(event) {
@@ -22,16 +23,15 @@ jQuery( document ).ready( function( $ ) {
         event.preventDefault();
     });
 
-    if(cancelButton) {
+    if (cancelButton) {
         // Close modal when clicking the Cancel button
         cancelButton.onclick = function() {
             modal.style.display = "none";
         };
     }
 
-
-    if(confirmButton) {
-    // Handle confirm action
+    if (confirmButton) {
+        // Handle confirm action
         confirmButton.onclick = function() {
             // Send the AJAX request to disable WhatsApp consent collection
             $.post(facebook_for_woocommerce_whatsapp_consent_remove.ajax_url, {
@@ -40,7 +40,18 @@ jQuery( document ).ready( function( $ ) {
             }, function(response) {
                 if (response.success) {
                     console.log('success', response);
-                    // You can add a redirect or page refresh here if needed
+                    // Change the status from "on-status" to "off-status" for the specific element.
+                    $statusElement.removeClass('on-status').addClass('off-status');
+                    // Update the text to "Off".
+                    $statusElement.text('Off');
+
+                    // Hide the original "Remove" button
+                    $('#wc-whatsapp-collect-consent-remove-container').addClass('fbwa-hidden-element');
+
+                    // Show the "Add" button
+                    $('#wc-whatsapp-collect-consent-add-container').removeClass('fbwa-hidden-element');
+                } else {
+                    console.error('Error:', response);
                 }
             });
 
@@ -49,11 +60,35 @@ jQuery( document ).ready( function( $ ) {
         };
     }
 
+    // Add event listener to the "Add" button
+    $('#wc-whatsapp-collect-consent-add').click(function() {
+        // Send the AJAX request to enable WhatsApp consent collection
+        $.post(facebook_for_woocommerce_whatsapp_consent.ajax_url, {
+            action: 'wc_facebook_whatsapp_consent_collection_enable',
+            nonce: facebook_for_woocommerce_whatsapp_consent.nonce
+        }, function(response) {
+            if (response.success) {
+                console.log('success', response);
+                // Change the status from "off-status" to "on-status" for the specific element.
+                $statusElement.removeClass('off-status').addClass('on-status');
+                // Update the text to "On".
+                $statusElement.text('On');
+
+                // Hide the "Add" button
+                $('#wc-whatsapp-collect-consent-add-container').addClass('fbwa-hidden-element');
+
+                // Show the original "Remove" button
+                $('#wc-whatsapp-collect-consent-remove-container').removeClass('fbwa-hidden-element');
+            } else {
+                console.error('Error:', response);
+            }
+        });
+    });
+
     // Close modal when clicking outside of it
     window.onclick = function(event) {
         if (event.target == modal) {
             modal.style.display = "none";
         }
     };
-
-} );
+});

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -362,7 +362,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<div class="card-content">
 					<div class="event-config-heading-container">
 						<h1><?php esc_html_e( 'Add WhatsApp option at checkout', 'facebook-for-woocommerce' ); ?></h1>
-						<div class="event-config-status on-status">
+						<div id="wc-whatsapp-collect-consent-status" class="event-config-status on-status">
 							<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
 						</div>
 					</div>
@@ -376,11 +376,18 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 						</a>
 					</span>
 				</div>
-				<div class="event-config-manage-button">
+				<div class="event-config-manage-button" id="wc-whatsapp-collect-consent-remove-container">
 					<a
 						id="wc-whatsapp-collect-consent-remove"
 						class="event-config-manage-button button"
 						href="#"><?php esc_html_e( 'Remove', 'facebook-for-woocommerce' ); ?>
+					</a>
+				</div>
+				<div class="event-config-manage-button fbwa-hidden-element" id="wc-whatsapp-collect-consent-add-container">
+					<a
+						id="wc-whatsapp-collect-consent-add"
+						class="event-config-manage-button button"
+						href="#"><?php esc_html_e( 'Add', 'facebook-for-woocommerce' ); ?>
 					</a>
 				</div>
 			</div>


### PR DESCRIPTION
## Description

Adding UI changes to handle "Remove" button logic, now when the user clicks on "Remove" button we would disable the consent collection feature and also turn the "On" button to "Off", we will also change the "Remove" button to "Add", logic for enabling consent collection back again is remaining.

### Type of change

- New feature (non-breaking change which adds functionality)


## Changelog entry
Handle logic for "Remove" button click, for consent collection widget.


## Test Plan
1. Open Marketing > Facebook tab in wordpress containing facebook-for-woocommerce screens
2. Open Utility Messages tab on the right.
3. After onboarding is completed, user is redirected to Utility Flows.
4. User clicks on "Remove" button to remove the consent.
5. Checked the Remove button turns to "Add" button.
6. Checked the green "On" button turns to grey "Off".

## Screenshots
### Before
Nothing happens on UI, after clicking remove button.

### After



https://github.com/user-attachments/assets/c3fa839a-9b49-4eda-a0be-fe52a3f77424


https://github.com/user-attachments/assets/ff9d342b-4c91-419c-8537-660046bcf55f




