### PR TITLE
[WAUM] Fix the Status on the Whatsapp Consent Collection Pill and Button

### DIFF
--- a/assets/js/admin/whatsapp-consent-remove.js
+++ b/assets/js/admin/whatsapp-consent-remove.js
@@ -14,6 +14,17 @@ jQuery( document ).ready( function( $ ) {
     var confirmButton = document.getElementById("wc-fb-warning-modal-confirm");
     var $statusElement = $('#wc-whatsapp-collect-consent-status');
 
+    if (!facebook_for_woocommerce_whatsapp_consent.consent_collection_enabled) {
+       // Change the status from "on-status" to "off-status" for the specific element.
+       $statusElement.removeClass('on-status').addClass('off-status');
+       // Update the text to "Off".
+       $statusElement.text('Off');
+       // Hide the original "Remove" button
+       $('#wc-whatsapp-collect-consent-remove-container').addClass('fbwa-hidden-element');
+       // Show the "Add" button
+       $('#wc-whatsapp-collect-consent-add-container').removeClass('fbwa-hidden-element');
+    }
+
     // On click of the remove button, show the warning modal
     $("#wc-whatsapp-collect-consent-remove").click(function(event) {
         // Show the modal


### PR DESCRIPTION
## Description
Issue:
The consent collection widget showed wrong status after update, when the page was refreshed. We update to ensure it always shows the right status.

### Type of change
- Bug fix (non-breaking change which fixes an issue)


## Changelog entry
Fix the Status on the Whatsapp Consent Collection Pill and Button


## Test Plan

https://github.com/user-attachments/assets/b23c9ed9-8d77-4460-ac0f-03e61a512797

