### PR TITLE
Product tags data and sets sync impl.

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -12,9 +12,9 @@
 require_once __DIR__ . '/fbutils.php';
 
 use WooCommerce\Facebook\Feed\ShippingProfilesFeed;
-use WooCommerce\Facebook\Framework\Plugin\Compatibility;
 use WooCommerce\Facebook\Framework\Helper;
 use WooCommerce\Facebook\Products;
+use WooCommerce\Facebook\ProductSets\ProductSetSync;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -813,7 +813,7 @@ class WC_Facebook_Product {
 	 */
 	public function get_internal_labels(): array
 	{
-		$labels = [];
+		$labels = $this->get_product_tags();
 		$labels[] = $this->get_shipping_class_label();
 
 		// Wrap labels in single quotes
@@ -829,6 +829,18 @@ class WC_Facebook_Product {
 	{
 		$shipping_class_id = (string) $this->woo_product->get_shipping_class_id();
 		return ShippingProfilesFeed::get_shipping_class_tag_for_class($shipping_class_id);
+	}
+
+	private function get_product_tags(): array
+	{
+		$tag_term_ids = $this->woo_product->get_tag_ids();
+		return array_map(
+			function ( $tag_term_id ) {
+				$wc_tag = get_term( $tag_term_id, ProductSetSync::WC_PRODUCT_TAG_TAXONOMY );
+				return ProductSetSync::get_fb_product_tag( $wc_tag );
+			},
+			$tag_term_ids
+    );
 	}
 
 	/**

--- a/tests/Unit/ProductSets/ProductSetSyncTest.php
+++ b/tests/Unit/ProductSets/ProductSetSyncTest.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/../../../includes/ProductSets/ProductSetSync.php';
 
 use WP_UnitTestCase;
 use WooCommerce\Facebook\ProductSets\ProductSetSync;
+use WooCommerce\Facebook\ProductSets\ProductSetSource;
 
 /**
  * Class FeedUploadUtilsTest
@@ -24,8 +25,22 @@ class ProductSetSyncTest extends WP_UnitTestCase {
 
 	/* ------------------ Test Methods ------------------ */
 
-    public function testCreate() {
-        $wc_category = $this->createWPCategory();
+	public function provide_test_data() {
+		return [
+			[
+				ProductSetSync::WC_PRODUCT_CATEGORY_TAXONOMY
+			],
+			[
+				ProductSetSync::WC_PRODUCT_TAG_TAXONOMY
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider provide_test_data
+	 */
+    public function testCreate( $wc_taxonomy ) {
+        $wc_term = $this->createWCTerm( $wc_taxonomy );
 
         $product_set_sync = $this->getMockBuilder( ProductSetSyncTestable::class )
             ->setMethods(['is_sync_enabled', 'get_fb_product_set_id','create_fb_product_set'])
@@ -36,20 +51,31 @@ class ProductSetSyncTest extends WP_UnitTestCase {
             ->willReturn(true);
         $product_set_sync->expects( $this->once() )
             ->method( 'get_fb_product_set_id' )
-            ->with($wc_category)
+            ->with( $wc_term )
             ->willReturn(null);
         $product_set_sync->expects( $this->once() )
             ->method( 'create_fb_product_set' );
         
-        $product_set_sync->on_create_or_update_product_wc_category_callback( 
-            $wc_category->term_id, 
-            $wc_category->term_taxonomy_id, 
-            array() 
-        );
+		if ( ProductSetSync::WC_PRODUCT_CATEGORY_TAXONOMY === $wc_taxonomy ) {
+			$product_set_sync->on_create_or_update_product_wc_category_callback( 
+				$wc_term->term_id,
+				$wc_term->term_taxonomy_id,
+				array() 
+			);
+		} else {
+			$product_set_sync->on_create_or_update_wc_product_tag_callback( 
+				$wc_term->term_id,
+				$wc_term->term_taxonomy_id,
+				array() 
+			);
+		}
     }
 
-    public function testUpdate() {
-        $wc_category = $this->createWPCategory();
+	/**
+	 * @dataProvider provide_test_data
+	 */
+    public function testUpdate( $wc_taxonomy ) {
+        $wc_term = $this->createWCTerm( $wc_taxonomy );
 
         $product_set_sync = $this->getMockBuilder( ProductSetSyncTestable::class )
             ->setMethods(['is_sync_enabled', 'get_fb_product_set_id','update_fb_product_set'])
@@ -60,21 +86,32 @@ class ProductSetSyncTest extends WP_UnitTestCase {
             ->willReturn(true);        
         $product_set_sync->expects( $this->once() )
             ->method( 'get_fb_product_set_id' )
-            ->with($wc_category)
+            ->with($wc_term)
             ->willReturn(self::FB_PRODUCT_SET_ID);
         $product_set_sync->expects( $this->once() )
             ->method( 'update_fb_product_set' )
-            ->with($wc_category, self::FB_PRODUCT_SET_ID);
-        
-        $product_set_sync->on_create_or_update_product_wc_category_callback( 
-            $wc_category->term_id, 
-            $wc_category->term_taxonomy_id, 
-            array() 
-        );
+            ->with($wc_term, self::FB_PRODUCT_SET_ID);
+		
+		if ( ProductSetSync::WC_PRODUCT_CATEGORY_TAXONOMY === $wc_taxonomy ) {
+			$product_set_sync->on_create_or_update_product_wc_category_callback( 
+				$wc_term->term_id, 
+				$wc_term->term_taxonomy_id, 
+				array() 
+			);
+		} else {
+			$product_set_sync->on_create_or_update_wc_product_tag_callback( 
+				$wc_term->term_id,
+				$wc_term->term_taxonomy_id,
+				array() 
+			);
+		}
     }
 
-    public function testDelete() {
-        $wc_category = $this->createWPCategory();
+	/**
+	 * @dataProvider provide_test_data
+	 */
+    public function testDelete( $wc_taxonomy ) {
+        $wc_term = $this->createWCTerm( $wc_taxonomy );
 
         $product_set_sync = $this->getMockBuilder( ProductSetSyncTestable::class )
             ->setMethods(['is_sync_enabled', 'get_fb_product_set_id','delete_fb_product_set'])
@@ -85,22 +122,34 @@ class ProductSetSyncTest extends WP_UnitTestCase {
             ->willReturn(true);
         $product_set_sync->expects( $this->once() )
             ->method( 'get_fb_product_set_id' )
-            ->with($wc_category)
+            ->with($wc_term)
             ->willReturn(self::FB_PRODUCT_SET_ID);
         $product_set_sync->expects( $this->once() )
             ->method( 'delete_fb_product_set' )
             ->with(self::FB_PRODUCT_SET_ID);
         
-        $product_set_sync->on_delete_wc_product_category_callback( 
-            $wc_category->term_id, 
-            $wc_category->term_taxonomy_id, 
-            $wc_category,
-            array() 
-        );
+		if ( ProductSetSync::WC_PRODUCT_CATEGORY_TAXONOMY === $wc_taxonomy ) {
+			$product_set_sync->on_delete_wc_product_category_callback( 
+				$wc_term->term_id, 
+				$wc_term->term_taxonomy_id, 
+				$wc_term,
+				array() 
+			);
+		} else {
+            $product_set_sync->on_delete_wc_product_tag_callback( 
+				$wc_term->term_id, 
+				$wc_term->term_taxonomy_id, 
+				$wc_term,
+				array() 
+			);
+		}
     }
 
-    public function testSyncDisabled() {
-        $wc_category = $this->createWPCategory();
+    /**
+	 * @dataProvider provide_test_data
+	 */
+    public function testSyncDisabled( $wc_taxonomy ) {
+        $wc_term = $this->createWCTerm( $wc_taxonomy );
 
         $product_set_sync = $this->getMockBuilder( ProductSetSyncTestable::class )
             ->setMethods(['is_sync_enabled', 'get_fb_product_set_id','create_fb_product_set'])
@@ -115,15 +164,17 @@ class ProductSetSyncTest extends WP_UnitTestCase {
             ->method( 'create_fb_product_set' );
         
         $product_set_sync->on_create_or_update_product_wc_category_callback( 
-            $wc_category->term_id, 
-            $wc_category->term_taxonomy_id, 
+            $wc_term->term_id, 
+            $wc_term->term_taxonomy_id, 
             array() 
         );
     }
 
     public function testSyncAllProductSets() {
-        $this->createWPCategory( self::WC_CATEGORY_NAME_1 );
-        $this->createWPCategory( self::WC_CATEGORY_NAME_2 );
+        $this->createWCTerm( ProductSetSync::WC_PRODUCT_CATEGORY_TAXONOMY, self::WC_CATEGORY_NAME_1 );
+        $this->createWCTerm( ProductSetSync::WC_PRODUCT_CATEGORY_TAXONOMY, self::WC_CATEGORY_NAME_2 );
+        $this->createWCTerm( ProductSetSync::WC_PRODUCT_TAG_TAXONOMY, self::WC_CATEGORY_NAME_1 );
+        $this->createWCTerm( ProductSetSync::WC_PRODUCT_TAG_TAXONOMY, self::WC_CATEGORY_NAME_2 );
 
         $product_set_sync = $this->getMockBuilder( ProductSetSyncTestable::class )
             ->setMethods(['is_sync_enabled', 'get_fb_product_set_id','create_fb_product_set'])
@@ -132,42 +183,53 @@ class ProductSetSyncTest extends WP_UnitTestCase {
 		$product_set_sync->expects( $this->exactly(1) )
             ->method( 'is_sync_enabled' )
             ->willReturn(true);
-        $product_set_sync->expects( $this->atLeast(2) )
+        $product_set_sync->expects( $this->atLeast(4) )
             ->method( 'get_fb_product_set_id' )
             ->willReturn(null);
-        $product_set_sync->expects( $this->atLeast(2) )
+        $product_set_sync->expects( $this->atLeast(4) )
             ->method( 'create_fb_product_set' );
         
         $product_set_sync->sync_all_product_sets();
     }
 
-    public function testProductSetData() {
-        $wc_category = $this->createWPCategory();
+    /**
+	 * @dataProvider provide_test_data
+	 */
+    public function testProductSetData( $wc_taxonomy ) {
+		$wc_term = $this->createWCTerm( $wc_taxonomy );
 
         $product_set_sync = $this->getMockBuilder( ProductSetSyncTestable::class )
             ->setMethods(['is_sync_enabled', 'get_fb_product_set_id','create_fb_product_set'])
             ->getMock();
         
-        $data = $product_set_sync->build_fb_product_set_data( $wc_category );
+        $data = $product_set_sync->build_fb_product_set_data( $wc_term, $wc_taxonomy );
+
         $this->assertEquals( self::WC_CATEGORY_NAME_1, $data['name'] );
-        $this->assertEquals( $wc_category->term_taxonomy_id, $data['retailer_id'] );
-        $this->assertEquals('{"and":[{"product_type":{"i_contains":"Test Category 1"}}]}', $data['filter'] );
-        $this->assertEquals( '{"description":"<p>This is a test category<\/p>\n","external_url":"http:\/\/example.org\/?product_cat=test-category"}', $data['metadata'] );
+        $this->assertEquals( $wc_term->term_taxonomy_id, $data['retailer_id'] );
+        
+		if ( ProductSetSync::WC_PRODUCT_CATEGORY_TAXONOMY === $wc_taxonomy ) {
+            $this->assertEquals('{"and":[{"product_type":{"i_contains":"Test Category 1"}}]}', $data['filter'] );
+            $this->assertEquals( '{"description":"<p>This is a test category<\/p>\n","external_url":"http:\/\/example.org\/?product_cat=test-category"}', $data['metadata'] );
+        } else {
+            $this->assertEquals('{"and":[{"tags":{"eq":"wc_tag_id_'.$wc_term->term_taxonomy_id.'"}}]}', $data['filter'] );
+            $this->assertEquals( '{"description":"<p>This is a test category<\/p>\n","external_url":"http:\/\/example.org\/?product_tag=test-category"}', $data['metadata'] );
+        }
     }
 
     /* ------------------ Utils Methods ------------------ */
 
-    private function createWPCategory( $name = self::WC_CATEGORY_NAME_1 ) {
-        $wc_category = wp_insert_term(
+    private function createWCTerm( $wc_taxonomy, $name = self::WC_CATEGORY_NAME_1 ) {
+
+        $wc_term = wp_insert_term(
             $name,
-            'product_cat', // taxonomy
+            $wc_taxonomy,
             array(
                 'description' => 'This is a test category',
                 'slug' => 'test-category',
             )
         );
 
-        return get_term( $wc_category['term_id'], ProductSetSync::WC_PRODUCT_CATEGORY_TAXONOMY );
+        return get_term( $wc_term['term_id'], $wc_taxonomy );
     }
 }
 
@@ -184,19 +246,19 @@ class ProductSetSyncTestable extends ProductSetSync {
         return parent::get_fb_product_set_id( $wc_category );
     }
 
-    public function create_fb_product_set( $wc_category ) {
-        return parent::create_fb_product_set( $wc_category );
+    public function create_fb_product_set( $wc_term, $wc_taxonomy ) {
+        return parent::create_fb_product_set( $wc_term, $wc_taxonomy );
     }
 
-    public function update_fb_product_set( $wc_category, $fb_product_set_id ) {
-        return parent::update_fb_product_set( $wc_category, $fb_product_set_id );
+    public function update_fb_product_set( $wc_term, $fb_product_set_id, $wc_taxonomy ) {
+        return parent::update_fb_product_set( $wc_term, $fb_product_set_id, $wc_taxonomy );
     }
 
     public function delete_fb_product_set( $fb_product_set_id ) {
         return parent::delete_fb_product_set( $fb_product_set_id );
     }
 
-    public function build_fb_product_set_data( $wc_category ) {
-        return parent::build_fb_product_set_data( $wc_category );
+    public function build_fb_product_set_data( $wc_term, $wc_taxonomy ) {
+        return parent::build_fb_product_set_data( $wc_term, $wc_taxonomy );
     }
 }


### PR DESCRIPTION
## Description

WooCommerce has a feature of product tags, where product tags can be created and then products are being tagged with it. This is another way to group some products together. Also, WooCommerce product tag has own Slug (URL).

In this PR we are suggesting to:
1/ Sync to Meta catalog products the corresponding tags.
2/ Sync to Meta (filter rule) product sets for each product tag (and keep fb sets in sync with WooCommerce tags).

Such product sets will also have corresponded external URL making it a 'collection' and will contribute to WooCommerce sellers having more options with pre-populated data while using different Ad products in Meta. 

### Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

- **Enhanced Product Tag Synchronization**: Automatically sync all WooCommerce product tags to Meta and create corresponding Facebook product sets for each tag. This feature ensures real-time synchronization, keeping your product sets up-to-date with the latest changes.


## Test Plan

The change is covered with tests. Also manually tested. Dogfooding session will be conducted in the working group.

`npm run lint:php`
`npm run test:php`

