### PR TITLE
Add admin notice for WhatsApp utility messaging recruitment

### DIFF
--- a/assets/js/admin/whatsapp-admin-notice.js
+++ b/assets/js/admin/whatsapp-admin-notice.js
@@ -1,0 +1,9 @@
+jQuery(function ($) {
+	$(document).on('click', '.wc-facebook-global-notice.is-dismissible .notice-dismiss', function () {
+		$.post(WCFBAdminNotice.ajax_url, {
+			action: 'wc_facebook_dismiss_notice',
+			nonce: WCFBAdminNotice.nonce,
+			notice_id: WCFBAdminNotice.notice_id
+		});
+	});
+});

--- a/facebook-commerce-admin-notice.php
+++ b/facebook-commerce-admin-notice.php
@@ -59,6 +59,10 @@ class WC_Facebookcommerce_Admin_Notice {
 	 * Displays the admin notice if not dismissed.
 	 */
 	public function show_notice() {
+		if ( strtotime( 'now' ) > strtotime( '2025-06-16 23:59:59' ) ) {
+			return;
+		}
+
 		if ( ! current_user_can( 'manage_woocommerce' ) ) {
 			return;
 		}

--- a/facebook-commerce-admin-notice.php
+++ b/facebook-commerce-admin-notice.php
@@ -25,6 +25,10 @@ class WC_Facebookcommerce_Admin_Notice {
 		add_action( 'admin_notices', array( $this, 'show_notice' ) );
 		add_action( 'admin_init', array( $this, 'dismiss_notice' ) );
 	}
+
+	/**
+	 * Displays the admin notice if not dismissed.
+	 */
 	public function show_notice() {
 		if ( ! current_user_can( 'manage_woocommerce' ) ) {
 			return;

--- a/facebook-commerce-admin-notice.php
+++ b/facebook-commerce-admin-notice.php
@@ -23,7 +23,6 @@ class WC_Facebookcommerce_Admin_Notice {
 	 */
 	public function __construct() {
 		add_action( 'admin_notices', array( $this, 'show_notice' ) );
-		add_action( 'admin_init', array( $this, 'dismiss_notice' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_notice_script' ) );
 		add_action( 'wp_ajax_wc_facebook_dismiss_notice', array( $this, 'ajax_dismiss_notice' ) );
 	}
@@ -99,20 +98,5 @@ class WC_Facebookcommerce_Admin_Notice {
 			</p>
 		</div>
 		<?php
-	}
-
-	/**
-	 * Handles the dismissal of the notice.
-	 */
-	public function dismiss_notice() {
-		if (
-			isset( $_GET[ self::NOTICE_ID ] ) &&
-			isset( $_GET['_wpnonce'] ) &&
-			wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), self::NOTICE_ID )
-		) {
-			update_user_meta( get_current_user_id(), self::NOTICE_ID, 1 );
-			wp_safe_redirect( remove_query_arg( array( self::NOTICE_ID, '_wpnonce' ) ) );
-			exit;
-		}
 	}
 }

--- a/facebook-commerce-admin-notice.php
+++ b/facebook-commerce-admin-notice.php
@@ -87,7 +87,7 @@ class WC_Facebookcommerce_Admin_Notice {
 					wp_kses(
 						// translators: %s: URL to the WhatsApp order tracking testing program sign-up page.
 						__(
-							"WhatsApp order tracking is now available for testing. <a href='%s'>Sign up our testing program</a> and get early access now!",
+							"WhatsApp order tracking is now available for testing. <a href='%s'>Sign up for our testing program</a> and get early access now!",
 							'facebook-for-woocommerce'
 						),
 						array(

--- a/facebook-commerce-admin-notice.php
+++ b/facebook-commerce-admin-notice.php
@@ -30,14 +30,14 @@ class WC_Facebookcommerce_Admin_Notice {
 
 	public function enqueue_notice_script() {
 		wp_enqueue_script(
-			'wc-facebook-admin-notice',
+			'whatsapp-admin-notice',
 			plugins_url( 'assets/js/admin/whatsapp-admin-notice.js', __FILE__ ),
 			array( 'jquery' ),
 			'1.0',
 			true
 		);
 		wp_localize_script(
-			'wc-facebook-admin-notice',
+			'whatsapp-admin-notice',
 			'WCFBAdminNotice',
 			array(
 				'ajax_url'  => admin_url( 'admin-ajax.php' ),

--- a/facebook-commerce-admin-notice.php
+++ b/facebook-commerce-admin-notice.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+/**
+ * Class WC_Facebook_Admin_Notice
+ *
+ * Adds a dismissible global admin notice for Facebook for WooCommerce.
+ *
+ * @since x.x.x
+ */
+class WC_Facebookcommerce_Admin_Notice {
+	const NOTICE_ID = 'wc_facebook_admin_notice';
+
+	/**
+	 * Hooks into WordPress.
+	 */
+	public function __construct() {
+		add_action( 'admin_notices', array( $this, 'show_notice' ) );
+	}
+	public function show_notice() {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+
+		?>
+
+		<div class="notice notice-info is-dismissible wc-facebook-global-notice">
+			<p>
+				<?php
+				printf(
+					wp_kses(
+						// translators: %s: URL to the WhatsApp order tracking testing program sign-up page.
+						__(
+							"WhatsApp order tracking is now available for testing. <a href='%s'>Sign up our testing program</a> and get early access now!",
+							'facebook-for-woocommerce'
+						),
+						array(
+							'a' => array(
+								'href' => array(),
+							),
+						)
+					),
+					'https://facebookpso.qualtrics.com/jfe/form/SV_0SVseus9UADOhhQ'
+				);
+				?>
+			</p>
+		</div>
+		<?php
+	}

--- a/facebook-commerce-admin-notice.php
+++ b/facebook-commerce-admin-notice.php
@@ -23,6 +23,7 @@ class WC_Facebookcommerce_Admin_Notice {
 	 */
 	public function __construct() {
 		add_action( 'admin_notices', array( $this, 'show_notice' ) );
+		add_action( 'admin_init', array( $this, 'dismiss_notice' ) );
 	}
 	public function show_notice() {
 		if ( ! current_user_can( 'manage_woocommerce' ) ) {
@@ -54,3 +55,19 @@ class WC_Facebookcommerce_Admin_Notice {
 		</div>
 		<?php
 	}
+
+	/**
+	 * Handles the dismissal of the notice.
+	 */
+	public function dismiss_notice() {
+		if (
+			isset( $_GET[ self::NOTICE_ID ] ) &&
+			isset( $_GET['_wpnonce'] ) &&
+			wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), self::NOTICE_ID )
+		) {
+			update_user_meta( get_current_user_id(), self::NOTICE_ID, 1 );
+			wp_safe_redirect( remove_query_arg( array( self::NOTICE_ID, '_wpnonce' ) ) );
+			exit;
+		}
+	}
+}

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -24,6 +24,9 @@ defined( 'ABSPATH' ) || exit;
 require_once 'facebook-config-warmer.php';
 require_once 'includes/fbproduct.php';
 require_once 'facebook-commerce-pixel-event.php';
+require_once 'facebook-commerce-admin-notice.php';
+
+new WC_Facebookcommerce_Admin_Notice();
 
 class WC_Facebookcommerce_Integration extends WC_Integration {
 
@@ -852,8 +855,8 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				}
 				$this->delete_fb_product( $delete_product );
 			}
-		} 
-		
+		}
+
 		if( $sync_enabled ) {
 				Products::enable_sync_for_products( [ $product ] );
 				Products::set_product_visibility( $product, Admin::SYNC_MODE_SYNC_AND_HIDE !== $sync_mode );


### PR DESCRIPTION
## Description

This changeset adds an admin notice with a call to action for taking part in the WhatsApp utility messaging program. The notice appears on all admin pages after the plugin is updated/activated. Dismissing the notice will make it stop appearing for that user.

### Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [yes] I have commented my code, particularly in hard-to-understand areas.
- [yes] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [yes] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [yes] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [n/a] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [yes] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [n/a] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Add admin notice for WhatsApp utility messaging recruitment


## Test Plan

Build a release artifact with this changeset and install on a testing site. As soon as the plugin is activated, the notice will be visible on top of all admin pages (see screenshot below).

## Screenshots

![recruitment notice](https://github.com/user-attachments/assets/b07c08ec-3b15-436e-925c-90a499dc8b34)


