### PR TITLE
[WAUM] Support Order Fulfilled and Order Refunded in Manage Events

### DIFF
--- a/assets/js/admin/whatsapp-events.js
+++ b/assets/js/admin/whatsapp-events.js
@@ -20,16 +20,16 @@ jQuery( document ).ready( function( $ ) {
         orderPlacedInactiveStatus.show();
     }
 
-    // Set Event Status for Order Shipped
-    var orderShippedActiveStatus = $('#order-shipped-active-status');
-    var orderShippedInactiveStatus = $('#order-shipped-inactive-status');
-    if(facebook_for_woocommerce_whatsapp_events.order_shipped_enabled){
-        orderShippedInactiveStatus.hide();
-        orderShippedActiveStatus.show();
+    // Set Event Status for Order FulFilled
+    var orderFulfilledActiveStatus = $('#order-fulfilled-active-status');
+    var orderFulfilledInactiveStatus = $('#order-fulfilled-inactive-status');
+    if(facebook_for_woocommerce_whatsapp_events.order_fulfilled_enabled){
+        orderFulfilledInactiveStatus.hide();
+        orderFulfilledActiveStatus.show();
     }
     else {
-        orderShippedActiveStatus.hide();
-        orderShippedInactiveStatus.show();
+        orderFulfilledActiveStatus.hide();
+        orderFulfilledInactiveStatus.show();
     }
 
     // Set Event Status for Order Refunded
@@ -44,11 +44,10 @@ jQuery( document ).ready( function( $ ) {
         orderRefundedInactiveStatus.show();
     }
 
-    var eventConfiglanguage = facebook_for_woocommerce_whatsapp_events.order_placed_language;
+    var eventConfiglanguage = getEventLanguage(facebook_for_woocommerce_whatsapp_events.event);
     $("#manage-event-language").val(eventConfiglanguage);
 
-    // update current view from utility settings to manage event when order confirmation button is clicked.
-    $('#woocommerce-whatsapp-manage-order-placed, #woocommerce-whatsapp-manage-order-shipped, #woocommerce-whatsapp-manage-order-refunded').click(function (event) {
+    $('#woocommerce-whatsapp-manage-order-placed, #woocommerce-whatsapp-manage-order-fulfilled, #woocommerce-whatsapp-manage-order-refunded').click(function (event) {
         var clickedButtonId = $(event.target).attr("id");
         let view=clickedButtonId.replace("woocommerce-whatsapp-", "");
         view = view.replaceAll("-", "_");
@@ -114,4 +113,17 @@ jQuery( document ).ready( function( $ ) {
             window.location.href = url.toString();
         });
     });
+
+    function getEventLanguage(event) {
+        switch (event) {
+            case "ORDER_PLACED":
+                return facebook_for_woocommerce_whatsapp_events.order_placed_language;
+            case "ORDER_FULFILLED":
+                return facebook_for_woocommerce_whatsapp_events.order_fulfilled_language;
+            case "ORDER_REFUNDED":
+                return facebook_for_woocommerce_whatsapp_events.order_refunded_language;
+            default:
+                return null;
+        }
+    }
 });

--- a/assets/js/admin/whatsapp-events.js
+++ b/assets/js/admin/whatsapp-events.js
@@ -48,10 +48,13 @@ jQuery( document ).ready( function( $ ) {
     $("#manage-event-language").val(eventConfiglanguage);
 
     // update current view from utility settings to manage event when order confirmation button is clicked.
-    $('#woocommerce-whatsapp-manage-order-confirmation').click(function (event) {
+    $('#woocommerce-whatsapp-manage-order-placed, #woocommerce-whatsapp-manage-order-shipped, #woocommerce-whatsapp-manage-order-refunded').click(function (event) {
+        var clickedButtonId = $(event.target).attr("id");
+        let view=clickedButtonId.replace("woocommerce-whatsapp-", "");
+        view = view.replaceAll("-", "_");
         let url = new URL(window.location.href);
         let params = new URLSearchParams(url.search);
-        params.set('view', 'manage_event');
+        params.set('view', view);
         url.search = params.toString();
         window.location.href = url.toString();
     });
@@ -60,7 +63,8 @@ jQuery( document ).ready( function( $ ) {
     $("#library-template-content").load(facebook_for_woocommerce_whatsapp_events.ajax_url, function () {
         $.post(facebook_for_woocommerce_whatsapp_events.ajax_url, {
             action: 'wc_facebook_whatsapp_fetch_library_template_info',
-            nonce: facebook_for_woocommerce_whatsapp_events.nonce
+            nonce: facebook_for_woocommerce_whatsapp_events.nonce,
+            event: facebook_for_woocommerce_whatsapp_events.event,
         }, function (response) {
             if (response.success) {
                 const parsedData = JSON.parse(response.data);
@@ -68,8 +72,17 @@ jQuery( document ).ready( function( $ ) {
                 // Parse template strings as HTML and extract text content to sanitize text
                 const header = $.parseHTML(apiResponseData.header)[0].textContent;
                 const body = $.parseHTML(apiResponseData.body)[0].textContent;
-                const button = $.parseHTML(apiResponseData.buttons[0].text)[0].textContent;
-                $('#library-template-content').html(`
+                if (facebook_for_woocommerce_whatsapp_events.event === "ORDER_REFUNDED") {
+                    $('#library-template-content').html(`
+                        <h3>Header</h3>
+                        <p>${header}</p>
+                        <h3>Body</h3>
+                        <p>${body}</p>
+                    `).show();
+                }
+                else {
+                    const button = $.parseHTML(apiResponseData.buttons[0].text)[0].textContent;
+                    $('#library-template-content').html(`
                     <h3>Header</h3>
                     <p>${header}</p>
                     <h3>Body</h3>
@@ -77,6 +90,7 @@ jQuery( document ).ready( function( $ ) {
                     <h3>Call to action</h3>
                     <p>${button}</p>
                 `).show();
+                }
             }
         });
     });
@@ -88,7 +102,7 @@ jQuery( document ).ready( function( $ ) {
         $.post(facebook_for_woocommerce_whatsapp_events.ajax_url, {
             action: 'wc_facebook_whatsapp_upsert_event_config',
             nonce: facebook_for_woocommerce_whatsapp_events.nonce,
-            event: 'ORDER_PLACED',
+            event: facebook_for_woocommerce_whatsapp_events.event,
             language: languageValue,
             status: statusValue
         }, function (response) {

--- a/facebook-commerce-whatsapp-utility-event.php
+++ b/facebook-commerce-whatsapp-utility-event.php
@@ -18,7 +18,7 @@ class WC_Facebookcommerce_Whatsapp_Utility_Event {
 	/** @var array Mapping of Order Status to Event name */
 	const ORDER_STATUS_TO_EVENT_MAPPING = array(
 		'processing' => 'ORDER_PLACED',
-		'completed'  => 'ORDER_SHIPPED',
+		'completed'  => 'ORDER_FULFILLED',
 		'refunded'   => 'ORDER_REFUNDED',
 	);
 

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -316,7 +316,9 @@ class AJAX {
 		if ( empty( $bisu_token ) ) {
 			wp_send_json_error( 'Missing access token for Library template API call' );
 		}
-		WhatsAppUtilityConnection::get_template_library_content( $bisu_token );
+		// Get POST parameters from the request
+		$event = isset( $_POST['event'] ) ? wc_clean( wp_unslash( $_POST['event'] ) ) : '';
+		WhatsAppUtilityConnection::get_template_library_content( $event, $bisu_token );
 	}
 	/**
 	 * Creates or Updates WhatsApp Utility Event Configs

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -38,6 +38,13 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	/** @var string Prefix for Whatsapp Utility Option Names */
 	const WA_UTILITY_OPTION_PREFIX = 'wc_facebook_wa';
 
+	/** @var array Values for Manage Events  */
+	const MANAGE_EVENT_VIEWS = array(
+		'manage_order_placed',
+		'manage_order_shipped',
+		'manage_order_refunded',
+	);
+
 	/**
 	 * Whatsapp Utility constructor.
 	 */
@@ -146,6 +153,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			array(
 				'ajax_url'                => admin_url( 'admin-ajax.php' ),
 				'nonce'                   => wp_create_nonce( 'facebook-for-wc-whatsapp-events-nonce' ),
+				'event'                   => $this->get_current_event(),
 				'order_placed_enabled'    => ! empty( $order_placed_event_config_id ),
 				'order_placed_language'   => $order_placed_language,
 				'order_shipped_enabled'   => ! empty( $order_shipped_event_config_id ),
@@ -239,7 +247,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 		$view = $this->get_current_view();
 		if ( 'utility_settings' === $view ) {
 			$this->render_utility_message_overview();
-		} elseif ( 'manage_event' === $view ) {
+		} elseif ( in_array( $view, self::MANAGE_EVENT_VIEWS, true ) ) {
 			$this->render_manage_events_view();
 		} else {
 			$this->render_utility_message_onboarding();
@@ -374,7 +382,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				</div>
 				<div class="event-config-manage-button">
 					<a
-						id="woocommerce-whatsapp-manage-order-confirmation"
+						id="woocommerce-whatsapp-manage-order-placed"
 						class="event-config-manage-button button"
 						href="#"><?php esc_html_e( 'Manage', 'facebook-for-woocommerce' ); ?></a>
 				</div>
@@ -516,12 +524,53 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	 * Renders the view to manage WhatsApp Utility Events.
 	 */
 	public function render_manage_events_view() {
+		$event = $this->get_current_event();
 		?>
 		<div class="onboarding-card">
 			<div class="manage-event-card-item">
 				<div class="card-content">
-					<h1><b><?php esc_html_e( 'Manage order confirmation message', 'facebook-for-woocommerce' ); ?></b></h1>
-					<p><?php esc_html_e( 'Send a confirmation to customers after they\'ve placed an order.', 'facebook-for-woocommerce' ); ?></p>
+					<h1><b>
+					<?php
+					switch ( $event ) {
+						case 'ORDER_PLACED':
+							?>
+							<?php esc_html_e( 'Manage order confirmation message', 'facebook-for-woocommerce' ); ?>
+							<?php
+							break;
+						case 'ORDER_SHIPPED':
+							?>
+							<?php esc_html_e( 'Manage order shipped message', 'facebook-for-woocommerce' ); ?>
+							<?php
+							break;
+						case 'ORDER_REFUNDED':
+							?>
+							<?php esc_html_e( 'Manage order refunded message', 'facebook-for-woocommerce' ); ?>
+							<?php
+							break;
+					}
+					?>
+					</b></h1>
+						<p>
+						<?php
+						switch ( $event ) {
+							case 'ORDER_PLACED':
+								?>
+								<?php esc_html_e( 'Send a confirmation to customers after they\'ve placed an order.', 'facebook-for-woocommerce' ); ?>
+									<?php
+								break;
+							case 'ORDER_SHIPPED':
+								?>
+								<?php esc_html_e( 'Send a confirmation to customers when their order has shipped.', 'facebook-for-woocommerce' ); ?>
+									<?php
+								break;
+							case 'ORDER_REFUNDED':
+								?>
+								<?php esc_html_e( 'Send a confirmation whenever an order has been refunded.', 'facebook-for-woocommerce' ); ?>
+									<?php
+								break;
+						}
+						?>
+				</p>
 				</div>
 			</div>
 			<div class="divider"></div>
@@ -538,7 +587,27 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<div class="manage-event-template-block">
 					<div class="manage-event-template-header">
 						<input type="radio" name="template-status" id="active-template-status" value="ACTIVE" checked="checked" />
-						<label for="active-template-status"><b><?php esc_html_e( 'Send order confirmation message', 'facebook-for-woocommerce' ); ?> </b></label>
+						<label for="active-template-status"><b>				
+						<?php
+						switch ( $event ) {
+							case 'ORDER_PLACED':
+								?>
+								<?php esc_html_e( 'Send order confirmation message', 'facebook-for-woocommerce' ); ?>
+								<?php
+								break;
+							case 'ORDER_SHIPPED':
+								?>
+								<?php esc_html_e( 'Send order shipped message', 'facebook-for-woocommerce' ); ?>
+								<?php
+								break;
+							case 'ORDER_REFUNDED':
+								?>
+								<?php esc_html_e( 'Send order refunded message', 'facebook-for-woocommerce' ); ?>
+								<?php
+								break;
+						}
+						?>
+						</b></label>
 					</div>
 					<div class="divider"></div>
 					<div class="manage-event-card-item fbwa-hidden-element" id="library-template-content"></div>
@@ -546,7 +615,27 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<div class="manage-event-template-block">
 					<div class="manage-event-template-header">
 						<input type="radio" name="template-status" id="inactive-template-status" value="INACTIVE" />
-						<label for="inactive-template-status"><b><?php esc_html_e( 'Turn off order confirmation', 'facebook-for-woocommerce' ); ?> </b></label>
+						<label for="inactive-template-status"><b>
+						<?php
+						switch ( $event ) {
+							case 'ORDER_PLACED':
+								?>
+								<?php esc_html_e( 'Turn off order confirmation message', 'facebook-for-woocommerce' ); ?>
+								<?php
+								break;
+							case 'ORDER_SHIPPED':
+								?>
+								<?php esc_html_e( 'Turn off order shipped message', 'facebook-for-woocommerce' ); ?>
+								<?php
+								break;
+							case 'ORDER_REFUNDED':
+								?>
+								<?php esc_html_e( 'Turn off order refunded message', 'facebook-for-woocommerce' ); ?>
+								<?php
+								break;
+						}
+						?>
+						</b></label>
 					</div>
 				</div>
 			</div>
@@ -580,6 +669,19 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	public function get_current_view() {
 		$current_view = Helper::get_requested_value( 'view' );
 		return $current_view;
+	}
+
+	/**
+	 * Gets the current event
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return array
+	 */
+	public function get_current_event() {
+		$view      = Helper::get_requested_value( 'view' );
+		$event_val = str_replace( 'manage_', '', $view );
+		return strtoupper( $event_val );
 	}
 
 	/**

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -30,7 +30,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	/** @var array Values for Manage Events  */
 	const MANAGE_EVENT_VIEWS = array(
 		'manage_order_placed',
-		'manage_order_shipped',
+		'manage_order_fulfilled',
 		'manage_order_refunded',
 	);
 
@@ -125,12 +125,12 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				),
 			)
 		);
-		$order_placed_event_config_id   = get_option( 'wc_facebook_wa_order_placed_event_config_id', null );
-		$order_placed_language          = get_option( 'wc_facebook_wa_order_placed_language', 'en' );
-		$order_shipped_event_config_id  = get_option( 'wc_facebook_wa_order_shipped_event_config_id', null );
-		$order_shipped_language         = get_option( 'wc_facebook_wa_order_shipped_language', 'en' );
-		$order_refunded_event_config_id = get_option( 'wc_facebook_wa_order_refunded_event_config_id', null );
-		$order_refunded_language        = get_option( 'wc_facebook_wa_order_refunded_language', 'en' );
+		$order_placed_event_config_id    = get_option( 'wc_facebook_wa_order_placed_event_config_id', null );
+		$order_placed_language           = get_option( 'wc_facebook_wa_order_placed_language', 'en' );
+		$order_fulfilled_event_config_id = get_option( 'wc_facebook_wa_order_fulfilled_event_config_id', null );
+		$order_fulfilled_language        = get_option( 'wc_facebook_wa_order_fulfilled_language', 'en' );
+		$order_refunded_event_config_id  = get_option( 'wc_facebook_wa_order_refunded_event_config_id', null );
+		$order_refunded_language         = get_option( 'wc_facebook_wa_order_refunded_language', 'en' );
 		wp_enqueue_script(
 			'facebook-for-woocommerce-whatsapp-events',
 			facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/whatsapp-events.js',
@@ -141,16 +141,16 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 			'facebook-for-woocommerce-whatsapp-events',
 			'facebook_for_woocommerce_whatsapp_events',
 			array(
-				'ajax_url'                => admin_url( 'admin-ajax.php' ),
-				'nonce'                   => wp_create_nonce( 'facebook-for-wc-whatsapp-events-nonce' ),
-				'event'                   => $this->get_current_event(),
-				'order_placed_enabled'    => ! empty( $order_placed_event_config_id ),
-				'order_placed_language'   => $order_placed_language,
-				'order_shipped_enabled'   => ! empty( $order_shipped_event_config_id ),
-				'order_shipped_language'  => $order_shipped_language,
-				'order_refunded_enabled'  => ! empty( $order_refunded_event_config_id ),
-				'order_refunded_language' => $order_refunded_language,
-				'i18n'                    => array(
+				'ajax_url'                 => admin_url( 'admin-ajax.php' ),
+				'nonce'                    => wp_create_nonce( 'facebook-for-wc-whatsapp-events-nonce' ),
+				'event'                    => $this->get_current_event(),
+				'order_placed_enabled'     => ! empty( $order_placed_event_config_id ),
+				'order_placed_language'    => $order_placed_language,
+				'order_fulfilled_enabled'  => ! empty( $order_fulfilled_event_config_id ),
+				'order_fulfilled_language' => $order_fulfilled_language,
+				'order_refunded_enabled'   => ! empty( $order_refunded_event_config_id ),
+				'order_refunded_language'  => $order_refunded_language,
+				'i18n'                     => array(
 					'result' => true,
 				),
 			)
@@ -382,10 +382,10 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<div>
 					<div class="event-config-heading-container">
 						<h3><?php esc_html_e( 'Order shipped', 'facebook-for-woocommerce' ); ?></h3>
-						<div class="event-config-status on-status fbwa-hidden-element" id="order-shipped-active-status">
+						<div class="event-config-status on-status fbwa-hidden-element" id="order-fulfilled-active-status">
 							<?php esc_html_e( 'On', 'facebook-for-woocommerce' ); ?>
 						</div>
-						<div class="event-config-status fbwa-hidden-element" id="order-shipped-inactive-status">
+						<div class="event-config-status fbwa-hidden-element" id="order-fulfilled-inactive-status">
 							<?php esc_html_e( 'Off', 'facebook-for-woocommerce' ); ?>
 						</div>
 					</div>
@@ -393,7 +393,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				</div>
 				<div class="event-config-manage-button">
 					<a
-						id="woocommerce-whatsapp-manage-order-shipped"
+						id="woocommerce-whatsapp-manage-order-fulfilled"
 						class="event-config-manage-button button"
 						href="#"><?php esc_html_e( 'Manage', 'facebook-for-woocommerce' ); ?></a>
 				</div>
@@ -527,7 +527,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 							<?php esc_html_e( 'Manage order confirmation message', 'facebook-for-woocommerce' ); ?>
 							<?php
 							break;
-						case 'ORDER_SHIPPED':
+						case 'ORDER_FULFILLED':
 							?>
 							<?php esc_html_e( 'Manage order shipped message', 'facebook-for-woocommerce' ); ?>
 							<?php
@@ -548,7 +548,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 								<?php esc_html_e( 'Send a confirmation to customers after they\'ve placed an order.', 'facebook-for-woocommerce' ); ?>
 									<?php
 								break;
-							case 'ORDER_SHIPPED':
+							case 'ORDER_FULFILLED':
 								?>
 								<?php esc_html_e( 'Send a confirmation to customers when their order has shipped.', 'facebook-for-woocommerce' ); ?>
 									<?php
@@ -569,7 +569,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<select id="manage-event-language" class="manage-event-selector">
 					<option value="en">English</option>
 					<option value="en_US">English (US)</option>
-					<option value="en_UK">English (UK)</option>
+					<option value="en_GB">English (UK)</option>
 					<option value="es">Spanish</option>
 				</select>
 			</div>
@@ -585,7 +585,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 								<?php esc_html_e( 'Send order confirmation message', 'facebook-for-woocommerce' ); ?>
 								<?php
 								break;
-							case 'ORDER_SHIPPED':
+							case 'ORDER_FULFILLED':
 								?>
 								<?php esc_html_e( 'Send order shipped message', 'facebook-for-woocommerce' ); ?>
 								<?php
@@ -613,7 +613,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 								<?php esc_html_e( 'Turn off order confirmation message', 'facebook-for-woocommerce' ); ?>
 								<?php
 								break;
-							case 'ORDER_SHIPPED':
+							case 'ORDER_FULFILLED':
 								?>
 								<?php esc_html_e( 'Turn off order shipped message', 'facebook-for-woocommerce' ); ?>
 								<?php

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -15,6 +15,7 @@ defined( 'ABSPATH' ) || exit;
 use WooCommerce\Facebook\Admin\Abstract_Settings_Screen;
 use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
 use WooCommerce\Facebook\Framework\Helper;
+use WooCommerce\Facebook\Handlers\WhatsAppUtilityConnection;
 
 /**
  * The Whatsapp Utility settings screen object.
@@ -27,13 +28,23 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	/** @var string screen ID */
 	const ID = 'whatsapp_utility';
 
+	/** @var array Mapping of Order Status to Event name */
+	const ORDER_STATUS_TO_EVENT_MAPPING = array(
+		'processing' => 'ORDER_PLACED',
+		'completed'  => 'ORDER_SHIPPED',
+		'refunded'   => 'ORDER_REFUNDED',
+	);
+
+	/** @var string Prefix for Whatsapp Utility Option Names */
+	const WA_UTILITY_OPTION_PREFIX = 'wc_facebook_wa';
+
 	/**
 	 * Whatsapp Utility constructor.
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'initHook' ) );
-
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+		add_action( 'woocommerce_order_status_changed', array( $this, 'process_wc_order_status_changed' ), 10, 3 );
 	}
 
 	/**
@@ -581,5 +592,69 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	 */
 	public function get_settings() {
 		return array();
+	}
+
+	public function process_wc_order_status_changed( $order_id, $old_status, $new_status ) {
+
+		// WhatsApp Utility Messages are supported only for Processing status
+		// TODO: add support for Completed and Refunded Status
+		if ( 'processing' !== $new_status ) {
+			return;
+		}
+
+		$event = self::ORDER_STATUS_TO_EVENT_MAPPING[ $new_status ];
+
+		// Check WhatsApp Event Config is active
+		$event_config_id_option_name       = implode( '_', array( self::WA_UTILITY_OPTION_PREFIX, strtolower( $event ), 'event_config_id' ) );
+		$event_config_language_option_name = implode( '_', array( self::WA_UTILITY_OPTION_PREFIX, strtolower( $event ), 'language' ) );
+		$event_config_id                   = get_option( $event_config_id_option_name, null );
+		$language_code                     = get_option( $event_config_language_option_name, null );
+		if ( empty( $event_config_id ) || empty( $language_code ) ) {
+			wc_get_logger()->info(
+				sprintf(
+				/* translators: %s $order_id */
+					__( 'Messages Post API call for Order id %1$s skipped due to no active event config', 'facebook-for-woocommerce' ),
+					$order_id,
+				)
+			);
+			return;
+		}
+
+		$order = wc_get_order( $order_id );
+		// Check WhatsApp Consent Checkbox is selected in shipping and billing
+		$billing_consent_value  = $order->get_meta( '_wc_billing/wc_facebook/whatsapp_consent_checkbox' );
+		$shipping_consent_value = $order->get_meta( '_wc_shipping/wc_facebook/whatsapp_consent_checkbox' );
+		$has_whatsapp_consent   = $billing_consent_value && $shipping_consent_value;
+		// Get WhatsApp Phone number from entered Billing and Shipping phone number
+		$billing_phone_number  = $order->get_billing_phone();
+		$shipping_phone_number = $order->get_shipping_phone();
+		$phone_number          = ( isset( $billing_phone_number ) && $billing_consent_value ) ? $billing_phone_number : $shipping_phone_number;
+		// Get Customer first name
+		$first_name = $order->get_billing_first_name();
+		if ( empty( $phone_number ) || ! $has_whatsapp_consent || empty( $event ) || empty( $first_name ) ) {
+			wc_get_logger()->info(
+				sprintf(
+				/* translators: %s $order_id */
+					__( 'Messages Post API call for Order id %1$s skipped due to missing whatsapp consent or Order info', 'facebook-for-woocommerce' ),
+					$order_id,
+				)
+			);
+			return;
+		}
+
+		// Check Access token and WACS is available
+		$bisu_token = get_option( 'wc_facebook_wa_integration_bisu_access_token', null );
+		$wacs_id    = get_option( 'wc_facebook_wa_integration_wacs_id', null );
+		if ( empty( $bisu_token ) || empty( $wacs_id ) ) {
+			wc_get_logger()->info(
+				sprintf(
+				/* translators: %s $order_id */
+					__( 'Messages Post API call for Order id %1$s Failed due to missing access token or wacs info', 'facebook-for-woocommerce' ),
+					$order_id,
+				)
+			);
+			return;
+		}
+		WhatsAppUtilityConnection::post_whatsapp_utility_messages_events_call( $event, $event_config_id, $language_code, $wacs_id, $order_id, $phone_number, $first_name, $bisu_token );
 	}
 }

--- a/includes/Handlers/WhatsAppUtilityConnection.php
+++ b/includes/Handlers/WhatsAppUtilityConnection.php
@@ -276,10 +276,10 @@ class WhatsAppUtilityConnection {
 
 			),
 		);
-		$response        = wp_remote_post( $base_url, $options );
-		$status_code     = wp_remote_retrieve_response_code( $response );
-		$data            = explode( "\n", wp_remote_retrieve_body( $response ) );
-		$response_object = json_decode( $data[0] );
+		$response             = wp_remote_post( $base_url, $options );
+		$status_code          = wp_remote_retrieve_response_code( $response );
+		$data                 = explode( "\n", wp_remote_retrieve_body( $response ) );
+		$response_object      = json_decode( $data[0] );
 		if ( is_wp_error( $response ) || 200 !== $status_code ) {
 			$error_message = $response_object->error->error_user_title ?? $response_object->error->message ?? 'Something went wrong. Please try again later!';
 			wc_get_logger()->info(

--- a/includes/Handlers/WhatsAppUtilityConnection.php
+++ b/includes/Handlers/WhatsAppUtilityConnection.php
@@ -40,7 +40,6 @@ class WhatsAppUtilityConnection {
 	/** @var string Default language for Library Template */
 	const DEFAULT_LANGUAGE = 'en';
 
-
 	/**
 	 * Makes an API call to Template Library API
 	 *

--- a/includes/Handlers/WhatsAppUtilityConnection.php
+++ b/includes/Handlers/WhatsAppUtilityConnection.php
@@ -325,12 +325,14 @@ class WhatsAppUtilityConnection {
 	 * @param string $order_id Order id
 	 * @param string $phone_number Customer phone number
 	 * @param string $first_name Customer first name
+	 * @param string $refund_value Amount refunded to the Customer
 	 * @param string $bisu_token the BISU token received in the webhook
 	 */
-	public static function post_whatsapp_utility_messages_events_call( $event, $event_config_id, $language_code, $wacs_id, $order_id, $phone_number, $first_name, $bisu_token ) {
+	public static function post_whatsapp_utility_messages_events_call( $event, $event_config_id, $language_code, $wacs_id, $order_id, $phone_number, $first_name, $refund_value, $bisu_token ) {
 		$base_url        = array( self::GRAPH_API_BASE_URL, self::API_VERSION, $wacs_id, "messages?access_token=$bisu_token" );
 		$base_url        = esc_url( implode( '/', $base_url ) );
 		$name            = self::EVENT_TO_LIBRARY_TEMPLATE_MAPPING[ $event ];
+		$components      = self::get_components_for_event( $event, $order_id, $first_name, $refund_value );
 		$options         = array(
 			'body' => array(
 				'messaging_product' => 'whatsapp',
@@ -340,32 +342,7 @@ class WhatsAppUtilityConnection {
 					'language'   => array(
 						'code' => $language_code,
 					),
-					'components' => array(
-						array(
-							'type'       => 'BODY',
-							'parameters' => array(
-								array(
-									'type' => 'text',
-									'text' => $first_name,
-								),
-								array(
-									'type' => 'text',
-									'text' => "#$order_id",
-								),
-							),
-						),
-						array(
-							'type'       => 'BUTTON',
-							'sub_type'   => 'url',
-							'index'      => 0,
-							'parameters' => array(
-								array(
-									'type' => 'text',
-									'text' => "$order_id",
-								),
-							),
-						),
-					),
+					'components' => $components,
 				),
 				'type'              => 'template',
 			),
@@ -391,6 +368,75 @@ class WhatsAppUtilityConnection {
 					__( 'Messages Post API call for Order id %1$s Succeeded.', 'facebook-for-woocommerce' ),
 					$order_id
 				)
+			);
+		}
+	}
+
+
+	/**
+	 * Gets Component Objects for Order Management Events
+	 *
+	 * @param string $event Order Management event
+	 * @param string $order_id Order id
+	 * @param string $first_name Customer first name
+	 * @param string $refund_value Amount refunded to the Customer
+	 */
+	public static function get_components_for_event( $event, $order_id, $first_name, $refund_value ) {
+		if ( 'ORDER_REFUNDED' === $event ) {
+			return array(
+				array(
+					'type'       => 'HEADER',
+					'parameters' => array(
+						array(
+							'type' => 'text',
+							'text' => $refund_value,
+						),
+					),
+				),
+				array(
+					'type'       => 'BODY',
+					'parameters' => array(
+						array(
+							'type' => 'text',
+							'text' => $first_name,
+						),
+						array(
+							'type' => 'text',
+							'text' => $refund_value,
+						),
+						array(
+							'type' => 'text',
+							'text' => "#$order_id",
+						),
+					),
+				),
+			);
+		} else {
+			return array(
+				array(
+					'type'       => 'BODY',
+					'parameters' => array(
+						array(
+							'type' => 'text',
+							'text' => $first_name,
+						),
+						array(
+							'type' => 'text',
+							'text' => "#$order_id",
+						),
+					),
+				),
+				array(
+					'type'       => 'BUTTON',
+					'sub_type'   => 'url',
+					'index'      => 0,
+					'parameters' => array(
+						array(
+							'type' => 'text',
+							'text' => "$order_id",
+						),
+					),
+				),
 			);
 		}
 	}

--- a/includes/Handlers/WhatsAppUtilityConnection.php
+++ b/includes/Handlers/WhatsAppUtilityConnection.php
@@ -40,6 +40,14 @@ class WhatsAppUtilityConnection {
 	/** @var string Default language for Library Template */
 	const DEFAULT_LANGUAGE = 'en';
 
+	/** @var array Mapping of Order Status to Event name */
+	const ORDER_STATUS_TO_EVENT_MAPPING = array(
+		'processing' => 'ORDER_PLACED',
+		'completed'  => 'ORDER_SHIPPED',
+		'refunded'   => 'ORDER_REFUNDED',
+	);
+
+
 	/**
 	 * Makes an API call to Template Library API
 	 *
@@ -276,10 +284,10 @@ class WhatsAppUtilityConnection {
 
 			),
 		);
-		$response             = wp_remote_post( $base_url, $options );
-		$status_code          = wp_remote_retrieve_response_code( $response );
-		$data                 = explode( "\n", wp_remote_retrieve_body( $response ) );
-		$response_object      = json_decode( $data[0] );
+		$response        = wp_remote_post( $base_url, $options );
+		$status_code     = wp_remote_retrieve_response_code( $response );
+		$data            = explode( "\n", wp_remote_retrieve_body( $response ) );
+		$response_object = json_decode( $data[0] );
 		if ( is_wp_error( $response ) || 200 !== $status_code ) {
 			$error_message = $response_object->error->error_user_title ?? $response_object->error->message ?? 'Something went wrong. Please try again later!';
 			wc_get_logger()->info(


### PR DESCRIPTION
## Description
Changes to support Order Fulfilled and Order Refunded events in Manage Events view.
Figma:
<img width="1441" alt="Screenshot 2025-05-03 at 11 15 24 PM" src="https://github.com/user-attachments/assets/d9b72419-f857-4c74-8d80-6da1fac606b0" />
<img width="1441" alt="Screenshot 2025-05-03 at 11 15 47 PM" src="https://github.com/user-attachments/assets/c732af26-8b3c-48c9-aaa5-32c1a36cda8a" />

### Type of change
- New feature (non-breaking change which adds functionality)

## Changelog entry
Changes to support Order Shipped and Order Refunded events in Manage events view

## Test Plan
1. Open Utility Messages View
2. Click on Manage button for all the events.
3. Validate Manage Event view and Library template content is updated for all events

## Screen Recording
https://github.com/user-attachments/assets/d5837bea-3348-4f12-9630-87b3272ca85f



