### PR TITLE
Enabled rollout switch only for plugin admins

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -210,7 +210,6 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 			$this->sync_background_handler   		= new WooCommerce\Facebook\Products\Sync\Background();
 			$this->configuration_detection   		= new WooCommerce\Facebook\Feed\FeedConfigurationDetection();
 			$this->legacy_product_sets_sync_handler = new WooCommerce\Facebook\ProductSets\Sync();
-			$this->product_sets_sync_handler 		= new WooCommerce\Facebook\ProductSets\ProductSetSync();
 			$this->commerce_handler          		= new WooCommerce\Facebook\Commerce();
 			$this->fb_categories             		= new WooCommerce\Facebook\Products\FBCategories();
 			$this->external_version_update   		= new WooCommerce\Facebook\ExternalVersionUpdate\Update();
@@ -239,7 +238,6 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 			$this->webhook_handler   				= new WooCommerce\Facebook\Handlers\WebHook( $this );
 			$this->whatsapp_webhook_handler = new WooCommerce\Facebook\Handlers\Whatsapp_Webhook( $this );
 			$this->tracker            			= new WooCommerce\Facebook\Utilities\Tracker();
-			$this->rollout_switches   			= new WooCommerce\Facebook\Admin\RolloutSwitches( $this );
 
 			// Init jobs
 			$this->job_manager = new WooCommerce\Facebook\Jobs\JobManager();
@@ -272,6 +270,8 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 			'admin_init',
 			function () {
 				$this->admin = new WooCommerce\Facebook\Admin();
+				$this->rollout_switches   			= new WooCommerce\Facebook\Admin\RolloutSwitches( $this );
+				$this->product_sets_sync_handler 	= new WooCommerce\Facebook\ProductSets\ProductSetSync();
 			},
 			0
 		);

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -126,7 +126,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	/** @var WooCommerce\Facebook\Products\FBCategories instance. */
 	private $fb_categories;
 
-	/** @var WooCommerce\Facebook\RolloutSwitches instance. */
+	/** @var WooCommerce\Facebook\Admin\RolloutSwitches instance. */
 	private $rollout_switches;
 
 	/**
@@ -210,7 +210,6 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 			$this->sync_background_handler   		= new WooCommerce\Facebook\Products\Sync\Background();
 			$this->configuration_detection   		= new WooCommerce\Facebook\Feed\FeedConfigurationDetection();
 			$this->legacy_product_sets_sync_handler = new WooCommerce\Facebook\ProductSets\Sync();
-			$this->product_sets_sync_handler 		= new WooCommerce\Facebook\ProductSets\ProductSetSync();
 			$this->commerce_handler          		= new WooCommerce\Facebook\Commerce();
 			$this->fb_categories             		= new WooCommerce\Facebook\Products\FBCategories();
 			$this->external_version_update   		= new WooCommerce\Facebook\ExternalVersionUpdate\Update();
@@ -248,8 +247,8 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 
 			// load admin handlers, before admin_init
 			if ( is_admin() ) {
-				$this->rollout_switches   			= new WooCommerce\Facebook\RolloutSwitches( $this );
-
+				$this->rollout_switches   			= new WooCommerce\Facebook\Admin\RolloutSwitches( $this );
+				$this->product_sets_sync_handler 		= new WooCommerce\Facebook\ProductSets\ProductSetSync();
 				if ($this->use_enhanced_onboarding()) {
 					$this->admin_enhanced_settings = new WooCommerce\Facebook\Admin\Enhanced_Settings( $this );
 				} else {
@@ -816,7 +815,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	/**
 	 * Gets the connection handler.
 	 *
-	 * @return WooCommerce\Facebook\RolloutSwitches
+	 * @return WooCommerce\Facebook\Admin\RolloutSwitches
 	 */
 	public function get_rollout_switches() {
 		return $this->rollout_switches;

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -210,6 +210,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 			$this->sync_background_handler   		= new WooCommerce\Facebook\Products\Sync\Background();
 			$this->configuration_detection   		= new WooCommerce\Facebook\Feed\FeedConfigurationDetection();
 			$this->legacy_product_sets_sync_handler = new WooCommerce\Facebook\ProductSets\Sync();
+			$this->product_sets_sync_handler 		= new WooCommerce\Facebook\ProductSets\ProductSetSync();
 			$this->commerce_handler          		= new WooCommerce\Facebook\Commerce();
 			$this->fb_categories             		= new WooCommerce\Facebook\Products\FBCategories();
 			$this->external_version_update   		= new WooCommerce\Facebook\ExternalVersionUpdate\Update();
@@ -238,6 +239,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 			$this->webhook_handler   				= new WooCommerce\Facebook\Handlers\WebHook( $this );
 			$this->whatsapp_webhook_handler = new WooCommerce\Facebook\Handlers\Whatsapp_Webhook( $this );
 			$this->tracker            			= new WooCommerce\Facebook\Utilities\Tracker();
+			$this->rollout_switches   			= new WooCommerce\Facebook\Admin\RolloutSwitches( $this );
 
 			// Init jobs
 			$this->job_manager = new WooCommerce\Facebook\Jobs\JobManager();
@@ -247,8 +249,6 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 
 			// load admin handlers, before admin_init
 			if ( is_admin() ) {
-				$this->rollout_switches   			= new WooCommerce\Facebook\Admin\RolloutSwitches( $this );
-				$this->product_sets_sync_handler 		= new WooCommerce\Facebook\ProductSets\ProductSetSync();
 				if ($this->use_enhanced_onboarding()) {
 					$this->admin_enhanced_settings = new WooCommerce\Facebook\Admin\Enhanced_Settings( $this );
 				} else {

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -217,9 +217,9 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 			$this->sync_background_handler          = new WooCommerce\Facebook\Products\Sync\Background();
 			$this->configuration_detection          = new WooCommerce\Facebook\Feed\FeedConfigurationDetection();
 			$this->legacy_product_sets_sync_handler = new WooCommerce\Facebook\ProductSets\Sync();
-			$this->commerce_handler          		= new WooCommerce\Facebook\Commerce();
-			$this->fb_categories             		= new WooCommerce\Facebook\Products\FBCategories();
-			$this->external_version_update   		= new WooCommerce\Facebook\ExternalVersionUpdate\Update();
+			$this->commerce_handler                 = new WooCommerce\Facebook\Commerce();
+			$this->fb_categories                    = new WooCommerce\Facebook\Products\FBCategories();
+			$this->external_version_update          = new WooCommerce\Facebook\ExternalVersionUpdate\Update();
 
 			if ( wp_doing_ajax() ) {
 				$this->ajax = new WooCommerce\Facebook\AJAX();
@@ -243,7 +243,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 			new WooCommerce\Facebook\Handlers\MetaExtension();
 			$this->webhook_handler          = new WooCommerce\Facebook\Handlers\WebHook( $this );
 			$this->whatsapp_webhook_handler = new WooCommerce\Facebook\Handlers\Whatsapp_Webhook( $this );
-			$this->tracker            			= new WooCommerce\Facebook\Utilities\Tracker();
+			$this->tracker                  = new WooCommerce\Facebook\Utilities\Tracker();
 
 			// Init jobs
 			$this->job_manager = new WooCommerce\Facebook\Jobs\JobManager();
@@ -276,9 +276,9 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 		add_action(
 			'admin_init',
 			function () {
-				$this->admin = new WooCommerce\Facebook\Admin();
-				$this->rollout_switches   			= new WooCommerce\Facebook\Admin\RolloutSwitches( $this );
-				$this->product_sets_sync_handler 	= new WooCommerce\Facebook\ProductSets\ProductSetSync();
+				$this->admin                     = new WooCommerce\Facebook\Admin();
+				$this->rollout_switches          = new WooCommerce\Facebook\Admin\RolloutSwitches( $this );
+				$this->product_sets_sync_handler = new WooCommerce\Facebook\ProductSets\ProductSetSync();
 			},
 			0
 		);

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -249,7 +249,6 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 			// load admin handlers, before admin_init
 			if ( is_admin() ) {
 				$this->rollout_switches   			= new WooCommerce\Facebook\RolloutSwitches( $this );
-				add_action( 'admin_init', array( $this->rollout_switches, 'init' ) );
 
 				if ($this->use_enhanced_onboarding()) {
 					$this->admin_enhanced_settings = new WooCommerce\Facebook\Admin\Enhanced_Settings( $this );

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -239,17 +239,18 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 			$this->webhook_handler   				= new WooCommerce\Facebook\Handlers\WebHook( $this );
 			$this->whatsapp_webhook_handler = new WooCommerce\Facebook\Handlers\Whatsapp_Webhook( $this );
 			$this->tracker            			= new WooCommerce\Facebook\Utilities\Tracker();
-			$this->rollout_switches   			= new WooCommerce\Facebook\RolloutSwitches( $this );
 
 			// Init jobs
 			$this->job_manager = new WooCommerce\Facebook\Jobs\JobManager();
 			add_action( 'init', [ $this->job_manager, 'init' ] );
-			add_action( 'admin_init', array( $this->rollout_switches, 'init' ) );
 			// Instantiate the debug tools.
 			$this->debug_tools = new DebugTools();
 
 			// load admin handlers, before admin_init
 			if ( is_admin() ) {
+				$this->rollout_switches   			= new WooCommerce\Facebook\RolloutSwitches( $this );
+				add_action( 'admin_init', array( $this->rollout_switches, 'init' ) );
+
 				if ($this->use_enhanced_onboarding()) {
 					$this->admin_enhanced_settings = new WooCommerce\Facebook\Admin\Enhanced_Settings( $this );
 				} else {

--- a/includes/Admin/Enhanced_Settings.php
+++ b/includes/Admin/Enhanced_Settings.php
@@ -16,7 +16,7 @@ use WooCommerce\Facebook\Admin\Settings_Screens\Shops;
 use WooCommerce\Facebook\Framework\Helper;
 use WooCommerce\Facebook\Framework\Plugin\Exception as PluginException;
 use WooCommerce\Facebook\Admin\Settings_Screens\Whatsapp_Utility;
-use WooCommerce\Facebook\RolloutSwitches;
+use WooCommerce\Facebook\Admin\RolloutSwitches;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/includes/Admin/Product_Sets.php
+++ b/includes/Admin/Product_Sets.php
@@ -13,7 +13,7 @@ namespace WooCommerce\Facebook\Admin;
 defined( 'ABSPATH' ) || exit;
 
 use WP_Term;
-use WooCommerce\Facebook\RolloutSwitches;
+use WooCommerce\Facebook\Admin\RolloutSwitches;
 
 /**
  * General handler for the product set admin functionality.

--- a/includes/Admin/RolloutSwitches.php
+++ b/includes/Admin/RolloutSwitches.php
@@ -11,6 +11,7 @@
 namespace WooCommerce\Facebook\Admin;
 
 use WooCommerce\Facebook\Framework\Api\Exception;
+use WooCommerce\Facebook\Utilities\Heartbeat;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -35,7 +36,7 @@ class RolloutSwitches {
 
 	public function __construct( \WC_Facebookcommerce $plugin ) {
 		$this->plugin = $plugin;
-		add_action( 'admin_init', array( $this->plugin->rollout_switches, 'init' ) );
+		add_action( Heartbeat::HOURLY, array( $this, 'init' ) );
 	}
 
 	public function init() {

--- a/includes/Admin/RolloutSwitches.php
+++ b/includes/Admin/RolloutSwitches.php
@@ -8,10 +8,9 @@
  * @package FacebookCommerce
  */
 
-namespace WooCommerce\Facebook;
+namespace WooCommerce\Facebook\Admin;
 
 use WooCommerce\Facebook\Framework\Api\Exception;
-use WooCommerce\Facebook\Utilities\Heartbeat;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -36,7 +35,7 @@ class RolloutSwitches {
 
 	public function __construct( \WC_Facebookcommerce $plugin ) {
 		$this->plugin = $plugin;
-		add_action( 'admin_init', array( $this->rollout_switches, 'init' ) );
+		add_action( 'admin_init', array( $this->plugin->rollout_switches, 'init' ) );
 	}
 
 	public function init() {

--- a/includes/Admin/RolloutSwitches.php
+++ b/includes/Admin/RolloutSwitches.php
@@ -49,7 +49,7 @@ class RolloutSwitches {
 		if ( 'yes' === get_transient( $flag_name ) ) {
 			return;
 		}
-		set_transient( $flag_name, 'yes', 60 * MINUTE_IN_SECONDS );
+		set_transient( $flag_name, 'yes', HOUR_IN_SECONDS );
 
 		try {
 			$external_business_id = $this->plugin->get_connection_handler()->get_external_business_id();

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -16,7 +16,7 @@ use WooCommerce\Facebook\Admin\Settings_Screens\Connection;
 use WooCommerce\Facebook\Admin\Settings_Screens\Whatsapp_Utility;
 use WooCommerce\Facebook\Framework\Helper;
 use WooCommerce\Facebook\Framework\Plugin\Exception as PluginException;
-use WooCommerce\Facebook\RolloutSwitches;
+use WooCommerce\Facebook\Admin\RolloutSwitches;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/includes/ProductSets/ProductSetSync.php
+++ b/includes/ProductSets/ProductSetSync.php
@@ -12,7 +12,7 @@ namespace WooCommerce\Facebook\ProductSets;
 
 defined( 'ABSPATH' ) || exit;
 
-use WooCommerce\Facebook\RolloutSwitches;
+use WooCommerce\Facebook\Admin\RolloutSwitches;
 use WooCommerce\Facebook\Utilities\Heartbeat;
 use WC_Facebookcommerce_Utils;
 

--- a/includes/RolloutSwitches.php
+++ b/includes/RolloutSwitches.php
@@ -36,6 +36,7 @@ class RolloutSwitches {
 
 	public function __construct( \WC_Facebookcommerce $plugin ) {
 		$this->plugin = $plugin;
+		add_action( 'admin_init', array( $this->rollout_switches, 'init' ) );
 	}
 
 	public function init() {

--- a/tests/Unit/RolloutSwitchesTest.php
+++ b/tests/Unit/RolloutSwitchesTest.php
@@ -3,7 +3,7 @@ use PHPUnit\Framework\TestCase;
 use WooCommerce\Facebook\Admin\Settings_Screens\Connection;
 use WooCommerce\Facebook\API;
 use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
-use WooCommerce\Facebook\RolloutSwitches;
+use WooCommerce\Facebook\Admin\RolloutSwitches;
 
 class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSafeFiltering {
 


### PR DESCRIPTION
## Description

Primary aim of the Rollout Switches is to control the rollouts of admin functionalities, thus it should be processed only for admins and not for every website user. Also, it should be executed on hourly basis but according to current implementation it will be executed only when admin dashboard initialisation which is incorrect because if we disable rollout switch for any business then it won't get disabled until log in activity of any admin of the WordPress site. Fixed it by implementing an hearbeat.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Enabled rollout switch functionality only for Plugin Admins