### PR TITLE
Fix linter errors for ./includes/Admin/Settings_Screens/Advertise.php

### DIFF
--- a/includes/Admin/Settings_Screens/Advertise.php
+++ b/includes/Admin/Settings_Screens/Advertise.php
@@ -69,6 +69,7 @@ class Advertise extends Abstract_Settings_Screen {
 			return;
 		}
 		wp_enqueue_style( 'wc-facebook-admin-advertise-settings', facebook_for_woocommerce()->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-advertise.css', array(), \WC_Facebookcommerce::VERSION );
+		wp_enqueue_style( 'wc-facebook-admin-whatsapp-banner', facebook_for_woocommerce()->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-whatsapp-banner.css', array(), \WC_Facebookcommerce::VERSION );
 	}
 
 
@@ -209,6 +210,10 @@ class Advertise extends Abstract_Settings_Screen {
 		}
 
 		$fbe_extras = wp_json_encode( $this->get_lwi_ads_configuration_data() );
+
+		$wa_banner = new \WC_Facebookcommerce_Admin_Banner();
+		$wa_banner->render_banner();
+		$wa_banner->enqueue_banner_script();
 
 		?>
 		<script async defer src="<?php echo esc_url( $this->get_lwi_ads_sdk_url() ); ?>"></script>

--- a/includes/Admin/Settings_Screens/Advertise.php
+++ b/includes/Admin/Settings_Screens/Advertise.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\Admin\Settings_Screens;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 use WooCommerce\Facebook\API;
 use WooCommerce\Facebook\Locale;
@@ -70,7 +69,6 @@ class Advertise extends Abstract_Settings_Screen {
 			return;
 		}
 		wp_enqueue_style( 'wc-facebook-admin-advertise-settings', facebook_for_woocommerce()->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-advertise.css', array(), \WC_Facebookcommerce::VERSION );
-		wp_enqueue_style( 'wc-facebook-admin-whatsapp-banner', facebook_for_woocommerce()->get_plugin_url() . '/assets/css/admin/facebook-for-woocommerce-whatsapp-banner.css', array(), \WC_Facebookcommerce::VERSION );
 	}
 
 
@@ -94,7 +92,7 @@ class Advertise extends Abstract_Settings_Screen {
 					appId            : '<?php echo esc_js( $connection_handler->get_client_id() ); ?>',
 					autoLogAppEvents : true,
 					xfbml            : true,
-					version          : '<?php echo esc_js( API::API_VERSION )?>',
+					version          : '<?php echo esc_js( API::API_VERSION ); ?>',
 				} );
 			};
 		</script>
@@ -134,12 +132,12 @@ class Advertise extends Abstract_Settings_Screen {
 	}
 
 
-	/*
+	/**
 	 * Converts the given timezone string to a name if needed.
 	 *
 	 * @since 2.2.0
 	 *
-	 * @param string $timezone_string Timezone string
+	 * @param string    $timezone_string Timezone string
 	 * @param int|float $timezone_offset Timezone offset
 	 * @return string timezone string
 	 */
@@ -191,6 +189,8 @@ class Advertise extends Abstract_Settings_Screen {
 	 * The contents of the Facebook box will be populated by the LWI Ads script through iframes.
 	 *
 	 * @since 2.2.0
+	 *
+	 * phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 	 */
 	public function render() {
 
@@ -210,11 +210,7 @@ class Advertise extends Abstract_Settings_Screen {
 
 		$fbe_extras = wp_json_encode( $this->get_lwi_ads_configuration_data() );
 
-		$wa_banner = new \WC_Facebookcommerce_Admin_Banner();
-		$wa_banner->render_banner();
-		$wa_banner->enqueue_banner_script();
 		?>
-
 		<script async defer src="<?php echo esc_url( $this->get_lwi_ads_sdk_url() ); ?>"></script>
 		<div
 			class="fb-lwi-ads-creation"


### PR DESCRIPTION
## Description
This PR fixes phpcs issues in `./includes/Admin/Settings_Screens/Advertise.php`. Comments were also added for several functions. The fixes were made manually (in conjunction with `./vendor/bin/phpcbf`) to ensure that the logic remains the same. Running `./vendor/bin/phpcs`:
```
FILE: /Users/angeloou/Local Sites/test-site-i/app/public/wp-content/plugins/facebook-for-woocommerce/includes/Admin/Settings_Screens/Advertise.php
--------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 5 ERRORS AFFECTING 4 LINES
--------------------------------------------------------------------------------------------------------------------------------------------------
  13 | ERROR | [ ] Logical operator "or" is prohibited; use "||" instead (Squiz.Operators.ValidLogicalOperators.NotAllowed)
  96 | ERROR | [x] Inline PHP statement must end with a semicolon (Squiz.PHP.EmbeddedPhp.NoSemicolon)
  96 | ERROR | [x] Expected 1 space before closing PHP tag; 0 found (Squiz.PHP.EmbeddedPhp.SpacingBeforeClose)
 145 | ERROR | [ ] You must use "/**" style comments for a function comment (Squiz.Commenting.FunctionComment.WrongStyle)
 217 | ERROR | [ ] Scripts must be registered/enqueued via wp_enqueue_script() (WordPress.WP.EnqueuedResources.NonEnqueuedScript)
--------------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 2 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------------------------------------------------------------------------
```

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected

## Test Plan
1. Run `./vendor/bin/phpcs`, you should get no errors in `./includes/Admin/Settings_Screens/Advertise.php`.
2. Run extension and test the basic functionality to ensure everything still works as intended.