### PR TITLE
Reset connection functionality

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -530,6 +530,7 @@ class Connection {
 		$this->update_instagram_business_id( '' );
 		$this->update_commerce_merchant_settings_id( '' );
 		$this->update_external_business_id( '' );
+		$this->update_commerce_partner_integration_id( '' );
 		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, '' );
 		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, '' );
 		facebook_for_woocommerce()->get_integration()->update_product_catalog_id( '' );


### PR DESCRIPTION
## Description
Fix the disconnect logic dose not reset the commerce partner integration ID

This lingering CPI ID Causing some reonboarded seller failed to load broken MiCE, some of them shouldn't even load MiCE as they only have the CPI ID due to it was left in the database.
![image](https://github.com/user-attachments/assets/04354231-9069-4d94-ba98-1c896ccf0eee)


### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry
Removing commerce partner integration ID when disconnect

## Test Plan
Manual verification:
Delete connection
<img width="1135" alt="image" src="https://github.com/user-attachments/assets/a5ba08b5-73c7-4951-be54-3041e0d46ec9" />

Before deletion:
<img width="1430" alt="image" src="https://github.com/user-attachments/assets/ad3c9709-d828-4875-b2ef-58a30b986362" />
After deletion:
<img width="1496" alt="image" src="https://github.com/user-attachments/assets/77640bae-03fd-4941-9a7d-665e01634d25" />
(No commerce partner... field can be found)


## Screenshots
(Set test plan)