### PR TITLE
[WAUM][32/n] Disconnect Whatsapp and Delete Options on Button Click

### DIFF
--- a/assets/js/admin/whatsapp-disconnect.js
+++ b/assets/js/admin/whatsapp-disconnect.js
@@ -23,4 +23,19 @@ jQuery( document ).ready( function( $ ) {
 			}
 		} );
     });
+
+    // handle whatsapp disconnect button click should disconnect whatsapp from woocommerce
+    $( '#wc-whatsapp-disconnect-button' ).click( function( event ) {
+        $.post( facebook_for_woocommerce_whatsapp_disconnect.ajax_url, {
+			action: 'wc_facebook_disconnect_whatsapp',
+			nonce:  facebook_for_woocommerce_whatsapp_disconnect.nonce
+		}, function ( response ) {
+            if ( response.success ) {
+                // TODO: redirect to onboarding view
+                console.log("Success!!!",response);
+			} else {
+                console.log("Disconnect Failure!!!",response);
+            }
+		} );
+    });
 } );

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -69,6 +69,9 @@ class AJAX {
 
 		// update the wp_options with wc_facebook_whatsapp_consent_collection_setting_status to disabled
 		add_action( 'wp_ajax_wc_facebook_whatsapp_consent_collection_disable', array( $this, 'whatsapp_consent_collection_disable' ) );
+
+		// disconnect whatsapp account from woocommcerce app
+		add_action( 'wp_ajax_wc_facebook_disconnect_whatsapp', array( $this, 'wc_facebook_disconnect_whatsapp' ) );
 	}
 
 
@@ -278,6 +281,27 @@ class AJAX {
 			update_option( 'wc_facebook_whatsapp_consent_collection_setting_status', 'disabled' );
 		}
 		wp_send_json_success();
+	}
+
+	/**
+	 * Disconnect Whatsapp from WooCommerce.
+	 *
+	 * @internal
+	 *
+	 * @since 1.10.0
+	 */
+	public function wc_facebook_disconnect_whatsapp() {
+		if ( ! check_ajax_referer( 'facebook-for-wc-whatsapp-disconnect-nonce', 'nonce', false ) ) {
+			wp_send_json_error( 'Invalid security token sent.' );
+		}
+
+		$integration_config_id = get_option( 'wc_facebook_wa_integration_config_id', null );
+		$bisu_token            = get_option( 'wc_facebook_wa_integration_bisu_access_token', null );
+		$waba_id               = get_option( 'wc_facebook_wa_integration_waba_id', null );
+		if ( empty( $integration_config_id ) || empty( $bisu_token ) || empty( $waba_id ) ) {
+			wp_send_json_error( 'Missing integration_config_id or bisu_token or waba_id for Disconnect API call' );
+		}
+		WhatsAppUtilityConnection::wc_facebook_disconnect_whatsapp( $waba_id, $integration_config_id, $bisu_token );
 	}
 
 	public function whatsapp_fetch_library_template_info() {

--- a/includes/Handlers/WhatsAppUtilityConnection.php
+++ b/includes/Handlers/WhatsAppUtilityConnection.php
@@ -122,4 +122,72 @@ class WhatsAppUtilityConnection {
 			wp_send_json_success( $response, 'Finish Onboarding Success' );
 		}
 	}
+
+	/**
+	 * Makes an API call to Whatsapp Utility Message Disconnect API and delete the options in DB
+	 *
+	 * @param string $waba_id WABA ID
+	 * @param string $integration_config_id whatsapp integration config ID
+	 * @param string $bisu_token BISU token
+	 */
+	public static function wc_facebook_disconnect_whatsapp( $waba_id, $integration_config_id, $bisu_token ) {
+		$base_url     = array( self::GRAPH_API_BASE_URL, self::API_VERSION, $waba_id, 'disconnect_utility_messages' );
+		$base_url     = esc_url( implode( '/', $base_url ) );
+		$query_params = array(
+			'integration_config_id' => $integration_config_id,
+			'access_token'          => $bisu_token,
+		);
+		$base_url     = add_query_arg( $query_params, $base_url );
+		$options      = array(
+			'headers' => array(
+				'Authorization' => $bisu_token,
+			),
+			'body'    => array(),
+		);
+		$response     = wp_remote_post( $base_url, $options );
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			$error_data    = explode( "\n", wp_remote_retrieve_body( $response ) );
+			$error_object  = json_decode( $error_data[0] );
+			$error_message = $error_object->error->error_user_title ?? $error_object->error->message ?? 'Something went wrong. Please try again later!';
+
+			wc_get_logger()->info(
+				sprintf(
+					/* translators: %s $error_message */
+					__( 'Disconnect Whatsapp API Call Error: %1$s ', 'facebook-for-woocommerce' ),
+					$error_message,
+				)
+			);
+			wp_send_json_error( $error_message, 'Disconnect Whatsapp Failure' );
+		} else {
+				wc_get_logger()->info(
+					sprintf(
+						__( 'Whatsapp Disconnect API Call Success!!!', 'facebook-for-woocommerce' )
+					)
+				);
+
+			// delete all the whatsapp setting options in DB
+			$wa_settings = array(
+				'wc_facebook_wa_integration_waba_id',
+				'wc_facebook_wa_integration_bisu_access_token',
+				'wc_facebook_wa_integration_business_id',
+				'wc_facebook_wa_integration_wacs_phone_number',
+				'wc_facebook_wa_integration_is_payment_setup',
+				'wc_facebook_wa_integration_wacs_id',
+				'wc_facebook_wa_integration_waba_profile_picture_url',
+				'wc_facebook_wa_integration_waba_display_name',
+				'wc_facebook_whatsapp_consent_collection_setting_status',
+				'wc_facebook_wa_integration_config_id',
+			);
+
+			self::wc_facebook_whatsapp_settings_delete( $wa_settings );
+
+			wp_send_json_success( $response, 'Disconnect Whatsapp Success' );
+		}
+	}
+
+	public static function wc_facebook_whatsapp_settings_delete( $wa_settings ) {
+		foreach ( $wa_settings as $setting ) {
+			delete_option( $setting ); // this only deletes if option exists, no error on failure
+		}
+	}
 }


### PR DESCRIPTION
## Description
When we click on the disconnect button in the disconnect widget, we call the Disconnect API with required params and delete the whatsapp options from DB.

### Type of change
- New feature (non-breaking change which adds functionality)


## Changelog entry
Disconnect Whatsapp and Delete Options on Button Click


## Test Plan

https://github.com/user-attachments/assets/fe22eae8-5fdd-4257-a3f6-44de1b7a5036


