### PR TITLE
add_filters for brand taxonomy slug for WC_Facebook_Product

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -665,7 +665,8 @@ class WC_Facebook_Product {
 		// Only fallback to store name if no brand is found on product or parent
 		if (empty($fb_brand)) {
 			$brand = get_post_meta($this->id, Products::ENHANCED_CATALOG_ATTRIBUTES_META_KEY_PREFIX . 'brand', true);
-			$brand_taxonomy = get_the_term_list($this->id, 'product_brand', '', ', ');
+            $brand_taxonomy_slug = apply_filters( 'facebook_for_woocommerce_fb_product_brand_taxonomy', 'product_brand', $this->id );
+			$brand_taxonomy = get_the_term_list($this->id, $brand_taxonomy_slug, '', ', ');
 
 			if ($brand) {
 				$fb_brand = $brand;


### PR DESCRIPTION
## Description

There is currently no way to modify the taxonomy slug used for the synced products' brand.

### Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Added new filter for modifying brand taxonomy slug for synced product.

