### PR TITLE
Fix function return typing for get_settings()

### DIFF
--- a/includes/Admin/Settings_Screens/Advertise.php
+++ b/includes/Admin/Settings_Screens/Advertise.php
@@ -242,7 +242,7 @@ class Advertise extends Abstract_Settings_Screen {
 	 *
 	 * @return array
 	 */
-	public function get_settings() {
+	public function get_settings(): array {
 		return array();
 	}
 }

--- a/includes/Admin/Settings_Screens/Product_Sets.php
+++ b/includes/Admin/Settings_Screens/Product_Sets.php
@@ -43,5 +43,14 @@ class Product_Sets extends Abstract_Settings_Screen {
 		exit;
 	}
 
-	public function get_settings(): array {}
+	/**
+	 * Gets the screen settings.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @return array
+	 */
+	public function get_settings(): array {
+		return array();
+	}
 }

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -697,7 +697,7 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 	 *
 	 * @return array
 	 */
-	public function get_settings() {
+	public function get_settings(): array {
 		return array();
 	}
 }


### PR DESCRIPTION
## Description
This PR fixes an issue introduced in https://github.com/facebook/facebook-for-woocommerce/pull/3253 where some classes were missing the `array` function return type for `get_settings()`.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected

## Test Plan
1. Go to http://test-site-i.local/wp-admin/admin.php?page=wc-facebook. Make sure the original error no longer appears.