### PR TITLE
Fix log_*_to_meta flow and event parameters

### DIFF
--- a/includes/API/Plugin/Settings/Handler.php
+++ b/includes/API/Plugin/Settings/Handler.php
@@ -275,7 +275,13 @@ class Handler extends AbstractRESTEndpoint {
 				if ( facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
 					facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_all_products();
 				} else {
-					\WC_Facebookcommerce_Utils::log_to_meta( 'Initial full product sync disabled by filter hook `facebook_for_woocommerce_allow_full_batch_api_sync`' );
+					\WC_Facebookcommerce_Utils::log_to_meta(
+						'Initial full product sync disabled by filter hook `facebook_for_woocommerce_allow_full_batch_api_sync`',
+						[
+							'flow_name' => 'product_sync',
+							'flow_step' => 'initial_sync',
+						]
+					);
 				}
 			}
 		} catch ( \Exception $exception ) {

--- a/includes/Checkout.php
+++ b/includes/Checkout.php
@@ -101,7 +101,7 @@ class Checkout {
 							\WC_Facebookcommerce_Utils::log_exception_immediately_to_meta(
 								$e,
 								array(
-									'flow_name'       => 'checkout',
+									'event'           => 'checkout_permalink_template_exception',
 									'incoming_params' => array(
 										'products_param' => $products_param,
 										'product_id'     => $product_id,

--- a/includes/Checkout.php
+++ b/includes/Checkout.php
@@ -101,7 +101,8 @@ class Checkout {
 							\WC_Facebookcommerce_Utils::log_exception_immediately_to_meta(
 								$e,
 								array(
-									'event'           => 'checkout_permalink_template_exception',
+									'event'           => 'checkout',
+									'event_type'      => 'checkout_permalink_template_exception',
 									'incoming_params' => array(
 										'products_param' => $products_param,
 										'product_id'     => $product_id,


### PR DESCRIPTION
## Description

log_exception_immediately_to_meta should use 'event' and 'event_type' to categorize exceptions
log_to_meta should use 'flow_name' and 'flow_step' to categorize exceptions

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [] I have commented my code, particularly in hard-to-understand areas.
- [] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


