### PR TITLE
fix: Handle WP_Error in get_product_categories function

### DIFF
--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -215,6 +215,13 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 				array( 'fields' => 'all' )
 			);
 
+			if ( is_wp_error( $category_path ) ) {
+				return array(
+					'name' => '',
+					'categories' => '""'
+				);
+			}
+
 			$content_category = array_values(
 				array_map(
 					function ( $item ) {


### PR DESCRIPTION
The get_product_categories function was throwing a fatal error when wp_get_post_terms() 
returned a WP_Error object instead of an array. This happened because array_map() was 
being called directly on the result without checking if it was an error.

The fix adds a proper error check using is_wp_error() and returns a default empty array 
structure when an error occurs, preventing the fatal error and allowing the checkout 
process to continue normally.

This change improves error handling and prevents the plugin from breaking the checkout 
process when there are issues retrieving product categories.