### PR TITLE
Sync Entire World Shipping Zone to Meta

### DIFF
--- a/includes/Feed/ShippingProfiles/ShippingProfilesFeed.php
+++ b/includes/Feed/ShippingProfiles/ShippingProfilesFeed.php
@@ -75,6 +75,19 @@ class ShippingProfilesFeed extends AbstractFeed {
 				$locations           = $zone['zone_locations'];
 				$countries_to_states = array();
 
+				// An empty location list indicates that the shipping profile applies to the whole world.
+				if ( empty( $locations ) ) {
+					$locations = array_map(
+						function ( $country_code ) {
+							return [
+								'code' => $country_code,
+								'type' => 'country',
+							];
+						},
+						array_keys( WC()->countries->get_countries() )
+					);
+				}
+
 				foreach ( $locations as $location ) {
 					$location = (array) $location;
 					if ( 'continent' === $location['type'] ) {

--- a/tests/Unit/Feed/ShippingProfiles/ShippingProfilesFeedTest.php
+++ b/tests/Unit/Feed/ShippingProfiles/ShippingProfilesFeedTest.php
@@ -307,6 +307,36 @@ class ShippingProfilesFeedTest extends FeedDataTestBase {
 		$this->asserttrue($every_country_data_applies_to_entire_country);
 	}
 
+	public function testEntireWorld(): void {
+		$zone = new WC_Shipping_Zone();
+		$zone->save();
+		self::create_and_save_method_instance($zone, 'free_shipping', array());
+		$result = ShippingProfilesFeed::get_shipping_profiles_data();
+		$shipping_zone_data = $result[0]['shipping_zones'];
+
+		$expected_shipping_zones = array_map(
+			function ( $country_code ) {
+				return [
+					'country'                   => $country_code,
+					'states'                    => [],
+					'applies_to_entire_country' => true,
+				];
+			},
+			array_keys( WC()->countries->get_countries() )
+		);
+
+		$this->assertEqualsCanonicalizing( $expected_shipping_zones, $shipping_zone_data );
+
+		// Prevent too many asserts by just making sure every one is true.
+		$every_country_data_applies_to_entire_country = true;
+		foreach($shipping_zone_data as $country_data) {
+			if (!$country_data['applies_to_entire_country']) {
+				$every_country_data_applies_to_entire_country = false;
+			}
+		}
+		$this->asserttrue($every_country_data_applies_to_entire_country);
+	}
+
 	// Dont Sync if Local Pickup
 	private static function create_default_shipping_zone(): WC_Shipping_Zone {
 		$zone = new WC_Shipping_Zone();


### PR DESCRIPTION


### Changes proposed in this Pull Request:
When no locations are selected for a shipping zone in WooCommerce, this indicates that the zone covers the whole world. This is not handled by WooC -> Meta shipping profile syncing logic today, where we currently only handle elements within the zone list that are either continent, countries, or states, but did not handle an empty list. This updates the logic to sync the shipping profile with an explicit list of every country if no locations are set in the shipping zone. 
Closes # .


- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


<img width="415" alt="image" src="https://github.com/user-attachments/assets/15bd9f18-3830-4cc5-922b-585640e30aa2" />


### Detailed test instructions:
1. Create a new shipping zone with no locations selected
2. Add a free shipping method to the zone to ensure zone gets included in data sync to Meta
3. Run shipping profile sync flow through scheduled actions
4. Observe synced shipping profile applies to all of shops Products on Meta.


### Changelog entry
Maps shipping zones that are set to apply to the entire world



