### PR TITLE
[WAUM][35/n] Add warning modal for Disconnect Button Click

### DIFF
--- a/assets/js/admin/whatsapp-disconnect.js
+++ b/assets/js/admin/whatsapp-disconnect.js
@@ -8,6 +8,51 @@
  */
 
 jQuery( document ).ready( function( $ ) {
+    // Get the modal and related elements
+    var modal = document.getElementById("wc-fb-disconnect-warning-modal");
+    var cancelButton = document.getElementById("wc-fb-disconnect-warning-modal-cancel");
+    var confirmButton = document.getElementById("wc-fb-disconnect-warning-modal-confirm");
+
+    // On click of the remove button, show the warning modal
+    $("#wc-whatsapp-disconnect-button").click(function(event) {
+        // Show the modal
+        modal.style.display = "block";
+
+        // Prevent default action
+        event.preventDefault();
+    });
+
+    if (cancelButton) {
+        // Close modal when clicking the Cancel button
+        cancelButton.onclick = function() {
+            modal.style.display = "none";
+        };
+    }
+
+    if (confirmButton) {
+        // Handle confirm action
+        confirmButton.onclick = function() {
+            $.post( facebook_for_woocommerce_whatsapp_disconnect.ajax_url, {
+                action: 'wc_facebook_disconnect_whatsapp',
+                nonce:  facebook_for_woocommerce_whatsapp_disconnect.nonce
+            }, function ( response ) {
+                if ( response.success ) {
+                    let url = new URL(window.location.href);
+                    let params = new URLSearchParams(url.search);
+                    params.delete('view');
+                    url.search = params.toString();
+                    window.location.href = url.toString();
+                    console.log( 'Whatsapp Disconnect Success', response );
+                } else {
+                    console.log("Whatsapp Disconnect Failure!!!",response);
+                }
+            } );
+
+            // Close the modal
+            modal.style.display = "none";
+        };
+    }
+
     // handle whatsapp disconnect widget edit link click should open business manager with whatsapp asset selected
 	$( '#wc-whatsapp-disconnect-edit' ).click( function( event ) {
         $.post( facebook_for_woocommerce_whatsapp_disconnect.ajax_url, {
@@ -27,22 +72,4 @@ jQuery( document ).ready( function( $ ) {
 		} );
     });
 
-    // handle whatsapp disconnect button click should disconnect whatsapp from woocommerce
-    $( '#wc-whatsapp-disconnect-button' ).click( function( event ) {
-        $.post( facebook_for_woocommerce_whatsapp_disconnect.ajax_url, {
-			action: 'wc_facebook_disconnect_whatsapp',
-			nonce:  facebook_for_woocommerce_whatsapp_disconnect.nonce
-		}, function ( response ) {
-            if ( response.success ) {
-                let url = new URL(window.location.href);
-                let params = new URLSearchParams(url.search);
-                params.delete('view');
-                url.search = params.toString();
-                window.location.href = url.toString();
-                console.log( 'Whatsapp Disconnect Success', response );
-			} else {
-                console.log("Whatsapp Disconnect Failure!!!",response);
-            }
-		} );
-    });
 } );

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -514,7 +514,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 					</div>
 					<div class="warning-modal-footer">
 						<button id="wc-fb-disconnect-warning-modal-cancel" class="button"><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></button>
-						<button id="wc-fb-disconnect-warning-modal-confirm" class="button button-primary"><?php esc_html_e( 'Remove', 'facebook-for-woocommerce' ); ?></button>
+						<button id="wc-fb-disconnect-warning-modal-confirm" class="button button-primary"><?php esc_html_e( 'Disconnect', 'facebook-for-woocommerce' ); ?></button>
 					</div>
 				</div>
 			</div>

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -506,6 +506,18 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				</a>
 			</div>
 			</div>
+			<div id="wc-fb-disconnect-warning-modal" class="warning-custom-modal">
+				<div class="warning-modal-content">
+					<h2><?php esc_html_e( 'Disconnect WhatsApp from WooCommerce?', 'facebook-for-woocommerce' ); ?></h2>
+					<div class="warning-modal-body">
+						<?php esc_html_e( 'Your WhatsApp Business account will be disconnected from WooCommerce, resulting in the loss of messaging features. To reconnect in the future, you\'ll need to set up the connection again. However, you can still view your old insights in WhatsApp Manager. ', 'facebook-for-woocommerce' ); ?>
+					</div>
+					<div class="warning-modal-footer">
+						<button id="wc-fb-disconnect-warning-modal-cancel" class="button"><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></button>
+						<button id="wc-fb-disconnect-warning-modal-confirm" class="button button-primary"><?php esc_html_e( 'Remove', 'facebook-for-woocommerce' ); ?></button>
+					</div>
+				</div>
+			</div>
 		</div>
 		<?php
 	}
@@ -578,7 +590,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<div class="manage-event-template-block">
 					<div class="manage-event-template-header">
 						<input type="radio" name="template-status" id="active-template-status" value="ACTIVE" checked="checked" />
-						<label for="active-template-status"><b>				
+						<label for="active-template-status"><b>
 						<?php
 						switch ( $event ) {
 							case 'ORDER_PLACED':


### PR DESCRIPTION
## Description
Add a warning modal before disconnecting the whatsapp business account from WooCommerce and deleting the settings

## Figma
<img width="758" alt="Screenshot 2025-05-06 at 5 47 15 PM" src="https://github.com/user-attachments/assets/ec6697b7-ca95-478d-9bfc-efd9495e5bc5" />

## Type of change
- New feature (non-breaking change which adds functionality)


## Changelog entry
Add warning modal for Disconnect Button Click


## Test Plan

https://github.com/user-attachments/assets/6639b15d-2b60-4e48-95d4-a970d96a83ce

Note: Button naming "Remove" -> "Disconnect" was updated after test plan



