### PR TITLE
[WAUM] Surface On/Off Status for available Utility Events

### DIFF
--- a/assets/js/admin/whatsapp-events.js
+++ b/assets/js/admin/whatsapp-events.js
@@ -8,6 +8,42 @@
  */
 
 jQuery( document ).ready( function( $ ) {
+    // Set Event Status for Order Placed
+    var orderPlacedActiveStatus = $('#order-placed-active-status');
+    var orderPlacedInactiveStatus = $('#order-placed-inactive-status');
+    if(facebook_for_woocommerce_whatsapp_events.order_placed_enabled){
+        orderPlacedInactiveStatus.hide();
+        orderPlacedActiveStatus.show();
+    }
+    else {
+        orderPlacedActiveStatus.hide();
+        orderPlacedInactiveStatus.show();
+    }
+
+    // Set Event Status for Order Shipped
+    var orderShippedActiveStatus = $('#order-shipped-active-status');
+    var orderShippedInactiveStatus = $('#order-shipped-inactive-status');
+    if(facebook_for_woocommerce_whatsapp_events.order_shipped_enabled){
+        orderShippedInactiveStatus.hide();
+        orderShippedActiveStatus.show();
+    }
+    else {
+        orderShippedActiveStatus.hide();
+        orderShippedInactiveStatus.show();
+    }
+
+    // Set Event Status for Order Refunded
+    var orderRefundedActiveStatus = $('#order-refunded-active-status');
+    var orderRefundedInactiveStatus = $('#order-refunded-inactive-status');
+    if(facebook_for_woocommerce_whatsapp_events.order_refunded_enabled){
+        orderRefundedInactiveStatus.hide();
+        orderRefundedActiveStatus.show();
+    }
+    else {
+        orderRefundedActiveStatus.hide();
+        orderRefundedInactiveStatus.show();
+    }
+
     // update current view from utility settings to manage event when order confirmation button is clicked.
     $('#woocommerce-whatsapp-manage-order-confirmation').click(function (event) {
         let url = new URL(window.location.href);

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -117,6 +117,9 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				),
 			)
 		);
+		$order_placed_event_config_id   = get_option( 'wc_facebook_wa_order_placed_event_config_id', '' );
+		$order_shipped_event_config_id  = get_option( 'wc_facebook_wa_order_shipped_event_config_id', '' );
+		$order_refunded_event_config_id = get_option( 'wc_facebook_wa_order_refunded_event_config_id', '' );
 		wp_enqueue_script(
 			'facebook-for-woocommerce-whatsapp-events',
 			facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/whatsapp-events.js',
@@ -127,9 +130,12 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			'facebook-for-woocommerce-whatsapp-events',
 			'facebook_for_woocommerce_whatsapp_events',
 			array(
-				'ajax_url' => admin_url( 'admin-ajax.php' ),
-				'nonce'    => wp_create_nonce( 'facebook-for-wc-whatsapp-events-nonce' ),
-				'i18n'     => array(
+				'ajax_url'               => admin_url( 'admin-ajax.php' ),
+				'nonce'                  => wp_create_nonce( 'facebook-for-wc-whatsapp-events-nonce' ),
+				'order_placed_enabled'   => ! empty( $order_placed_event_config_id ),
+				'order_shipped_enabled'  => ! empty( $order_shipped_event_config_id ),
+				'order_refunded_enabled' => ! empty( $order_refunded_event_config_id ),
+				'i18n'                   => array(
 					'result' => true,
 				),
 			)
@@ -323,8 +329,11 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<div>
 					<div class="event-config-heading-container">
 						<h3><?php esc_html_e( 'Order confirmation', 'facebook-for-woocommerce' ); ?></h3>
-						<div class="event-config-status on-status">
+						<div class="event-config-status on-status fbwa-hidden-element" id="order-placed-active-status">
 							<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
+						</div>
+						<div class="event-config-status fbwa-hidden-element" id="order-placed-inactive-status">
+							<?php esc_html_e( 'Off', 'facebook-for-woocommerce' ); ?>
 						</div>
 					</div>
 					<p><?php esc_html_e( 'Send a confirmation to customers after they\'ve placed an order.', 'facebook-for-woocommerce' ); ?></p>
@@ -341,7 +350,10 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<div>
 					<div class="event-config-heading-container">
 						<h3><?php esc_html_e( 'Order shipped', 'facebook-for-woocommerce' ); ?></h3>
-						<div class="event-config-status">
+						<div class="event-config-status on-status fbwa-hidden-element" id="order-shipped-active-status">
+							<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
+						</div>
+						<div class="event-config-status fbwa-hidden-element" id="order-shipped-inactive-status">
 							<?php esc_html_e( 'Off', 'facebook-for-woocommerce' ); ?>
 						</div>
 					</div>
@@ -359,7 +371,10 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<div>
 					<div class="event-config-heading-container">
 						<h3><?php esc_html_e( 'Order refunded', 'facebook-for-woocommerce' ); ?></h3>
-						<div class="event-config-status">
+						<div class="event-config-status on-status fbwa-hidden-element" id="order-refunded-active-status">
+							<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
+						</div>
+						<div class="event-config-status fbwa-hidden-element" id="order-refunded-inactive-status">
 							<?php esc_html_e( 'Off', 'facebook-for-woocommerce' ); ?>
 						</div>
 					</div>


### PR DESCRIPTION
## Description
Changes to show on and off status for Order placed, Order shipped, Order refunded events in WhatsApp Utility Settings view.

### Type of change
- New feature (non-breaking change which adds functionality)

## Changelog entry
Changes to display on and off event status for WhatsApp Utility Events

## Test Plan
1. Open WhatsApp Utility Tab
2. In Utility Settings view, validate On/Off status is visible in Utility Messages card.
3. Click on Manage for Order Confirmation and select option to deactivate event.
4. Validate status for Order Confirmation is updated to Off after clicking Save
5. Click on Manage for Order Confirmation and select option to activate event
6. Validate status for Order Confirmation is updated to On after clicking Save

## Screen Recording
https://github.com/user-attachments/assets/298af786-0d92-4b8a-9835-a820f8ae31b1


