### PR TITLE
[WAUM] Fix the product sync button showing up twice

### DIFF
--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -55,7 +55,6 @@ class Settings {
 
 		$this->screens = $this->build_menu_item_array();
 
-		add_action( 'admin_menu', array( $this, 'build_menu_item_array' ) );
 		add_action( 'admin_init', array( $this, 'add_extra_screens' ) );
 		add_action( 'admin_menu', array( $this, 'add_menu_item' ) );
 		add_action( 'wp_loaded', array( $this, 'save' ) );


### PR DESCRIPTION
## Description

The product sync button was showing up twice due to a change we added when building the rollout switch. Fixing this in this diff.

### Type of change
- Bug fix (non-breaking change which fixes an issue)


## Changelog entry
Fix the product sync button showing up twice


## Test Plan
## Screenshots
### Before Change
<img width="1131" alt="Screenshot 2025-05-15 at 11 16 56 AM" src="https://github.com/user-attachments/assets/40f9da5b-57aa-402d-abe1-edc3d1e19905" />



### With GK
Product sync shows once with utility messages tab
<img width="961" alt="Screenshot 2025-05-15 at 11 02 41 AM" src="https://github.com/user-attachments/assets/5bf92fd0-0c22-4449-8e96-3ef351c1f6cb" />
### Without GK
Product sync shows once without utility messages tab
<img width="960" alt="Screenshot 2025-05-15 at 11 11 19 AM" src="https://github.com/user-attachments/assets/21074f65-9910-4cc7-b6dd-3f182d1486f8" />