### PR TITLE
Fixing the non static method called as static issue

### DIFF
--- a/includes/Handlers/PluginRender.php
+++ b/includes/Handlers/PluginRender.php
@@ -150,7 +150,7 @@ class PluginRender {
 	}
 
 
-	private function get_opted_out_successfully_banner_class() {
+	public static function get_opted_out_successfully_banner_class() {
 		$hidden              = ! self::is_master_sync_on();
 		$opt_in_banner_class = 'notice notice-success is-dismissible';
 
@@ -162,7 +162,7 @@ class PluginRender {
 		return $opt_in_banner_class;
 	}
 
-	private function get_opt_out_banner_class() {
+	public static function get_opt_out_banner_class() {
 		$hidden               = ! self::is_master_sync_on();
 		$opt_out_banner_class = 'notice notice-info is-dismissible';
 
@@ -174,7 +174,7 @@ class PluginRender {
 		return $opt_out_banner_class;
 	}
 
-	private static function get_opt_out_modal_message() {
+	public static function get_opt_out_modal_message() {
 		return '
             <h4>Opt out of automatic product sync?</h4>
             <p>
@@ -191,7 +191,7 @@ class PluginRender {
         ';
 	}
 
-	private static function get_opt_out_modal_buttons() {
+	public static function get_opt_out_modal_buttons() {
 		return '
             <a href="javascript:void(0);" class="button wc-forward upgrade_plugin_button" id="modal_opt_out_button">
             	Opt out


### PR DESCRIPTION
## Description

Bug happened becasue a private method which was non static was called statically

### Type of change

Bug fix: Changed all the method to be public static
This way should be accessible to everyone

## Checklist

- [] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Test Plan

Check the debug logs should not get something like : Uncaught Error: Non-static method WooCommerce\Facebook\Handlers\PluginRender::get_opt_out_banner_class() cannot be called statically
