### PR TITLE
[WAUM] Surface On/Off Status for available Utility Events

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
+++ b/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
@@ -112,6 +112,13 @@
     color: #FFFFFF;
     border:none;
 }
+.manage-event-card-item {
+    padding: 20px;
+    justify-content: space-between;
+}
+.manage-event-selector {
+    min-width: 100%;
+}
 .manage-event-template-block {
     border: 1px solid #c4c3c3;
     margin-bottom: 20px;
@@ -126,6 +133,7 @@
     padding: 20px;
     display: flex;
     flex-direction: row-reverse;
+    justify-content: flex-start;
 }
 .manage-event-button {
     margin-left: 20px;

--- a/assets/js/admin/whatsapp-events.js
+++ b/assets/js/admin/whatsapp-events.js
@@ -41,4 +41,24 @@ jQuery( document ).ready( function( $ ) {
             }
         });
     });
+
+    $('#woocommerce-whatsapp-save-order-confirmation').click(function (event) {
+        var languageValue = $("#manage-event-language").val();
+        var statusValue = $('input[name="template-status"]:checked').val();
+        console.log('Save confirmation clicked: ', languageValue, statusValue);
+        $.post(facebook_for_woocommerce_whatsapp_events.ajax_url, {
+            action: 'wc_facebook_whatsapp_upsert_event_config',
+            nonce: facebook_for_woocommerce_whatsapp_events.nonce,
+            event: 'ORDER_PLACED',
+            language: languageValue,
+            status: statusValue
+        }, function (response) {
+            //TODO: Add Error Handling
+            let url = new URL(window.location.href);
+            let params = new URLSearchParams(url.search);
+            params.set('view', 'utility_settings');
+            url.search = params.toString();
+            window.location.href = url.toString();
+        });
+    });
 });

--- a/assets/js/admin/whatsapp-events.js
+++ b/assets/js/admin/whatsapp-events.js
@@ -8,6 +8,42 @@
  */
 
 jQuery( document ).ready( function( $ ) {
+    // Set Event Status for Order Placed
+    var orderPlacedActiveStatus = $('#order-placed-active-status');
+    var orderPlacedInactiveStatus = $('#order-placed-inactive-status');
+    if(facebook_for_woocommerce_whatsapp_events.order_placed_enabled){
+        orderPlacedInactiveStatus.hide();
+        orderPlacedActiveStatus.show();
+    }
+    else {
+        orderPlacedActiveStatus.hide();
+        orderPlacedInactiveStatus.show();
+    }
+
+    // Set Event Status for Order Shipped
+    var orderShippedActiveStatus = $('#order-shipped-active-status');
+    var orderShippedInactiveStatus = $('#order-shipped-inactive-status');
+    if(facebook_for_woocommerce_whatsapp_events.order_shipped_enabled){
+        orderShippedInactiveStatus.hide();
+        orderShippedActiveStatus.show();
+    }
+    else {
+        orderShippedActiveStatus.hide();
+        orderShippedInactiveStatus.show();
+    }
+
+    // Set Event Status for Order Refunded
+    var orderRefundedActiveStatus = $('#order-refunded-active-status');
+    var orderRefundedInactiveStatus = $('#order-refunded-inactive-status');
+    if(facebook_for_woocommerce_whatsapp_events.order_refunded_enabled){
+        orderRefundedInactiveStatus.hide();
+        orderRefundedActiveStatus.show();
+    }
+    else {
+        orderRefundedActiveStatus.hide();
+        orderRefundedInactiveStatus.show();
+    }
+
     // update current view from utility settings to manage event when order confirmation button is clicked.
     $('#woocommerce-whatsapp-manage-order-confirmation').click(function (event) {
         let url = new URL(window.location.href);

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -64,6 +64,9 @@ class AJAX {
 		// fetch configured library template info
 		add_action( 'wp_ajax_wc_facebook_whatsapp_fetch_library_template_info', array( $this, 'whatsapp_fetch_library_template_info' ) );
 
+		// action to create or update utility event config info
+		add_action( 'wp_ajax_wc_facebook_whatsapp_upsert_event_config', array( $this, 'whatsapp_upsert_event_config' ) );
+
 		// search a product's attributes for the given term
 		add_action( 'wp_ajax_' . self::ACTION_SEARCH_PRODUCT_ATTRIBUTES, array( $this, 'admin_search_product_attributes' ) );
 
@@ -290,6 +293,33 @@ class AJAX {
 			wp_send_json_error( 'Missing access token for Library template API call' );
 		}
 		WhatsAppUtilityConnection::get_template_library_content( $bisu_token );
+	}
+
+	/**
+	 * Creates or Updates WhatsApp Utility Event Configs
+	 *
+	 * @internal
+	 *
+	 * @since 1.10.0
+	 */
+	public function whatsapp_upsert_event_config() {
+		facebook_for_woocommerce()->log( 'Calling POST API to upsert whatsapp utility event' );
+		if ( ! check_ajax_referer( 'facebook-for-wc-whatsapp-events-nonce', 'nonce', false ) ) {
+			wp_send_json_error( 'Invalid security token sent.' );
+		}
+		// Get BISU token
+		$bisu_token = get_option( 'wc_facebook_wa_integration_bisu_access_token', null );
+		if ( empty( $bisu_token ) ) {
+			wp_send_json_error( 'Missing access token for Event Configs POST API call' );
+		}
+		// Get POST parameters from the request
+		$event    = isset( $_POST['event'] ) ? wc_clean( wp_unslash( $_POST['event'] ) ) : '';
+		$language = isset( $_POST['language'] ) ? wc_clean( wp_unslash( $_POST['language'] ) ) : '';
+		$status   = isset( $_POST['status'] ) ? wc_clean( wp_unslash( $_POST['status'] ) ) : '';
+		if ( empty( $event ) || empty( $language ) || empty( $status ) ) {
+			wp_send_json_error( 'Missing request parameters for Event Configs POST API call' );
+		}
+		WhatsAppUtilityConnection::post_whatsapp_utility_messages_event_configs_call( $event, $language, $status, $bisu_token );
 	}
 
 	/**

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -117,6 +117,9 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				),
 			)
 		);
+		$order_placed_event_config_id   = get_option( 'wc_facebook_wa_order_placed_event_config_id', '' );
+		$order_shipped_event_config_id  = get_option( 'wc_facebook_wa_order_shipped_event_config_id', '' );
+		$order_refunded_event_config_id = get_option( 'wc_facebook_wa_order_refunded_event_config_id', '' );
 		wp_enqueue_script(
 			'facebook-for-woocommerce-whatsapp-events',
 			facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/whatsapp-events.js',
@@ -127,9 +130,12 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			'facebook-for-woocommerce-whatsapp-events',
 			'facebook_for_woocommerce_whatsapp_events',
 			array(
-				'ajax_url' => admin_url( 'admin-ajax.php' ),
-				'nonce'    => wp_create_nonce( 'facebook-for-wc-whatsapp-events-nonce' ),
-				'i18n'     => array(
+				'ajax_url'               => admin_url( 'admin-ajax.php' ),
+				'nonce'                  => wp_create_nonce( 'facebook-for-wc-whatsapp-events-nonce' ),
+				'order_placed_enabled'   => ! empty( $order_placed_event_config_id ),
+				'order_shipped_enabled'  => ! empty( $order_shipped_event_config_id ),
+				'order_refunded_enabled' => ! empty( $order_refunded_event_config_id ),
+				'i18n'                   => array(
 					'result' => true,
 				),
 			)
@@ -306,8 +312,11 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<div>
 					<div class="event-config-heading-container">
 						<h3><?php esc_html_e( 'Order confirmation', 'facebook-for-woocommerce' ); ?></h3>
-						<div class="event-config-status on-status">
+						<div class="event-config-status on-status fbwa-hidden-element" id="order-placed-active-status">
 							<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
+						</div>
+						<div class="event-config-status fbwa-hidden-element" id="order-placed-inactive-status">
+							<?php esc_html_e( 'Off', 'facebook-for-woocommerce' ); ?>
 						</div>
 					</div>
 					<p><?php esc_html_e( 'Send a confirmation to customers after they\'ve placed an order.', 'facebook-for-woocommerce' ); ?></p>
@@ -324,7 +333,10 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<div>
 					<div class="event-config-heading-container">
 						<h3><?php esc_html_e( 'Order shipped', 'facebook-for-woocommerce' ); ?></h3>
-						<div class="event-config-status">
+						<div class="event-config-status on-status fbwa-hidden-element" id="order-shipped-active-status">
+							<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
+						</div>
+						<div class="event-config-status fbwa-hidden-element" id="order-shipped-inactive-status">
 							<?php esc_html_e( 'Off', 'facebook-for-woocommerce' ); ?>
 						</div>
 					</div>
@@ -342,7 +354,10 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<div>
 					<div class="event-config-heading-container">
 						<h3><?php esc_html_e( 'Order refunded', 'facebook-for-woocommerce' ); ?></h3>
-						<div class="event-config-status">
+						<div class="event-config-status on-status fbwa-hidden-element" id="order-refunded-active-status">
+							<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
+						</div>
+						<div class="event-config-status fbwa-hidden-element" id="order-refunded-inactive-status">
 							<?php esc_html_e( 'Off', 'facebook-for-woocommerce' ); ?>
 						</div>
 					</div>

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -408,8 +408,10 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 		?>
 		<div class="onboarding-card">
 			<div class="card-item">
-				<h1><b><?php esc_html_e( 'Manage order confirmation message', 'facebook-for-woocommerce' ); ?></b></h1>
-				<p><?php esc_html_e( 'Send a confirmation to customers after they\'ve placed an order.', 'facebook-for-woocommerce' ); ?></p>
+				<div class="card-content">
+					<h1><b><?php esc_html_e( 'Manage order confirmation message', 'facebook-for-woocommerce' ); ?></b></h1>
+					<p><?php esc_html_e( 'Send a confirmation to customers after they\'ve placed an order.', 'facebook-for-woocommerce' ); ?></p>
+				</div>
 			</div>
 			<div class="divider"></div>
 			<div class="card-item">
@@ -422,16 +424,16 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			<div class="card-item">
 				<div class="manage-event-template-block">
 					<div class="manage-event-template-header">
-						<input type="radio" name="template-status" value="on" />
-						<label for="template-status"><b><?php esc_html_e( 'Send order confirmation message', 'facebook-for-woocommerce' ); ?> </b></label>
+						<input type="radio" name="template-status" id="active-template-status" value="ACTIVE" checked="checked" />
+						<label for="active-template-status"><b><?php esc_html_e( 'Send order confirmation message', 'facebook-for-woocommerce' ); ?> </b></label>
 					</div>
 					<div class="divider"></div>
 					<div class="card-item fbwa-hidden-element" id="library-template-content"></div>
 				</div>
 				<div class="manage-event-template-block">
 					<div class="manage-event-template-header">
-						<input type="radio" name="template-status" value="off" />
-						<label for="template-status"><b><?php esc_html_e( 'Turn off order confirmation', 'facebook-for-woocommerce' ); ?> </b></label>
+						<input type="radio" name="template-status" id="inactive-template-status" value="INACTIVE" />
+						<label for="inactive-template-status"><b><?php esc_html_e( 'Turn off order confirmation', 'facebook-for-woocommerce' ); ?> </b></label>
 					</div>
 				</div>
 			</div>

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -407,28 +407,28 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	public function render_manage_events_view() {
 		?>
 		<div class="onboarding-card">
-			<div class="card-item">
+			<div class="manage-event-card-item">
 				<div class="card-content">
 					<h1><b><?php esc_html_e( 'Manage order confirmation message', 'facebook-for-woocommerce' ); ?></b></h1>
 					<p><?php esc_html_e( 'Send a confirmation to customers after they\'ve placed an order.', 'facebook-for-woocommerce' ); ?></p>
 				</div>
 			</div>
 			<div class="divider"></div>
-			<div class="card-item">
+			<div class="manage-event-card-item">
 				<p><b><?php esc_html_e( 'Select a language', 'facebook-for-woocommerce' ); ?></b></p>
-				<select id="manage-event-language">
+				<select id="manage-event-language" class="manage-event-selector">
 					<option value="en_US">English (US)</option>
 					<option value="en_UK">English (UK)</option>
 				</select>
 			</div>
-			<div class="card-item">
+			<div class="manage-event-card-item">
 				<div class="manage-event-template-block">
 					<div class="manage-event-template-header">
 						<input type="radio" name="template-status" id="active-template-status" value="ACTIVE" checked="checked" />
 						<label for="active-template-status"><b><?php esc_html_e( 'Send order confirmation message', 'facebook-for-woocommerce' ); ?> </b></label>
 					</div>
 					<div class="divider"></div>
-					<div class="card-item fbwa-hidden-element" id="library-template-content"></div>
+					<div class="manage-event-card-item fbwa-hidden-element" id="library-template-content"></div>
 				</div>
 				<div class="manage-event-template-block">
 					<div class="manage-event-template-header">
@@ -437,7 +437,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 					</div>
 				</div>
 			</div>
-			<div class="card-item manage-event-template-footer">
+			<div class="manage-event-card-item manage-event-template-footer">
 				<div class="manage-event-button">
 					<a
 						id="woocommerce-whatsapp-save-order-confirmation"


### PR DESCRIPTION
Changes to show on and off status for Order placed, Order shipped, Order refunded events in WhatsApp Utility Settings view.

### Type of change
- New feature (non-breaking change which adds functionality)

## Changelog entry
Changes to display on and off event status for WhatsApp Utility Events

## Test Plan
1. Open WhatsApp Utility Tab
2. In Utility Settings view, validate On/Off status is visible in Utility Messages card.
3. Click on Manage for Order Confirmation and select option to deactivate event.
4. Validate status for Order Confirmation is updated to Off after clicking Save
5. Click on Manage for Order Confirmation and select option to activate event
6. Validate status for Order Confirmation is updated to On after clicking Save

## Screen Recording

https://github.com/user-attachments/assets/308fa413-bc89-42f1-8497-6cb22cc65247


