### PR TITLE
[fix] logging toggle initializer

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -251,6 +251,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		WC_Facebookcommerce_Utils::$ems = $this->get_external_merchant_settings_id();
 
+		// Set meta diagnosis to yes by default
+		if(!get_option( self::SETTING_ENABLE_META_DIAGNOSIS )) {
+			update_option(self::SETTING_ENABLE_META_DIAGNOSIS, 'yes');
+		}
+
 		if ( is_admin() ) {
 
 			$this->init_pixel();

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -3236,4 +3236,13 @@ class WCFacebookCommerceIntegrationTest extends \WooCommerce\Facebook\Tests\Abst
 		$this->assertEquals( null, $facebook_product_id );
 		$this->assertEquals( null, get_post_meta( $product->get_id(), WC_Facebookcommerce_Integration::FB_PRODUCT_ITEM_ID, true ) );
 	}
+
+	/**
+	 * Tests if meta diagnosis is enabled by default.
+	 *
+	 * @return void
+	 */
+	public function  test_meta_diagnosis_enabled_by_default() {
+		$this->assertEquals( 'yes', get_option( WC_Facebookcommerce_Integration::SETTING_ENABLE_META_DIAGNOSIS ) );
+	}
 }


### PR DESCRIPTION
## Description

bug reported by logging dogfooding session: https://docs.google.com/document/d/1Z0LPU5w0D1Bfvhf01c7gsOPkSnWqtcDXXf5oOXKHqjk/edit?tab=t.0

We should enable meta diagnosis by default, but currently there is no initializer for it. this diff adds the initializer.

### Type of change

- Bug fix (non-breaking change which fixes an issue)



Test Plan:

```
nealwei@nealwei-mbp facebook-for-woocommerce % npm run test:php

> facebook-for-woocommerce@3.4.4 test:php
> composer test-unit

> ./vendor/bin/phpunit
Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
Installing WooCommerce...
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
PHPUnit 9.6.19 by Sebastian Bergmann and contributors.

...............................................................  63 / 321 ( 19%)
............................................................... 126 / 321 ( 39%)
............................................................... 189 / 321 ( 58%)
............................................................... 252 / 321 ( 78%)
............................................................... 315 / 321 ( 98%)
......                                                          321 / 321 (100%)

Time: 00:10.513, Memory: 127.00 MB

OK (321 tests, 846 assertions)
```
