### PR TITLE
Fix linter errors for ./class-wc-facebookcommerce.php

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -26,6 +25,11 @@ use WooCommerce\Facebook\Utilities\Background_Remove_Duplicate_Visibility_Meta;
 use WooCommerce\Facebook\Utilities\DebugTools;
 use WooCommerce\Facebook\Utilities\Heartbeat;
 
+/**
+ * Class WC_Facebookcommerce
+ *
+ * This class is the main entry point for the Facebook for WooCommerce plugin.
+ */
 class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	/** @var string the plugin version */
 	const VERSION = WC_Facebook_Loader::PLUGIN_VERSION;
@@ -181,7 +185,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 		add_action( 'init', array( $this, 'get_integration' ) );
 		add_action( 'init', array( $this, 'register_custom_taxonomy' ) );
 		add_action( 'add_meta_boxes_product', array( $this, 'remove_product_fb_product_set_metabox' ), 50 );
-		add_action( 'woocommerce_init', array($this, 'add_whatsapp_consent_checkout_fields'));
+		add_action( 'woocommerce_init', array( $this, 'add_whatsapp_consent_checkout_fields' ) );
 		add_filter( 'fb_product_set_row_actions', array( $this, 'product_set_links' ) );
 		add_filter( 'manage_edit-fb_product_set_columns', array( $this, 'manage_fb_product_set_columns' ) );
 
@@ -194,7 +198,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 		add_filter( 'woocommerce_navigation_get_breadcrumbs', array( $this, 'wc_page_breadcrumbs_filter' ), 99 );
 
 		add_filter(
-			'wc_' . WC_Facebookcommerce::PLUGIN_ID . '_http_request_args',
+			'wc_' . self::PLUGIN_ID . '_http_request_args',
 			array( $this, 'force_user_agent_in_latin' )
 		);
 
@@ -205,18 +209,18 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 
 			$this->heartbeat = new Heartbeat( WC()->queue() );
 			$this->heartbeat->init();
-			$this->feed_manager              		= new WooCommerce\Facebook\Feed\FeedManager();
-			$this->checkout           		 		= new WooCommerce\Facebook\Checkout();
-			$this->product_feed              		= new WooCommerce\Facebook\Products\Feed();
-			$this->products_stock_handler    		= new WooCommerce\Facebook\Products\Stock();
-			$this->products_sync_handler     		= new WooCommerce\Facebook\Products\Sync();
-			$this->sync_background_handler   		= new WooCommerce\Facebook\Products\Sync\Background();
-			$this->configuration_detection   		= new WooCommerce\Facebook\Feed\FeedConfigurationDetection();
+			$this->feed_manager                     = new WooCommerce\Facebook\Feed\FeedManager();
+			$this->checkout                         = new WooCommerce\Facebook\Checkout();
+			$this->product_feed                     = new WooCommerce\Facebook\Products\Feed();
+			$this->products_stock_handler           = new WooCommerce\Facebook\Products\Stock();
+			$this->products_sync_handler            = new WooCommerce\Facebook\Products\Sync();
+			$this->sync_background_handler          = new WooCommerce\Facebook\Products\Sync\Background();
+			$this->configuration_detection          = new WooCommerce\Facebook\Feed\FeedConfigurationDetection();
 			$this->legacy_product_sets_sync_handler = new WooCommerce\Facebook\ProductSets\Sync();
-			$this->product_sets_sync_handler 		= new WooCommerce\Facebook\ProductSets\ProductSetSync();
-			$this->commerce_handler          		= new WooCommerce\Facebook\Commerce();
-			$this->fb_categories             		= new WooCommerce\Facebook\Products\FBCategories();
-			$this->external_version_update   		= new WooCommerce\Facebook\ExternalVersionUpdate\Update();
+			$this->product_sets_sync_handler        = new WooCommerce\Facebook\ProductSets\ProductSetSync();
+			$this->commerce_handler                 = new WooCommerce\Facebook\Commerce();
+			$this->fb_categories                    = new WooCommerce\Facebook\Products\FBCategories();
+			$this->external_version_update          = new WooCommerce\Facebook\ExternalVersionUpdate\Update();
 
 			if ( wp_doing_ajax() ) {
 				$this->ajax = new WooCommerce\Facebook\AJAX();
@@ -235,15 +239,13 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 				$this->background_remove_duplicate_visibility_meta = new Background_Remove_Duplicate_Visibility_Meta();
 			}
 
-
 			new WooCommerce\Facebook\API\Plugin\InitializeRestAPI();
 			$this->connection_handler = new WooCommerce\Facebook\Handlers\Connection( $this );
 			new WooCommerce\Facebook\Handlers\MetaExtension();
-			$this->webhook_handler   				= new WooCommerce\Facebook\Handlers\WebHook( $this );
+			$this->webhook_handler          = new WooCommerce\Facebook\Handlers\WebHook( $this );
 			$this->whatsapp_webhook_handler = new WooCommerce\Facebook\Handlers\Whatsapp_Webhook( $this );
-			$this->tracker            			= new WooCommerce\Facebook\Utilities\Tracker();
-			$this->rollout_switches   			= new WooCommerce\Facebook\RolloutSwitches( $this );
-			
+			$this->tracker                  = new WooCommerce\Facebook\Utilities\Tracker();
+			$this->rollout_switches         = new WooCommerce\Facebook\RolloutSwitches( $this );
 
 			// Init jobs
 			$this->job_manager = new WooCommerce\Facebook\Jobs\JobManager();
@@ -254,12 +256,12 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 
 			// load admin handlers, before admin_init
 			if ( is_admin() ) {
-				if ($this->use_enhanced_onboarding()) {
+				if ( $this->use_enhanced_onboarding() ) {
 					$this->admin_enhanced_settings = new WooCommerce\Facebook\Admin\Enhanced_Settings( $this );
 				} else {
 					$this->admin_settings = new WooCommerce\Facebook\Admin\Settings( $this );
 				}
-				$this->plugin_render_handler = new \WooCommerce\Facebook\Handlers\PluginRender($this);
+				$this->plugin_render_handler = new \WooCommerce\Facebook\Handlers\PluginRender( $this );
 			}
 		}
 	}
@@ -387,7 +389,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 		}
 
 		// Maybe remove headers from the debug log.
-		if( ! $this->get_integration()->are_headers_requested_for_debug() ) {
+		if ( ! $this->get_integration()->are_headers_requested_for_debug() ) {
 			unset( $request['headers'] );
 			unset( $response['headers'] );
 		}
@@ -541,8 +543,8 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 		if ( isset( $http_request_headers['user-agent'] ) ) {
 			$http_request_headers['user-agent'] = sprintf(
 				'%s/%s (WooCommerce/%s; WordPress/%s)',
-				WC_Facebookcommerce::PLUGIN_USER_AGENT_NAME,
-				WC_Facebookcommerce::PLUGIN_VERSION,
+				self::PLUGIN_USER_AGENT_NAME,
+				self::PLUGIN_VERSION,
 				defined( 'WC_VERSION' ) ? WC_VERSION : WC_Facebook_Loader::MINIMUM_WC_VERSION,
 				$GLOBALS['wp_version']
 			);
@@ -561,7 +563,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	 *
 	 * @param string $access_token access token to use for this API request
 	 * @return WooCommerce\Facebook\API
-	 * @throws ApiException
+	 * @throws ApiException If the access token is missing.
 	 */
 	public function get_api( string $access_token = '' ): WooCommerce\Facebook\API {
 		// if none provided, use the general access token
@@ -913,25 +915,25 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	}
 
 	/**
-	* Add checkout fields to collect whatsapp consent if consent collection is enabled
-	*
-	* @since 2.3.0
-	*
-	* @param array $fields
-	*
-	* @return array
-	*/
-	function add_whatsapp_consent_checkout_fields($fields) {
-		if (get_option('wc_facebook_whatsapp_consent_collection_setting_status', 'disabled') === 'enabled') {
+	 * Add checkout fields to collect whatsapp consent if consent collection is enabled
+	 *
+	 * @since 2.3.0
+	 *
+	 * @param array $fields
+	 *
+	 * @return array
+	 */
+	public function add_whatsapp_consent_checkout_fields( $fields ) {
+		if ( get_option( 'wc_facebook_whatsapp_consent_collection_setting_status', 'disabled' ) === 'enabled' ) {
 			woocommerce_register_additional_checkout_field(
-					array(
-						'id'       => 'wc_facebook/whatsapp_consent_checkbox', // id = namespace/field_name
-						'label'    => esc_html('Get order updates on WhatsApp'),
-						'location' => 'address',
-						'type'     => 'checkbox',
-						'optionalLabel' => esc_html('Get order updates on WhatsApp')
-					)
-				);
+				array(
+					'id'            => 'wc_facebook/whatsapp_consent_checkbox', // id = namespace/field_name
+					'label'         => esc_html( 'Get order updates on WhatsApp' ),
+					'location'      => 'address',
+					'type'          => 'checkbox',
+					'optionalLabel' => esc_html( 'Get order updates on WhatsApp' ),
+				)
+			);
 		}
 		return $fields;
 	}
@@ -940,7 +942,6 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	 * Determines if the enhanced onboarding (iframe) should be used.
 	 *
 	 * @return bool
-	 *
 	 */
 	public function use_enhanced_onboarding(): bool {
 		$connection_handler              = $this->get_connection_handler();
@@ -961,7 +962,9 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
  * @since 1.10.0
  *
  * @return \WC_Facebookcommerce instance of the plugin
+ *
+ * phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed
  */
 function facebook_for_woocommerce() {
-	return apply_filters('wc_facebook_instance', \WC_Facebookcommerce::instance());
+	return apply_filters( 'wc_facebook_instance', \WC_Facebookcommerce::instance() );
 }


### PR DESCRIPTION
## Description
This PR fixes phpcs issues in `./class-wc-facebookcommerce.php`. Comments were also added for several functions. The fixes were made manually (in conjunction with `./vendor/bin/phpcbf`) to ensure that the logic remains the same. Running `./vendor/bin/phpcs`:
```
FILE: /Users/angeloou/Local Sites/test-site-i/app/public/wp-content/plugins/facebook-for-woocommerce/class-wc-facebookcommerce.php
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 57 ERRORS AND 7 WARNINGS AFFECTING 45 LINES
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  28 | ERROR   | [ ] Missing doc comment for class WC_Facebookcommerce (Squiz.Commenting.ClassComment.Missing)
 183 | ERROR   | [x] Expected 1 space after the array opener in a single line array. Found: no spaces (NormalizedArrays.Arrays.ArrayBraceSpacing.SpaceAfterArrayOpenerSingleLine)
 183 | ERROR   | [x] Expected 1 space before the array closer in a single line array. Found: no spaces (NormalizedArrays.Arrays.ArrayBraceSpacing.SpaceBeforeArrayCloserSingleLine)
 183 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
 196 | ERROR   | [x] Must use "self::" for local static member reference (Squiz.Classes.SelfMemberReference.NotUsed)
 207 | ERROR   | [x] Spaces must be used for mid-line alignment; tabs are not allowed (Universal.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed)
 208 | ERROR   | [x] Spaces must be used for mid-line alignment; tabs are not allowed (Universal.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed)
 209 | ERROR   | [x] Spaces must be used for mid-line alignment; tabs are not allowed (Universal.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed)
 210 | ERROR   | [x] Spaces must be used for mid-line alignment; tabs are not allowed (Universal.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed)
 211 | ERROR   | [x] Spaces must be used for mid-line alignment; tabs are not allowed (Universal.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed)
 212 | ERROR   | [x] Spaces must be used for mid-line alignment; tabs are not allowed (Universal.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed)
 213 | ERROR   | [x] Spaces must be used for mid-line alignment; tabs are not allowed (Universal.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed)
 215 | ERROR   | [x] Spaces must be used for mid-line alignment; tabs are not allowed (Universal.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed)
 216 | ERROR   | [x] Spaces must be used for mid-line alignment; tabs are not allowed (Universal.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed)
 217 | ERROR   | [x] Spaces must be used for mid-line alignment; tabs are not allowed (Universal.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed)
 218 | ERROR   | [x] Spaces must be used for mid-line alignment; tabs are not allowed (Universal.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed)
 236 | ERROR   | [x] Functions must not contain multiple empty lines in a row; found 2 empty lines (Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines)
 241 | ERROR   | [x] Spaces must be used for mid-line alignment; tabs are not allowed (Universal.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed)
 241 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 10 spaces but found 18 spaces (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 243 | ERROR   | [x] Spaces must be used for mid-line alignment; tabs are not allowed (Universal.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed)
 243 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 18 spaces but found 22 spaces (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 244 | ERROR   | [x] Spaces must be used for mid-line alignment; tabs are not allowed (Universal.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed)
 244 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 9 spaces but found 13 spaces (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 245 | ERROR   | [x] Functions must not contain multiple empty lines in a row; found 2 empty lines (Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines)
 256 | ERROR   | [x] No space after opening parenthesis is prohibited (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis)
 256 | ERROR   | [x] No space before closing parenthesis is prohibited (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeCloseParenthesis)
 261 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket)
 261 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
 389 | ERROR   | [x] Space after opening control structure is required (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterStructureOpen)
 389 | ERROR   | [x] No space before opening parenthesis is prohibited (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeOpenParenthesis)
 389 | ERROR   | [x] Expected 1 space after IF keyword; 0 found (Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword)
 543 | ERROR   | [x] Must use "self::" for local static member reference (Squiz.Classes.SelfMemberReference.NotUsed)
 544 | ERROR   | [x] Must use "self::" for local static member reference (Squiz.Classes.SelfMemberReference.NotUsed)
 563 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 915 | ERROR   | [x] Expected 5 spaces before asterisk; 4 found (Squiz.Commenting.DocCommentAlignment.SpaceBeforeStar)
 916 | ERROR   | [x] Expected 5 spaces before asterisk; 4 found (Squiz.Commenting.DocCommentAlignment.SpaceBeforeStar)
 917 | ERROR   | [x] Expected 5 spaces before asterisk; 4 found (Squiz.Commenting.DocCommentAlignment.SpaceBeforeStar)
 918 | ERROR   | [x] Expected 5 spaces before asterisk; 4 found (Squiz.Commenting.DocCommentAlignment.SpaceBeforeStar)
 919 | ERROR   | [x] Expected 5 spaces before asterisk; 4 found (Squiz.Commenting.DocCommentAlignment.SpaceBeforeStar)
 920 | ERROR   | [x] Expected 5 spaces before asterisk; 4 found (Squiz.Commenting.DocCommentAlignment.SpaceBeforeStar)
 921 | ERROR   | [x] Expected 5 spaces before asterisk; 4 found (Squiz.Commenting.DocCommentAlignment.SpaceBeforeStar)
 922 | ERROR   | [x] Expected 5 spaces before asterisk; 4 found (Squiz.Commenting.DocCommentAlignment.SpaceBeforeStar)
 923 | ERROR   | [ ] Visibility must be declared on method "add_whatsapp_consent_checkout_fields" (Squiz.Scope.MethodScope.Missing)
 923 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen)
 923 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeClose)
 924 | ERROR   | [x] No space after opening parenthesis is prohibited (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis)
 924 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket)
 924 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
 924 | ERROR   | [x] No space before closing parenthesis is prohibited (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeCloseParenthesis)
 926 | ERROR   | [x] Multi-line function call not indented correctly; expected 16 spaces but found 20 (PEAR.Functions.FunctionCallSignature.Indent)
 927 | WARNING | [x] Array double arrow not aligned correctly; expected 12 space(s) between "'id'" and double arrow, but found 7.
     |         |     (WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned)
 928 | WARNING | [x] Array double arrow not aligned correctly; expected 9 space(s) between "'label'" and double arrow, but found 4.
     |         |     (WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned)
 928 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket)
 928 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
 929 | WARNING | [x] Array double arrow not aligned correctly; expected 6 space(s) between "'location'" and double arrow, but found 1.
     |         |     (WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned)
 930 | WARNING | [x] Array double arrow not aligned correctly; expected 10 space(s) between "'type'" and double arrow, but found 5.
     |         |     (WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned)
 931 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket)
 931 | ERROR   | [x] There should be a comma after the last array item in a multi-line array. (NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLine)
 931 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
 933 | ERROR   | [x] Multi-line function call not indented correctly; expected 12 spaces but found 16 (PEAR.Functions.FunctionCallSignature.Indent)
 943 | ERROR   | [x] Additional blank lines found at end of doc comment (Generic.Commenting.DocComment.SpacingAfter)
 964 | ERROR   | [ ] A file should either contain function declarations or OO structure declarations, but not both. Found 1 function declaration(s) and 1 OO structure declaration(s). The
     |         |     first function declaration was found on line 964; the first OO declaration was found on line 28 (Universal.Files.SeparateFunctionsFromOO.Mixed)
 965 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket)
 965 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 60 MARKED SNIFF VIOLATIONS AUTOMATICALLY
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected

## Test Plan
1. Run `./vendor/bin/phpcs`, you should get no errors in `./class-wc-facebookcommerce.php`.
2. Run extension and test the basic functionality to ensure everything still works as intended.