### PR TITLE
Fix - Removed html tags from product set description.

### DIFF
--- a/includes/ProductSets/ProductSetSync.php
+++ b/includes/ProductSets/ProductSetSync.php
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || exit;
 
 use WooCommerce\Facebook\RolloutSwitches;
 use WooCommerce\Facebook\Utilities\Heartbeat;
+use WC_Facebookcommerce_Utils;
 
 /**
  * The product set sync handler.
@@ -171,7 +172,7 @@ class ProductSetSync {
 			$fb_product_set_metadata['cover_image_url'] = $wc_category_thumbnail_url;
 		}
 		if ( ! empty( $wc_category_description ) ) {
-			$fb_product_set_metadata['description'] = $wc_category_description;
+			$fb_product_set_metadata['description'] = WC_Facebookcommerce_Utils::clean_string( $wc_category_description );
 		}
 		if ( ! empty( $wc_category_url ) ) {
 			$fb_product_set_metadata['external_url'] = $wc_category_url;

--- a/tests/Unit/ProductSets/ProductSetSyncTest.php
+++ b/tests/Unit/ProductSets/ProductSetSyncTest.php
@@ -152,7 +152,7 @@ class ProductSetSyncTest extends WP_UnitTestCase {
         $this->assertEquals( self::WC_CATEGORY_NAME_1, $data['name'] );
         $this->assertEquals( $wc_category->term_taxonomy_id, $data['retailer_id'] );
         $this->assertEquals('{"and":[{"product_type":{"i_contains":"Test Category 1"}}]}', $data['filter'] );
-        $this->assertEquals( '{"description":"<p>This is a test category<\/p>\n","external_url":"http:\/\/example.org\/?product_cat=test-category"}', $data['metadata'] );
+        $this->assertEquals( '{"description":"This is a test category","external_url":"http:\/\/example.org\/?product_cat=test-category"}', $data['metadata'] );
     }
 
     /* ------------------ Utils Methods ------------------ */


### PR DESCRIPTION
## Description

Problem. The raw WC category description contains html tag (e.g. <p>). This gest synced to Meta and the string is not expected to contain the tags.
Fix. Remove the tags from the raw description before it is synchronised to Meta.

### Type of change

- Bug fix (non-breaking change which fixes an issue)


## Changelog entry

- Fix - Removed html tags from product set description. 


## Test Plan

`./vendor/bin/phpunit --filter ProductSetSyncTest`

