### PR TITLE
[LINTFIX] Fixes for Compatibility.php

### DIFF
--- a/includes/Framework/Plugin/Compatibility.php
+++ b/includes/Framework/Plugin/Compatibility.php
@@ -1,12 +1,11 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Facebook for WooCommerce
  */
 
 namespace WooCommerce\Facebook\Framework\Plugin;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * WooCommerce Compatibility Utility Class
@@ -75,8 +74,7 @@ class Compatibility {
 	 * @return string|null Woocommerce version number or null if undetermined
 	 */
 	public static function get_wc_version() {
-
-		return defined( 'WC_VERSION' ) && WC_VERSION ? WC_VERSION : null;
+		return defined( 'WC_VERSION' ) ? constant( 'WC_VERSION' ) : null;
 	}
 
 


### PR DESCRIPTION

## Description

This PR fixes linter errors in the Compatibility class by replacing the deprecated logical operator 'or' with '||' and resolving namespace resolution issues with WC_VERSION constant access.

### Type of change

- Bug fix (non-breaking change which fixes an issue)
- Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.

## Changelog entry

Fixed linter warnings in Compatibility class related to logical operators and global constant access.

## Test Plan

1. Verified that the code passes linting checks
2. Tested the get_wc_version() function returns the correct version
3. Confirmed backward compatibility with older PHP versions

## Screenshots
### Before
Linter showing errors for 'or' operator usage and undefined WC_VERSION constant in namespace.

### After
Clean linter report with no errors or warnings.
