### PR TITLE
[WAUM][Easy] Fix css for Event Management view

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
+++ b/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
@@ -112,6 +112,13 @@
     color: #FFFFFF;
     border:none;
 }
+.manage-event-card-item {
+    padding: 20px;
+    justify-content: space-between;
+}
+.manage-event-selector {
+    min-width: 100%;
+}
 .manage-event-template-block {
     border: 1px solid #c4c3c3;
     margin-bottom: 20px;
@@ -126,6 +133,7 @@
     padding: 20px;
     display: flex;
     flex-direction: row-reverse;
+    justify-content: flex-start;
 }
 .manage-event-button {
     margin-left: 20px;

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -407,28 +407,28 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	public function render_manage_events_view() {
 		?>
 		<div class="onboarding-card">
-			<div class="card-item">
+			<div class="manage-event-card-item">
 				<div class="card-content">
 					<h1><b><?php esc_html_e( 'Manage order confirmation message', 'facebook-for-woocommerce' ); ?></b></h1>
 					<p><?php esc_html_e( 'Send a confirmation to customers after they\'ve placed an order.', 'facebook-for-woocommerce' ); ?></p>
 				</div>
 			</div>
 			<div class="divider"></div>
-			<div class="card-item">
+			<div class="manage-event-card-item">
 				<p><b><?php esc_html_e( 'Select a language', 'facebook-for-woocommerce' ); ?></b></p>
-				<select id="manage-event-language">
+				<select id="manage-event-language" class="manage-event-selector">
 					<option value="en_US">English (US)</option>
 					<option value="en_UK">English (UK)</option>
 				</select>
 			</div>
-			<div class="card-item">
+			<div class="manage-event-card-item">
 				<div class="manage-event-template-block">
 					<div class="manage-event-template-header">
 						<input type="radio" name="template-status" id="active-template-status" value="ACTIVE" checked="checked" />
 						<label for="active-template-status"><b><?php esc_html_e( 'Send order confirmation message', 'facebook-for-woocommerce' ); ?> </b></label>
 					</div>
 					<div class="divider"></div>
-					<div class="card-item fbwa-hidden-element" id="library-template-content"></div>
+					<div class="manage-event-card-item fbwa-hidden-element" id="library-template-content"></div>
 				</div>
 				<div class="manage-event-template-block">
 					<div class="manage-event-template-header">
@@ -437,7 +437,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 					</div>
 				</div>
 			</div>
-			<div class="card-item manage-event-template-footer">
+			<div class="manage-event-card-item manage-event-template-footer">
 				<div class="manage-event-button">
 					<a
 						id="woocommerce-whatsapp-save-order-confirmation"


### PR DESCRIPTION
## Description
Fix the alignment of the css in Event Management view to match the figma:
<img width="894" alt="Screenshot 2025-04-30 at 11 14 58 PM" src="https://github.com/user-attachments/assets/8ff1113f-4841-4710-9d15-2bec96ab69ae" />

### Type of change
- Bug fix (non-breaking change which fixes an issue)


## Changelog entry
Fix alignment of components in Event Management view

## Test Plan
1. Open Whatsapp Utility Tab
2. In Utility Settings view, select Manage for Order Confirmation

## Screenshots
### Before
<img width="1720" alt="Screenshot 2025-04-30 at 11 38 47 PM" src="https://github.com/user-attachments/assets/10eaf844-b176-4797-813b-c828be657e64" />

### After
<img width="1720" alt="Screenshot 2025-04-30 at 11 32 18 PM" src="https://github.com/user-attachments/assets/f89cf720-9c1e-4f72-9ca7-2a1ff9b8e35d" />

