### PR TITLE
Manual shipping profile feed upload button

### DIFF
--- a/assets/js/admin/enhanced-settings-sync.js
+++ b/assets/js/admin/enhanced-settings-sync.js
@@ -73,4 +73,37 @@ jQuery(document).ready(function($) {
             button.prop('disabled', false);
         });
     });
+
+	/**
+	 * Handle the sync shipping profiles button click event
+	 *
+	 * @since 3.5.0
+	 *
+	 * @param {object} event
+	 */
+	$('#wc-facebook-enhanced-settings-sync-shipping-profiles').click(function(event) {
+		event.preventDefault();
+		var button = $(this);
+
+		button.html('Syncing...');
+		button.prop('disabled', true);
+
+		var data = {
+			action: "wc_facebook_sync_shipping_profiles",
+			nonce: wc_facebook_enhanced_settings_sync.sync_shipping_profiles_nonce
+		};
+
+		$.post(wc_facebook_enhanced_settings_sync.ajax_url, data, function(response) {
+			if (response.success) {
+				button.html('Sync completed');
+				button.prop('disabled', false);
+			} else {
+				button.html('Sync failed');
+				button.prop('disabled', false);
+			}
+		}).fail(function() {
+			button.html('Sync failed');
+			button.prop('disabled', false);
+		});
+	});
 });

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -45,6 +45,9 @@ class AJAX {
 		// sync all coupons via AJAX
 		add_action( 'wp_ajax_wc_facebook_sync_coupons', array( $this, 'sync_coupons' ) );
 
+		// sync all shipping profiles via AJAX
+		add_action( 'wp_ajax_wc_facebook_sync_shipping_profiles', array( $this, 'sync_shipping_profiles' ) );
+
 		// get the current sync status
 		add_action( 'wp_ajax_wc_facebook_get_sync_status', array( $this, 'get_sync_status' ) );
 
@@ -117,18 +120,36 @@ class AJAX {
 		}
 	}
 
-		/**
-		 * Syncs all coupons via AJAX.
-		 *
-		 * @internal
-		 *
-		 * @since 3.5.0
-		 */
+	/**
+	 * Syncs all coupons via AJAX.
+	 *
+	 * @internal
+	 *
+	 * @since 3.5.0
+	 */
 	public function sync_coupons() {
 		check_admin_referer( Shops::ACTION_SYNC_COUPONS, 'nonce' );
 
 		try {
 			facebook_for_woocommerce()->feed_manager->get_feed_instance( 'promotions' )->regenerate_feed();
+			wp_send_json_success();
+		} catch ( \Exception $exception ) {
+			wp_send_json_error( $exception->getMessage() );
+		}
+	}
+
+	/**
+	 * Syncs all shipping profiles via AJAX.
+	 *
+	 * @internal
+	 *
+	 * @since 3.5.0
+	 */
+	public function sync_shipping_profiles() {
+		check_admin_referer( Shops::ACTION_SYNC_SHIPPING_PROFILES, 'nonce' );
+
+		try {
+			facebook_for_woocommerce()->feed_manager->get_feed_instance( 'shipping_profiles' )->regenerate_feed();
 			wp_send_json_success();
 		} catch ( \Exception $exception ) {
 			wp_send_json_error( $exception->getMessage() );

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -31,6 +31,9 @@ class Shops extends Abstract_Settings_Screen {
 	/** @var string */
 	const ACTION_SYNC_COUPONS = 'wc_facebook_sync_coupons';
 
+	/** @var string */
+	const ACTION_SYNC_SHIPPING_PROFILES = 'wc_facebook_sync_shipping_profiles';
+
 	/**
 	 * Shops constructor.
 	 *
@@ -126,9 +129,10 @@ class Shops extends Abstract_Settings_Screen {
 			'wc-facebook-enhanced-settings-sync',
 			'wc_facebook_enhanced_settings_sync',
 			array(
-				'ajax_url'            => admin_url( 'admin-ajax.php' ),
-				'sync_products_nonce' => wp_create_nonce( self::ACTION_SYNC_PRODUCTS ),
-				'sync_coupons_nonce'  => wp_create_nonce( self::ACTION_SYNC_COUPONS ),
+				'ajax_url'                     => admin_url( 'admin-ajax.php' ),
+				'sync_products_nonce'          => wp_create_nonce( self::ACTION_SYNC_PRODUCTS ),
+				'sync_coupons_nonce'           => wp_create_nonce( self::ACTION_SYNC_COUPONS ),
+				'sync_shipping_profiles_nonce' => wp_create_nonce( self::ACTION_SYNC_SHIPPING_PROFILES ),
 			)
 		);
 	}
@@ -231,6 +235,22 @@ class Shops extends Abstract_Settings_Screen {
 							</button>
 							<p id="coupon-sync-description" class="sync-description">
 								Manually sync your coupons from WooCommerce to your shop. It may take a couple of minutes for the changes to populate.
+							</p>
+						</td>
+					</tr>
+					<tr valign="top" class="wc-facebook-shops-sample">
+						<th scope="row" class="titledesc">
+							Shipping profiles sync
+						</th>
+						<td class="forminp">
+							<button
+								id="wc-facebook-enhanced-settings-sync-shipping-profiles"
+								class="button"
+								type="button">
+								<?php esc_html_e( 'Sync now', 'facebook-for-woocommerce' ); ?>
+							</button>
+							<p id="shipping-profile-sync-description" class="sync-description">
+								Manually sync your shipping profiles from WooCommerce to your shop. It may take a couple of minutes for the changes to populate.
 							</p>
 						</td>
 					</tr>

--- a/includes/Feed/ShippingProfiles/ShippingProfilesFeed.php
+++ b/includes/Feed/ShippingProfiles/ShippingProfilesFeed.php
@@ -58,11 +58,6 @@ class ShippingProfilesFeed extends AbstractFeed {
 		return FeedManager::SHIPPING_PROFILES;
 	}
 
-	protected static function get_feed_gen_interval(): int {
-		return HOUR_IN_SECONDS;
-	}
-
-
 	/**
 	 * @throws \Exception If an error is encountered mapping shipping profile data.
 	 */

--- a/tests/Unit/RolloutSwitchesTest.php
+++ b/tests/Unit/RolloutSwitchesTest.php
@@ -5,7 +5,7 @@ use WooCommerce\Facebook\API;
 use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
 use WooCommerce\Facebook\RolloutSwitches;
 
-class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSafeFiltering {
+class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\Unit\AbstractWPUnitTestWithSafeFiltering {
 
 	/**
 	 * Facebook Graph API endpoint.
@@ -20,7 +20,7 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 	 * @var string
 	 */
 	private $version = Api::API_VERSION;
-
+	
 	/**
 	 * @var Api
 	 */
@@ -36,8 +36,8 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 		parent::setUp();
 		$this->api = new Api( $this->access_token );
 	}
-
-	public function test_api() {
+	
+	public function test_api() {	
 		$response = function( $result, $parsed_args, $url ) {
 			$this->assertEquals( 'GET', $parsed_args['method'] );
 			$url_params = "access_token={$this->access_token}&fbe_external_business_id={$this->external_business_id}";
@@ -52,7 +52,7 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 			];
 		};
 		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
-
+		
 		$response = $this->api->get_rollout_switches( $this->external_business_id );
 		$this->assertEquals([
 			[
@@ -70,8 +70,8 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 		], $response->get_data());
 	}
 
-	public function test_plugin() {
-
+	public function test_plugin() {	
+		
 		// mock the active filters to test business values
 		$plugin = facebook_for_woocommerce();
 		$plugin_ref_obj          = new ReflectionObject( $plugin );
@@ -98,7 +98,7 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 				)
 			))));
 		$prop_api->setValue( $plugin, $mock_api );
-
+		
 		$switch_mock = $this->getMockBuilder(RolloutSwitches::class)
 			->setConstructorArgs( array( $plugin ) )
             ->onlyMethods(['is_switch_active'])
@@ -122,7 +122,7 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 		// If the feature is active and in the response -> response value
 		$this->assertEquals( $switch_mock->is_switch_enabled("switch_a"), true );
 		$this->assertEquals( $switch_mock->is_switch_enabled("switch_b"), false );
-
+		
 		// If the switch is active but not in the response -> TRUE
 		$this->assertEquals( $switch_mock->is_switch_enabled("switch_d"), true );
 	}

--- a/tests/Unit/RolloutSwitchesTest.php
+++ b/tests/Unit/RolloutSwitchesTest.php
@@ -5,7 +5,7 @@ use WooCommerce\Facebook\API;
 use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
 use WooCommerce\Facebook\RolloutSwitches;
 
-class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\Unit\AbstractWPUnitTestWithSafeFiltering {
+class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSafeFiltering {
 
 	/**
 	 * Facebook Graph API endpoint.
@@ -20,7 +20,7 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\Unit\AbstractWPUni
 	 * @var string
 	 */
 	private $version = Api::API_VERSION;
-	
+
 	/**
 	 * @var Api
 	 */
@@ -36,8 +36,8 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\Unit\AbstractWPUni
 		parent::setUp();
 		$this->api = new Api( $this->access_token );
 	}
-	
-	public function test_api() {	
+
+	public function test_api() {
 		$response = function( $result, $parsed_args, $url ) {
 			$this->assertEquals( 'GET', $parsed_args['method'] );
 			$url_params = "access_token={$this->access_token}&fbe_external_business_id={$this->external_business_id}";
@@ -52,7 +52,7 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\Unit\AbstractWPUni
 			];
 		};
 		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
-		
+
 		$response = $this->api->get_rollout_switches( $this->external_business_id );
 		$this->assertEquals([
 			[
@@ -70,8 +70,8 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\Unit\AbstractWPUni
 		], $response->get_data());
 	}
 
-	public function test_plugin() {	
-		
+	public function test_plugin() {
+
 		// mock the active filters to test business values
 		$plugin = facebook_for_woocommerce();
 		$plugin_ref_obj          = new ReflectionObject( $plugin );
@@ -98,7 +98,7 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\Unit\AbstractWPUni
 				)
 			))));
 		$prop_api->setValue( $plugin, $mock_api );
-		
+
 		$switch_mock = $this->getMockBuilder(RolloutSwitches::class)
 			->setConstructorArgs( array( $plugin ) )
             ->onlyMethods(['is_switch_active'])
@@ -122,7 +122,7 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\Unit\AbstractWPUni
 		// If the feature is active and in the response -> response value
 		$this->assertEquals( $switch_mock->is_switch_enabled("switch_a"), true );
 		$this->assertEquals( $switch_mock->is_switch_enabled("switch_b"), false );
-		
+
 		// If the switch is active but not in the response -> TRUE
 		$this->assertEquals( $switch_mock->is_switch_enabled("switch_d"), true );
 	}


### PR DESCRIPTION
## Description

This PR sets up a button to allow sellers to manually trigger an ad hoc shipping profiles feed upload. This new button is setup the same way as the existing product data and coupon codes buttons.

This PR also tweaks ShippingProfilesFeed.php to remove the override for get_feed_gen_interval() to have the feed upload for shipping profiles run every day instead of every hour (every hour is the default in AbstractFeed).

### Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

New button to manually trigger shipping profiles feed upload to Meta


## Test Plan

1. Pushed local changes to lightsail instance (had to run npm start first)
2. Navigated to the troubleshoot dropdown in the facebook shops tab
3. Clicked button to trigger ad hoc shipping profiles feed upload
4. Verified that there was a log for the API call and a new feed upload session created (and successful)

https://github.com/user-attachments/assets/ae8a97b9-5f8d-4379-948d-720dea65c122

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before
![Screenshot 2025-05-05 at 7 21 25 PM](https://github.com/user-attachments/assets/35b2d04d-29d9-4269-8fdd-21640217f5d0)
### After
![Screenshot 2025-05-05 at 7 21 45 PM](https://github.com/user-attachments/assets/298b7b89-4f87-408c-af6b-ee28c3fe7721)