### PR TITLE
Fix disconnect

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,122 @@
 *** Facebook for WooCommerce Changelog ***
 
+= 3.5.0 - 2025-05-28 =
+*  Add - Create basic checkout permalink w/ products and coupon support by @ajello-meta in #2887
+*  Add - Common Feed Upload Framework by @jmencab in #2875
+*  Fix - Fix bug where templates were not loading correctly by @ajello-meta in #2915
+*  Tweak - Change MICE to use base site url instead of shop url by @carterbuce in #2934
+*  Tweak - Improve custom checkout UI by @ajello-meta in #2930
+*  Tweak - Make custom checkout UI mobile compatible by @ajello-meta in #2942
+*  Fix - Update parsing for Checkout URL Product IDs by @carterbuce in #2935
+*  Add - Implement dummy logging util by @nealweiMeta in #2920
+*  Add - Setup cron job for batch logging with global message queue by @nealweiMeta in #2924
+*  Add - Error log request api activate by @nealweiMeta in #2933
+*  Add - Log locally with debug mode enabled by @nealweiMeta in #2939
+*  Add - Ratings and reviews feed upload by @nrostrow-meta in #2937
+*  Tweak - Feed upload skip logic and logging calls by @nrostrow-meta in #2964
+*  Add - Add function to fetch feed upload instance by @nrostrow-meta in #2970
+*  Tweak - Have feed uploads always use feed generator by @nrostrow-meta in #2971
+*  Tweak - Trigger metadata feed uploads on CPI ID change (post onboarding) by @nrostrow-meta in #2995
+*  Add - Shipping profile feed upload button by @nrostrow-meta in #3140
+*  Add - Navigation menu feed upload logic by @nrostrow-meta in #3159
+*  Fix - Fixing some fclose and logging gaps in the feed upload logic by @nrostrow-meta in #3192
+*  Add - Enabling navigation menu feed upload and adding manual sync button by @nrostrow-meta in #3223
+*  Add - Promotions feed upload by @carterbuce in #2941
+*  Add - Plugin AJAX API Framework by @sol-loup in #2928
+*  Tweak - Test Infrastructure Enhancement by @sol-loup in #2944
+*  Add - Implement telemetry logs api by @nealweiMeta in #2940
+*  Fix -  Make error logging event configurable by @nealweiMeta in #2954
+*  Add - Implement logging toggle by @nealweiMeta in #2959
+*  Fix - auto products sync by @nealweiMeta in #2978
+*  Tweak - Sync products with restriction by @nealweiMeta in #2983
+*  Fix - Fix use_enhanced_onboarding for legacy connections by @carterbuce in #2986
+*  Add - Create enhanced settings UI by @ajello-meta in #2968
+*  Add - Create new troubleshooting drawer from legacy debug settings by @ajello-meta in #2977
+*  Add - Add manual product and coupon sync buttons by @ajello-meta in #2984
+*  Tweak - Make page title in enhanced settings static by @ajello-meta in #2985
+*  Tweak - Align finalized content for logging toggle by @nealweiMeta in #2992
+*  Tweak - Improve local log by @nealweiMeta in #3009
+*  Fix - Fix free shipping coupon sync by @carterbuce in #2993
+*  Tweak - Add logging for feed generation scheduling failure by @carterbuce in #2994
+*  Tweak - Add logging in checkout for coupon code by @ajello-meta in #2991
+*  Tweak - Clean up CSS in enhanced settings UI by @ajello-meta in #2996
+*  Tweak - Remove the "Advertise" tab by @ajello-meta in #3024
+*  Tweak - Sync "Usage Count" in Promos Feed by @carterbuce in #3036
+*  Tweak - Disable mini_shops product capability for unsupported items by @carterbuce in #3084
+*  Add - Add usage logging for enhanced settings tabs by @ajello-meta in #3202
+*  Tweak - Remove UI of a checkbox that controls enablement of the new style feed generation by @mshymon in #3056
+*  Fix - Fix linter errors for ./includes/fbutils.php files by @ajello-meta in #3075
+
+= 3.4.10 - 2025-05-22 =
+* Fix - Disabled the RollOut switch
+* Fix - Removed the Global Admin Notice
+
+= 3.4.9 - 2025-05-14 =
+* Add - Support for rollout switches in the plugin to control feature rollouts from meta side @francorisso in #3126
+* Fix - Tests in the rollout switches file by @francorisso in #3146
+* Fix - RolloutSwitches Init by @carterbuce in #3157
+* Add - Integrate Whatsapp Utility Messaging for WooCommerce Order Update Notifications by @sharunaanandraj in #3164
+* Tweak - Improve Test Filter Management with AbstractWPUnitTestWithSafeFiltering by @sol-loup in #2944
+* Fix - Namespacing issue causing some tests to be skipped @sol-loup in #3037
+* Tweak - Additional logs and timeout for Utility Message Flows by @woo-ardsouza in #3171
+* Fix - The WAUM payment progress to only Show Up after Consent Collection is Enabled by @sharunaanandraj in #3175
+* Tweak - Update language dropdown based on supported_languages in GET api response by @woo-ardsouza in #3178
+* Add - Error notice to gracefully handle errors in Manage Events view by @woo-ardsouza in #3179
+* Fix - The Status on the Whatsapp Consent Collection Pill and Button @sharunaanandraj in #3183
+* Tweak - Update Message Sending API from Messages to Message Events by @woo-ardsouza in #3182
+* Tweak - Update the Authentication mechanism for Whatsapp Webhook by @sharunaanandraj #3186
+* Tweak - Minor design updates to Utility Event Settings card by @woo-ardsouza in #3193
+* Add - Admin notice for WhatsApp utility messaging recruitment @iodic in #3177
+* Fix - The product sync button showing up twice by @sharunaanandraj in #3199
+* Tweak - Bump WooCommerce and WordPress compatibility by @iodic in #3200
+* Add - An automated process that synchronizes all WooCommerce product categories with Meta, creating catalog product sets for each category. The synchronization process ensures that any changes made to the WooCommerce product categories are reflected in the corresponding Meta catalog product sets by @mshymon in #3168
+* Add - A banner in product sets tab to explain recent changes to product sets sync by @mshymon in #3207
+* Add - Admin notice for WhatsApp utility messaging recruitment by @iodic in #3211
+
+= 3.4.8 - 2025-05-06 =
+* Add - Feature to sync global attributes to Meta and test API format by @devbodaghe in #3050
+* Fix - Facebook attribute dropdown display and syncing issues by @devbodaghe in #3051
+* Tweak - Set helper text for dropdown sync by @devbodaghe in #3104
+* Tweak - Remove unused condition field code for variable products by @devbodaghe in #3114
+* Fix - Cursor style not resetting after attribute removal by @devbodaghe in #3113
+* Fix - 'Call to a member function is_taxonomy() on string' error when processing variable products by @devbodaghe in #3155
+
+= 3.4.7 - 2025-04-17 =
+* Tweak - Added external_variant_id to the feed file by @mshymon in #2998
+* Tweak - Added support for syncing product type by @vinkmeta in #3013
+* Tweak - Relocating bulk actions by @SayanPandey in #2943
+* Tweak - Filtration on All Products page | Synced and Not Synced by @SayanPandey in #2999
+* Tweak - Updated PR Template by @vinkmeta in #3019
+* Fix - Null check exceptions by @vinkmeta in #3015
+* Tweak - Relaxing sync validations by @raymon1 in #2969
+* Tweak - Truncates extra characters from title and description by @raymon1 in #3023
+* Tweak - Updated PR template by @vinkmeta in #3053
+* Fix - The item not found error by using filter in the product endpoint @vinkmeta in #3054
+* Fix - Bug where MPN input box had no tooltip by @devbodaghe in #3034
+* Tweak - Investigation: WooCommerce to Facebook Product Attribute Syncing by @devbodaghe in #3033
+* Fix - Add parent product material inheritance for variations by @devbodaghe in #3035
+* Fix - Tooltip Messages for Skirt Length and Sleeve Length by @devbodaghe in #3039
+* Fix - Typo in Admin.php by @SayanPandey in #3063
+* Add - Add separate short_description field to Facebook product data by @devbodaghe in #3029
+* Tweak - Sync short description remove dropdown by @devbodaghe in #3031
+* Tweak - Short Description Fallback by @devbodaghe in #3048
+* Fix - A problem where Purchase event was not firing if thankyou page was not shown or Purchase state updated through Woo dashboard by @vahidkay-meta in #3060
+* Tweak - Remove type casting for gpc to int by @devbodaghe in 3078
+* Tweak - Disable unmapped fields to batch api by @devbodaghe in #3079
+* Fix - Product variation fields not saving correctly by @devbodaghe in #3090
+* Fix - Removed failing test due to merge conflicts @vinkmeta in #3103
+
+= 3.4.6 - 2025-04-04 =
+* Fix - Product availability syncing by @vinkmeta in #3010
+* Fix - Product attribute sort error which prevented product edits in certain scenarios by @iodic in #3012
+
+= 3.4.5 - 2025-04-01 =
+* Tweak - Add new product field external_update_time to measure product update latency by @mshymon in #2973
+* Fix - for 'PHP Warning: Undefined variable $fb_product_parent' by @mshymon in #2976
+* Fix - Updated logic to choose/create the feed for product sync by @mshymon in #2989
+* Add - Facebook Product Data Tab Enhancement by @devbodaghe in #2938
+* Fix - PHP Warning for empty attributes by @vinkmeta in #3001
+
 = 3.4.4 - 2025-03-26 =
 * Add - Create tests for ProductFeedUploads create endpoint by @ajello-meta in #2902
 * Add - Create tests for ProductFeedUploads read endpoint by @ajello-meta in #2903
@@ -25,7 +142,7 @@
 = 3.4.2 - 2025-03-13 =
 * Tweak - Update README.md - Added noification for ownership transfer by @SayanPandey in #2910 and #2916
 
-= 3.4.1 - 2025-02-27 = 
+= 3.4.1 - 2025-02-27 =
 * Tweak - Removed custom field definitions by @devbodaghe in #2876
 * Dev - Improved readability of function prepare_product() in fbproduct.php by @mshymon in #2889
 * Dev - Enabled PHPUnit code coverage report generation by @carterbruce in #2893
@@ -37,13 +154,13 @@
 * Fix - translations loading before the init hook by @iodic in #2866
 * Fix - Fixed feeds by requesting a feed file upload session after feed file is generated and added missing new fields to the feed file by @mshymon in #2841
 
-= 3.3.5 - 2025-02-12 = 
+= 3.3.5 - 2025-02-12 =
 * Add - Rich Text Description to Woo Product Sync with Meta by devbodaghe in #2843
 
 = 3.3.4 - 2025-02-11 =
 * Fix - Fixing the issue with version number
 
-= 3.3.3 - 2025-02-06 = 
+= 3.3.3 - 2025-02-06 =
 * Fix - Use of recommended delete connection endpoint over delete permission endpoint by atuld123 in #2844
 * Add - Expose Brand & MPN to Woocommerce UI by @devbodaghe in #2842
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -46,6 +46,7 @@
 *  Add - Add usage logging for enhanced settings tabs by @ajello-meta in #3202
 *  Tweak - Remove UI of a checkbox that controls enablement of the new style feed generation by @mshymon in #3056
 *  Fix - Fix linter errors for ./includes/fbutils.php files by @ajello-meta in #3075
+*  Fix - Hotfix for Rollout Switches by @vinkmeta in #3236
 
 = 3.4.10 - 2025-05-22 =
 * Fix - Disabled the RollOut switch

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -244,8 +244,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 			// Init jobs
 			$this->job_manager = new WooCommerce\Facebook\Jobs\JobManager();
 			add_action( 'init', [ $this->job_manager, 'init' ] );
-			add_action( 'admin_init', [ $this->rollout_switches, 'init' ] );
-
+			add_action( 'admin_init', array( $this->rollout_switches, 'init' ) );
 			// Instantiate the debug tools.
 			$this->debug_tools = new DebugTools();
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -26,8 +26,6 @@ require_once 'includes/fbproduct.php';
 require_once 'facebook-commerce-pixel-event.php';
 require_once 'facebook-commerce-admin-notice.php';
 
-new WC_Facebookcommerce_Admin_Notice();
-
 class WC_Facebookcommerce_Integration extends WC_Integration {
 
 

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -10,7 +10,7 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 3.4.4
+ * Version: 3.5.0
  * Requires at least: 5.6
  * Requires PHP: 7.4
  * Text Domain: facebook-for-woocommerce
@@ -62,7 +62,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '3.4.4'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '3.5.0'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.4.0';

--- a/includes/Admin/Enhanced_Settings.php
+++ b/includes/Admin/Enhanced_Settings.php
@@ -56,7 +56,6 @@ class Enhanced_Settings {
 
 		$this->screens = $this->build_menu_item_array();
 
-		add_action( 'admin_menu', array( $this, 'build_menu_item_array' ) );
 		add_action( 'admin_init', array( $this, 'add_extra_screens' ) );
 		add_action( 'admin_menu', array( $this, 'add_menu_item' ) );
 		add_action( 'wp_loaded', array( $this, 'save' ) );
@@ -225,8 +224,8 @@ class Enhanced_Settings {
 				<?php $url = admin_url( 'admin.php?page=' . self::PAGE_ID . '&tab=' . esc_attr( $id ) ); ?>
 				<?php if ( 'whatsapp_utility' === $id ) : ?>
 					<?php
-					$wa_onboarding_completion_setting = get_option( 'wc_facebook_wa_integration_onboarding_complete', '' );
-					if ( 'true' === $wa_onboarding_completion_setting ) {
+					$wa_integration_config_id = get_option( 'wc_facebook_wa_integration_config_id', '' );
+					if ( ! empty( $wa_integration_config_id ) ) {
 						$url .= '&view=utility_settings';
 					}
 					?>

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -530,6 +530,7 @@ class Connection {
 		$this->update_instagram_business_id( '' );
 		$this->update_commerce_merchant_settings_id( '' );
 		$this->update_external_business_id( '' );
+		$this->update_commerce_partner_integration_id( '' );
 		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, '' );
 		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, '' );
 		facebook_for_woocommerce()->get_integration()->update_product_catalog_id( '' );

--- a/includes/ProductSets/ProductSetSync.php
+++ b/includes/ProductSets/ProductSetSync.php
@@ -104,6 +104,12 @@ class ProductSetSync {
 	 */
 	public function sync_all_product_sets() {
 		try {
+			$flag_name = '_wc_facebook_for_woocommerce_product_sets_sync_flag';
+			if ( 'yes' === get_transient( $flag_name ) ) {
+				return;
+			}
+			set_transient( $flag_name, 'yes', DAY_IN_SECONDS - 1 );
+
 			if ( ! $this->is_sync_enabled() ) {
 				return;
 			}

--- a/includes/RolloutSwitches.php
+++ b/includes/RolloutSwitches.php
@@ -26,22 +26,16 @@ class RolloutSwitches {
 	public const SWITCH_ROLLOUT_FEATURES          = 'rollout_enabled';
 	public const WHATSAPP_UTILITY_MESSAGING       = 'whatsapp_utility_messages_enabled';
 	public const SWITCH_PRODUCT_SETS_SYNC_ENABLED = 'product_sets_sync_enabled';
+	private const SETTINGS_KEY                    = 'wc_facebook_for_woocommerce_rollout_switches';
 
 	private const ACTIVE_SWITCHES = array(
 		self::SWITCH_ROLLOUT_FEATURES,
 		self::WHATSAPP_UTILITY_MESSAGING,
 		self::SWITCH_PRODUCT_SETS_SYNC_ENABLED,
 	);
-	/**
-	 * Stores the rollout switches and their enabled/disabled states.
-	 *
-	 * @var array
-	 */
-	private array $rollout_switches = array();
 
 	public function __construct( \WC_Facebookcommerce $plugin ) {
 		$this->plugin = $plugin;
-		add_action( Heartbeat::HOURLY, array( $this, 'init' ) );
 	}
 
 	public function init() {
@@ -50,18 +44,41 @@ class RolloutSwitches {
 			return;
 		}
 
+		$flag_name = '_wc_facebook_for_woocommerce_rollout_switch_flag';
+		if ( 'yes' === get_transient( $flag_name ) ) {
+			return;
+		}
+		set_transient( $flag_name, 'yes', 60 * MINUTE_IN_SECONDS );
+
 		try {
 			$external_business_id = $this->plugin->get_connection_handler()->get_external_business_id();
 			$switches             = $this->plugin->get_api()->get_rollout_switches( $external_business_id );
 			$data                 = $switches->get_data();
+			if ( empty( $data ) ) {
+				throw new Exception( 'Empty data' );
+			}
+			$fb_options = array();
 			foreach ( $data as $switch ) {
 				if ( ! isset( $switch['switch'] ) || ! $this->is_switch_active( $switch['switch'] ) ) {
 					continue;
 				}
-				$this->rollout_switches[ $switch['switch'] ] = (bool) $switch['enabled'];
+				$fb_options[ $switch['switch'] ] = (bool) $switch['enabled'] ? 'yes' : 'no';
 			}
+			update_option( self::SETTINGS_KEY, $fb_options );
 		} catch ( Exception $e ) {
-			\WC_Facebookcommerce_Utils::log_exception_immediately_to_meta(
+			$fb_options = get_option( self::SETTINGS_KEY );
+			if ( empty( $fb_options ) ) {
+				$fb_options = array();
+			}
+			foreach ( $this->get_active_switches() as $switch_name ) {
+				// if the switch is not in the response and we have a failure
+				// we fallback to the old value first and false otherwise
+				if ( ! isset( $fb_options[ $switch_name ] ) ) {
+					$fb_options[ $switch_name ] = 'no';
+				}
+			}
+			update_option( self::SETTINGS_KEY, $fb_options );
+			\WC_Facebookcommerce_Utils::fblog(
 				$e,
 				[
 					'event'      => 'rollout_switches',
@@ -91,11 +108,23 @@ class RolloutSwitches {
 		if ( ! $this->is_switch_active( $switch_name ) ) {
 			return false;
 		}
+		$features = get_option( self::SETTINGS_KEY );
+		if ( empty( $features ) ) {
+			return false;
+		}
 
-		return isset( $this->rollout_switches[ $switch_name ] ) ? $this->rollout_switches[ $switch_name ] : true;
+		if ( ! isset( $features[ $switch_name ] ) ) {
+			return true;
+		}
+
+		return 'yes' === $features[ $switch_name ] ? true : false;
 	}
 
 	public function is_switch_active( string $switch_name ): bool {
 		return in_array( $switch_name, self::ACTIVE_SWITCHES, true );
+	}
+
+	public function get_active_switches(): array {
+		return self::ACTIVE_SWITCHES;
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.4.4",
+  "version": "3.5.0",
   "author": "Facebook",
   "homepage": "https://woocommerce.com/products/facebook/",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -86,5 +86,6 @@ When opening a bug on GitHub, please give us as many details as possible.
 *  Add - Add usage logging for enhanced settings tabs by @ajello-meta in #3202
 *  Tweak - Remove UI of a checkbox that controls enablement of the new style feed generation by @mshymon in #3056
 *  Fix - Fix linter errors for ./includes/fbutils.php files by @ajello-meta in #3075
+*  Fix - Hotfix for Rollout Switches by @vinkmeta in #3236
 
 [See changelog for all versions](https://raw.githubusercontent.com/facebook/facebook-for-woocommerce/refs/heads/main/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -40,18 +40,51 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
-= 3.4.4 - 2025-03-26 =
-* Add - Create tests for ProductFeedUploads create endpoint by @ajello-meta in #2902
-* Add - Create tests for ProductFeedUploads read endpoint by @ajello-meta in #2903
-* Tweak - Remove phpcs:ignoreFile annotation + Enable code coverage report generation with phpunit by @sol-loup in #2897 and #2901
-* Fix - Restores the original dynamic property behavior in the AsyncRequest class by @sol-loup in #2921
-* Tweak - Changing APP to PLUGIN on README.MD by @SayanPandey in #2916
-* Tweak - Update README.md - Added noification for ownership transfer by @SayanPandey in #2910
-* Tweak - Added is_multisite logging to the update_plugin_version_configuration request by @carterbuce in #2955
-* Tweak - Add woo_commerce_retailer_id to products API request by @crisojog in #2958
-* Tweak - Syncing plugin version info by @vinkmeta in #2960
-* Fix - sync products out of stock to meta despite visibility config by @francorisso in #2952
-* Fix - Update woo_commerce_retailer_id to existing field external_variant_id by @crisojog in #2963
-* Tweak - Update readme.txt by @vinkmeta in #2949
+= 3.5.0 - 2025-05-28 =
+*  Add - Create basic checkout permalink w/ products and coupon support by @ajello-meta in #2887
+*  Add - Common Feed Upload Framework by @jmencab in #2875
+*  Fix - Fix bug where templates were not loading correctly by @ajello-meta in #2915
+*  Tweak - Change MICE to use base site url instead of shop url by @carterbuce in #2934
+*  Tweak - Improve custom checkout UI by @ajello-meta in #2930
+*  Tweak - Make custom checkout UI mobile compatible by @ajello-meta in #2942
+*  Fix - Update parsing for Checkout URL Product IDs by @carterbuce in #2935
+*  Add - Implement dummy logging util by @nealweiMeta in #2920
+*  Add - Setup cron job for batch logging with global message queue by @nealweiMeta in #2924
+*  Add - Error log request api activate by @nealweiMeta in #2933
+*  Add - Log locally with debug mode enabled by @nealweiMeta in #2939
+*  Add - Ratings and reviews feed upload by @nrostrow-meta in #2937
+*  Tweak - Feed upload skip logic and logging calls by @nrostrow-meta in #2964
+*  Add - Add function to fetch feed upload instance by @nrostrow-meta in #2970
+*  Tweak - Have feed uploads always use feed generator by @nrostrow-meta in #2971
+*  Tweak - Trigger metadata feed uploads on CPI ID change (post onboarding) by @nrostrow-meta in #2995
+*  Add - Shipping profile feed upload button by @nrostrow-meta in #3140
+*  Add - Navigation menu feed upload logic by @nrostrow-meta in #3159
+*  Fix - Fixing some fclose and logging gaps in the feed upload logic by @nrostrow-meta in #3192
+*  Add - Enabling navigation menu feed upload and adding manual sync button by @nrostrow-meta in #3223
+*  Add - Promotions feed upload by @carterbuce in #2941
+*  Add - Plugin AJAX API Framework by @sol-loup in #2928
+*  Tweak - Test Infrastructure Enhancement by @sol-loup in #2944
+*  Add - Implement telemetry logs api by @nealweiMeta in #2940
+*  Fix -  Make error logging event configurable by @nealweiMeta in #2954
+*  Add - Implement logging toggle by @nealweiMeta in #2959
+*  Fix - auto products sync by @nealweiMeta in #2978
+*  Tweak - Sync products with restriction by @nealweiMeta in #2983
+*  Fix - Fix use_enhanced_onboarding for legacy connections by @carterbuce in #2986
+*  Add - Create enhanced settings UI by @ajello-meta in #2968
+*  Add - Create new troubleshooting drawer from legacy debug settings by @ajello-meta in #2977
+*  Add - Add manual product and coupon sync buttons by @ajello-meta in #2984
+*  Tweak - Make page title in enhanced settings static by @ajello-meta in #2985
+*  Tweak - Align finalized content for logging toggle by @nealweiMeta in #2992
+*  Tweak - Improve local log by @nealweiMeta in #3009
+*  Fix - Fix free shipping coupon sync by @carterbuce in #2993
+*  Tweak - Add logging for feed generation scheduling failure by @carterbuce in #2994
+*  Tweak - Add logging in checkout for coupon code by @ajello-meta in #2991
+*  Tweak - Clean up CSS in enhanced settings UI by @ajello-meta in #2996
+*  Tweak - Remove the "Advertise" tab by @ajello-meta in #3024
+*  Tweak - Sync "Usage Count" in Promos Feed by @carterbuce in #3036
+*  Tweak - Disable mini_shops product capability for unsupported items by @carterbuce in #3084
+*  Add - Add usage logging for enhanced settings tabs by @ajello-meta in #3202
+*  Tweak - Remove UI of a checkbox that controls enablement of the new style feed generation by @mshymon in #3056
+*  Fix - Fix linter errors for ./includes/fbutils.php files by @ajello-meta in #3075
 
 [See changelog for all versions](https://raw.githubusercontent.com/facebook/facebook-for-woocommerce/refs/heads/main/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook
 Tags: meta, facebook, conversions api, catalog sync, ads
 Requires at least: 5.6
 Tested up to: 6.8.1
-Stable tag: 3.4.4
+Stable tag: 3.5.0
 Requires PHP: 7.4
 MySQL: 5.6 or greater
 License: GPLv2 or later

--- a/tests/Unit/RolloutSwitchesTest.php
+++ b/tests/Unit/RolloutSwitchesTest.php
@@ -127,4 +127,64 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 		// If the switch is active but not in the response -> TRUE
 		$this->assertEquals( $switch_mock->is_switch_enabled("switch_d"), true );
 	}
+
+	public function test_plugin_when_failing() {
+
+		// mock the active filters to test business values
+		$plugin = facebook_for_woocommerce();
+		$plugin_ref_obj          = new ReflectionObject( $plugin );
+		// setup connection handler
+		$prop_connection_handler = $plugin_ref_obj->getProperty( 'connection_handler' );
+		$prop_connection_handler->setAccessible( true );
+		$mock_connection_handler = $this->getMockBuilder( Connection::class )
+			->disableOriginalConstructor()
+			->setMethods( array( 'get_external_business_id', 'is_connected', 'get_access_token' ) )
+			->getMock();
+		$mock_connection_handler->expects( $this->any() )->method( 'get_external_business_id' )->willReturn( $this->external_business_id );
+		$mock_connection_handler->expects( $this->any() )->method( 'get_access_token' )->willReturn( $this->access_token );
+		$mock_connection_handler->expects( $this->any() )->method( 'is_connected' )->willReturn( true );
+		$prop_connection_handler->setValue( $plugin, $mock_connection_handler );
+		// setup API
+		$prop_api = $plugin_ref_obj->getProperty( 'api' );
+		$prop_api->setAccessible( true );
+		$mock_api = $this->getMockBuilder( API::class )->disableOriginalConstructor()->setMethods( array( 'do_remote_request' ) )->getMock();
+		$mock_api->expects( $this->any() )->method( 'do_remote_request' )->willReturn(
+			array('body' => json_encode(array())));
+		$prop_api->setValue( $plugin, $mock_api );
+
+		$switch_mock = $this->getMockBuilder(RolloutSwitches::class)
+			->setConstructorArgs( array( $plugin ) )
+            ->onlyMethods(['is_switch_active', 'get_active_switches'])
+            ->getMock();
+		$switch_mock->expects($this->any())->method('is_switch_active')
+			->willReturnCallback(function($switch_name) {
+				switch ($switch_name) {
+					case 'switch_a':
+					case 'switch_b':
+					case 'switch_d':
+						return true;
+					default:
+						return false;
+				}
+			});
+		$switch_mock->expects($this->any())->method('get_active_switches')
+			->willReturnCallback(function() {
+				return array(
+					'switch_a',
+					'switch_b',
+					'switch_d',
+				);
+			});
+		$switch_mock->init();
+
+		// If the switch is not active -> FALSE (independent of the response being true)
+		$this->assertEquals( $switch_mock->is_switch_enabled("switch_c"), false );
+
+		// If the feature is active and in the response -> response value
+		$this->assertEquals( $switch_mock->is_switch_enabled("switch_a"), false );
+		$this->assertEquals( $switch_mock->is_switch_enabled("switch_b"), false );
+
+		// If the switch is active but not in the response -> TRUE
+		$this->assertEquals( $switch_mock->is_switch_enabled("switch_d"), false );
+	}
 }


### PR DESCRIPTION
## Description
Fix the disconnect logic dose not reset the commerce partner integration ID

### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry
Removing commerce partner integration ID when disconnect

## Test Plan
Manual verification:
Delete connection
<img width="1135" alt="image" src="https://github.com/user-attachments/assets/a5ba08b5-73c7-4951-be54-3041e0d46ec9" />

Before deletion:
<img width="1430" alt="image" src="https://github.com/user-attachments/assets/ad3c9709-d828-4875-b2ef-58a30b986362" />
After deletion:
<img width="1496" alt="image" src="https://github.com/user-attachments/assets/77640bae-03fd-4941-9a7d-665e01634d25" />
(No commerce partner... field can be found)


## Screenshots
(Set test plan)