### PR TITLE
Add management for exceptions from the backend

### DIFF
--- a/includes/RolloutSwitches.php
+++ b/includes/RolloutSwitches.php
@@ -15,8 +15,6 @@ use WooCommerce\Facebook\Utilities\Heartbeat;
 
 defined( 'ABSPATH' ) || exit;
 
-const MINUTE_IN_SECONDS = 60;
-
 /**
  * The rollout switches is used to control available
  * features in the Facebook for WooCommerce plugin.

--- a/includes/RolloutSwitches.php
+++ b/includes/RolloutSwitches.php
@@ -15,6 +15,8 @@ use WooCommerce\Facebook\Utilities\Heartbeat;
 
 defined( 'ABSPATH' ) || exit;
 
+const MINUTE_IN_SECONDS = 60;
+
 /**
  * The rollout switches is used to control available
  * features in the Facebook for WooCommerce plugin.
@@ -59,6 +61,9 @@ class RolloutSwitches {
 			$external_business_id = $this->plugin->get_connection_handler()->get_external_business_id();
 			$switches             = $this->plugin->get_api()->get_rollout_switches( $external_business_id );
 			$data                 = $switches->get_data();
+			if ( empty( $data ) ) {
+				throw new Exception( 'Empty data' );
+			}
 			foreach ( $data as $switch ) {
 				if ( ! isset( $switch['switch'] ) || ! $this->is_switch_active( $switch['switch'] ) ) {
 					continue;
@@ -66,7 +71,11 @@ class RolloutSwitches {
 				$this->rollout_switches[ $switch['switch'] ] = (bool) $switch['enabled'];
 			}
 		} catch ( Exception $e ) {
-			\WC_Facebookcommerce_Utils::log_exception_immediately_to_meta(
+			// if there is an exception we will assume that the switch is disabled
+			foreach ( self::ACTIVE_SWITCHES as $switch ) {
+				$this->rollout_switches[ $switch ] = false;
+			}
+			\WC_Facebookcommerce_Utils::fblog(
 				$e,
 				[
 					'event'      => 'rollout_switches',


### PR DESCRIPTION
## Description

Test and add error management

Right now we assume if the response doesn't have data it's throwing an exception, and we default all the active flags to false to avoid leakage.

## Changelog entry

rollout_switches: Add management for exception from the backend


## Test Plan

