### PR TITLE
[Easy] Update Message Sending API from Messages to Message Events

### DIFF
--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -153,7 +153,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				'order_refunded_enabled'   => ! empty( $order_refunded_event_config_id ),
 				'order_refunded_language'  => $order_refunded_language,
 				'i18n'                     => array(
-					'result' => true,
+					'result'        => true,
 					'generic_error' => __( 'Something went wrong. Please try again.', 'facebook-for-woocommerce' ),
 
 				),

--- a/includes/Handlers/WhatsAppUtilityConnection.php
+++ b/includes/Handlers/WhatsAppUtilityConnection.php
@@ -340,7 +340,6 @@ class WhatsAppUtilityConnection {
 
 	/**
 	 * Makes an API call to Event Processor: Message Events Post API to send whatsapp utility messages
-	 * TODO: Update API Endpoint from Messages to Message Events
 	 *
 	 * @param string $event Order Managerment event
 	 * @param string $event_config_id Event Config Id
@@ -354,7 +353,7 @@ class WhatsAppUtilityConnection {
 	 * @param string $bisu_token the BISU token received in the webhook
 	 */
 	public static function post_whatsapp_utility_messages_events_call( $event, $event_config_id, $language_code, $wacs_id, $order_id, $phone_number, $first_name, $refund_value, $currency, $bisu_token ) {
-		$base_url        = array( self::GRAPH_API_BASE_URL, self::API_VERSION, $wacs_id, "messages?access_token=$bisu_token" );
+		$base_url        = array( self::GRAPH_API_BASE_URL, self::API_VERSION, $wacs_id, "message_events?access_token=$bisu_token" );
 		$base_url        = esc_url( implode( '/', $base_url ) );
 		$name            = self::EVENT_TO_LIBRARY_TEMPLATE_MAPPING[ $event ];
 		$components      = self::get_components_for_event( $event, $order_id, $first_name, $refund_value, $currency );
@@ -362,8 +361,9 @@ class WhatsAppUtilityConnection {
 			'body'    => array(
 				'messaging_product' => 'whatsapp',
 				'to'                => $phone_number,
+				'event_config_id'   => $event_config_id,
+				'external_event_id' => "${order_id}",
 				'template'          => array(
-					'name'       => $name,
 					'language'   => array(
 						'code' => $language_code,
 					),
@@ -380,7 +380,7 @@ class WhatsAppUtilityConnection {
 		wc_get_logger()->info(
 			sprintf(
 					/* translators: %s $error_message */
-				__( 'Messages Post API call Response: %1$s ', 'facebook-for-woocommerce' ),
+				__( 'Message Events Post API call Response: %1$s ', 'facebook-for-woocommerce' ),
 				json_encode( $response ),
 			)
 		);
@@ -389,7 +389,7 @@ class WhatsAppUtilityConnection {
 			wc_get_logger()->info(
 				sprintf(
 				/* translators: %s $order_id %s $error_message */
-					__( 'Messages Post API call for Order id %1$s Failed %2$s ', 'facebook-for-woocommerce' ),
+					__( 'Message Events Post API call for Order id %1$s Failed %2$s ', 'facebook-for-woocommerce' ),
 					$order_id,
 					$error_message,
 				)
@@ -398,7 +398,7 @@ class WhatsAppUtilityConnection {
 			wc_get_logger()->info(
 				sprintf(
 				/* translators: %s $order_id */
-					__( 'Messages Post API call for Order id %1$s Succeeded.', 'facebook-for-woocommerce' ),
+					__( 'Message Events Post API call for Order id %1$s Succeeded.', 'facebook-for-woocommerce' ),
 					$order_id
 				)
 			);


### PR DESCRIPTION
## Description
We were using CloudAPI to send WhatsApp Utility Messages due to a dedupe logic bug in the Message Events Post API. With this issue being resolved in [D74522961](https://www.internalfb.com/diff/D74522961), updated the message sending api to Message Events

## Changelog entry
Update Message Sending API from Messages to Message Events


## Test Plan

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration.

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before

### After
