### PR TITLE
Refactor Shop Settings List + Lint Fixes

### DIFF
--- a/includes/Admin/Abstract_Settings_Screen.php
+++ b/includes/Admin/Abstract_Settings_Screen.php
@@ -148,7 +148,7 @@ abstract class Abstract_Settings_Screen {
 	 *
 	 * @return array
 	 */
-	abstract public function get_settings();
+	abstract public function get_settings(): array;
 
 
 	/**

--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -303,35 +303,7 @@ class Connection extends Abstract_Settings_Screen {
 	 * @return array
 	 * @since 3.5.0
 	 */
-	public function get_settings() {
-
-		return array(
-
-			array(
-				'title' => __( 'Debug', 'facebook-for-woocommerce' ),
-				'type'  => 'title',
-			),
-
-			array(
-				'id'       => \WC_Facebookcommerce_Integration::SETTING_ENABLE_META_DIAGNOSIS,
-				'title'    => __( 'Enable meta diagnosis', 'facebook-for-woocommerce' ),
-				'type'     => 'checkbox',
-				'desc'     => __( 'Upload plugin events to Meta', 'facebook-for-woocommerce' ),
-				'desc_tip' => sprintf( __( 'Allow Meta to monitor event and error logs to help fix issues.', 'facebook-for-woocommerce' ) ),
-				'default'  => 'yes',
-			),
-
-			array(
-				'id'       => \WC_Facebookcommerce_Integration::SETTING_ENABLE_DEBUG_MODE,
-				'title'    => __( 'Enable debug mode', 'facebook-for-woocommerce' ),
-				'type'     => 'checkbox',
-				'desc'     => __( 'Log plugin events for debugging.', 'facebook-for-woocommerce' ),
-				/* translators: %s URL to the documentation page. */
-				'desc_tip' => sprintf( __( 'Only enable this if you are experiencing problems with the plugin. <a href="%s" target="_blank">Learn more</a>.', 'facebook-for-woocommerce' ), 'https://woocommerce.com/document/facebook-for-woocommerce/#debug-tools' ),
-				'default'  => 'no',
-			),
-
-			array( 'type' => 'sectionend' ),
-		);
+	public function get_settings(): array {
+		return Shops::get_settings_with_title_static( __( 'Debug', 'facebook-for-woocommerce' ) );
 	}
 }

--- a/includes/Admin/Settings_Screens/Product_Sets.php
+++ b/includes/Admin/Settings_Screens/Product_Sets.php
@@ -43,5 +43,5 @@ class Product_Sets extends Abstract_Settings_Screen {
 		exit;
 	}
 
-	public function get_settings() {}
+	public function get_settings(): array {}
 }

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -243,7 +243,7 @@ class Product_Sync extends Abstract_Settings_Screen {
 	 *
 	 * @return array
 	 */
-	public function get_settings() {
+	public function get_settings(): array {
 		$term_query = new \WP_Term_Query(
 			array(
 				'taxonomy'   => 'product_cat',

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -312,11 +312,22 @@ class Shops extends Abstract_Settings_Screen {
 	 * @return array
 	 * @since 3.5.0
 	 */
-	public function get_settings() {
+	public function get_settings(): array {
+		//phpcs:ignore WordPress.WP.I18n.NoEmptyStrings
+		return self::get_settings_with_title_static( __( '', 'facebook-for-woocommerce' ) );
+	}
+
+	/**
+	 * Returns the shop-wide settings array.
+	 * Reused in Connection.php.
+	 *
+	 * @param string $title A translated title.
+	 * @return array
+	 */
+	public static function get_settings_with_title_static( string $title ): array {
 		return array(
 			array(
-				//phpcs:ignore WordPress.WP.I18n.NoEmptyStrings
-				'title' => __( '', 'facebook-for-woocommerce' ),
+				'title' => $title,
 				'type'  => 'title',
 			),
 

--- a/includes/Handlers/PluginRender.php
+++ b/includes/Handlers/PluginRender.php
@@ -46,7 +46,7 @@ class PluginRender {
 		$this->add_hooks();
 	}
 
-	public function enqueue_assets() {
+	public static function enqueue_assets() {
 		wp_enqueue_script( 'wc-backbone-modal', null, array( 'backbone' ) );
 		wp_enqueue_script(
 			'facebook-for-woocommerce-modal',
@@ -109,7 +109,7 @@ class PluginRender {
 		return '' === $option_value;
 	}
 
-	public function upcoming_woo_all_products_banner() {
+	public static function upcoming_woo_all_products_banner() {
 		$screen = get_current_screen();
 
 		if ( isset( $screen->id ) && 'marketing_page_wc-facebook' === $screen->id ) {
@@ -171,7 +171,7 @@ class PluginRender {
 		return $opt_out_banner_class;
 	}
 
-	private function get_opt_out_modal_message() {
+	private static function get_opt_out_modal_message() {
 		return '
             <h4>Opt out of automatic product sync?</h4>
             <p>
@@ -188,7 +188,7 @@ class PluginRender {
         ';
 	}
 
-	private function get_opt_out_modal_buttons() {
+	private static function get_opt_out_modal_buttons() {
 		return '
             <a href="javascript:void(0);" class="button wc-forward upgrade_plugin_button" id="modal_opt_out_button">
             	Opt out


### PR DESCRIPTION
## Description

Extract shop-wide settings list into a helper function to be re-used across the legacy and current facebook connection UX's.

Fixed issue where instance functions were being called statically by updating instance functions to be static. 

Added array return type to Abstract_Settings_Screen get_settings()

### Type of change

- Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)


## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Code improvements.


## Test Plan

Load settings page, observe settings screen loads sucessfully.



## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before
![image](https://github.com/user-attachments/assets/6332dff8-11d6-445f-a8b8-adf2b18ddc4f)


### After
![image](https://github.com/user-attachments/assets/68314287-3689-4fa6-9807-1ff4f2642c35)
