### PR TITLE
[WAUM] Error handling for Manage Events view

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
+++ b/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
@@ -150,6 +150,9 @@
 .manage-event-button {
     margin-left: 20px;
 }
+.manage-event-error-notice {
+    margin-right: 5px;
+}
 .fbwa-hidden-element {
     display: none;
 }

--- a/assets/js/admin/whatsapp-events.js
+++ b/assets/js/admin/whatsapp-events.js
@@ -123,6 +123,13 @@ jQuery(document).ready(function ($) {
             }
             else {
                 console.log('Whatsapp Library Template call failed', response);
+                const message = facebook_for_woocommerce_whatsapp_finish.i18n.generic_error;
+                const errorNoticeHtml = `
+                <div class="notice-error">
+                  <p>${message}</p>
+                </div>
+              `;
+                $('#events-error-notice').html(errorNoticeHtml).show();
             }
         });
     });
@@ -138,13 +145,24 @@ jQuery(document).ready(function ($) {
             language: languageValue,
             status: statusValue
         }, function (response) {
-            //TODO: Add Error Handling
-            let url = new URL(window.location.href);
-            let params = new URLSearchParams(url.search);
-            params.set('view', 'utility_settings');
-            url.search = params.toString();
-            window.location.href = url.toString();
-            console.log('Whatsapp Event Config has been updated', response);
+            if (response.success) {
+                let url = new URL(window.location.href);
+                let params = new URLSearchParams(url.search);
+                params.set('view', 'utility_settings');
+                url.search = params.toString();
+                window.location.href = url.toString();
+                console.log('Whatsapp Event Config has been updated', response);
+            }
+            else {
+                console.log('Whatsapp Event Config Update failure', response);
+                const message = facebook_for_woocommerce_whatsapp_finish.i18n.generic_error;
+                const errorNoticeHtml = `
+                <div class="notice-error">
+                  <p>${message}</p>
+                </div>
+              `;
+                $('#events-error-notice').html(errorNoticeHtml).show();
+            }
         });
     });
 

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -154,6 +154,8 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				'order_refunded_language'  => $order_refunded_language,
 				'i18n'                     => array(
 					'result' => true,
+					'generic_error' => __( 'Something went wrong. Please try again.', 'facebook-for-woocommerce' ),
+
 				),
 			)
 		);
@@ -656,6 +658,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 						</b></label>
 					</div>
 				</div>
+				<div id="events-error-notice" class="manage-event-error-notice"></div>
 			</div>
 			<div class="manage-event-card-item manage-event-template-footer">
 				<div class="manage-event-button">


### PR DESCRIPTION
## Description
Added an error notice if the post api call fails while creating or editing event configs in the Manage Events view

### Type of change
- New feature (non-breaking change which adds functionality)

## Changelog entry
Error notice to gracefully handle errors in Manage Events view

## Test Plan
![Screenshot 2025-05-13 at 8 11 18 AM](https://github.com/user-attachments/assets/9e832a87-5600-4551-adaa-efdcc4448802)
