### PR TITLE
[WAUM] Order Placed WA Utility Message Send

### DIFF
--- a/assets/js/admin/whatsapp-events.js
+++ b/assets/js/admin/whatsapp-events.js
@@ -20,16 +20,16 @@ jQuery( document ).ready( function( $ ) {
         orderPlacedInactiveStatus.show();
     }
 
-    // Set Event Status for Order Shipped
-    var orderShippedActiveStatus = $('#order-shipped-active-status');
-    var orderShippedInactiveStatus = $('#order-shipped-inactive-status');
-    if(facebook_for_woocommerce_whatsapp_events.order_shipped_enabled){
-        orderShippedInactiveStatus.hide();
-        orderShippedActiveStatus.show();
+    // Set Event Status for Order FulFilled
+    var orderFulfilledActiveStatus = $('#order-fulfilled-active-status');
+    var orderFulfilledInactiveStatus = $('#order-fulfilled-inactive-status');
+    if(facebook_for_woocommerce_whatsapp_events.order_fulfilled_enabled){
+        orderFulfilledInactiveStatus.hide();
+        orderFulfilledActiveStatus.show();
     }
     else {
-        orderShippedActiveStatus.hide();
-        orderShippedInactiveStatus.show();
+        orderFulfilledActiveStatus.hide();
+        orderFulfilledInactiveStatus.show();
     }
 
     // Set Event Status for Order Refunded
@@ -44,14 +44,16 @@ jQuery( document ).ready( function( $ ) {
         orderRefundedInactiveStatus.show();
     }
 
-    var eventConfiglanguage = facebook_for_woocommerce_whatsapp_events.order_placed_language;
+    var eventConfiglanguage = getEventLanguage(facebook_for_woocommerce_whatsapp_events.event);
     $("#manage-event-language").val(eventConfiglanguage);
 
-    // update current view from utility settings to manage event when order confirmation button is clicked.
-    $('#woocommerce-whatsapp-manage-order-confirmation').click(function (event) {
+    $('#woocommerce-whatsapp-manage-order-placed, #woocommerce-whatsapp-manage-order-fulfilled, #woocommerce-whatsapp-manage-order-refunded').click(function (event) {
+        var clickedButtonId = $(event.target).attr("id");
+        let view=clickedButtonId.replace("woocommerce-whatsapp-", "");
+        view = view.replaceAll("-", "_");
         let url = new URL(window.location.href);
         let params = new URLSearchParams(url.search);
-        params.set('view', 'manage_event');
+        params.set('view', view);
         url.search = params.toString();
         window.location.href = url.toString();
     });
@@ -60,7 +62,8 @@ jQuery( document ).ready( function( $ ) {
     $("#library-template-content").load(facebook_for_woocommerce_whatsapp_events.ajax_url, function () {
         $.post(facebook_for_woocommerce_whatsapp_events.ajax_url, {
             action: 'wc_facebook_whatsapp_fetch_library_template_info',
-            nonce: facebook_for_woocommerce_whatsapp_events.nonce
+            nonce: facebook_for_woocommerce_whatsapp_events.nonce,
+            event: facebook_for_woocommerce_whatsapp_events.event,
         }, function (response) {
             if (response.success) {
                 const parsedData = JSON.parse(response.data);
@@ -68,8 +71,17 @@ jQuery( document ).ready( function( $ ) {
                 // Parse template strings as HTML and extract text content to sanitize text
                 const header = $.parseHTML(apiResponseData.header)[0].textContent;
                 const body = $.parseHTML(apiResponseData.body)[0].textContent;
-                const button = $.parseHTML(apiResponseData.buttons[0].text)[0].textContent;
-                $('#library-template-content').html(`
+                if (facebook_for_woocommerce_whatsapp_events.event === "ORDER_REFUNDED") {
+                    $('#library-template-content').html(`
+                        <h3>Header</h3>
+                        <p>${header}</p>
+                        <h3>Body</h3>
+                        <p>${body}</p>
+                    `).show();
+                }
+                else {
+                    const button = $.parseHTML(apiResponseData.buttons[0].text)[0].textContent;
+                    $('#library-template-content').html(`
                     <h3>Header</h3>
                     <p>${header}</p>
                     <h3>Body</h3>
@@ -77,6 +89,7 @@ jQuery( document ).ready( function( $ ) {
                     <h3>Call to action</h3>
                     <p>${button}</p>
                 `).show();
+                }
             }
         });
     });
@@ -88,7 +101,7 @@ jQuery( document ).ready( function( $ ) {
         $.post(facebook_for_woocommerce_whatsapp_events.ajax_url, {
             action: 'wc_facebook_whatsapp_upsert_event_config',
             nonce: facebook_for_woocommerce_whatsapp_events.nonce,
-            event: 'ORDER_PLACED',
+            event: facebook_for_woocommerce_whatsapp_events.event,
             language: languageValue,
             status: statusValue
         }, function (response) {
@@ -100,4 +113,17 @@ jQuery( document ).ready( function( $ ) {
             window.location.href = url.toString();
         });
     });
+
+    function getEventLanguage(event) {
+        switch (event) {
+            case "ORDER_PLACED":
+                return facebook_for_woocommerce_whatsapp_events.order_placed_language;
+            case "ORDER_FULFILLED":
+                return facebook_for_woocommerce_whatsapp_events.order_fulfilled_language;
+            case "ORDER_REFUNDED":
+                return facebook_for_woocommerce_whatsapp_events.order_refunded_language;
+            default:
+                return null;
+        }
+    }
 });

--- a/facebook-commerce-whatsapp-utility-event.php
+++ b/facebook-commerce-whatsapp-utility-event.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+use WooCommerce\Facebook\Handlers\WhatsAppUtilityConnection;
+
+/**
+ * Event Processor for sending WhatsApp Utility Message when Order Management events are triggered
+ */
+class WC_Facebookcommerce_Whatsapp_Utility_Event {
+
+	/** @var array Mapping of Order Status to Event name */
+	const ORDER_STATUS_TO_EVENT_MAPPING = array(
+		'processing' => 'ORDER_PLACED',
+		'completed'  => 'ORDER_SHIPPED',
+		'refunded'   => 'ORDER_REFUNDED',
+	);
+
+	public function __construct() {
+		if ( ! $this->is_whatsapp_utility_enabled() ) {
+			return;
+		}
+		add_action( 'woocommerce_order_status_changed', array( $this, 'process_wc_order_status_changed' ), 10, 3 );
+	}
+
+	/**
+	 * Determines if WhatsApp Utility Messages are enabled
+	 * TODO: Update this function to check for gating logic for Alpha businesses
+	 *
+	 * @since 2.3.0
+	 *
+	 * @return bool
+	 */
+	private function is_whatsapp_utility_enabled() {
+		return true;
+	}
+
+
+	/**
+	 * Hook to process Order Processing, Order Completed and Order Refunded events for WhatsApp Utility Messages
+	 *
+	 * @param string $order_id Order id
+	 * @param string $old_status Old Order Status
+	 * @param string $new_status New Order Status
+	 *
+	 * @return void
+	 * @since 2.3.0
+	 */
+	public function process_wc_order_status_changed( $order_id, $old_status, $new_status ) {
+		// WhatsApp Utility Messages are supported only for Processing status
+		// TODO: add support for Completed and Refunded Status
+		if ( 'processing' !== $new_status ) {
+			return;
+		}
+
+		wc_get_logger()->info(
+			sprintf(
+			/* translators: %s $order_id */
+				__( 'Processing Order id %1$s to send Whatsapp Utility messages', 'facebook-for-woocommerce' ),
+				$order_id,
+			)
+		);
+		$event = self::ORDER_STATUS_TO_EVENT_MAPPING[ $new_status ];
+
+		// Check WhatsApp Event Config is active
+		$event_config_id_option_name       = implode( '_', array( WhatsAppUtilityConnection::WA_UTILITY_OPTION_PREFIX, strtolower( $event ), 'event_config_id' ) );
+		$event_config_language_option_name = implode( '_', array( WhatsAppUtilityConnection::WA_UTILITY_OPTION_PREFIX, strtolower( $event ), 'language' ) );
+		$event_config_id                   = get_option( $event_config_id_option_name, null );
+		$language_code                     = get_option( $event_config_language_option_name, null );
+		if ( empty( $event_config_id ) || empty( $language_code ) ) {
+			wc_get_logger()->info(
+				sprintf(
+				/* translators: %s $order_id */
+					__( 'Messages Post API call for Order id %1$s skipped due to no active event config', 'facebook-for-woocommerce' ),
+					$order_id,
+				)
+			);
+			return;
+		}
+
+		$order = wc_get_order( $order_id );
+		// Check WhatsApp Consent Checkbox is selected in shipping and billing
+		$billing_consent_value  = $order->get_meta( '_wc_billing/wc_facebook/whatsapp_consent_checkbox' );
+		$shipping_consent_value = $order->get_meta( '_wc_shipping/wc_facebook/whatsapp_consent_checkbox' );
+		$has_whatsapp_consent   = $billing_consent_value && $shipping_consent_value;
+		// Get WhatsApp Phone number from entered Billing and Shipping phone number
+		$billing_phone_number  = $order->get_billing_phone();
+		$shipping_phone_number = $order->get_shipping_phone();
+		$phone_number          = ( isset( $billing_phone_number ) && $billing_consent_value ) ? $billing_phone_number : $shipping_phone_number;
+		// Get Customer first name
+		$first_name = $order->get_billing_first_name();
+		if ( empty( $phone_number ) || ! $has_whatsapp_consent || empty( $event ) || empty( $first_name ) ) {
+			wc_get_logger()->info(
+				sprintf(
+				/* translators: %s $order_id */
+					__( 'Messages Post API call for Order id %1$s skipped due to missing whatsapp consent or Order info', 'facebook-for-woocommerce' ),
+					$order_id,
+				)
+			);
+			return;
+		}
+
+		// Check Access token and WACS is available
+		$bisu_token = get_option( 'wc_facebook_wa_integration_bisu_access_token', null );
+		$wacs_id    = get_option( 'wc_facebook_wa_integration_wacs_id', null );
+		if ( empty( $bisu_token ) || empty( $wacs_id ) ) {
+			wc_get_logger()->info(
+				sprintf(
+				/* translators: %s $order_id */
+					__( 'Messages Post API call for Order id %1$s Failed due to missing access token or wacs info', 'facebook-for-woocommerce' ),
+					$order_id,
+				)
+			);
+			return;
+		}
+		WhatsAppUtilityConnection::post_whatsapp_utility_messages_events_call( $event, $event_config_id, $language_code, $wacs_id, $order_id, $phone_number, $first_name, $bisu_token );
+	}
+}

--- a/facebook-commerce-whatsapp-utility-event.php
+++ b/facebook-commerce-whatsapp-utility-event.php
@@ -18,7 +18,7 @@ class WC_Facebookcommerce_Whatsapp_Utility_Event {
 	/** @var array Mapping of Order Status to Event name */
 	const ORDER_STATUS_TO_EVENT_MAPPING = array(
 		'processing' => 'ORDER_PLACED',
-		'completed'  => 'ORDER_SHIPPED',
+		'completed'  => 'ORDER_FULFILLED',
 		'refunded'   => 'ORDER_REFUNDED',
 	);
 
@@ -54,8 +54,8 @@ class WC_Facebookcommerce_Whatsapp_Utility_Event {
 	 */
 	public function process_wc_order_status_changed( $order_id, $old_status, $new_status ) {
 		// WhatsApp Utility Messages are supported only for Processing status
-		// TODO: add support for Completed and Refunded Status
-		if ( 'processing' !== $new_status ) {
+		$supported_statuses = array_keys( self::ORDER_STATUS_TO_EVENT_MAPPING );
+		if ( ! in_array( $new_status, $supported_statuses, true ) ) {
 			return;
 		}
 
@@ -95,6 +95,13 @@ class WC_Facebookcommerce_Whatsapp_Utility_Event {
 		$phone_number          = ( isset( $billing_phone_number ) && $billing_consent_value ) ? $billing_phone_number : $shipping_phone_number;
 		// Get Customer first name
 		$first_name = $order->get_billing_first_name();
+		// Get Total Refund Amount for Order Refunded event
+		$total_refund = 0;
+		foreach ( $order->get_refunds() as $refund ) {
+			$total_refund += $refund->get_amount();
+		}
+		$currency_symbol = get_woocommerce_currency_symbol( $currency );
+		$refund_amount   = $currency_symbol . $total_refund;
 		if ( empty( $phone_number ) || ! $has_whatsapp_consent || empty( $event ) || empty( $first_name ) ) {
 			wc_get_logger()->info(
 				sprintf(
@@ -119,6 +126,6 @@ class WC_Facebookcommerce_Whatsapp_Utility_Event {
 			);
 			return;
 		}
-		WhatsAppUtilityConnection::post_whatsapp_utility_messages_events_call( $event, $event_config_id, $language_code, $wacs_id, $order_id, $phone_number, $first_name, $bisu_token );
+		WhatsAppUtilityConnection::post_whatsapp_utility_messages_events_call( $event, $event_config_id, $language_code, $wacs_id, $order_id, $phone_number, $first_name, $refund_amount, $bisu_token );
 	}
 }

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -204,6 +204,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/** @var WC_Facebook_Product_Feed instance. */
 	private $fbproductfeed;
 
+	/** @var WC_Facebookcommerce_Whatsapp_Utility_Event instance. */
+	private $wa_utility_event_processor;
+
 	/**
 	 * Init and hook in the integration.
 	 *
@@ -392,6 +395,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		// Product Set hooks.
 		add_action( 'fb_wc_product_set_sync', [ $this, 'create_or_update_product_set_item' ], 99, 2 );
 		add_action( 'fb_wc_product_set_delete', [ $this, 'delete_product_set_item' ], 99 );
+
+		// Init Whatsapp Utility Event Processor
+		$this->wa_utility_event_processor = $this->load_whatsapp_utility_event_processor();
 	}
 
 	/**
@@ -3137,6 +3143,21 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		delete_option( 'fb_test_pass' );
 		printf( json_encode( $response ) );
 		wp_die();
+	}
+
+	/**
+	 * Init WhatsApp Utility Event Processor.
+	 *
+	 * @return void
+	 */
+	public function load_whatsapp_utility_event_processor() {
+		// Attempt to load WhatsApp Utility Event Processor
+		include_once 'facebook-commerce-whatsapp-utility-event.php';
+		if ( class_exists( 'WC_Facebookcommerce_Whatsapp_Utility_Event' ) ) {
+			if ( ! isset( $this->wa_utility_event_processor ) ) {
+				$this->wa_utility_event_processor = new WC_Facebookcommerce_Whatsapp_Utility_Event( $this );
+			}
+		}
 	}
 
 }

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -316,7 +316,9 @@ class AJAX {
 		if ( empty( $bisu_token ) ) {
 			wp_send_json_error( 'Missing access token for Library template API call' );
 		}
-		WhatsAppUtilityConnection::get_template_library_content( $bisu_token );
+		// Get POST parameters from the request
+		$event = isset( $_POST['event'] ) ? wc_clean( wp_unslash( $_POST['event'] ) ) : '';
+		WhatsAppUtilityConnection::get_template_library_content( $event, $bisu_token );
 	}
 	/**
 	 * Creates or Updates WhatsApp Utility Event Configs

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -27,6 +27,14 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	/** @var string screen ID */
 	const ID = 'whatsapp_utility';
 
+	/** @var array Values for Manage Events  */
+	const MANAGE_EVENT_VIEWS = array(
+		'manage_order_placed',
+		'manage_order_fulfilled',
+		'manage_order_refunded',
+	);
+
+
 	/**
 	 * Whatsapp Utility constructor.
 	 */
@@ -117,12 +125,12 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				),
 			)
 		);
-		$order_placed_event_config_id   = get_option( 'wc_facebook_wa_order_placed_event_config_id', null );
-		$order_placed_language          = get_option( 'wc_facebook_wa_order_placed_language', 'en' );
-		$order_shipped_event_config_id  = get_option( 'wc_facebook_wa_order_shipped_event_config_id', null );
-		$order_shipped_language         = get_option( 'wc_facebook_wa_order_shipped_language', 'en' );
-		$order_refunded_event_config_id = get_option( 'wc_facebook_wa_order_refunded_event_config_id', null );
-		$order_refunded_language        = get_option( 'wc_facebook_wa_order_refunded_language', 'en' );
+		$order_placed_event_config_id    = get_option( 'wc_facebook_wa_order_placed_event_config_id', null );
+		$order_placed_language           = get_option( 'wc_facebook_wa_order_placed_language', 'en' );
+		$order_fulfilled_event_config_id = get_option( 'wc_facebook_wa_order_fulfilled_event_config_id', null );
+		$order_fulfilled_language        = get_option( 'wc_facebook_wa_order_fulfilled_language', 'en' );
+		$order_refunded_event_config_id  = get_option( 'wc_facebook_wa_order_refunded_event_config_id', null );
+		$order_refunded_language         = get_option( 'wc_facebook_wa_order_refunded_language', 'en' );
 		wp_enqueue_script(
 			'facebook-for-woocommerce-whatsapp-events',
 			facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/whatsapp-events.js',
@@ -133,15 +141,16 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			'facebook-for-woocommerce-whatsapp-events',
 			'facebook_for_woocommerce_whatsapp_events',
 			array(
-				'ajax_url'                => admin_url( 'admin-ajax.php' ),
-				'nonce'                   => wp_create_nonce( 'facebook-for-wc-whatsapp-events-nonce' ),
-				'order_placed_enabled'    => ! empty( $order_placed_event_config_id ),
-				'order_placed_language'   => $order_placed_language,
-				'order_shipped_enabled'   => ! empty( $order_shipped_event_config_id ),
-				'order_shipped_language'  => $order_shipped_language,
-				'order_refunded_enabled'  => ! empty( $order_refunded_event_config_id ),
-				'order_refunded_language' => $order_refunded_language,
-				'i18n'                    => array(
+				'ajax_url'                 => admin_url( 'admin-ajax.php' ),
+				'nonce'                    => wp_create_nonce( 'facebook-for-wc-whatsapp-events-nonce' ),
+				'event'                    => $this->get_current_event(),
+				'order_placed_enabled'     => ! empty( $order_placed_event_config_id ),
+				'order_placed_language'    => $order_placed_language,
+				'order_fulfilled_enabled'  => ! empty( $order_fulfilled_event_config_id ),
+				'order_fulfilled_language' => $order_fulfilled_language,
+				'order_refunded_enabled'   => ! empty( $order_refunded_event_config_id ),
+				'order_refunded_language'  => $order_refunded_language,
+				'i18n'                     => array(
 					'result' => true,
 				),
 			)
@@ -228,7 +237,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 		$view = $this->get_current_view();
 		if ( 'utility_settings' === $view ) {
 			$this->render_utility_message_overview();
-		} elseif ( 'manage_event' === $view ) {
+		} elseif ( in_array( $view, self::MANAGE_EVENT_VIEWS, true ) ) {
 			$this->render_manage_events_view();
 		} else {
 			$this->render_utility_message_onboarding();
@@ -363,7 +372,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				</div>
 				<div class="event-config-manage-button">
 					<a
-						id="woocommerce-whatsapp-manage-order-confirmation"
+						id="woocommerce-whatsapp-manage-order-placed"
 						class="event-config-manage-button button"
 						href="#"><?php esc_html_e( 'Manage', 'facebook-for-woocommerce' ); ?></a>
 				</div>
@@ -373,10 +382,10 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<div>
 					<div class="event-config-heading-container">
 						<h3><?php esc_html_e( 'Order shipped', 'facebook-for-woocommerce' ); ?></h3>
-						<div class="event-config-status on-status fbwa-hidden-element" id="order-shipped-active-status">
+						<div class="event-config-status on-status fbwa-hidden-element" id="order-fulfilled-active-status">
 							<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
 						</div>
-						<div class="event-config-status fbwa-hidden-element" id="order-shipped-inactive-status">
+						<div class="event-config-status fbwa-hidden-element" id="order-fulfilled-inactive-status">
 							<?php esc_html_e( 'Off', 'facebook-for-woocommerce' ); ?>
 						</div>
 					</div>
@@ -384,7 +393,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				</div>
 				<div class="event-config-manage-button">
 					<a
-						id="woocommerce-whatsapp-manage-order-shipped"
+						id="woocommerce-whatsapp-manage-order-fulfilled"
 						class="event-config-manage-button button"
 						href="#"><?php esc_html_e( 'Manage', 'facebook-for-woocommerce' ); ?></a>
 				</div>
@@ -505,12 +514,53 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	 * Renders the view to manage WhatsApp Utility Events.
 	 */
 	public function render_manage_events_view() {
+		$event = $this->get_current_event();
 		?>
 		<div class="onboarding-card">
 			<div class="manage-event-card-item">
 				<div class="card-content">
-					<h1><b><?php esc_html_e( 'Manage order confirmation message', 'facebook-for-woocommerce' ); ?></b></h1>
-					<p><?php esc_html_e( 'Send a confirmation to customers after they\'ve placed an order.', 'facebook-for-woocommerce' ); ?></p>
+					<h1><b>
+					<?php
+					switch ( $event ) {
+						case 'ORDER_PLACED':
+							?>
+							<?php esc_html_e( 'Manage order confirmation message', 'facebook-for-woocommerce' ); ?>
+							<?php
+							break;
+						case 'ORDER_FULFILLED':
+							?>
+							<?php esc_html_e( 'Manage order shipped message', 'facebook-for-woocommerce' ); ?>
+							<?php
+							break;
+						case 'ORDER_REFUNDED':
+							?>
+							<?php esc_html_e( 'Manage order refunded message', 'facebook-for-woocommerce' ); ?>
+							<?php
+							break;
+					}
+					?>
+					</b></h1>
+						<p>
+						<?php
+						switch ( $event ) {
+							case 'ORDER_PLACED':
+								?>
+								<?php esc_html_e( 'Send a confirmation to customers after they\'ve placed an order.', 'facebook-for-woocommerce' ); ?>
+									<?php
+								break;
+							case 'ORDER_FULFILLED':
+								?>
+								<?php esc_html_e( 'Send a confirmation to customers when their order has shipped.', 'facebook-for-woocommerce' ); ?>
+									<?php
+								break;
+							case 'ORDER_REFUNDED':
+								?>
+								<?php esc_html_e( 'Send a confirmation whenever an order has been refunded.', 'facebook-for-woocommerce' ); ?>
+									<?php
+								break;
+						}
+						?>
+				</p>
 				</div>
 			</div>
 			<div class="divider"></div>
@@ -519,7 +569,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<select id="manage-event-language" class="manage-event-selector">
 					<option value="en">English</option>
 					<option value="en_US">English (US)</option>
-					<option value="en_UK">English (UK)</option>
+					<option value="en_GB">English (UK)</option>
 					<option value="es">Spanish</option>
 				</select>
 			</div>
@@ -527,7 +577,27 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<div class="manage-event-template-block">
 					<div class="manage-event-template-header">
 						<input type="radio" name="template-status" id="active-template-status" value="ACTIVE" checked="checked" />
-						<label for="active-template-status"><b><?php esc_html_e( 'Send order confirmation message', 'facebook-for-woocommerce' ); ?> </b></label>
+						<label for="active-template-status"><b>				
+						<?php
+						switch ( $event ) {
+							case 'ORDER_PLACED':
+								?>
+								<?php esc_html_e( 'Send order confirmation message', 'facebook-for-woocommerce' ); ?>
+								<?php
+								break;
+							case 'ORDER_FULFILLED':
+								?>
+								<?php esc_html_e( 'Send order shipped message', 'facebook-for-woocommerce' ); ?>
+								<?php
+								break;
+							case 'ORDER_REFUNDED':
+								?>
+								<?php esc_html_e( 'Send order refunded message', 'facebook-for-woocommerce' ); ?>
+								<?php
+								break;
+						}
+						?>
+						</b></label>
 					</div>
 					<div class="divider"></div>
 					<div class="manage-event-card-item fbwa-hidden-element" id="library-template-content"></div>
@@ -535,7 +605,27 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<div class="manage-event-template-block">
 					<div class="manage-event-template-header">
 						<input type="radio" name="template-status" id="inactive-template-status" value="INACTIVE" />
-						<label for="inactive-template-status"><b><?php esc_html_e( 'Turn off order confirmation', 'facebook-for-woocommerce' ); ?> </b></label>
+						<label for="inactive-template-status"><b>
+						<?php
+						switch ( $event ) {
+							case 'ORDER_PLACED':
+								?>
+								<?php esc_html_e( 'Turn off order confirmation message', 'facebook-for-woocommerce' ); ?>
+								<?php
+								break;
+							case 'ORDER_FULFILLED':
+								?>
+								<?php esc_html_e( 'Turn off order shipped message', 'facebook-for-woocommerce' ); ?>
+								<?php
+								break;
+							case 'ORDER_REFUNDED':
+								?>
+								<?php esc_html_e( 'Turn off order refunded message', 'facebook-for-woocommerce' ); ?>
+								<?php
+								break;
+						}
+						?>
+						</b></label>
 					</div>
 				</div>
 			</div>
@@ -569,6 +659,19 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	public function get_current_view() {
 		$current_view = Helper::get_requested_value( 'view' );
 		return $current_view;
+	}
+
+	/**
+	 * Gets the current event
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return array
+	 */
+	public function get_current_event() {
+		$view      = Helper::get_requested_value( 'view' );
+		$event_val = str_replace( 'manage_', '', $view );
+		return strtoupper( $event_val );
 	}
 
 	/**

--- a/includes/Handlers/WhatsAppUtilityConnection.php
+++ b/includes/Handlers/WhatsAppUtilityConnection.php
@@ -32,9 +32,9 @@ class WhatsAppUtilityConnection {
 
 	/** @var array Mapping of Events to Template Library name */
 	const EVENT_TO_LIBRARY_TEMPLATE_MAPPING = array(
-		'ORDER_PLACED'   => 'order_management_4',
-		'ORDER_SHIPPED'  => 'shipment_confirmation_4',
-		'ORDER_REFUNDED' => 'refund_confirmation_1',
+		'ORDER_PLACED'    => 'order_management_4',
+		'ORDER_FULFILLED' => 'shipment_confirmation_4',
+		'ORDER_REFUNDED'  => 'refund_confirmation_1',
 	);
 
 	/** @var string Default language for Library Template */
@@ -43,9 +43,10 @@ class WhatsAppUtilityConnection {
 	/**
 	 * Makes an API call to Template Library API
 	 *
+	 * @param string $event Order Management Event
 	 * @param string $bisu_token the BISU token received in the webhook
 	 */
-	public static function get_template_library_content( $bisu_token ) {
+	public static function get_template_library_content( $event, $bisu_token ) {
 		wc_get_logger()->info(
 			sprintf(
 				__( 'In Template Library Get API call ', 'facebook-for-woocommerce' ),
@@ -53,7 +54,7 @@ class WhatsAppUtilityConnection {
 		);
 		$base_url     = array( self::GRAPH_API_BASE_URL, self::API_VERSION, 'message_template_library' );
 		$base_url     = esc_url( implode( '/', $base_url ) );
-		$library_name = self::EVENT_TO_LIBRARY_TEMPLATE_MAPPING['ORDER_PLACED'];
+		$library_name = self::EVENT_TO_LIBRARY_TEMPLATE_MAPPING[ $event ];
 
 		$params  = array(
 			'name'         => $library_name,
@@ -197,8 +198,8 @@ class WhatsAppUtilityConnection {
 				'wc_facebook_wa_integration_config_id',
 				'wc_facebook_wa_order_placed_event_config_id',
 				'wc_facebook_wa_order_placed_language',
-				'wc_facebook_wa_order_shipped_event_config_id',
-				'wc_facebook_wa_order_shipped_language',
+				'wc_facebook_wa_order_fulfilled_event_config_id',
+				'wc_facebook_wa_order_fulfilled_language',
 				'wc_facebook_wa_order_refunded_event_config_id',
 				'wc_facebook_wa_order_refunded_language',
 			);
@@ -236,57 +237,48 @@ class WhatsAppUtilityConnection {
 		$account_url          = get_permalink( get_option( 'woocommerce_myaccount_page_id' ) );
 		$view_orders_endpoint = get_option( 'woocommerce_myaccount_view_order_endpoint' );
 		$view_orders_base_url = esc_url( $account_url . $view_orders_endpoint );
-		$query_params         = array(
+		// Order Refunded template has no CTA
+		$library_template_button_inputs = 'ORDER_REFUNDED' === $event ? array() : array(
+			array(
+				'type' => 'URL',
+				'url'  => array(
+					// View Url is dynamic and has order_id as suffix
+					'base_url'           => "$view_orders_base_url/{{1}}",
+					// Example view orders url with order id: 1234
+					'url_suffix_example' => "$view_orders_base_url/1234",
+				),
+			),
+		);
+		$query_params                   = array(
 			'event'                          => $event,
 			'language'                       => $language,
 			'status'                         => $status,
 			'library_template_name'          => self::EVENT_TO_LIBRARY_TEMPLATE_MAPPING[ $event ],
-			'library_template_button_inputs' => array(
-				array(
-					'type' => 'URL',
-					'url'  => array(
-						// View Url is dynamic and has order_id as suffix
-						'base_url'           => "$view_orders_base_url/{{1}}",
-						// Example view orders url with order id: 1234
-						'url_suffix_example' => "$view_orders_base_url/1234",
-					),
-				),
-			),
+			'library_template_button_inputs' => $library_template_button_inputs,
 			'access_token'                   => $bisu_token,
 		);
-		$base_url             = add_query_arg( $query_params, $base_url );
-		$options              = array(
+		$base_url                       = add_query_arg( $query_params, $base_url );
+		$options                        = array(
 			'headers' => array(
 				'Authorization' => $bisu_token,
 			),
-			'body'    => array(
-				'event'                          => $event,
-				'language'                       => $language,
-				'status'                         => $status,
-				'library_template_name'          => self::EVENT_TO_LIBRARY_TEMPLATE_MAPPING[ $event ],
-				'library_template_button_inputs' => array(
-					array(
-						'type' => 'URL',
-						'url'  => array(
-							'base_url'           => $view_order_url,
-							'url_suffix_example' => $view_order_example_url,
-						),
-					),
-				),
-
-			),
+			'body'    => array(),
+			'timeout' => 300, // 5 minutes
 		);
-		$response        = wp_remote_post( $base_url, $options );
-		$status_code     = wp_remote_retrieve_response_code( $response );
-		$data            = explode( "\n", wp_remote_retrieve_body( $response ) );
-		$response_object = json_decode( $data[0] );
+		$response                       = wp_remote_post( $base_url, $options );
+		$status_code                    = wp_remote_retrieve_response_code( $response );
+		$data                           = explode( "\n", wp_remote_retrieve_body( $response ) );
+		$response_object                = json_decode( $data[0] );
+		$is_error                       = is_wp_error( $response );
 		if ( is_wp_error( $response ) || 200 !== $status_code ) {
 			$error_message = $response_object->error->error_user_title ?? $response_object->error->message ?? 'Something went wrong. Please try again later!';
 			wc_get_logger()->info(
 				sprintf(
-					/* translators: %s $error_message */
-					__( 'Event Configs Post API call Failed %1$s ', 'facebook-for-woocommerce' ),
+					/* translators: %s $error_message %s status code %s is_wp_error value*/
+					__( 'Event Configs Post API call Failed with Error: %1$s, Status code: %2$d, Is Wp Error: %3$s', 'facebook-for-woocommerce' ),
 					$error_message,
+					$status_code,
+					(string) $is_error,
 				)
 			);
 			wp_send_json_error( $response, 'Event Configs Post API call Failed' );
@@ -333,12 +325,14 @@ class WhatsAppUtilityConnection {
 	 * @param string $order_id Order id
 	 * @param string $phone_number Customer phone number
 	 * @param string $first_name Customer first name
+	 * @param string $refund_value Amount refunded to the Customer
 	 * @param string $bisu_token the BISU token received in the webhook
 	 */
-	public static function post_whatsapp_utility_messages_events_call( $event, $event_config_id, $language_code, $wacs_id, $order_id, $phone_number, $first_name, $bisu_token ) {
+	public static function post_whatsapp_utility_messages_events_call( $event, $event_config_id, $language_code, $wacs_id, $order_id, $phone_number, $first_name, $refund_value, $bisu_token ) {
 		$base_url        = array( self::GRAPH_API_BASE_URL, self::API_VERSION, $wacs_id, "messages?access_token=$bisu_token" );
 		$base_url        = esc_url( implode( '/', $base_url ) );
 		$name            = self::EVENT_TO_LIBRARY_TEMPLATE_MAPPING[ $event ];
+		$components      = self::get_components_for_event( $event, $order_id, $first_name, $refund_value );
 		$options         = array(
 			'body' => array(
 				'messaging_product' => 'whatsapp',
@@ -348,32 +342,7 @@ class WhatsAppUtilityConnection {
 					'language'   => array(
 						'code' => $language_code,
 					),
-					'components' => array(
-						array(
-							'type'       => 'BODY',
-							'parameters' => array(
-								array(
-									'type' => 'text',
-									'text' => $first_name,
-								),
-								array(
-									'type' => 'text',
-									'text' => "#$order_id",
-								),
-							),
-						),
-						array(
-							'type'       => 'BUTTON',
-							'sub_type'   => 'url',
-							'index'      => 0,
-							'parameters' => array(
-								array(
-									'type' => 'text',
-									'text' => "$order_id",
-								),
-							),
-						),
-					),
+					'components' => $components,
 				),
 				'type'              => 'template',
 			),
@@ -399,6 +368,75 @@ class WhatsAppUtilityConnection {
 					__( 'Messages Post API call for Order id %1$s Succeeded.', 'facebook-for-woocommerce' ),
 					$order_id
 				)
+			);
+		}
+	}
+
+
+	/**
+	 * Gets Component Objects for Order Management Events
+	 *
+	 * @param string $event Order Management event
+	 * @param string $order_id Order id
+	 * @param string $first_name Customer first name
+	 * @param string $refund_value Amount refunded to the Customer
+	 */
+	public static function get_components_for_event( $event, $order_id, $first_name, $refund_value ) {
+		if ( 'ORDER_REFUNDED' === $event ) {
+			return array(
+				array(
+					'type'       => 'HEADER',
+					'parameters' => array(
+						array(
+							'type' => 'text',
+							'text' => $refund_value,
+						),
+					),
+				),
+				array(
+					'type'       => 'BODY',
+					'parameters' => array(
+						array(
+							'type' => 'text',
+							'text' => $first_name,
+						),
+						array(
+							'type' => 'text',
+							'text' => $refund_value,
+						),
+						array(
+							'type' => 'text',
+							'text' => "#$order_id",
+						),
+					),
+				),
+			);
+		} else {
+			return array(
+				array(
+					'type'       => 'BODY',
+					'parameters' => array(
+						array(
+							'type' => 'text',
+							'text' => $first_name,
+						),
+						array(
+							'type' => 'text',
+							'text' => "#$order_id",
+						),
+					),
+				),
+				array(
+					'type'       => 'BUTTON',
+					'sub_type'   => 'url',
+					'index'      => 0,
+					'parameters' => array(
+						array(
+							'type' => 'text',
+							'text' => "$order_id",
+						),
+					),
+				),
 			);
 		}
 	}


### PR DESCRIPTION
## Description
Changes to send to the configured Order Placed Utility Message on WhatsApp when order status is changed to "processing"

### Type of change
- New feature (non-breaking change which adds functionality)

## Changelog entry
Changes to send Order Placed utility messages

## Screen Recording of WooCommerce Steps using Admin Flow
1. Open WhatsApp Utility view
2. Validate Order Confirmation Event is On
3. Open WooCommerce > Orders
4. Set Order Status to On Hold
5. Update Order Status to Processing
6. Open WooCommerce > Status > Logs for Success
7. Validate the message is sent on WhatsApp
8. Click View orders in WhatsApp message directs to the Order page
https://github.com/user-attachments/assets/14845301-346d-4c92-8c35-c7757f009600

### Screenshots
WhatsApp Message in Step 7
<img width="715" alt="Screenshot 2025-05-03 at 4 36 50 PM" src="https://github.com/user-attachments/assets/eea4bd2a-e8ce-483a-9394-937ce706c76a" />

View Order Click in Step 8
<img width="1650" alt="Screenshot 2025-05-03 at 4 37 15 PM" src="https://github.com/user-attachments/assets/98f6aa9c-9edb-430f-b29e-b0dc7ef368f7" />

## Screen Recording of WooCommerce Steps using Customer Checkout Flow
1. Open Store
2. Checkout item in Cart
3. Select checkbox to receive updates on WhatsApp
4. Validate the message is sent on WhatsApp
5. Click View orders in WhatsApp message directs to the Order page

https://github.com/user-attachments/assets/65d01c71-f5a7-4e0d-8c24-58f195b4f798




