### PR TITLE
Fix linter errors for ./facebook-commerce-events-tracker.php

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -23,6 +22,11 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		include_once 'facebook-commerce-pixel-event.php';
 	}
 
+	/**
+	 * Class WC_Facebookcommerce_EventsTracker
+	 *
+	 * This class is responsible for tracking events and sending them to Facebook.
+	 */
 	class WC_Facebookcommerce_EventsTracker {
 
 		/** @var \WC_Facebookcommerce_Pixel instance */
@@ -50,8 +54,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		/**
 		 * Events tracker constructor.
 		 *
-		 * @param $user_info
-		 * @param $aam_settings
+		 * @param array       $user_info
+		 * @param AAMSettings $aam_settings
 		 */
 		public function __construct( $user_info, $aam_settings ) {
 
@@ -127,7 +131,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			// InitiateCheckout events for checkout block.
 			add_action( 'woocommerce_blocks_checkout_enqueue_data', array( $this, 'inject_initiate_checkout_event' ) );
-			
+
 			// Purchase and Subscribe events
 			add_action( 'woocommerce_new_order', array( $this, 'inject_purchase_event' ) );
 			add_action( 'woocommerce_payment_complete', array( $this, 'inject_purchase_event' ), 10 );
@@ -146,12 +150,12 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 
 		/**
-		 * Prints the base JavaScript pixel code.
+		 * Prints the base JavaScript pixel code
+		 *
+		 * phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 		 */
 		public function inject_base_pixel() {
-
 			if ( $this->is_pixel_enabled() ) {
-				// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 				echo $this->pixel->pixel_base_code();
 			}
 		}
@@ -161,11 +165,11 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 * Prints the base <noscript> pixel code.
 		 *
 		 * This is necessary to avoid W3 validation errors.
+		 *
+		 * phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 		 */
 		public function inject_base_pixel_noscript() {
-
 			if ( $this->is_pixel_enabled() ) {
-				// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 				echo $this->pixel->pixel_base_code_noscript();
 			}
 		}
@@ -183,7 +187,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			$products = array_values(
 				array_map(
-					function( $post ) {
+					function ( $post ) {
 						return wc_get_product( $post );
 					},
 					$wp_query->posts
@@ -289,6 +293,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 * This does nothing if there is no session set.
 		 *
 		 * @since 2.1.2
+		 *
+		 * @param Event $event
 		 *
 		 * @return void
 		 */
@@ -509,10 +515,10 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			}
 
 			if ( WC_Facebookcommerce_Utils::is_variable_type( $product->get_type() ) ) {
-                            $product_price = $product->get_variation_price( 'min' );
-                        } else {
-                            $product_price = $product->get_price();
-                        }
+							$product_price = $product->get_variation_price( 'min' );
+			} else {
+				$product_price = $product->get_price();
+			}
 
 			$categories = \WC_Facebookcommerce_Utils::get_product_categories( $product->get_id() );
 
@@ -573,7 +579,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			if ( ! isset( $cart->cart_contents[ $cart_item_key ] ) ) {
 				return;
 			}
-
+			// phpcs:ignore Universal.Operators.DisallowShortTernary.Found
 			$product = wc_get_product( $variation_id ?: $product_id );
 
 			// bail if invalid product or error
@@ -590,8 +596,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 					'contents'     => wp_json_encode(
 						array(
 							array(
-								"id"	   => \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product ),
-								"quantity" =>  $quantity,
+								'id'       => \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product ),
+								'quantity' => $quantity,
 							),
 						)
 					),
@@ -641,17 +647,18 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 *
 		 * @param array $fragments add to cart fragments
 		 * @return array
+		 *
+		 * phpcs:disable WordPress.Security.NonceVerification.Missing
 		 */
 		public function add_add_to_cart_event_fragment( $fragments ) {
 
 			$product_id = isset( $_POST['product_id'] ) ? (int) $_POST['product_id'] : '';
-			$quantity   = isset( $_POST['quantity']) ? (int) $_POST['quantity'] : '';
-			$product 	= wc_get_product($product_id);
+			$quantity   = isset( $_POST['quantity'] ) ? (int) $_POST['quantity'] : '';
+			$product    = wc_get_product( $product_id );
 
 			if ( ! $product instanceof \WC_Product || empty( $quantity ) ) {
 				return $fragments;
 			}
-
 
 			if ( $this->is_pixel_enabled() ) {
 
@@ -672,7 +679,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				);
 
 				// send the event ID to prevent duplication
-				if ( ! empty( $event_id = WC()->session->get( 'facebook_for_woocommerce_add_to_cart_event_id' ) ) ) {
+				$event_id = WC()->session->get( 'facebook_for_woocommerce_add_to_cart_event_id' );
+				if ( ! empty( $event_id ) ) {
 					$params['event_id'] = $event_id;
 				}
 
@@ -717,7 +725,6 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		public function add_conditional_add_to_cart_event_fragment( $fragments ) {
 
 			if ( $this->is_pixel_enabled() ) {
-
 				$params = array(
 					'content_ids'  => $this->get_cart_content_ids(),
 					'content_name' => $this->get_cart_content_names(),
@@ -728,8 +735,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				);
 
 				// send the event ID to prevent duplication
-				if ( ! empty( $event_id = WC()->session->get( 'facebook_for_woocommerce_add_to_cart_event_id' ) ) ) {
-
+				$event_id = WC()->session->get( 'facebook_for_woocommerce_add_to_cart_event_id' );
+				if ( ! empty( $event_id ) ) {
 					$params['event_id'] = $event_id;
 				}
 
@@ -768,7 +775,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			);
 
 			// if there is only one item in the cart, send its first category
-			if ( ( $cart = WC()->cart ) && count( $cart->get_cart() ) === 1 ) {
+			$cart = WC()->cart;
+			if ( ( $cart ) && count( $cart->get_cart() ) === 1 ) {
 
 				$item = current( $cart->get_cart() );
 
@@ -823,7 +831,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			if ( ! $order ) {
 				return;
 			}
-			
+
 			// Get the status of the order to ensure we track the actual purchases and not the ones that have a failed payment.
 			$order_state = $order->get_status();
 
@@ -874,7 +882,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			$event_data = array(
 				'event_name'  => $event_name,
 				'custom_data' => array(
-					'content_ids'  => wp_json_encode( array_merge( ... $product_ids ) ),
+					'content_ids'  => wp_json_encode( array_merge( ...$product_ids ) ),
 					'content_name' => wp_json_encode( $product_names ),
 					'contents'     => wp_json_encode( $contents ),
 					'content_type' => $content_type,
@@ -893,7 +901,6 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			$this->pixel->inject_event( $event_name, $event_data );
 
 			$this->inject_subscribe_event( $order_id );
-
 		}
 
 
@@ -962,7 +969,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 * @since 2.0.0
 		 *
 		 * @param Event $event event object
-		 * @param bool $send_now optional, defaults to true
+		 * @param bool  $send_now optional, defaults to true
 		 */
 		protected function send_api_event( Event $event, bool $send_now = true ) {
 			$this->tracked_events[] = $event;
@@ -1003,7 +1010,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			$product_ids = array( array() );
 
-			if ( $cart = WC()->cart ) {
+			$cart = WC()->cart;
+			if ( $cart ) {
 
 				foreach ( $cart->get_cart() as $item ) {
 
@@ -1014,7 +1022,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				}
 			}
 
-			return wp_json_encode( array_unique( array_merge( ... $product_ids ) ) );
+			return wp_json_encode( array_unique( array_merge( ...$product_ids ) ) );
 		}
 
 
@@ -1029,7 +1037,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			$product_names = array();
 
-			if ( $cart = WC()->cart ) {
+			$cart = WC()->cart;
+			if ( $cart ) {
 
 				foreach ( $cart->get_cart() as $item ) {
 
@@ -1055,7 +1064,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			$cart_contents = array();
 
-			if ( $cart = WC()->cart ) {
+			$cart = WC()->cart;
+			if ( $cart ) {
 
 				foreach ( $cart->get_cart() as $item ) {
 
@@ -1091,10 +1101,12 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 *
 		 * @since 2.0.3
 		 *
+		 * @param \WC_Order $order
+		 *
 		 * @return array
 		 */
 		private function get_user_data_from_billing_address( $order ) {
-			if ( $this->aam_settings == null || ! $this->aam_settings->get_enable_automatic_matching() ) {
+			if ( null === $this->aam_settings || ! $this->aam_settings->get_enable_automatic_matching() ) {
 				return array();
 			}
 			$user_data       = array();
@@ -1111,7 +1123,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			$user_data['ph']      = $order->get_billing_phone();
 			// The fields contain country, so we do not need to add a condition
 			foreach ( $user_data as $field => $value ) {
-				if ( $value === null || $value === '' ||
+				if ( null === $value || '' === $value ||
 					! in_array( $field, $this->aam_settings->get_enabled_automatic_matching_fields() )
 				) {
 					unset( $user_data[ $field ] );
@@ -1154,7 +1166,6 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				$this->send_api_event( $event );
 			}
 		}
-
 	}
 
 endif;


### PR DESCRIPTION
## Description
This PR fixes phpcs issues in `./facebook-commerce-events-tracker.php`. Comments were also added for several functions. The fixes were made manually (in conjunction with `./vendor/bin/phpcbf`) to ensure that the logic remains the same. Running `./vendor/bin/phpcs`:
```
[FILE: /Users/angeloou/Local Sites/test-site-i/app/public/wp-content/plugins/facebook-for-woocommerce/facebook-commerce-events-tracker.php](https://woo2.staging.magento-commerce-extension-testing.com/wp-admin/)
[-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------](https://woo2.staging.magento-commerce-extension-testing.com/wp-admin/)
[FOUND 44 ERRORS AND 12 WARNINGS AFFECTING 38 LINES](https://woo2.staging.magento-commerce-extension-testing.com/wp-admin/)
[-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------](https://woo2.staging.magento-commerce-extension-testing.com/wp-admin/)
   25 | ERROR   | [ ] Missing doc comment for class WC_Facebookcommerce_EventsTracker (Squiz.Commenting.ClassComment.Missing)
   49 | ERROR   | [ ] Doc comment for parameter "$user_info" missing (Squiz.Commenting.FunctionComment.MissingParamTag)
   49 | ERROR   | [ ] Doc comment for parameter "$aam_settings" missing (Squiz.Commenting.FunctionComment.MissingParamTag)
   52 | ERROR   | [ ] Missing parameter type (Squiz.Commenting.FunctionComment.MissingParamType)
   53 | ERROR   | [ ] Missing parameter type (Squiz.Commenting.FunctionComment.MissingParamType)
  154 | ERROR   | [ ] All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$this'.
      |         |     (WordPress.Security.EscapeOutput.OutputNotEscaped)
  168 | ERROR   | [ ] All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$this'.
      |         |     (WordPress.Security.EscapeOutput.OutputNotEscaped)
  185 | ERROR   | [x] Expected 1 space after FUNCTION keyword; 0 found (Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction)
 [ 226 | WARNING | [ ] json_encode() is discouraged. Use wp_json_encode() instead. (WordPress.WP.AlternativeFunctions.json_encode_json_encode)](https://woo2.staging.magento-commerce-extension-testing.com/wp-admin/)
  285 | ERROR   | [ ] Doc comment for parameter "$event" missing (Squiz.Commenting.FunctionComment.MissingParamTag)
 [ 449 | WARNING | [ ] json_encode() is discouraged. Use wp_json_encode() instead. (WordPress.WP.AlternativeFunctions.json_encode_json_encode)](https://woo2.staging.magento-commerce-extension-testing.com/wp-admin/)
  511 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
  512 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
  512 | ERROR   | [x] Line indented incorrectly; expected 3 tabs, found 6 (Generic.WhiteSpace.ScopeIndent.IncorrectExact)
  513 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
  514 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
  514 | ERROR   | [x] Line indented incorrectly; expected 3 tabs, found 6 (Generic.WhiteSpace.ScopeIndent.IncorrectExact)
  576 | ERROR   | [ ] Using short ternaries is not allowed as they are rarely used correctly (Universal.Operators.DisallowShortTernary.Found)
  592 | ERROR   | [x] String "id" does not require double quotes; use single quotes instead (Squiz.Strings.DoubleQuoteUsage.NotRequired)
  592 | ERROR   | [x] Spaces must be used for mid-line alignment; tabs are not allowed (Universal.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed)
  593 | ERROR   | [x] String "quantity" does not require double quotes; use single quotes instead (Squiz.Strings.DoubleQuoteUsage.NotRequired)
  593 | ERROR   | [x] Expected 1 space after "=>"; 2 found (WordPress.WhiteSpace.OperatorSpacing.SpacingAfter)
  646 | ERROR   | [ ] Processing form data without nonce verification. (WordPress.Security.NonceVerification.Missing)
  646 | ERROR   | [ ] Processing form data without nonce verification. (WordPress.Security.NonceVerification.Missing)
  647 | ERROR   | [ ] Processing form data without nonce verification. (WordPress.Security.NonceVerification.Missing)
  647 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
  647 | ERROR   | [ ] Processing form data without nonce verification. (WordPress.Security.NonceVerification.Missing)
  648 | ERROR   | [x] Spaces must be used for mid-line alignment; tabs are not allowed (Universal.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed)
  648 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket)
  648 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
  653 | ERROR   | [x] Functions must not contain multiple empty lines in a row; found 2 empty lines (Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines)
 [ 674 | WARNING | [ ] Variable assignment found within a condition. Did you mean to do a comparison ? (Generic.CodeAnalysis.AssignmentInCondition.Found)](https://woo2.staging.magento-commerce-extension-testing.com/wp-admin/)
  674 | ERROR   | [ ] Assignments must be the first block of code on a line (Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure)
 [ 730 | WARNING | [ ] Variable assignment found within a condition. Did you mean to do a comparison ? (Generic.CodeAnalysis.AssignmentInCondition.Found)](https://woo2.staging.magento-commerce-extension-testing.com/wp-admin/)
  730 | ERROR   | [ ] Assignments must be the first block of code on a line (Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure)
 [ 770 | WARNING | [ ] Variable assignment found within a condition. Did you mean to do a comparison ? (Generic.CodeAnalysis.AssignmentInCondition.Found)](https://woo2.staging.magento-commerce-extension-testing.com/wp-admin/)
  770 | ERROR   | [ ] Assignments must be the first block of code on a line (Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure)
 [ 833 | WARNING | [ ] Not using strict comparison for in_array; supply true for $strict argument. (WordPress.PHP.StrictInArray.MissingTrueStrict)](https://woo2.staging.magento-commerce-extension-testing.com/wp-admin/)
  876 | ERROR   | [x] Expected 0 spaces after the spread operator; 1 found (Generic.WhiteSpace.SpreadOperatorSpacingAfter.TooMuchSpace)
  896 | ERROR   | [x] Function closing brace must go on the next line following the body; found 1 blank lines before brace (PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose)
 [ 919 | WARNING | [ ] This comment is 41% valid code; is this commented out code? (Squiz.PHP.CommentedOutCode.Found)](https://woo2.staging.magento-commerce-extension-testing.com/wp-admin/)
  964 | ERROR   | [x] Expected 2 spaces after parameter type; 1 found (Squiz.Commenting.FunctionComment.SpacingAfterParamType)
[ 1005 | WARNING | [ ] Variable assignment found within a condition. Did you mean to do a comparison ? (Generic.CodeAnalysis.AssignmentInCondition.Found)](https://woo2.staging.magento-commerce-extension-testing.com/wp-admin/)
 1005 | ERROR   | [ ] Assignments must be the first block of code on a line (Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure)
 1016 | ERROR   | [x] Expected 0 spaces after the spread operator; 1 found (Generic.WhiteSpace.SpreadOperatorSpacingAfter.TooMuchSpace)
[ 1031 | WARNING | [ ] Variable assignment found within a condition. Did you mean to do a comparison ? (Generic.CodeAnalysis.AssignmentInCondition.Found)](https://woo2.staging.magento-commerce-extension-testing.com/wp-admin/)
 1031 | ERROR   | [ ] Assignments must be the first block of code on a line (Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure)
[ 1057 | WARNING | [ ] Variable assignment found within a condition. Did you mean to do a comparison ? (Generic.CodeAnalysis.AssignmentInCondition.Found)](https://woo2.staging.magento-commerce-extension-testing.com/wp-admin/)
 1057 | ERROR   | [ ] Assignments must be the first block of code on a line (Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure)
 1088 | ERROR   | [ ] Doc comment for parameter "$order" missing (Squiz.Commenting.FunctionComment.MissingParamTag)
[ 1096 | WARNING | [x] Loose comparisons are not allowed. Expected: "==="; Found: "==" (Universal.Operators.StrictComparisons.LooseEqual)](https://woo2.staging.magento-commerce-extension-testing.com/wp-admin/)
 1096 | ERROR   | [ ] Use Yoda Condition checks, you must. (WordPress.PHP.YodaConditions.NotYoda)
 1113 | ERROR   | [ ] Use Yoda Condition checks, you must. (WordPress.PHP.YodaConditions.NotYoda)
 1113 | ERROR   | [ ] Use Yoda Condition checks, you must. (WordPress.PHP.YodaConditions.NotYoda)
[ 1114 | WARNING | [ ] Not using strict comparison for in_array; supply true for $strict argument. (WordPress.PHP.StrictInArray.MissingTrueStrict)](https://woo2.staging.magento-commerce-extension-testing.com/wp-admin/)
 1157 | ERROR   | [x] The closing brace for the class must go on the next line after the body (PSR2.Classes.ClassDeclaration.CloseBraceAfterBody)
[-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------](https://woo2.staging.magento-commerce-extension-testing.com/wp-admin/)
[PHPCBF CAN FIX THE 22 MARKED SNIFF VIOLATIONS AUTOMATICALLY](https://woo2.staging.magento-commerce-extension-testing.com/wp-admin/)
[-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------](https://woo2.staging.magento-commerce-extension-testing.com/wp-admin/)
```

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected

## Test Plan
1. Run `./vendor/bin/phpcs`, you should get:
```
FILE: /Users/angeloou/Local Sites/test-site-i/app/public/wp-content/plugins/facebook-for-woocommerce/facebook-commerce-events-tracker.php
----------------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 5 WARNINGS AFFECTING 5 LINES
----------------------------------------------------------------------------------------------------------------------------------------------
  231 | WARNING | json_encode() is discouraged. Use wp_json_encode() instead. (WordPress.WP.AlternativeFunctions.json_encode_json_encode)
  456 | WARNING | json_encode() is discouraged. Use wp_json_encode() instead. (WordPress.WP.AlternativeFunctions.json_encode_json_encode)
  842 | WARNING | Not using strict comparison for in_array; supply true for $strict argument. (WordPress.PHP.StrictInArray.MissingTrueStrict)
  927 | WARNING | This comment is 41% valid code; is this commented out code? (Squiz.PHP.CommentedOutCode.Found)
 1127 | WARNING | Not using strict comparison for in_array; supply true for $strict argument. (WordPress.PHP.StrictInArray.MissingTrueStrict)
----------------------------------------------------------------------------------------------------------------------------------------------
```
2. Run extension and test the basic functionality to ensure everything still works as intended.