### PR TITLE
Added a transient flag to avoid flooding of api requests

### DIFF
--- a/includes/ProductSets/ProductSetSync.php
+++ b/includes/ProductSets/ProductSetSync.php
@@ -104,6 +104,12 @@ class ProductSetSync {
 	 */
 	public function sync_all_product_sets() {
 		try {
+			$flag_name = '_wc_facebook_for_woocommerce_product_sets_sync_flag';
+			if ( 'yes' === get_transient( $flag_name ) ) {
+				return;
+			}
+			set_transient( $flag_name, 'yes', DAY_IN_SECONDS - 1 );
+
 			if ( ! $this->is_sync_enabled() ) {
 				return;
 			}


### PR DESCRIPTION
## Description

Added a transient flag to avoid flooding of Product Sets api requests since the daily heartbeat hook being set by every user visit.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Added a transient flag to avoid flooding of product set api requests