### PR TITLE
[WAUM][33/n][Easy]Fix nonce verification on whatsapp disconnect widget edit click

### DIFF
--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -202,7 +202,7 @@ class AJAX {
 	 */
 	public function wc_facebook_whatsapp_fetch_url_info() {
 		facebook_for_woocommerce()->log( 'Fetching url info for whatsapp pages' );
-		if ( ! check_ajax_referer( 'facebook-for-wc-whatsapp-billing-nonce', 'nonce', false ) && ! check_ajax_referer( 'facebook-for-wc-whatsapp-templates-nonce', 'nonce', false ) ) {
+		if ( ! check_ajax_referer( 'facebook-for-wc-whatsapp-billing-nonce', 'nonce', false ) && ! check_ajax_referer( 'facebook-for-wc-whatsapp-templates-nonce', 'nonce', false ) && ! check_ajax_referer( 'facebook-for-wc-whatsapp-disconnect-nonce', 'nonce', false ) ) {
 			wp_send_json_error( 'Invalid security token sent.' );
 		}
 


### PR DESCRIPTION
## Description
Fix nonce check to fetch url info on whatsapp disconnect widget edit click.

### Type of change
- Bug fix (non-breaking change which fixes an issue)


## Changelog entry
Fix nonce on whatsapp disconnect widget edit click


## Test Plan

https://github.com/user-attachments/assets/dbc98b76-2965-46ac-8757-13689fa91ac6

