### PR TITLE
Add usage logging for enhanced settings tabs

### DIFF
--- a/includes/Admin/Enhanced_Settings.php
+++ b/includes/Admin/Enhanced_Settings.php
@@ -188,6 +188,14 @@ class Enhanced_Settings {
 		$current_tab = $this->get_current_tab();
 		$screen      = $this->get_screen( $current_tab );
 
+		\WC_Facebookcommerce_Utils::log_to_meta(
+      'User visited the Facebook for WooCommerce settings' . $current_tab . 'tab',
+      array(
+        'flow_name' => 'settings',
+        'flow_step' => $current_tab . '_tab_rendered',
+      )
+    );
+
 		?>
 		<div class="wrap woocommerce">
 			<?php $this->render_tabs( $current_tab ); ?>

--- a/includes/Admin/Enhanced_Settings.php
+++ b/includes/Admin/Enhanced_Settings.php
@@ -189,12 +189,12 @@ class Enhanced_Settings {
 		$screen      = $this->get_screen( $current_tab );
 
 		\WC_Facebookcommerce_Utils::log_to_meta(
-      'User visited the Facebook for WooCommerce settings' . $current_tab . 'tab',
-      array(
-        'flow_name' => 'settings',
-        'flow_step' => $current_tab . '_tab_rendered',
-      )
-    );
+			'User visited the Facebook for WooCommerce settings' . $current_tab . 'tab',
+			array(
+				'flow_name' => 'settings',
+				'flow_step' => $current_tab . '_tab_rendered',
+			)
+		);
 
 		?>
 		<div class="wrap woocommerce">

--- a/includes/Framework/AdminNoticeHandler.php
+++ b/includes/Framework/AdminNoticeHandler.php
@@ -299,7 +299,7 @@ class AdminNoticeHandler {
 		if ( is_null( $user_id ) ) {
 			$user_id = get_current_user_id();
 		}
-		$dismissed_notices = $this->get_dismissed_notices( $user_id );
+		$dismissed_notices                = $this->get_dismissed_notices( $user_id );
 		$dismissed_notices[ $message_id ] = true;
 		update_user_meta( $user_id, '_wc_plugin_framework_' . $this->get_plugin()->get_id() . '_dismissed_messages', $dismissed_notices );
 		/**
@@ -326,7 +326,7 @@ class AdminNoticeHandler {
 		if ( is_null( $user_id ) ) {
 			$user_id = get_current_user_id();
 		}
-		$dismissed_notices = $this->get_dismissed_notices( $user_id );
+		$dismissed_notices                = $this->get_dismissed_notices( $user_id );
 		$dismissed_notices[ $message_id ] = false;
 		update_user_meta( $user_id, '_wc_plugin_framework_' . $this->get_plugin()->get_id() . '_dismissed_messages', $dismissed_notices );
 	}

--- a/includes/Framework/Plugin.php
+++ b/includes/Framework/Plugin.php
@@ -373,7 +373,7 @@ abstract class Plugin {
 			// store the previous minor while we loop patch versions, which we ignore
 			$previous_minor = $older_minor;
 
-			$supported_minor--;
+			--$supported_minor;
 		}
 
 		// for strict comparison, we strip the patch version from the determined versions and compare only major, minor versions, ignoring patches (i.e. 1.2.3 becomes 1.2)
@@ -548,7 +548,7 @@ abstract class Plugin {
 			$level,
 			$message,
 			array(
-				'source'  => $log_id,
+				'source' => $log_id,
 			)
 		);
 	}

--- a/includes/Framework/Plugin/Dependencies.php
+++ b/includes/Framework/Plugin/Dependencies.php
@@ -61,7 +61,7 @@ class Dependencies {
 	 * @return array
 	 */
 	private function parse_dependencies( $args ) {
-		$dependencies = wp_parse_args(
+		$dependencies     = wp_parse_args(
 			$args,
 			array(
 				'php_extensions' => array(),
@@ -199,7 +199,7 @@ class Dependencies {
 	protected function add_deprecated_notices() {
 		// add a notice for PHP < 5.6
 		if ( version_compare( PHP_VERSION, '5.6.0', '<' ) ) {
-			$message = '<p>';
+			$message  = '<p>';
 			$message .= sprintf(
 				/* translators: Placeholders: %1$s - <strong>, %2$s - </strong> */
 				__(
@@ -259,7 +259,7 @@ class Dependencies {
 		 *
 		 * @param array $plugins an array of file identifiers (keys) and plugin names (values)
 		 */
-		$plugins = (array) apply_filters(
+		$plugins        = (array) apply_filters(
 			'wc_' . $this->get_plugin()->get_id() . '_scripts_optimization_plugins',
 			[
 				'async-javascript.php' => 'Async JavaScript',

--- a/includes/ProductSets/ProductSetSync.php
+++ b/includes/ProductSets/ProductSetSync.php
@@ -63,7 +63,7 @@ class ProductSetSync {
 				return;
 			}
 
-			$wc_category = get_term( $term_id, self::WC_PRODUCT_CATEGORY_TAXONOMY );
+			$wc_category       = get_term( $term_id, self::WC_PRODUCT_CATEGORY_TAXONOMY );
 			$fb_product_set_id = $this->get_fb_product_set_id( $wc_category );
 			if ( ! empty( $fb_product_set_id ) ) {
 				$this->update_fb_product_set( $wc_category, $fb_product_set_id );

--- a/includes/RolloutSwitches.php
+++ b/includes/RolloutSwitches.php
@@ -23,8 +23,8 @@ class RolloutSwitches {
 	/** @var \WC_Facebookcommerce commerce handler */
 	private \WC_Facebookcommerce $plugin;
 
-	public const SWITCH_ROLLOUT_FEATURES    = 'rollout_enabled';
-	public const WHATSAPP_UTILITY_MESSAGING = 'whatsapp_utility_messages_enabled';
+	public const SWITCH_ROLLOUT_FEATURES          = 'rollout_enabled';
+	public const WHATSAPP_UTILITY_MESSAGING       = 'whatsapp_utility_messages_enabled';
 	public const SWITCH_PRODUCT_SETS_SYNC_ENABLED = 'product_sets_sync_enabled';
 
 	private const ACTIVE_SWITCHES = array(


### PR DESCRIPTION
## Description
This PR adds logging in enhanced settings to track the usage of each tab. This data is used to inform improvements on the user experience.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Test Plan
1. Go to `http://test-site-i.local/wp-admin/admin.php?page=wc-facebook`. Make sure you are seeing the new enhanced setting UI. 
2. Ensure that your have onboarded onto Shops; you should be seeing three different tabs on the settings screen. Click into each of the tabs.
3. Check Meta side logging to ensure that the logs are visible.
