### PR TITLE
Removing `Enable sync` checkbox, Global sync logic and tagging newly synced products

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -74,9 +74,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/** @var string the "access token" setting ID */
 	const SETTING_ACCESS_TOKEN = 'access_token';
 
-	/** @var string the "enable product sync" setting ID */
-	const SETTING_ENABLE_PRODUCT_SYNC = 'wc_facebook_enable_product_sync';
-
 	/** @var string the excluded product category IDs setting ID */
 	const SETTING_EXCLUDED_PRODUCT_CATEGORY_IDS = 'wc_facebook_excluded_product_category_ids';
 
@@ -2158,11 +2155,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 * @throws PluginException If the plugin is not configured or the Catalog ID is missing.
 	 */
 	private function sync_facebook_products_using_background_processor() {
-		if ( ! $this->is_product_sync_enabled() ) {
-			WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( 'Sync to Facebook is disabled' );
-			throw new PluginException( __( 'Product sync is disabled.', 'facebook-for-woocommerce' ) );
-		}
-
 		if ( ! $this->is_configured() || ! $this->get_product_catalog_id() ) {
 			WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( sprintf( 'Not syncing, the plugin is not configured or the Catalog ID is missing' ) );
 			throw new PluginException( __( 'The plugin is not configured or the Catalog ID is missing.', 'facebook-for-woocommerce' ) );
@@ -2621,24 +2613,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		 * @since 1.10.0
 		 */
 		return (bool) apply_filters( 'wc_facebook_is_advanced_matching_enabled', true, $this );
-	}
-
-	/**
-	 * Determines whether product sync is enabled.
-	 *
-	 * @return bool
-	 * @since 1.10.0
-	 */
-	public function is_product_sync_enabled() {
-		/**
-		 * Filters whether product sync is enabled.
-		 *
-		 * @param bool $is_enabled whether product sync is enabled
-		 * @param \WC_Facebookcommerce_Integration $integration the integration instance
-		 *
-		 * @since 1.10.0
-		 */
-		return (bool) apply_filters( 'wc_facebook_is_product_sync_enabled', 'yes' === get_option( self::SETTING_ENABLE_PRODUCT_SYNC, 'yes' ), $this );
 	}
 
 	/**

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -270,15 +270,6 @@ class Product_Sync extends Abstract_Settings_Screen {
 				'title' => __( 'Product sync', 'facebook-for-woocommerce' ),
 			),
 			array(
-				'id'       => \WC_Facebookcommerce_Integration::SETTING_ENABLE_PRODUCT_SYNC,
-				'title'    => __( 'Enable product sync', 'facebook-for-woocommerce' ),
-				'type'     => 'checkbox',
-				'label'    => ' ',
-				'default'  => 'yes',
-				'desc_tip' => __( 'Enable product syncing with Facebook.', 'facebook-for-woocommerce' ),
-			),
-
-			array(
 				'id'                => \WC_Facebookcommerce_Integration::SETTING_EXCLUDED_PRODUCT_CATEGORY_IDS,
 				'title'             => __( 'Exclude categories from sync', 'facebook-for-woocommerce' ),
 				'type'              => 'multiselect',

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -144,12 +144,6 @@ class Lifecycle extends Framework\Lifecycle {
 			}
 		}
 
-		// migrate settings from standalone options
-		if ( ! isset( $new_settings[ \WC_Facebookcommerce_Integration::SETTING_ENABLE_PRODUCT_SYNC ] ) ) {
-			$product_sync_enabled = empty( get_option( 'fb_disable_sync_on_dev_environment', 0 ) );
-			$new_settings[ \WC_Facebookcommerce_Integration::SETTING_ENABLE_PRODUCT_SYNC ] = $product_sync_enabled ? 'yes' : 'no';
-		}
-
 		if ( ! isset( $new_settings[ \WC_Facebookcommerce_Integration::SETTING_SCHEDULED_RESYNC_OFFSET ] ) ) {
 			$autosync_time = get_option( 'woocommerce_fb_autosync_time' );
 			$parsed_time   = ! empty( $autosync_time ) ? strtotime( $autosync_time ) : false;
@@ -214,7 +208,6 @@ class Lifecycle extends Framework\Lifecycle {
 			$settings_map = array(
 				'facebook_pixel_id'             => \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID,
 				'facebook_page_id'              => \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID,
-				'enable_product_sync'           => \WC_Facebookcommerce_Integration::SETTING_ENABLE_PRODUCT_SYNC,
 				'excluded_product_category_ids' => \WC_Facebookcommerce_Integration::SETTING_EXCLUDED_PRODUCT_CATEGORY_IDS,
 				'excluded_product_tag_ids'      => \WC_Facebookcommerce_Integration::SETTING_EXCLUDED_PRODUCT_TAG_IDS,
 				'enable_messenger'              => self::SETTING_ENABLE_MESSENGER,

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -117,7 +117,6 @@ class ProductValidator {
 	 * @throws ProductExcludedException If product should not be synced.
 	 */
 	public function validate() {
-		$this->validate_sync_enabled_globally();
 		$this->validate_product_sync_field();
 		$this->validate_product_status();
 		$this->validate_product_visibility();
@@ -132,7 +131,6 @@ class ProductValidator {
 	 * @throws ProductExcludedException If product should not be synced.
 	 */
 	public function validate_but_skip_status_check() {
-		$this->validate_sync_enabled_globally();
 		$this->validate_product_sync_field();
 		$this->validate_product_visibility();
 		$this->validate_product_terms();
@@ -145,7 +143,6 @@ class ProductValidator {
 	 * @throws ProductExcludedException|ProductInvalidException If product should not be synced.
 	 */
 	public function validate_but_skip_sync_field() {
-		$this->validate_sync_enabled_globally();
 		$this->validate_product_visibility();
 		$this->validate_product_terms();
 	}
@@ -216,17 +213,6 @@ class ProductValidator {
 		}
 
 		return true;
-	}
-
-	/**
-	 * Check whether product sync is globally disabled.
-	 *
-	 * @throws ProductExcludedException If product should not be synced.
-	 */
-	protected function validate_sync_enabled_globally() {
-		if ( ! $this->integration->is_product_sync_enabled() ) {
-			throw new ProductExcludedException( __( 'Product sync is globally disabled.', 'facebook-for-woocommerce' ) );
-		}
 	}
 
 	/**

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -170,7 +170,7 @@ class Feed {
 		$configured_ok = $integration && $integration->is_configured();
 		// Only schedule if has not opted out of feed generation (e.g. large stores).
 		$store_allows_feed = $configured_ok && $integration->is_legacy_feed_file_generation_enabled();
-		if (! $store_allows_feed ) {
+		if ( ! $store_allows_feed ) {
 			as_unschedule_all_actions( self::GENERATE_FEED_ACTION );
 
 			$message = '';

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -170,7 +170,7 @@ class Feed {
 		$configured_ok = $integration && $integration->is_configured();
 		// Only schedule if has not opted out of feed generation (e.g. large stores).
 		$store_allows_feed = $configured_ok && $integration->is_legacy_feed_file_generation_enabled();
-		if ( ! $store_allows_feed ) {
+		if ( ! $store_allows_feed || ! $configured_ok) {
 			as_unschedule_all_actions( self::GENERATE_FEED_ACTION );
 
 			$message = '';

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -168,11 +168,9 @@ class Feed {
 		set_transient( $flag_name, 'yes', HOUR_IN_SECONDS );
 		$integration   = facebook_for_woocommerce()->get_integration();
 		$configured_ok = $integration && $integration->is_configured();
-		// Only schedule feed job if store has not opted out of product sync.
-		$store_allows_sync = $configured_ok && $integration->is_product_sync_enabled();
 		// Only schedule if has not opted out of feed generation (e.g. large stores).
 		$store_allows_feed = $configured_ok && $integration->is_legacy_feed_file_generation_enabled();
-		if ( ! $store_allows_sync || ! $store_allows_feed ) {
+		if (! $store_allows_feed ) {
 			as_unschedule_all_actions( self::GENERATE_FEED_ACTION );
 
 			$message = '';
@@ -180,8 +178,6 @@ class Feed {
 				$message = 'Integration not configured.';
 			} elseif ( ! $store_allows_feed ) {
 				$message = 'Store does not allow feed.';
-			} elseif ( ! $store_allows_sync ) {
-				$message = 'Store does not allow sync.';
 			}
 			WC_Facebookcommerce_Utils::log_to_meta(
 				sprintf( 'Product feed scheduling failed: %s', $message ),

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -170,7 +170,7 @@ class Feed {
 		$configured_ok = $integration && $integration->is_configured();
 		// Only schedule if has not opted out of feed generation (e.g. large stores).
 		$store_allows_feed = $configured_ok && $integration->is_legacy_feed_file_generation_enabled();
-		if ( ! $store_allows_feed || ! $configured_ok) {
+		if ( ! $store_allows_feed || ! $configured_ok ) {
 			as_unschedule_all_actions( self::GENERATE_FEED_ACTION );
 
 			$message = '';

--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -114,12 +114,11 @@ class Tracker {
 		$data['extensions']['facebook-for-woocommerce']['is-connected'] = wc_bool_to_string( $connection_is_happy );
 
 		/**
-		 * What features are enabled on this site?
+		 * Sync will always be allowed post WooAllProducts
 		 *
-		 * @since 2.3.4
+		 * @since 3.4.12
 		 */
-		$product_sync_enabled = facebook_for_woocommerce()->get_integration()->is_product_sync_enabled();
-		$data['extensions']['facebook-for-woocommerce']['product-sync-enabled'] = wc_bool_to_string( $product_sync_enabled );
+		$data['extensions']['facebook-for-woocommerce']['product-sync-enabled'] = true;
 
 		/**
 		 * How long did the last feed generation take (or did it fail - 0)? This counts just the time when the batches have been generated.

--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -114,9 +114,9 @@ class Tracker {
 		$data['extensions']['facebook-for-woocommerce']['is-connected'] = wc_bool_to_string( $connection_is_happy );
 
 		/**
-		 * Sync will always be allowed post WooAllProducts
+		 * Synchronization will always be permitted once we initiate the process of syncing all WooCommerce products.
 		 *
-		 * @since 3.4.12
+		 * @since 3.5.3
 		 */
 		$data['extensions']['facebook-for-woocommerce']['product-sync-enabled'] = true;
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1781,15 +1781,13 @@ class WC_Facebook_Product {
 		}
 
 		/**
-		 * If code has reached this point of execution
-		 * Means that sync validations have been checked.
 		 * Visibility has been set for the products, both for simple and variations
 		 * Now if prevously they had product sync checkbox/ global products sync off, we will mark the products
 		 * This is in accordance with the facet that now all the products will sync
 		 */
 
-		 $global_sync_checkbox_status = 'yes' === get_option('wc_facebook_enable_product_sync', 'yes' );
-		 if($global_sync_checkbox_status === false){
+		 $deprecated_global_sync_checkbox_status = 'yes' === get_option('wc_facebook_enable_product_sync', 'yes' );
+		 if($deprecated_global_sync_checkbox_status === false){
 			/**
 			 * Previously they wouldn't have syned
 			 * But now they are 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1792,7 +1792,7 @@ class WC_Facebook_Product {
 			 * Previously they wouldn't have syned
 			 * But now they are 
 			 */
-			 $product_data["is_woo_all_products_sync"] = true;
+			 $product_data["is_woo_all_products_sync"] = 1;
 		 }
 
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1783,7 +1783,6 @@ class WC_Facebook_Product {
 		/**
 		 * Visibility has been set for the products, both for simple and variations
 		 * Now if prevously they had product sync checkbox/ global products sync off, we will mark the products
-		 * This is in accordance with the facet that now all the products will sync
 		 */
 
 		 $deprecated_global_sync_checkbox_status = 'yes' === get_option('wc_facebook_enable_product_sync', 'yes' );

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1780,6 +1780,24 @@ class WC_Facebook_Product {
 			}
 		}
 
+		/**
+		 * If code has reached this point of execution
+		 * Means that sync validations have been checked.
+		 * Visibility has been set for the products, both for simple and variations
+		 * Now if prevously they had product sync checkbox/ global products sync off, we will mark the products
+		 * This is in accordance with the facet that now all the products will sync
+		 */
+
+		 $global_sync_checkbox_status = 'yes' === get_option('wc_facebook_enable_product_sync', 'yes' );
+		 if($global_sync_checkbox_status === false){
+			/**
+			 * Previously they wouldn't have syned
+			 * But now they are 
+			 */
+			 $product_data["is_woo_all_products_sync"] = true;
+		 }
+
+
 		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
 			$product_data['title'] = Helper::str_truncate( WC_Facebookcommerce_Utils::clean_string( $this->get_title() ), self::MAX_TITLE_LENGTH );
 			$product_data['image_link'] = $image_urls[0];

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -2461,59 +2461,6 @@ class WCFacebookCommerceIntegrationTest extends \WooCommerce\Facebook\Tests\Abst
 	}
 
 	/**
-	 * Tests is product sync enabled returns default value.
-	 *
-	 * @return void
-	 */
-	public function test_is_product_sync_enabled_no_filter_no_option() {
-		$this->teardown_callback_category_safely( 'wc_facebook_is_product_sync_enabled' );
-		delete_option( WC_Facebookcommerce_Integration::SETTING_ENABLE_PRODUCT_SYNC );
-
-		$result = $this->integration->is_product_sync_enabled();
-
-		$this->assertTrue( $result );
-	}
-
-	/**
-	 * Tests is product sync enabled returns option value.
-	 *
-	 * @return void
-	 */
-	public function test_is_product_sync_enabled_no_filter() {
-		$this->teardown_callback_category_safely( 'wc_facebook_is_product_sync_enabled' );
-		add_option(
-			WC_Facebookcommerce_Integration::SETTING_ENABLE_PRODUCT_SYNC,
-			'no'
-		);
-
-		$result = $this->integration->is_product_sync_enabled();
-
-		$this->assertFalse( $result );
-	}
-
-	/**
-	 * Tests is product sync enabled with filter.
-	 *
-	 * @return void
-	 */
-	public function test_is_product_sync_enabled_with_filter() {
-		$this->add_filter_with_safe_teardown(
-			'wc_facebook_is_product_sync_enabled',
-			function ( $is_enabled ) {
-				return false;
-			}
-		);
-		add_option(
-			WC_Facebookcommerce_Integration::SETTING_ENABLE_PRODUCT_SYNC,
-			'yes'
-		);
-
-		$result = $this->integration->is_product_sync_enabled();
-
-		$this->assertFalse( $result );
-	}
-
-	/**
 	 * Tests is legacy feed file generation enabled with no option set.
 	 *
 	 * @return void


### PR DESCRIPTION
## Description

The PR will remove sync all function

### Type of change

Please delete options that are not relevant.

New feature

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Test Plan

Enable plugin checkbox will no longer appear in the product sync panel
