### PR TITLE
Fix RolloutSwitches Init

### DIFF
--- a/includes/RolloutSwitches.php
+++ b/includes/RolloutSwitches.php
@@ -10,6 +10,7 @@
 
 namespace WooCommerce\Facebook;
 
+use WooCommerce\Facebook\Framework\Api\Exception;
 use WooCommerce\Facebook\Utilities\Heartbeat;
 
 defined( 'ABSPATH' ) || exit;
@@ -19,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
  * features in the Facebook for WooCommerce plugin.
  */
 class RolloutSwitches {
-	/** @var WooCommerce\Facebook\Commerce commerce handler */
+	/** @var \WC_Facebookcommerce commerce handler */
 	private \WC_Facebookcommerce $plugin;
 
 	public const SWITCH_ROLLOUT_FEATURES = 'rollout_enabled';
@@ -32,7 +33,7 @@ class RolloutSwitches {
 	 *
 	 * @var array
 	 */
-	private $rollout_switches = array();
+	private array $rollout_switches = array();
 
 	public function __construct( \WC_Facebookcommerce $plugin ) {
 		$this->plugin = $plugin;
@@ -40,18 +41,26 @@ class RolloutSwitches {
 	}
 
 	public function init() {
-		$external_business_id = $this->plugin->get_connection_handler()->get_external_business_id();
-		if ( empty( $external_business_id ) ) {
+		$is_connected = $this->plugin->get_connection_handler()->is_connected();
+		if ( ! $is_connected ) {
 			return;
 		}
 
-		$swiches = $this->plugin->get_api()->get_rollout_switches( $external_business_id );
-		$data    = $swiches->get_data();
-		foreach ( $data as $switch ) {
-			if ( ! isset( $switch['switch'] ) || ! $this->is_switch_active( $switch['switch'] ) ) {
-				continue;
+		try {
+			$external_business_id = $this->plugin->get_connection_handler()->get_external_business_id();
+			$switches             = $this->plugin->get_api()->get_rollout_switches( $external_business_id );
+			$data                 = $switches->get_data();
+			foreach ( $data as $switch ) {
+				if ( ! isset( $switch['switch'] ) || ! $this->is_switch_active( $switch['switch'] ) ) {
+					continue;
+				}
+				$this->rollout_switches[ $switch['switch'] ] = (bool) $switch['enabled'];
 			}
-			$this->rollout_switches[ $switch['switch'] ] = (bool) $switch['enabled'];
+		} catch ( Exception $e ) {
+			\WC_Facebookcommerce_Utils::log_exception_immediately_to_meta(
+				$e,
+				[ 'event' => 'rollout_switches_init' ]
+			);
 		}
 	}
 
@@ -79,7 +88,7 @@ class RolloutSwitches {
 		return $this->rollout_switches[ $switch_name ] ?? true;
 	}
 
-	public function is_switch_active( string $switch_name ) {
+	public function is_switch_active( string $switch_name ): bool {
 		return in_array( $switch_name, self::ACTIVE_SWITCHES, true );
 	}
 }

--- a/includes/RolloutSwitches.php
+++ b/includes/RolloutSwitches.php
@@ -59,7 +59,10 @@ class RolloutSwitches {
 		} catch ( Exception $e ) {
 			\WC_Facebookcommerce_Utils::log_exception_immediately_to_meta(
 				$e,
-				[ 'event' => 'rollout_switches_init' ]
+				[
+					'event'      => 'rollout_switches',
+					'event_type' => 'init',
+				]
 			);
 		}
 	}

--- a/tests/Unit/RolloutSwitchesTest.php
+++ b/tests/Unit/RolloutSwitchesTest.php
@@ -20,7 +20,7 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 	 * @var string
 	 */
 	private $version = Api::API_VERSION;
-	
+
 	/**
 	 * @var Api
 	 */
@@ -36,8 +36,8 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 		parent::setUp();
 		$this->api = new Api( $this->access_token );
 	}
-	
-	public function test_api() {	
+
+	public function test_api() {
 		$response = function( $result, $parsed_args, $url ) {
 			$this->assertEquals( 'GET', $parsed_args['method'] );
 			$url_params = "access_token={$this->access_token}&fbe_external_business_id={$this->external_business_id}";
@@ -52,7 +52,7 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 			];
 		};
 		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
-		
+
 		$response = $this->api->get_rollout_switches( $this->external_business_id );
 		$this->assertEquals([
 			[
@@ -70,8 +70,8 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 		], $response->get_data());
 	}
 
-	public function test_plugin() {	
-		
+	public function test_plugin() {
+
 		// mock the active filters to test business values
 		$plugin = facebook_for_woocommerce();
 		$plugin_ref_obj          = new ReflectionObject( $plugin );
@@ -84,6 +84,7 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 			->getMock();
 		$mock_connection_handler->expects( $this->any() )->method( 'get_external_business_id' )->willReturn( $this->external_business_id );
 		$mock_connection_handler->expects( $this->any() )->method( 'get_access_token' )->willReturn( $this->access_token );
+		$mock_connection_handler->expects( $this->any() )->method( 'is_connected' )->willReturn( true );
 		$prop_connection_handler->setValue( $plugin, $mock_connection_handler );
 		// setup API
 		$prop_api = $plugin_ref_obj->getProperty( 'api' );
@@ -98,7 +99,7 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 				)
 			))));
 		$prop_api->setValue( $plugin, $mock_api );
-		
+
 		$switch_mock = $this->getMockBuilder(RolloutSwitches::class)
 			->setConstructorArgs( array( $plugin ) )
             ->onlyMethods(['is_switch_active'])
@@ -122,7 +123,7 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 		// If the feature is active and in the response -> response value
 		$this->assertEquals( $switch_mock->is_switch_enabled("switch_a"), true );
 		$this->assertEquals( $switch_mock->is_switch_enabled("switch_b"), false );
-		
+
 		// If the switch is active but not in the response -> TRUE
 		$this->assertEquals( $switch_mock->is_switch_enabled("switch_d"), true );
 	}


### PR DESCRIPTION
## Description

I am running into the following exception message when my shop is in a disconnected state:
<img width="507" alt="image" src="https://github.com/user-attachments/assets/19da8967-6bc7-4d82-b923-e47c4f03497f" />

This is because upon disconnection, the external_business_id is not reset. We should be checking is_connected() at the start of the init function rather than existence of the EBID 

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [] I have commented my code, particularly in hard-to-understand areas.
- [] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry



## Test Plan

Verified extension tab now loads properly
<img width="2282" alt="image" src="https://github.com/user-attachments/assets/352e3d7b-1d28-40da-a906-9dbab358485d" />

