### PR TITLE
Fix: 'Call to a member function is_taxonomy() on string' error when processing variable products

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1274,7 +1274,7 @@ class WC_Facebook_Product {
 			}
 		}
 
-		if ($attribute_found && $attribute_obj && $attribute_obj->is_taxonomy()) {
+		if ($attribute_found && $attribute_obj && is_object($attribute_obj) && method_exists($attribute_obj, 'is_taxonomy') && $attribute_obj->is_taxonomy()) {
 			$terms = $attribute_obj->get_terms();
 			if ($terms && !is_wp_error($terms)) {
 				return wp_list_pluck($terms, 'name');
@@ -1313,12 +1313,12 @@ class WC_Facebook_Product {
 			// Check if the attribute label contains our target type
 			if (stripos($normalized_label, $attribute_type) !== false) {
 				// Found an attribute with the requested type in the label
-				if ($attr_obj->is_taxonomy()) {
+				if (is_object($attr_obj) && method_exists($attr_obj, 'is_taxonomy') && $attr_obj->is_taxonomy()) {
 					$terms = $attr_obj->get_terms();
 					if ($terms && !is_wp_error($terms)) {
 						return wp_list_pluck($terms, 'name');
 					}
-				} else if (method_exists($attr_obj, 'get_options')) {
+				} else if (is_object($attr_obj) && method_exists($attr_obj, 'get_options')) {
 					return $attr_obj->get_options();
 				}
 			}
@@ -1350,12 +1350,12 @@ class WC_Facebook_Product {
 						$normalized_label = strtolower($attr_label);
 
 						if (stripos($normalized_label, $attribute_type) !== false) {
-							if ($attr_obj->is_taxonomy()) {
+							if (is_object($attr_obj) && method_exists($attr_obj, 'is_taxonomy') && $attr_obj->is_taxonomy()) {
 								$terms = $attr_obj->get_terms();
 								if ($terms && !is_wp_error($terms)) {
 									return wp_list_pluck($terms, 'name');
 								}
-							} else if (method_exists($attr_obj, 'get_options')) {
+							} else if (is_object($attr_obj) && method_exists($attr_obj, 'get_options')) {
 								return $attr_obj->get_options();
 							}
 						}


### PR DESCRIPTION
# Fix 'Call to a member function is_taxonomy() on string' error when processing variable products

## Description

This PR fixes a critical error that occurs when attempting to upload feed files for variable products with the Facebook for WooCommerce plugin. Users encounter an "Uncaught Error: Call to a member function is_taxonomy() on string" error because the code attempts to call methods on attribute values that are sometimes strings rather than objects.

The fix adds proper type checking before calling methods on attribute objects to prevent PHP errors when processing variable products with string attributes.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki](https://fburl.com/wiki/2cgfduwc).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki](https://fburl.com/wiki/nhx73tgs).

## Changelog entry

Fixed PHP error "Call to a member function is_taxonomy() on string" when uploading feed files for variable products.

## Test Plan

1. Create a variable product with multiple attributes (some custom, some taxonomy-based)
2. Attempt to upload feed files for variable products
3. Verify that the process completes without errors


