### PR TITLE
Add a banner in product sets tab to explain recent changes

### DIFF
--- a/includes/Admin/Product_Sets.php
+++ b/includes/Admin/Product_Sets.php
@@ -13,6 +13,7 @@ namespace WooCommerce\Facebook\Admin;
 defined( 'ABSPATH' ) || exit;
 
 use WP_Term;
+use WooCommerce\Facebook\RolloutSwitches;
 
 /**
  * General handler for the product set admin functionality.
@@ -65,7 +66,29 @@ class Product_Sets {
 		// save custom field data
 		add_action( 'created_fb_product_set', array( $this, 'save_custom_field' ), 10, 2 );
 		add_action( 'edited_fb_product_set', array( $this, 'save_custom_field' ), 10, 2 );
+		// show a banner about chnages to product sets sync
+		add_action( 'admin_notices', array( $this, 'display_fb_product_sets_banner' ) );
 	}
+
+	public function display_fb_product_sets_banner() {
+		if ( isset( $_GET['taxonomy'] ) && 'fb_product_set' === $_GET['taxonomy'] ) {
+			$is_product_sets_sync_enbaled = facebook_for_woocommerce()->get_rollout_switches()->is_switch_enabled(
+				RolloutSwitches::SWITCH_PRODUCT_SETS_SYNC_ENABLED
+			);
+			if ( $is_product_sets_sync_enbaled ) {
+				$fb_catalog_id = facebook_for_woocommerce()->get_integration()->get_product_catalog_id();
+
+				?>
+					<div class="notice notice-info">
+						<p><b>Your categories now automatically sync as product sets on Facebook</b></p>
+						<p>To make changes to automatically synced sets going forward, you should <a href="edit-tags.php?taxonomy=product_cat" target="_blank">edit your categories on WooCommerce</a>. This may take some time to update initially, but then will automatically sync every few minutes. There are no changes to any sets you previously created.
+						To see what’s synced, go to <a href="https://business.facebook.com/commerce/catalogs/<?php echo esc_attr( $fb_catalog_id ); ?>/sets" target="_blank">sets in Commerce Manager</a>.</p>
+					</div>
+				<?php
+			}
+		}
+	}
+
 
 
 	/**


### PR DESCRIPTION
## Description

In PR #3168 we merged new changes to the product sets sync: automatic sync of all WooCommerce product categories to Meta as catalog dynamic (filter) Product Sets with all the metadata associated (URL, image, description, retailer ID).

This PR is a follow up to add a banner in the UI of the product sets tab to explain recent changes to users.

### Type of change

- New feature (non-breaking change which adds functionality)


## Changelog entry

- Add a banner in product sets tab to explain recent changes to product sets sync.


## Test Plan
- `npm run test:php`
- Dogfood doc in internal to Meta

## Screenshots

After

![Screenshot 2025-05-19 at 09 52 46](https://github.com/user-attachments/assets/353dfd10-2be5-475f-a40c-473160695712)
