### PR TITLE
Fix internal_label generation for Product Feed

### DIFF
--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -399,7 +399,6 @@ class WC_Facebook_Product_Feed {
 	 * @return string product feed line data
 	 */
 	private function prepare_product_for_feed( $woo_product, &$attribute_variants ) {
-
 		$product_data  = $woo_product->prepare_product( null, \WC_Facebook_Product::PRODUCT_PREP_TYPE_FEED );
 		$item_group_id = $product_data['retailer_id'];
 
@@ -537,7 +536,7 @@ class WC_Facebook_Product_Feed {
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'gtin' )) . ',' .
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'quantity_to_sell_on_facebook' )) . ',' .
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'rich_text_description' ) ) . ',' .
-		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'internal_label' ) ) . ',' .
+		static::format_internal_labels_for_feed( static::get_value_from_product_data( $product_data, 'internal_label' ) ) . ',' .
 		static::get_value_from_product_data( $product_data, 'external_update_time' ) . ',' .
 		static::get_value_from_product_data( $product_data, 'external_variant_id' ) . PHP_EOL;
 	}
@@ -563,6 +562,13 @@ class WC_Facebook_Product_Feed {
 		} else {
 			return '';
 		}
+	}
+
+	private static function format_internal_labels_for_feed( $internal_labels ): string {
+		$quoted_internal_labels = array_map(function(string $label) {
+			return sprintf("'%s'", $label);
+		} , $internal_labels);
+		return sprintf("[%s]", implode( ',', $quoted_internal_labels ));
 	}
 
 	private static function format_price_for_feed( $value, $currency ) {


### PR DESCRIPTION
## Description

Fixes an issue where the internal label array was not properly converted to a string for the product feed workflow, causing the value to be sent as an invalid string (without otherwise breaking the feed).  This properly generates the feed file for the internal_label string.

### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

- Fix internal_label field generation in product feed.

## Test Plan

Test syncing of products to Meta shop. Verified that tags are set correctly and apply to shipping profiles. 

