### PR TITLE
Product Specific Flat Rate Shipping Profiles

### DIFF
--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -386,7 +386,7 @@ class WC_Facebook_Product_Feed {
 		'brand,price,availability,item_group_id,checkout_url,' .
 		'additional_image_link,sale_price_effective_date,sale_price,condition,' .
 		'visibility,gender,color,size,pattern,google_product_category,default_product,'.
-		'variant,gtin,quantity_to_sell_on_facebook,rich_text_description,external_update_time,'.
+		'variant,gtin,quantity_to_sell_on_facebook,rich_text_description,internal_label,external_update_time,'.
 		'external_variant_id'. PHP_EOL;
 	}
 
@@ -537,6 +537,7 @@ class WC_Facebook_Product_Feed {
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'gtin' )) . ',' .
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'quantity_to_sell_on_facebook' )) . ',' .
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'rich_text_description' ) ) . ',' .
+		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'internal_label' ) ) . ',' .
 		static::get_value_from_product_data( $product_data, 'external_update_time' ) . ',' .
 		static::get_value_from_product_data( $product_data, 'external_variant_id' ) . PHP_EOL;
 	}


### PR DESCRIPTION

### Changes proposed in this Pull Request:

Updates shipping profile syncing to support syncing of flat rate shipping methods which are free for some shipping classes.
For example, if a flat rate shipping profile has a base cost of 0, and a cost of 3 for shipping class = heavy, then we will sync the shipping profile to apply to all products that dont have a shipping class of heavy.  This involves two main changes:

1. We sync the shipping class (or non-shipping-class) of each product as a tag using the internal_label product feed field. (https://www.facebook.com/business/help/120325381656392?id=725943027795860). This logic is set in fbProduct
2. The internal_label values can then be queried using a product filter. The product filter must filter on the 'tags' field. This logic is set in ShippingProfileFeed. 

### Screenshots:

![image](https://github.com/user-attachments/assets/f4a1d1c6-4de5-4154-8d5a-b11e735c5f6a)

Data: 

![image](https://github.com/user-attachments/assets/5de7786d-9947-4152-bb39-01604e98d182)


### Detailed test instructions:
Detailed test instructions:
1. Create shipping profiles in a test shop by adding a shipping zone, then adding shipping methods. Modify flat rate shipping methods with different shipping classes with different costs. 
2. Run the feed upload job. See https://github.com/facebook/facebook-for-woocommerce/pull/2937 for detailed instructions
3. Examine output feed file
4. Verify shipping profiles are created on Meta


