### PR TITLE
Respect Disabled Shipping Methods for Shipping Profile Sync

### DIFF
--- a/includes/Feed/ShippingProfiles/ShippingProfilesFeed.php
+++ b/includes/Feed/ShippingProfiles/ShippingProfilesFeed.php
@@ -121,6 +121,9 @@ class ShippingProfilesFeed extends AbstractFeed {
 
 				$shipping_method_data = [];
 				foreach ( $shipping_methods as $shipping_method ) {
+					if ( 'yes' !== $shipping_method['enabled'] ) {
+						continue;
+					}
 					try {
 						if ( 'free_shipping' === $shipping_method['id'] ) {
 							$shipping_method_data[] = self::get_free_shipping_method_data( $zone, $shipping_method );


### PR DESCRIPTION
## Description

Ignores disabled shipping methods when syncing shipping profiles where previously they were included in the sync and seen as enabled. 

### Type of change



- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

- Fixes issue where disabled shipping profile data was being synced to Meta. 


## Test Plan

Create disabled shipping method and observe it not being included in data sync to Meta. 

