### PR TITLE
Remove "Tested up to"

### DIFF
--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -15,9 +15,7 @@
  * Requires PHP: 7.4
  * Text Domain: facebook-for-woocommerce
  * Requires Plugins: woocommerce
- * Tested up to: 6.7
  * WC requires at least: 6.4
- * WC tested up to: 9.6
  *
  * @package FacebookCommerce
  */


### PR DESCRIPTION
## Description

Removing "WC tested up to" and "Tested up to" to prevent warnings from showing up on the back-end.
Unless those declarations are updated every time WP and WC are updated, the plugin will display those notices to everyone who accesses the back-end.
Those warnings are supposedly dismissable, but they come back.
They also make admins (of any level) anxious that something will break with the plugin, so they do more harm than good.

### Fixes
#3020
https://wordpress.org/support/topic/facebook-for-woocommerce-version-3-4-7-is-untested-with-woocommerce-9-8-3/
https://wordpress.org/support/topic/facebook-for-woocommerce-version-3-4-1-is-untested-with-woocommerce-9-7-0/
https://wordpress.org/support/topic/facebook-for-woocommerce-version-3-3-1-is-untested-with-woocommerce-9-5-2/
https://wordpress.org/support/topic/untested-with-woocomerce-9-8-1-and-wordpress-6-8/
https://wordpress.org/support/topic/shows-as-untested/
https://wordpress.org/support/topic/compatibility-issue-facebook-for-woocommerce-3-4-1-with-woocommerce-9-7-1/
https://wordpress.org/support/topic/persistent-compatibility-notifications-not-disappearing-after-being-ignored/

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [X] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [X] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [X] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [X] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [X] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Remove  "WC tested up to" and "Tested up to" to prevent notices showing on admin


## Test Plan

Using the latest version of WP and WC, install the plugin and check any page on admin. You'll notice those warnings
Update to the proposed PR and check admin again. Those notices should no longer show

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before
![image](https://github.com/user-attachments/assets/b8427b04-1a36-4642-b1ab-ae009397e358)
