### PR TITLE
[WAUM] Update the Authentication mechanism for Whatsapp Webhook

### DIFF
--- a/includes/Handlers/Whatsapp_Webhook.php
+++ b/includes/Handlers/Whatsapp_Webhook.php
@@ -70,7 +70,7 @@ class Whatsapp_Webhook {
 	}
 
 	/**
-	 * Authenticates Whatsapp Webhook using the SHA1 of the external business ID and BISU token
+	 * Authenticates Whatsapp Webhook using the SHA1 of the business ID and BISU token
 	 *
 	 * @param string $auth_key the auth key received in the webhook
 	 * @param string $bisu_token the BISU token received in the webhook
@@ -79,9 +79,9 @@ class Whatsapp_Webhook {
 	 * @internal
 	 */
 	private static function authenticate_request( $auth_key, $bisu_token ) {
-		$external_business_id = get_option( 'wc_facebook_business_manager_id' );
+		$business_id = get_option( 'wc_facebook_business_manager_id' );
 
-		$expected_auth_key = 'sha1=' . (string) hash_hmac( 'sha1', $bisu_token, $external_business_id );
+		$expected_auth_key = 'sha1=' . (string) hash_hmac( 'sha1', $bisu_token, $business_id );
 
 		return hash_equals( $expected_auth_key, $auth_key );
 	}
@@ -110,7 +110,7 @@ class Whatsapp_Webhook {
 			$waba_display_name        = sanitize_text_field( $request_params['wabaDisplayName'] );
 			$auth_key                 = sanitize_text_field( $request_params['authKey'] );
 
-			// authentication is done via auth_key using sha_1 hash mac of BISU token and external business ID stored in woo DB
+			// authentication is done via auth_key using sha_1 hash mac of BISU token and business ID stored in woo DB
 			$authentication_result = self::authenticate_request( $auth_key, $bisu_token );
 
 			if ( false === $authentication_result ) {

--- a/includes/Handlers/Whatsapp_Webhook.php
+++ b/includes/Handlers/Whatsapp_Webhook.php
@@ -79,7 +79,7 @@ class Whatsapp_Webhook {
 	 * @internal
 	 */
 	private static function authenticate_request( $auth_key, $bisu_token ) {
-		$external_business_id = get_option( 'wc_facebook_external_business_id' );
+		$external_business_id = get_option( 'wc_facebook_business_manager_id' );
 
 		$expected_auth_key = 'sha1=' . (string) hash_hmac( 'sha1', $bisu_token, $external_business_id );
 


### PR DESCRIPTION
## Description
Issue:
We previously used the hash of external_business_id + bisu token as an authentication mechanism while sending the onboarding info back to woo business. But during vendor testing, we realized that clients might connect the same external_business_id to MBE using multiple test websites , hence having multiple enabled EBCs.
Solution:
So we update the authentication mechanism to be a hash of business_id + BISU token instead.
Note: This is a short term solution for alpha, we need to rethink this authentication flow

### Type of change
- Bug fix (non-breaking change which fixes an issue)


## Changelog entry
Update the Authentication mechanism for Whatsapp Webhook


## Test Plan

https://github.com/user-attachments/assets/6c0f8beb-c32b-4f66-a9ff-10508acae45c


