### PR TITLE
[WAUM] Fix the WAUM payment progress to only Show Up after Consent Collection is Enabled

### DIFF
--- a/assets/js/admin/whatsapp-connection.js
+++ b/assets/js/admin/whatsapp-connection.js
@@ -52,12 +52,6 @@ jQuery( document ).ready( function( $ ) {
                 $('#wc-fb-whatsapp-consent-subcontent').show();
 	            $('#wc-fb-whatsapp-consent-button-wrapper').show();
 
-                // update the progress of payment step if payment already setup
-                if(response.data['is_payment_setup'] === true) {
-                    $('#wc-fb-whatsapp-billing-inprogress').hide();
-                    $('#wc-fb-whatsapp-billing-notstarted').hide();
-                    $('#wc-fb-whatsapp-billing-success').show();
-                }
 			} else {
                 console.log('Whatsapp connection is not complete. Checking again in 5 seconds:', response, ', retry attempt:', retryCount, 'pollingTimeout', pollingTimeout);
                 if(retryCount >= pollingTimeout) {


### PR DESCRIPTION
## Description
Fix the payment progress to only Show Up after Consent Collection is Enabled

### Type of change
- Bug fix (non-breaking change which fixes an issue)



## Changelog entry
Fix the WAUM payment progress to only Show Up after Consent Collection is Enabled


## Test Plan
### Before
https://github.com/user-attachments/assets/011012db-3378-4fdc-89b2-4d41be683928

### After

https://github.com/user-attachments/assets/e8500ba3-8d4f-4f5c-8591-e6ab43e4c9e7




