### PR TITLE
Enabling navigation menu feed upload scheduling and adding sync button

### DIFF
--- a/assets/js/admin/enhanced-settings-sync.js
+++ b/assets/js/admin/enhanced-settings-sync.js
@@ -106,4 +106,37 @@ jQuery(document).ready(function($) {
 			button.prop('disabled', false);
 		});
 	});
+
+	/**
+	 * Handle the sync navigation menu button click event
+	 *
+	 * @since 3.5.0
+	 *
+	 * @param {object} event
+	 */
+	$('#wc-facebook-enhanced-settings-sync-navigation-menu').click(function(event) {
+		event.preventDefault();
+		var button = $(this);
+
+		button.html('Syncing...');
+		button.prop('disabled', true);
+
+		var data = {
+			action: "wc_facebook_sync_navigation_menu",
+			nonce: wc_facebook_enhanced_settings_sync.sync_navigation_menu_nonce
+		};
+
+		$.post(wc_facebook_enhanced_settings_sync.ajax_url, data, function(response) {
+			if (response.success) {
+				button.html('Sync completed');
+				button.prop('disabled', false);
+			} else {
+				button.html('Sync failed');
+				button.prop('disabled', false);
+			}
+		}).fail(function() {
+			button.html('Sync failed');
+			button.prop('disabled', false);
+		});
+	});
 });

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -49,6 +49,9 @@ class AJAX {
 		// sync all shipping profiles via AJAX
 		add_action( 'wp_ajax_wc_facebook_sync_shipping_profiles', array( $this, 'sync_shipping_profiles' ) );
 
+		// sync navigation menu via AJAX
+		add_action( 'wp_ajax_wc_facebook_sync_navigation_menu', array( $this, 'sync_navigation_menu' ) );
+
 		// get the current sync status
 		add_action( 'wp_ajax_wc_facebook_get_sync_status', array( $this, 'get_sync_status' ) );
 
@@ -178,6 +181,24 @@ class AJAX {
 
 		try {
 			facebook_for_woocommerce()->feed_manager->get_feed_instance( 'shipping_profiles' )->regenerate_feed();
+			wp_send_json_success();
+		} catch ( \Exception $exception ) {
+			wp_send_json_error( $exception->getMessage() );
+		}
+	}
+
+	/**
+	 * Syncs navigation menu via AJAX.
+	 *
+	 * @internal
+	 *
+	 * @since 3.5.0
+	 */
+	public function sync_navigation_menu() {
+		check_admin_referer( Shops::ACTION_SYNC_NAVIGATION_MENU, 'nonce' );
+
+		try {
+			facebook_for_woocommerce()->feed_manager->get_feed_instance( 'navigation_menu' )->regenerate_feed();
 			wp_send_json_success();
 		} catch ( \Exception $exception ) {
 			wp_send_json_error( $exception->getMessage() );

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -34,6 +34,9 @@ class Shops extends Abstract_Settings_Screen {
 	/** @var string */
 	const ACTION_SYNC_SHIPPING_PROFILES = 'wc_facebook_sync_shipping_profiles';
 
+	/** @var string */
+	const ACTION_SYNC_NAVIGATION_MENU = 'wc_facebook_sync_navigation_menu';
+
 	/**
 	 * Shops constructor.
 	 *
@@ -133,6 +136,7 @@ class Shops extends Abstract_Settings_Screen {
 				'sync_products_nonce'          => wp_create_nonce( self::ACTION_SYNC_PRODUCTS ),
 				'sync_coupons_nonce'           => wp_create_nonce( self::ACTION_SYNC_COUPONS ),
 				'sync_shipping_profiles_nonce' => wp_create_nonce( self::ACTION_SYNC_SHIPPING_PROFILES ),
+				'sync_navigation_menu_nonce'   => wp_create_nonce( self::ACTION_SYNC_NAVIGATION_MENU ),
 			)
 		);
 	}
@@ -251,6 +255,22 @@ class Shops extends Abstract_Settings_Screen {
 							</button>
 							<p id="shipping-profile-sync-description" class="sync-description">
 								Manually sync your shipping profiles from WooCommerce to your shop. It may take a couple of minutes for the changes to populate.
+							</p>
+						</td>
+					</tr>
+					<tr valign="top" class="wc-facebook-shops-sample">
+						<th scope="row" class="titledesc">
+							Navigation menu sync
+						</th>
+						<td class="forminp">
+							<button
+								id="wc-facebook-enhanced-settings-sync-navigation-menu"
+								class="button"
+								type="button">
+								<?php esc_html_e( 'Sync now', 'facebook-for-woocommerce' ); ?>
+							</button>
+							<p id="navigation-menu-sync-description" class="sync-description">
+								Manually sync your category navigation menu from WooCommerce to your shop. It may take a couple of minutes for the changes to populate.
 							</p>
 						</td>
 					</tr>

--- a/includes/Feed/FeedManager.php
+++ b/includes/Feed/FeedManager.php
@@ -74,7 +74,6 @@ class FeedManager {
 	 * @since 3.5.0
 	 */
 	public static function get_active_feed_types(): array {
-		// TODO add self::NAVIGATION_MENU once category sync is implemented
 		return array( self::PROMOTIONS, self::RATINGS_AND_REVIEWS, self::SHIPPING_PROFILES, self::NAVIGATION_MENU );
 	}
 

--- a/includes/Feed/FeedManager.php
+++ b/includes/Feed/FeedManager.php
@@ -75,7 +75,7 @@ class FeedManager {
 	 */
 	public static function get_active_feed_types(): array {
 		// TODO add self::NAVIGATION_MENU once category sync is implemented
-		return array( self::PROMOTIONS, self::RATINGS_AND_REVIEWS, self::SHIPPING_PROFILES );
+		return array( self::PROMOTIONS, self::RATINGS_AND_REVIEWS, self::SHIPPING_PROFILES, self::NAVIGATION_MENU );
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR follows up on https://github.com/facebook/facebook-for-woocommerce/pull/3159 to enable the automated scheduling of the navigation menu feed upload and adds a button to the troubleshooting UI to trigger an ad hoc navigation menu feed upload. This new button is setup the same way as the existing product data, coupon codes, and shipping profiles sync buttons.

### Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Enabling automated navigation menu feed upload scheduling and adding manual sync button

## Test Plan

1. Pushed local changes to lightsail instance (had to run npm start first)
2. Navigated to the troubleshoot dropdown in the facebook shops tab
3. Clicked button to trigger ad hoc shipping profiles feed upload
4. Verified that there was a log for the API call and a new feed upload session created (and successful)
<img width="1016" alt="Screenshot 2025-05-20 at 3 50 10 PM" src="https://github.com/user-attachments/assets/98d737cd-cca1-4b8d-b536-77841788d2a8" />
<img width="1159" alt="Screenshot 2025-05-20 at 3 50 54 PM" src="https://github.com/user-attachments/assets/cac36faf-3fa9-441c-9fd5-ec6f2a0ee364" />
<img width="1308" alt="Screenshot 2025-05-20 at 3 51 16 PM" src="https://github.com/user-attachments/assets/eab70dd4-c62a-48ee-8b47-9a5265c7f002" />

## Screenshots
### Before
<img width="1115" alt="Screenshot 2025-05-20 at 3 44 48 PM" src="https://github.com/user-attachments/assets/ac985703-437d-4165-81d5-7bfbd23a0a6b" />

### After
<img width="1113" alt="Screenshot 2025-05-20 at 3 45 10 PM" src="https://github.com/user-attachments/assets/bb4db9b6-1cbd-4cf2-8761-60e49010fbb5" />