### PR TITLE
Fix mb_strlen error: ensure array arguments are properly handled

### DIFF
--- a/includes/Framework/Helper.php
+++ b/includes/Framework/Helper.php
@@ -106,6 +106,15 @@ class Helper {
 	 * @return string
 	 */
 	public static function str_truncate( $input_string, $length, $omission = '...' ) {
+		// Ensure input is a string
+		if (!is_string($input_string)) {
+			if (is_array($input_string)) {
+				$input_string = isset($input_string[0]) ? $input_string[0] : '';
+			} else {
+				$input_string = (string) $input_string;
+			}
+		}
+		
 		if ( self::multibyte_loaded() ) {
 			// bail if string doesn't need to be truncated
 			if ( mb_strlen( $input_string, self::MB_ENCODING ) <= $length ) {

--- a/includes/Framework/Helper.php
+++ b/includes/Framework/Helper.php
@@ -107,14 +107,14 @@ class Helper {
 	 */
 	public static function str_truncate( $input_string, $length, $omission = '...' ) {
 		// Ensure input is a string
-		if (!is_string($input_string)) {
-			if (is_array($input_string)) {
-				$input_string = isset($input_string[0]) ? $input_string[0] : '';
+		if ( ! is_string( $input_string ) ) {
+			if ( is_array( $input_string ) ) {
+				$input_string = isset( $input_string[0] ) ? $input_string[0] : '';
 			} else {
 				$input_string = (string) $input_string;
 			}
 		}
-		
+
 		if ( self::multibyte_loaded() ) {
 			// bail if string doesn't need to be truncated
 			if ( mb_strlen( $input_string, self::MB_ENCODING ) <= $length ) {


### PR DESCRIPTION
## Description

This PR fixes a critical PHP Fatal error that occurs when the Facebook for WooCommerce plugin encounters an array value where a string is expected in the `str_truncate()` method. Specifically, the error was: `Uncaught TypeError: mb_strlen(): Argument #1 ($string) must be of type string, array given`.

The fix adds type checking before using `mb_strlen()` to ensure that if an array is passed to the method, only the first element of the array is used. This prevents the plugin from crashing when a product description or other field contains unexpected array data.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Changelog entry

Fixed PHP Fatal error when `mb_strlen()` receives array data instead of expected string values.

## Test Plan

1. Install the plugin and create a product that triggers the bug (product with array data in description field)
2. Before fix: Website shows PHP Fatal error on product pages
3. After fix: Website loads normally without errors
4. Verified that the fix properly handles array input by using only the first element of an array

## Screenshots
### Before
![PHP Fatal error message showing mb_strlen() error with array given instead of string]

### After
[Website loads normally without error messages]