### PR TITLE
sollipse lintfixes 5 2 A

### DIFF
--- a/includes/Framework/AdminNoticeHandler.php
+++ b/includes/Framework/AdminNoticeHandler.php
@@ -1,12 +1,11 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Facebook for WooCommerce.
  */
 
 namespace WooCommerce\Facebook\Framework;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Admin Notice Handler Class
@@ -24,25 +23,26 @@ class AdminNoticeHandler {
 	private $admin_notices = [];
 
 	/** @var boolean static member to enforce a single rendering of the admin notice placeholder element */
-	static private $admin_notice_placeholder_rendered = false;
+	private static $admin_notice_placeholder_rendered = false;
 
 	/** @var boolean static member to enforce a single rendering of the admin notice javascript */
-	static private $admin_notice_js_rendered = false;
+	private static $admin_notice_js_rendered = false;
 
 
 	/**
 	 * Initialize and setup the Admin Notice Handler
 	 *
 	 * @since 3.0.0
+	 * @param Plugin $plugin The plugin instance.
 	 */
 	public function __construct( $plugin ) {
 
-		$this->plugin      = $plugin;
+		$this->plugin = $plugin;
 
 		// render any admin notices, delayed notices, and
-		add_action( 'admin_notices', array( $this, 'render_admin_notices'         ), 15 );
-		add_action( 'admin_footer',  array( $this, 'render_delayed_admin_notices' ), 15 );
-		add_action( 'admin_footer',  array( $this, 'render_admin_notice_js'       ), 20 );
+		add_action( 'admin_notices', array( $this, 'render_admin_notices' ), 15 );
+		add_action( 'admin_footer', array( $this, 'render_delayed_admin_notices' ), 15 );
+		add_action( 'admin_footer', array( $this, 'render_admin_notice_js' ), 20 );
 
 		// AJAX handler to dismiss any warning/error notices
 		add_action( 'wp_ajax_wc_plugin_framework_' . $this->get_plugin()->get_id() . '_dismiss_notice', array( $this, 'handle_dismiss_notice' ) );
@@ -56,7 +56,7 @@ class AdminNoticeHandler {
 	 * @since 3.0.0
 	 * @param string $message the notice message to display
 	 * @param string $message_id the message id
-	 * @param array $params {
+	 * @param array  $params {
 	 *     Optional parameters.
 	 *
 	 *     @type bool $dismissible             If the notice should be dismissible
@@ -67,11 +67,14 @@ class AdminNoticeHandler {
 	 */
 	public function add_admin_notice( $message, $message_id, $params = [] ) {
 
-		$params = wp_parse_args( $params, array(
-			'dismissible'             => true,
-			'always_show_on_settings' => true,
-			'notice_class'            => 'updated',
-		) );
+		$params = wp_parse_args(
+			$params,
+			array(
+				'dismissible'             => true,
+				'always_show_on_settings' => true,
+				'notice_class'            => 'updated',
+			)
+		);
 
 		if ( $this->should_display_notice( $message_id, $params ) ) {
 			$this->admin_notices[ $message_id ] = array(
@@ -89,7 +92,7 @@ class AdminNoticeHandler {
 	 *
 	 * @since 3.0.0
 	 * @param string $message_id the message id
-	 * @param array $params {
+	 * @param array  $params {
 	 *     Optional parameters.
 	 *
 	 *     @type bool $dismissible             If the notice should be dismissible
@@ -105,10 +108,13 @@ class AdminNoticeHandler {
 			return false;
 		}
 
-		$params = wp_parse_args( $params, array(
-			'dismissible'             => true,
-			'always_show_on_settings' => true,
-		) );
+		$params = wp_parse_args(
+			$params,
+			array(
+				'dismissible'             => true,
+				'always_show_on_settings' => true,
+			)
+		);
 
 		// if the notice is always shown on the settings page, and we're on the settings page
 		if ( $params['always_show_on_settings'] && $this->get_plugin()->is_plugin_settings() ) {
@@ -151,7 +157,6 @@ class AdminNoticeHandler {
 			echo '<div class="js-wc-' . esc_attr( $this->get_plugin()->get_id_dasherized() ) . '-admin-notice-placeholder"></div>';
 			self::$admin_notice_placeholder_rendered = true;
 		}
-
 	}
 
 
@@ -171,7 +176,7 @@ class AdminNoticeHandler {
 	 * @since 3.0.0
 	 * @param string $message the notice message to display
 	 * @param string $message_id the message id
-	 * @param array $params {
+	 * @param array  $params {
 	 *     Optional parameters.
 	 *
 	 *     @type bool $dismissible             If the notice should be dismissible
@@ -183,12 +188,15 @@ class AdminNoticeHandler {
 	 */
 	public function render_admin_notice( $message, $message_id, $params = [] ) {
 
-		$params = wp_parse_args( $params, array(
-			'dismissible'             => true,
-			'is_visible'              => true,
-			'always_show_on_settings' => true,
-			'notice_class'            => 'updated',
-		) );
+		$params = wp_parse_args(
+			$params,
+			array(
+				'dismissible'             => true,
+				'is_visible'              => true,
+				'always_show_on_settings' => true,
+				'notice_class'            => 'updated',
+			)
+		);
 
 		$classes = array(
 			'notice',
@@ -202,7 +210,7 @@ class AdminNoticeHandler {
 			$classes[] = 'is-dismissible';
 		}
 
-		echo sprintf(
+		printf(
 			'<div class="%1$s" data-plugin-id="%2$s" data-message-id="%3$s" %4$s><p>%5$s</p></div>',
 			esc_attr( implode( ' ', $classes ) ),
 			esc_attr( $this->get_plugin()->get_id() ),
@@ -285,7 +293,7 @@ class AdminNoticeHandler {
 	 *
 	 * @since 3.0.0
 	 * @param string $message_id the message identifier
-	 * @param int $user_id optional user identifier, defaults to current user
+	 * @param int    $user_id optional user identifier, defaults to current user
 	 */
 	public function dismiss_notice( $message_id, $user_id = null ) {
 		if ( is_null( $user_id ) ) {
@@ -303,7 +311,7 @@ class AdminNoticeHandler {
 		 * @param string $message_id notice identifier
 		 * @param string|int $user_id
 		 */
-		do_action( 'wc_' . $this->get_plugin()->get_id(). '_dismiss_notice', $message_id, $user_id );
+		do_action( 'wc_' . $this->get_plugin()->get_id() . '_dismiss_notice', $message_id, $user_id );
 	}
 
 
@@ -312,7 +320,7 @@ class AdminNoticeHandler {
 	 *
 	 * @since 3.0.0
 	 * @param string $message_id the message identifier
-	 * @param int $user_id optional user identifier, defaults to current user
+	 * @param int    $user_id optional user identifier, defaults to current user
 	 */
 	public function undismiss_notice( $message_id, $user_id = null ) {
 		if ( is_null( $user_id ) ) {
@@ -330,7 +338,7 @@ class AdminNoticeHandler {
 	 *
 	 * @since 3.0.0
 	 * @param string $message_id the message identifier
-	 * @param int $user_id optional user identifier, defaults to current user
+	 * @param int    $user_id optional user identifier, defaults to current user
 	 * @return boolean true if the message has been dismissed by the admin user
 	 */
 	public function is_notice_dismissed( $message_id, $user_id = null ) {
@@ -386,6 +394,4 @@ class AdminNoticeHandler {
 	protected function get_plugin() {
 		return $this->plugin;
 	}
-
-
 }


### PR DESCRIPTION
- Improve Test Filter Management (#2944)
- Updated Pull Request Template (#2948)
- Update readme.txt (#2949)
- Fix feed upload error "feed_column_count_mismatch" when product has multiple colors separated by a coma (#2947)
- Bump tj-actions/changed-files from 41 to 46 in /.github/workflows (#2951)
- Release 3.4.2 (#2950)
- Implement telemetry logs api (#2940)
- Sync products that are out of stock (#2952)
- Make error logging event configurable (#2954)
- Promotions feed upload (#2941)
- Rest API endpoint framework for WP-local APIs (#2345)
- Add woo_commerce_retailer_id to products API request (#2958)
- Add is_multisite logging to FBE plugin version update request (#2955)
- Syncing plugin version info regularly (#2960)
- Replace woo_commerce_retailer_id with external_variant_id (#2963)
- Conditional feed upload scheduling (#2964)
- Adding new rules for showing the new MiCE experience (#2965)
- Implement logging toggle (#2959)
- fix terminology (#2966)
- Fetch feed upload classes from feed manager (#2970)
- Updating regenerate_feed to always use feed_generator (#2971)
- Fix missing CMS_ID and misaligned catalog_id param name (#2972)
- Create enhanced settings UI (#2968)
- Add new product field external_update_time to measure product update latency (#2973)
- Fix for 'PHP Warning: Undefined variable $fb_product_parent' (#2976)
- Fix fb Products Attributes tab (#2938)
- Create new troubleshooting drawer from legacy debug settings (#2977)
- fix: auto products sync (#2978)
- Make page title in enhanced settings static (#2985)
- Add manual product and coupon sync buttons (#2984)
- Sync products with restriction (#2983)
- Releases - merging release 3.4.3 and 3.4.4 to main (#2988)
- Fix - Updated logic to choose/create the feed for product sync (#2989)
- Trigger feed uploads on onboarding completion (#2995)
- Fix free shipping coupon sync (#2993)
- Update PULL_REQUEST_TEMPLATE.md (#2990)
- Clean up CSS in enhanced settings UI (#2996)
- Fix use_enhanced_onboarding for legacy connections (#2986)
- Add logging for feed generation scheduling failure (#2994)
- Added external_variant_id to the feed file (#2998)
- Fixed PHP Warning for empty attributes (#3001)
- Align finalized content for logging toggle (#2992)
- Bugfix: Hide Out Of Stock items (#3010)
- Added support for syncing product type (#3013)
- Fix product attribute sort error (#3012)
- Relocating bulk actions (#2943)
- Filtration on All Products page | Synced and Not Synced (#2999)
- Updated PR Template (#3019)
- Fixed Null check exceptions (#3015)
- Remove the "Advertise" tab (#3024)
- Relaxing sync validation (#2969)
- Add GitHub Actions Workflow for JavaScript Unit Testing (#2975)
- Feature/truncate title description (#3023)
- Improve local log (#3009)
- feat(product-sync): Add separate short_description field to Facebook product data (#3029)
- fix: Update descriptive tooltip for MPN text input (#3034)
- docs: Document get_unmapped_attributes from Woo to Meta (#3033)
- Feature/sync short description remove dropdown (#3031)
- fix: Add parent product material inheritance for variations (#3035)
- fix: mismatch between tooltip messages for Skirt Length and Sleeve Le… (#3039)
- Fixing namespacing issue causing some tests to be skipped (#3037)
- Updated the plugin tags, and removed the legacy contributors (#2956)
- Updated PR template (#3053)
- Removing Modal on Do Not Sync (#3040)
- Fixed the item not found error by using filter in the product endpoint (#3054)
- Feature: Short Description Fallback (#3048)
- Sync "Usage Count" in Promos Feed (#3036)
- Unit test abstract class to allow options to be globally set in isolation between tests (#3057)
- fix skipped tests2 (#3058)
- Remove UI of a checkbox that controls enablement of the new style feed generation. (#3056)
- Fixing meta to Meta (#3063)
- Lint fixes for AdminMessageHandlerFile (#3068)
- Clean up unused code from Connection.php (#3071)
- Fix linter errors for ./includes/fbutils.php files (#3075)
- Remove type cast for GPC (#3078)
- Fix for the gap in Purchase events through CAPI (#3060)
- Disable unmatched fields to batch api (#3079)
- Disable mini_shops product capability for unsupported items (#3084)
- Lintfixes for Helper class (#3085)
- Add feature to sync global attributes to Meta and test API format (#3050)
- Lint fixes for Framework/Lifecycle.php (#3083)
- Fix Facebook attribute dropdown display and syncing issues (#3051)
- Fix product variation fields not saving correctly (#3090)
- Lint fixes for includes/Products/Sync.php (#3081)
- Lint fixes for includes/Framework/Plugin.php (#3082)
- Removed failing test due to merge conflicts (#3103)
- Set helper text for dropdown sync (#3104)
- Shipping Profiles Feed Up (#3098)
- [LINTFIX] Fixes for AdminNoticeHandler

## Description

Please include a summary of the changes and the related issue. 
Please also include relevant motivation and context. 
List any dependencies that are required for this change.

### Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [] I have commented my code, particularly in hard-to-understand areas.
- [] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

One liner entry to be surfaced in changelog.txt


## Test Plan

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration.

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before

### After
