### PR TITLE
Fix linter errors for ./includes/Admin/Settings_Screens/Product_Sync.php

### DIFF
--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook\Admin\Settings_Screens;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 use WooCommerce\Facebook\Admin\Abstract_Settings_Screen;
 use WooCommerce\Facebook\Admin\Google_Product_Category_Field;
@@ -200,7 +199,7 @@ class Product_Sync extends Abstract_Settings_Screen {
 	 * @since 2.0.0
 	 */
 	public function save() {
-		$integration = facebook_for_woocommerce()->get_integration();
+		$integration              = facebook_for_woocommerce()->get_integration();
 		$previous_product_cat_ids = $integration->get_excluded_product_category_ids();
 		$previous_product_tag_ids = $integration->get_excluded_product_tag_ids();
 		parent::save();
@@ -245,7 +244,7 @@ class Product_Sync extends Abstract_Settings_Screen {
 	 * @return array
 	 */
 	public function get_settings() {
-		$term_query = new \WP_Term_Query(
+		$term_query         = new \WP_Term_Query(
 			array(
 				'taxonomy'   => 'product_cat',
 				'hide_empty' => false,
@@ -253,7 +252,7 @@ class Product_Sync extends Abstract_Settings_Screen {
 			)
 		);
 		$product_categories = $term_query->get_terms();
-		$term_query = new \WP_Term_Query(
+		$term_query         = new \WP_Term_Query(
 			array(
 				'taxonomy'     => 'product_tag',
 				'hide_empty'   => false,
@@ -261,7 +260,7 @@ class Product_Sync extends Abstract_Settings_Screen {
 				'fields'       => 'id=>name',
 			)
 		);
-		$product_tags = $term_query->get_terms();
+		$product_tags       = $term_query->get_terms();
 		return array(
 			array(
 				'type'  => 'product_sync_title',


### PR DESCRIPTION
## Description
This PR fixes phpcs issues in `./includes/Admin/Settings_Screens/Product_Sync.php`. Comments were also added for several functions. The fixes were made manually (in conjunction with `./vendor/bin/phpcbf`) to ensure that the logic remains the same. Running `./vendor/bin/phpcs`:
```
FILE: /Users/angeloou/Local Sites/test-site-i/app/public/wp-content/plugins/facebook-for-woocommerce/includes/Admin/Settings_Screens/Product_Sync.php
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AND 8 WARNINGS AFFECTING 8 LINES
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  13 | ERROR   | [ ] Logical operator "or" is prohibited; use "||" instead (Squiz.Operators.ValidLogicalOperators.NotAllowed)
  67 | WARNING | [ ] Resource version not set in call to wp_enqueue_script(). This means new versions of the script may not always be loaded due to browser caching.
     |         |     (WordPress.WP.EnqueuedResourceParameters.MissingVersion)
  67 | WARNING | [ ] In footer ($in_footer) is not set explicitly wp_enqueue_script; It is recommended to load scripts in the footer. Please set this value to `true`
     |         |     to load it in the footer, or explicitly `false` if it should be loaded in the header. (WordPress.WP.EnqueuedResourceParameters.NotInFooter)
  68 | WARNING | [ ] In footer ($in_footer) is not set explicitly wp_enqueue_script; It is recommended to load scripts in the footer. Please set this value to `true`
     |         |     to load it in the footer, or explicitly `false` if it should be loaded in the header. (WordPress.WP.EnqueuedResourceParameters.NotInFooter)
  74 | WARNING | [ ] In footer ($in_footer) is not set explicitly wp_enqueue_script; It is recommended to load scripts in the footer. Please set this value to `true`
     |         |     to load it in the footer, or explicitly `false` if it should be loaded in the header. (WordPress.WP.EnqueuedResourceParameters.NotInFooter)
 202 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 14 spaces but found 1 space
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 247 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 9 spaces but found 1 space
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 255 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 9 spaces but found 1 space
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 263 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 7 spaces but found 1 space
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 4 MARKED SNIFF VIOLATIONS AUTOMATICALLY
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected

## Test Plan
1. Run `./vendor/bin/phpcs`, you should get:
```
FILE: /Users/angeloou/Local Sites/test-site-i/app/public/wp-content/plugins/facebook-for-woocommerce/includes/Admin/Settings_Screens/Product_Sync.php
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 4 WARNINGS AFFECTING 3 LINES
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 67 | WARNING | Resource version not set in call to wp_enqueue_script(). This means new versions of the script may not always be loaded due to browser caching.
    |         | (WordPress.WP.EnqueuedResourceParameters.MissingVersion)
 67 | WARNING | In footer ($in_footer) is not set explicitly wp_enqueue_script; It is recommended to load scripts in the footer. Please set this value to `true` to load it in the
    |         | footer, or explicitly `false` if it should be loaded in the header. (WordPress.WP.EnqueuedResourceParameters.NotInFooter)
 68 | WARNING | In footer ($in_footer) is not set explicitly wp_enqueue_script; It is recommended to load scripts in the footer. Please set this value to `true` to load it in the
    |         | footer, or explicitly `false` if it should be loaded in the header. (WordPress.WP.EnqueuedResourceParameters.NotInFooter)
 74 | WARNING | In footer ($in_footer) is not set explicitly wp_enqueue_script; It is recommended to load scripts in the footer. Please set this value to `true` to load it in the
    |         | footer, or explicitly `false` if it should be loaded in the header. (WordPress.WP.EnqueuedResourceParameters.NotInFooter)
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
2. Run extension and test the basic functionality to ensure everything still works as intended.