### PR TITLE
Revert "Fix WC Product Bundles compatibility by using empty().trigger"

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -2117,9 +2117,7 @@ class Admin {
 						// Reset select2 if applicable
 						if ($select.hasClass('wc-enhanced-select') || $select.hasClass('select2-hidden-accessible')) {
 							try {
-								// Use .empty().trigger('change') instead of setting val('')
-								// This fixes compatibility with WooCommerce Product Bundles
-								$select.empty().trigger('change');
+								$select.select2('val', '');
 							} catch (e) {
 								// Ignore select2 errors
 							}


### PR DESCRIPTION
## Description

This reverts commit 32d3707f4ef9f2e44d1bb10f6efd8114f328de7c as it breaks Product Category dropdown.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Revert "Fix WC Product Bundles compatibility by using empty().trigger"