### PR TITLE
[WAUM] Fix currency encoding for Order Refunded Message

### DIFF
--- a/facebook-commerce-whatsapp-utility-event.php
+++ b/facebook-commerce-whatsapp-utility-event.php
@@ -100,8 +100,8 @@ class WC_Facebookcommerce_Whatsapp_Utility_Event {
 		foreach ( $order->get_refunds() as $refund ) {
 			$total_refund += $refund->get_amount();
 		}
-		$currency_symbol = get_woocommerce_currency_symbol( $currency );
-		$refund_amount   = $currency_symbol . $total_refund;
+		$currency      = $order->get_currency();
+		$refund_amount = $total_refund * 1000;
 		if ( empty( $phone_number ) || ! $has_whatsapp_consent || empty( $event ) || empty( $first_name ) ) {
 			wc_get_logger()->info(
 				sprintf(
@@ -126,6 +126,6 @@ class WC_Facebookcommerce_Whatsapp_Utility_Event {
 			);
 			return;
 		}
-		WhatsAppUtilityConnection::post_whatsapp_utility_messages_events_call( $event, $event_config_id, $language_code, $wacs_id, $order_id, $phone_number, $first_name, $refund_amount, $bisu_token );
+		WhatsAppUtilityConnection::post_whatsapp_utility_messages_events_call( $event, $event_config_id, $language_code, $wacs_id, $order_id, $phone_number, $first_name, $refund_amount, $currency, $bisu_token );
 	}
 }

--- a/includes/Handlers/WhatsAppUtilityConnection.php
+++ b/includes/Handlers/WhatsAppUtilityConnection.php
@@ -339,14 +339,15 @@ class WhatsAppUtilityConnection {
 	 * @param string $order_id Order id
 	 * @param string $phone_number Customer phone number
 	 * @param string $first_name Customer first name
-	 * @param string $refund_value Amount refunded to the Customer
+	 * @param int    $refund_value Amount refunded to the Customer
+	 * @param string $currency Currency code
 	 * @param string $bisu_token the BISU token received in the webhook
 	 */
-	public static function post_whatsapp_utility_messages_events_call( $event, $event_config_id, $language_code, $wacs_id, $order_id, $phone_number, $first_name, $refund_value, $bisu_token ) {
+	public static function post_whatsapp_utility_messages_events_call( $event, $event_config_id, $language_code, $wacs_id, $order_id, $phone_number, $first_name, $refund_value, $currency, $bisu_token ) {
 		$base_url        = array( self::GRAPH_API_BASE_URL, self::API_VERSION, $wacs_id, "messages?access_token=$bisu_token" );
 		$base_url        = esc_url( implode( '/', $base_url ) );
 		$name            = self::EVENT_TO_LIBRARY_TEMPLATE_MAPPING[ $event ];
-		$components      = self::get_components_for_event( $event, $order_id, $first_name, $refund_value );
+		$components      = self::get_components_for_event( $event, $order_id, $first_name, $refund_value, $currency );
 		$options         = array(
 			'body' => array(
 				'messaging_product' => 'whatsapp',
@@ -394,16 +395,21 @@ class WhatsAppUtilityConnection {
 	 * @param string $order_id Order id
 	 * @param string $first_name Customer first name
 	 * @param string $refund_value Amount refunded to the Customer
+	 * @param string $currency Currency code
 	 */
-	public static function get_components_for_event( $event, $order_id, $first_name, $refund_value ) {
+	public static function get_components_for_event( $event, $order_id, $first_name, $refund_value, $currency ) {
 		if ( 'ORDER_REFUNDED' === $event ) {
 			return array(
 				array(
 					'type'       => 'HEADER',
 					'parameters' => array(
 						array(
-							'type' => 'text',
-							'text' => $refund_value,
+							'type'     => 'currency',
+							'currency' => array(
+								'fallback_value' => 'VALUE',
+								'code'           => $currency,
+								'amount_1000'    => $refund_value,
+							),
 						),
 					),
 				),
@@ -415,8 +421,12 @@ class WhatsAppUtilityConnection {
 							'text' => $first_name,
 						),
 						array(
-							'type' => 'text',
-							'text' => $refund_value,
+							'type'     => 'currency',
+							'currency' => array(
+								'fallback_value' => 'VALUE',
+								'code'           => $currency,
+								'amount_1000'    => $refund_value,
+							),
 						),
 						array(
 							'type' => 'text',


### PR DESCRIPTION
## Description
Using currency parameter instead of text parameter in order refunded library template to fix currency symbol encoding issue:
<img width="445" alt="Screenshot 2025-05-06 at 11 33 37 AM" src="https://github.com/user-attachments/assets/d928fb36-7c47-4c17-bdaf-bc0e3999668e" />

### Type of change
- New feature (non-breaking change which adds functionality)


## Changelog entry
Fix for Order Refunded Utility Message

## Test Plan
1. Setup Order Refunded event in Utility Settings view
2. Set Order Status to Refunded
3. Validate message is sent on Whatsapp

## Screen Recording

https://github.com/user-attachments/assets/1baad398-c6fc-42d8-834c-33000c72739e


