### PR TITLE
FB Public Key Retrieval and Storage

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -643,6 +643,17 @@ class API extends Base {
 		return $this->perform_request( $request );
 	}
 
+    /**
+     * @return Response
+     * @throws ApiException
+     * @throws API\Exceptions\Request_Limit_Reached
+     */
+    public function get_public_key( string $key_project ): Response
+    {
+        $request = new API\PublicKeyGet\Request( $key_project );
+        $this->set_response_handler( API\Response::class );
+        return $this->perform_request( $request );
+    }
 
 	/**
 	 * Gets the next page of results for a paginated response.

--- a/includes/API/PublicKeyGet/Request.php
+++ b/includes/API/PublicKeyGet/Request.php
@@ -1,0 +1,34 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\Facebook\API\PublicKeyGet;
+
+defined( 'ABSPATH' ) || exit;
+
+use WooCommerce\Facebook\API;
+
+/**
+ * Page API request object.
+ *
+ * @since 2.0.0
+ */
+class Request extends API\Request {
+	const API_REQUEST_PATH = 'shops_public_key';
+	const API_METHOD       = 'GET';
+	const API_VERSION      = '1.0.0';
+
+	public function __construct( string $project ) {
+		$path_with_param = sprintf( '%s/%s', self::API_REQUEST_PATH, $project );
+		parent::__construct( $path_with_param, self::API_METHOD );
+	}
+
+	public function get_base_path_override(): string {
+		return 'https://api.facebook.com/';
+	}
+
+	public function get_request_specific_headers(): array {
+		return [
+			'X-API-Version' => self::API_VERSION,
+		];
+	}
+}

--- a/includes/API/Request.php
+++ b/includes/API/Request.php
@@ -115,4 +115,18 @@ class Request extends JSONRequest {
 	public function get_retry_codes() {
 		return $this->retry_codes;
 	}
+
+	/**
+	 * @return string|null
+	 */
+	public function get_base_path_override(): ?string {
+		return null;
+	}
+
+	/**
+	 * @return array|null
+	 */
+	public function get_request_specific_headers(): array {
+		return [];
+	}
 }

--- a/includes/FBSignedData/FBPublicKey.php
+++ b/includes/FBSignedData/FBPublicKey.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace WooCommerce\Facebook\FBSignedData;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class to represent a public key retrieved from FB.
+ */
+class FBPublicKey {
+
+	const ENCODING_FORMAT_PEM = 'PEM';
+	const ENCODING_FORMAT_HEX = 'HEX';
+
+	const ALGORITHM_ES256 = 'ES256';
+	const ALGORITHM_EDDSA = 'EdDSA';
+
+	/**
+	 * The public key string to be used to verify data signed by Meta.
+	 *
+	 * @var string
+	 */
+	private string $key;
+
+	/**
+	 * The encoding format for the key string. Either hex encoded or in pem file format.
+	 *
+	 * @var string
+	 */
+	private string $encoding_format;
+
+	/**
+	 * The project containing the rotating key. A current key will rotate to the next key in a project.
+	 *
+	 * @var string
+	 */
+	private string $project;
+
+
+	/**
+	 * The signing algorithm that the key is used for.
+	 *
+	 * @var string
+	 */
+	private string $algorithm;
+
+	public function __construct( string $key_string, string $algorithm, string $encoding_format, string $project ) {
+		$this->key             = $key_string;
+		$this->algorithm       = $algorithm;
+		$this->encoding_format = $encoding_format;
+		$this->project         = $project;
+	}
+
+	public function get_key(): string {
+		return $this->key;
+	}
+
+	public function get_algorithm(): string {
+		return $this->algorithm;
+	}
+
+	public function get_encoding_format(): string {
+		return $this->encoding_format;
+	}
+
+	public function get_project(): string {
+		return $this->project;
+	}
+}

--- a/includes/FBSignedData/PublicKeyStorageHelper.php
+++ b/includes/FBSignedData/PublicKeyStorageHelper.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace WooCommerce\Facebook\FBSignedData;
+
+use WooCommerce\Facebook\API\Exceptions\Request_Limit_Reached;
+use WooCommerce\Facebook\Framework\Api\Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class to handle storage and retrieval of Meta's public key used to verify signed data.
+ */
+final class PublicKeyStorageHelper {
+
+	const SETTING_CURRENT_PUBLIC_KEY = 'wc_facebook_current_public_key';
+	const SETTING_NEXT_PUBLIC_KEY    = 'wc_facebook_next_public_key';
+
+	/**
+	 * Calls the API to retrieve public key from Meta
+	 *
+	 * @param \WC_Facebookcommerce $plugin facebook plugin instance
+	 * @param string               $key_project The project associated with the key on Facebook.
+	 * @throws Request_Limit_Reached If the request to get the public key from Meta is rate limited.
+	 * @throws Exception If there is an error retrieving the public key from Meta.
+	 */
+	public static function request_and_store_public_key( \WC_Facebookcommerce $plugin, string $key_project ) {
+		$key_data_response = $plugin->get_api()->get_public_key( $key_project );
+		$key_response_data = $key_data_response->response_data;
+
+		$project          = $key_response_data['project'];
+		$current_key_data = $key_response_data['current'] ?? [];
+		$next_key_data    = $key_response_data['next'] ?? [];
+
+		self::maybe_update_single_key_option( self::SETTING_CURRENT_PUBLIC_KEY, $current_key_data, $project );
+		self::maybe_update_single_key_option( self::SETTING_NEXT_PUBLIC_KEY, $next_key_data, $project );
+	}
+
+	private static function maybe_update_single_key_option( string $option_name, array $key_data, string $project ): void {
+		$key_data['project'] = $project;
+		if ( self::is_valid_key_data( $key_data ) ) {
+			update_option( $option_name, $key_data );
+		}
+	}
+
+	private static function is_valid_key_data( $key_data ): bool {
+		if ( ! is_array( $key_data ) ) {
+			return false;
+		}
+
+		$key             = $key_data['key'] ?? null;
+		$alg             = $key_data['algorithm'] ?? null;
+		$encoding_format = $key_data['encoding_format'] ?? null;
+		$project         = $key_data['project'] ?? null;
+
+		// Valid key needs to have all values.
+		foreach ( [ $key, $alg, $encoding_format, $project ] as $value ) {
+			if ( empty( $value ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public static function get_current_public_key(): ?FBPublicKey {
+		$current_key_data = get_option( self::SETTING_CURRENT_PUBLIC_KEY );
+		return self::fb_signed_key_from_data( $current_key_data );
+	}
+
+	public static function get_next_public_key(): ?FBPublicKey {
+		$next_key_data = get_option( self::SETTING_NEXT_PUBLIC_KEY );
+		return self::fb_signed_key_from_data( $next_key_data );
+	}
+
+	private static function fb_signed_key_from_data( $key_data ): ?FBPublicKey {
+		if ( ! self::is_valid_key_data( $key_data ) ) {
+			return null;
+		}
+		return new FBPublicKey( $key_data['key'], $key_data['algorithm'], $key_data['encoding_format'], $key_data['project'] );
+	}
+}

--- a/includes/Framework/Api/Base.php
+++ b/includes/Framework/Api/Base.php
@@ -242,8 +242,9 @@ abstract class Base {
 	 * @return string
 	 */
 	protected function get_request_uri() {
-		$uri   = $this->request_uri . $this->get_request_path();
-		$query = $this->get_request_query();
+		$base_path = $this->get_request()->get_base_path_override() ?? $this->request_uri;
+		$uri       = $base_path . $this->get_request_path();
+		$query     = $this->get_request_query();
 
 		// Append any query params to the URL when necessary.
 		if ( $query ) {
@@ -400,7 +401,7 @@ abstract class Base {
 	 * @return array
 	 */
 	protected function get_request_headers() {
-		return $this->request_headers;
+		return array_merge( $this->request_headers, $this->get_request()->get_request_specific_headers() );
 	}
 
 

--- a/tests/Unit/FBSignedData/FBPublicKeyTest.php
+++ b/tests/Unit/FBSignedData/FBPublicKeyTest.php
@@ -1,0 +1,31 @@
+<?php
+/** Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+use WooCommerce\Facebook\FBSignedData\FBPublicKey;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+
+/**
+ * Class FBPublicKeyTest
+ */
+class FBPublicKeyTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering
+{
+	public function test_fb_public_key_getters(): void {
+		$algorithm = FBPublicKey::ALGORITHM_ES256;
+		$key = 'test_key';
+		$encoding_format = FBPublicKey::ENCODING_FORMAT_PEM;
+		$project = 'test_project';
+
+		$fb_public_key = new FBPublicKey($key, $algorithm, $encoding_format, $project );
+
+		$this->assertEquals($fb_public_key->get_key(), $key);
+		$this->assertEquals($fb_public_key->get_algorithm(), $algorithm);
+		$this->assertEquals($fb_public_key->get_encoding_format(), $encoding_format);
+		$this->assertEquals($fb_public_key->get_project(), $project);
+	}
+}

--- a/tests/Unit/FBSignedData/PublicKeyStorageHelperTest.php
+++ b/tests/Unit/FBSignedData/PublicKeyStorageHelperTest.php
@@ -1,0 +1,131 @@
+<?php
+/** Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+use WooCommerce\Facebook\FBSignedData\FBPublicKey;
+use WooCommerce\Facebook\FBSignedData\PublicKeyStorageHelper;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+
+/**
+ * Class FBPublicKeyTest
+ */
+class PublicKeyStorageHelperTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+	const PROJECT_NAME = 'TEST_PROJECT';
+
+	const MOCK_CURRENT_PUBLIC_KEY =
+		[
+			'key' => 'current_key_1',
+			'algorithm' => FBPublicKey::ALGORITHM_ES256,
+			'encoding_format' => FBPublicKey::ENCODING_FORMAT_PEM
+		];
+
+	const MOCK_NEXT_PUBLIC_KEY =
+		[
+			'key' => 'next_key_1',
+			'algorithm' => FBPublicKey::ALGORITHM_EDDSA,
+			'encoding_format' => FBPublicKey::ENCODING_FORMAT_HEX
+		];
+
+	public function test_store_api_response(): void {
+		$this->assertFalse(get_option(PublicKeyStorageHelper::SETTING_CURRENT_PUBLIC_KEY));
+		$this->assertFalse(get_option(PublicKeyStorageHelper::SETTING_NEXT_PUBLIC_KEY));
+
+		$mock_fb = $this->get_plugin_with_mocked_response(self::MOCK_CURRENT_PUBLIC_KEY, self::MOCK_NEXT_PUBLIC_KEY, self::PROJECT_NAME);
+		PublicKeyStorageHelper::request_and_store_public_key( $mock_fb, self::PROJECT_NAME );
+
+		$expected_stored_current_key_data = array_merge(self::MOCK_CURRENT_PUBLIC_KEY, ['project' => self::PROJECT_NAME]);
+		$expected_stored_next_key_data = array_merge(self::MOCK_NEXT_PUBLIC_KEY, ['project' => self::PROJECT_NAME]);
+
+		$this->assert_on_key_data(
+            [
+                'current' => $expected_stored_current_key_data,
+                'next' => $expected_stored_next_key_data,
+            ]);
+
+		// Test setting invalid data
+		$mock_fb = $this->get_plugin_with_mocked_response(null, null,  self::PROJECT_NAME);
+		PublicKeyStorageHelper::request_and_store_public_key( $mock_fb, self::PROJECT_NAME );
+		$this->assert_on_key_data(
+			[
+				'current' => $expected_stored_current_key_data,
+				'next' => $expected_stored_next_key_data,
+			]);
+	}
+
+    public function test_store_invalid_data(): void {
+        $mock_invalid_current_key_data =
+        [
+            'key' => 'current_key_1',
+            'encoding_format' => FBPublicKey::ENCODING_FORMAT_PEM
+        ];
+
+        $mock_fb = $this->get_plugin_with_mocked_response($mock_invalid_current_key_data, null, self::PROJECT_NAME);
+
+        $this->assertFalse(get_option(PublicKeyStorageHelper::SETTING_CURRENT_PUBLIC_KEY));
+        $this->assertFalse(get_option(PublicKeyStorageHelper::SETTING_NEXT_PUBLIC_KEY));
+
+        PublicKeyStorageHelper::request_and_store_public_key( $mock_fb, self::PROJECT_NAME );
+
+        $this->assertFalse(get_option(PublicKeyStorageHelper::SETTING_CURRENT_PUBLIC_KEY));
+        $this->assertFalse(get_option(PublicKeyStorageHelper::SETTING_NEXT_PUBLIC_KEY));
+
+        $this->assertNull(PublicKeyStorageHelper::get_current_public_key());
+        $this->assertNull(PublicKeyStorageHelper::get_next_public_key());
+    }
+
+    private function assert_on_key_data($expected_key_data) {
+        $current_expected_key_data  = $expected_key_data['current'];
+        $next_expected_key_data     = $expected_key_data['next'];
+
+        $this->assertEquals($current_expected_key_data, get_option(PublicKeyStorageHelper::SETTING_CURRENT_PUBLIC_KEY));
+        $this->assertEquals($next_expected_key_data, get_option(PublicKeyStorageHelper::SETTING_NEXT_PUBLIC_KEY));
+
+
+        $current_key = PublicKeyStorageHelper::get_current_public_key();
+        $this->assertEquals($current_expected_key_data['key'], $current_key->get_key());
+        $this->assertEquals($current_expected_key_data['algorithm'], $current_key->get_algorithm());
+        $this->assertEquals($current_expected_key_data['encoding_format'], $current_key->get_encoding_format());
+
+        $next_key = PublicKeyStorageHelper::get_next_public_key();
+        $this->assertEquals($next_expected_key_data['key'], $next_key->get_key());
+        $this->assertEquals($next_expected_key_data['algorithm'], $next_key->get_algorithm());
+        $this->assertEquals($next_expected_key_data['encoding_format'], $next_key->get_encoding_format());
+    }
+
+
+	private function get_plugin_with_mocked_response(?array $current_key, ?array $next_key, string $project): \WC_Facebookcommerce{
+		$response_data =
+			[
+				'current' => $current_key,
+				'next' => $next_key,
+				'project' => $project,
+			];
+		$response_string = wp_json_encode($response_data);
+		$response = new WooCommerce\Facebook\API\Response($response_string );
+
+		$mock_api = $this->getMockBuilder(WooCommerce\Facebook\API::class)
+			->setConstructorArgs(['access_token'])
+			->setMethods(['get_public_key'])
+			->getMock();
+		$mock_api->method('get_public_key')
+			->willReturnCallback(function( string $key_project ) use (&$response) {
+				return $response;
+			});
+
+		$mock_fb = $this->getMockBuilder( \WC_Facebookcommerce::class )
+			->setMethods(['get_api'])
+			->getMock();
+		$mock_fb->method('get_api')
+			->willReturnCallback(function($access_token) use (&$mock_api) {
+				return $mock_api;
+			});
+
+		return $mock_fb;
+	}
+}


### PR DESCRIPTION
## Description
Adds skeleton framework for calling Facebook to retrieve a rotating Meta public key that will be used to verify signed requests coming from Meta. The data ingested from Meta includes the current key used for verification, but also previous rotated keys, as well as the next key in the rotation. All keys should be used to check for verification in the case that the keys have rotated but have not been updated yet.

### Type of change
- New feature (non-breaking change which adds functionality)


## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

One liner entry to be surfaced in changelog.txt


## Test Plan

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration.

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before

### After
