### PR TITLE
Fix WC Product Bundles compatibility by using empty().trigger('change') for Select2 fields

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -2117,7 +2117,9 @@ class Admin {
 						// Reset select2 if applicable
 						if ($select.hasClass('wc-enhanced-select') || $select.hasClass('select2-hidden-accessible')) {
 							try {
-								$select.select2('val', '');
+								// Use .empty().trigger('change') instead of setting val('')
+								// This fixes compatibility with WooCommerce Product Bundles
+								$select.empty().trigger('change');
 							} catch (e) {
 								// Ignore select2 errors
 							}


### PR DESCRIPTION
## Description

This PR fixes an issue where WooCommerce Product Bundles was breaking when Facebook for WooCommerce was active. The problem occurred in the `cleanupAllUIElements` function which was resetting Select2 fields by setting their value to an empty string (`$select.select2('val', '')`), causing the product search functionality in WC Product Bundles to malfunction.

The fix changes how the code resets Select2 fields to use `.empty().trigger('change')` instead, which properly clears the fields without breaking third-party plugins that rely on Select2.

Related issue: #3184

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki](https://fburl.com/wiki/2cgfduwc).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki](https://fburl.com/wiki/nhx73tgs).

## Changelog entry

Fix - WC Product Bundles compatibility issue with Select2 field resets.

## Test Plan

1. Install and activate both Facebook for WooCommerce and WooCommerce Product Bundles plugins
2. Create a bundled product and attempt to add a product to the bundle
3. Before the fix: The product search field doesn't work when selecting a product
4. After the fix: The product search field works correctly and products can be added to bundles

## Screenshots
### Before
When trying to add a product to a bundle, the Select2 search doesn't work correctly. After searching and selecting a product, the search field becomes empty again and the product is not added.

### After
The product search works correctly. After searching and selecting a product, it is properly added to the bundle.