### PR TITLE
Release/3.5.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -69,6 +69,16 @@
 *  Add - reset connection functionality by @jczhuoMeta in #3262
 *  Fix - fixing the non static method called as static issue by @SayanPandey in #3263
 *  Fix - Fix linter errors for ./facebook-commerce.php by @ajello-meta in #3251
+*  Fix - updating banners to show the latest version as 3.5.1 by @SayanPandey in #3265
+*  Tweak - enforced product sets functionality for plugin admins by @vinkmeta in #3243
+*  Tweak - removing the product set functionality migration to Admin by @vinkmeta in #3267
+*  Tweak - removing the migration of rollout switch to Admin by @vinkmeta in #3268
+*  Fix - fix to remove html encoding in fb product sets names by @mshymon in #3266
+*  Add - trigger product sets sync in Handler on catalog ID update (new SAOff MBE onboarding flow) by @mshymon in #3270
+*  Fix - fix linter errors for ./facebook-commerce-pixel-event.php by @ajello-meta in #3248
+*  Fix - fix /variation field persistence & rich text description handling for variants by @devbodaghe in #3269
+*  Tweak - update product validation logic for checkout by @ajello-meta in #3271
+*  Fix - Adding percautionary bug fix by @SayanPandey in #3275
 
 = 3.4.10 - 2025-05-22 =
 * Fix - Disabled the RollOut switch

--- a/changelog.txt
+++ b/changelog.txt
@@ -81,6 +81,7 @@
 *  Fix - Adding precautionary bug fix by @SayanPandey in #3275
 *  Add - Added Loading States to WAUM flows by @woo-ardsouza in #3272
 *  Add - Add logging for coupon in checkout by @ajello-meta in #3279
+*  Fix - fix inconsistency between enhanced and legacy flow by @jczhuoMeta in #3285
 
 = 3.4.10 - 2025-05-22 =
 * Fix - Disabled the RollOut switch

--- a/changelog.txt
+++ b/changelog.txt
@@ -82,6 +82,7 @@
 *  Add - Added Loading States to WAUM flows by @woo-ardsouza in #3272
 *  Add - Add logging for coupon in checkout by @ajello-meta in #3279
 *  Fix - fix inconsistency between enhanced and legacy flow by @jczhuoMeta in #3285
+*  Fix - Removing the tag to get rid of warnings by @SayanPandey in #3287
 
 = 3.4.10 - 2025-05-22 =
 * Fix - Disabled the RollOut switch

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,122 @@
 *** Facebook for WooCommerce Changelog ***
 
+= 3.5.0 - 2025-05-28 =
+*  Add - Create basic checkout permalink w/ products and coupon support by @ajello-meta in #2887
+*  Add - Common Feed Upload Framework by @jmencab in #2875
+*  Fix - Fix bug where templates were not loading correctly by @ajello-meta in #2915
+*  Tweak - Change MICE to use base site url instead of shop url by @carterbuce in #2934
+*  Tweak - Improve custom checkout UI by @ajello-meta in #2930
+*  Tweak - Make custom checkout UI mobile compatible by @ajello-meta in #2942
+*  Fix - Update parsing for Checkout URL Product IDs by @carterbuce in #2935
+*  Add - Implement dummy logging util by @nealweiMeta in #2920
+*  Add - Setup cron job for batch logging with global message queue by @nealweiMeta in #2924
+*  Add - Error log request api activate by @nealweiMeta in #2933
+*  Add - Log locally with debug mode enabled by @nealweiMeta in #2939
+*  Add - Ratings and reviews feed upload by @nrostrow-meta in #2937
+*  Tweak - Feed upload skip logic and logging calls by @nrostrow-meta in #2964
+*  Add - Add function to fetch feed upload instance by @nrostrow-meta in #2970
+*  Tweak - Have feed uploads always use feed generator by @nrostrow-meta in #2971
+*  Tweak - Trigger metadata feed uploads on CPI ID change (post onboarding) by @nrostrow-meta in #2995
+*  Add - Shipping profile feed upload button by @nrostrow-meta in #3140
+*  Add - Navigation menu feed upload logic by @nrostrow-meta in #3159
+*  Fix - Fixing some fclose and logging gaps in the feed upload logic by @nrostrow-meta in #3192
+*  Add - Enabling navigation menu feed upload and adding manual sync button by @nrostrow-meta in #3223
+*  Add - Promotions feed upload by @carterbuce in #2941
+*  Add - Plugin AJAX API Framework by @sol-loup in #2928
+*  Tweak - Test Infrastructure Enhancement by @sol-loup in #2944
+*  Add - Implement telemetry logs api by @nealweiMeta in #2940
+*  Fix -  Make error logging event configurable by @nealweiMeta in #2954
+*  Add - Implement logging toggle by @nealweiMeta in #2959
+*  Fix - auto products sync by @nealweiMeta in #2978
+*  Tweak - Sync products with restriction by @nealweiMeta in #2983
+*  Fix - Fix use_enhanced_onboarding for legacy connections by @carterbuce in #2986
+*  Add - Create enhanced settings UI by @ajello-meta in #2968
+*  Add - Create new troubleshooting drawer from legacy debug settings by @ajello-meta in #2977
+*  Add - Add manual product and coupon sync buttons by @ajello-meta in #2984
+*  Tweak - Make page title in enhanced settings static by @ajello-meta in #2985
+*  Tweak - Align finalized content for logging toggle by @nealweiMeta in #2992
+*  Tweak - Improve local log by @nealweiMeta in #3009
+*  Fix - Fix free shipping coupon sync by @carterbuce in #2993
+*  Tweak - Add logging for feed generation scheduling failure by @carterbuce in #2994
+*  Tweak - Add logging in checkout for coupon code by @ajello-meta in #2991
+*  Tweak - Clean up CSS in enhanced settings UI by @ajello-meta in #2996
+*  Tweak - Remove the "Advertise" tab by @ajello-meta in #3024
+*  Tweak - Sync "Usage Count" in Promos Feed by @carterbuce in #3036
+*  Tweak - Disable mini_shops product capability for unsupported items by @carterbuce in #3084
+*  Add - Add usage logging for enhanced settings tabs by @ajello-meta in #3202
+*  Tweak - Remove UI of a checkbox that controls enablement of the new style feed generation by @mshymon in #3056
+*  Fix - Fix linter errors for ./includes/fbutils.php files by @ajello-meta in #3075
+
+= 3.4.10 - 2025-05-22 =
+* Fix - Disabled the RollOut switch
+* Fix - Removed the Global Admin Notice
+
+= 3.4.9 - 2025-05-14 =
+* Add - Support for rollout switches in the plugin to control feature rollouts from meta side @francorisso in #3126
+* Fix - Tests in the rollout switches file by @francorisso in #3146
+* Fix - RolloutSwitches Init by @carterbuce in #3157
+* Add - Integrate Whatsapp Utility Messaging for WooCommerce Order Update Notifications by @sharunaanandraj in #3164
+* Tweak - Improve Test Filter Management with AbstractWPUnitTestWithSafeFiltering by @sol-loup in #2944
+* Fix - Namespacing issue causing some tests to be skipped @sol-loup in #3037
+* Tweak - Additional logs and timeout for Utility Message Flows by @woo-ardsouza in #3171
+* Fix - The WAUM payment progress to only Show Up after Consent Collection is Enabled by @sharunaanandraj in #3175
+* Tweak - Update language dropdown based on supported_languages in GET api response by @woo-ardsouza in #3178
+* Add - Error notice to gracefully handle errors in Manage Events view by @woo-ardsouza in #3179
+* Fix - The Status on the Whatsapp Consent Collection Pill and Button @sharunaanandraj in #3183
+* Tweak - Update Message Sending API from Messages to Message Events by @woo-ardsouza in #3182
+* Tweak - Update the Authentication mechanism for Whatsapp Webhook by @sharunaanandraj #3186
+* Tweak - Minor design updates to Utility Event Settings card by @woo-ardsouza in #3193
+* Add - Admin notice for WhatsApp utility messaging recruitment @iodic in #3177
+* Fix - The product sync button showing up twice by @sharunaanandraj in #3199
+* Tweak - Bump WooCommerce and WordPress compatibility by @iodic in #3200
+* Add - An automated process that synchronizes all WooCommerce product categories with Meta, creating catalog product sets for each category. The synchronization process ensures that any changes made to the WooCommerce product categories are reflected in the corresponding Meta catalog product sets by @mshymon in #3168
+* Add - A banner in product sets tab to explain recent changes to product sets sync by @mshymon in #3207
+* Add - Admin notice for WhatsApp utility messaging recruitment by @iodic in #3211
+
+= 3.4.8 - 2025-05-06 =
+* Add - Feature to sync global attributes to Meta and test API format by @devbodaghe in #3050
+* Fix - Facebook attribute dropdown display and syncing issues by @devbodaghe in #3051
+* Tweak - Set helper text for dropdown sync by @devbodaghe in #3104
+* Tweak - Remove unused condition field code for variable products by @devbodaghe in #3114
+* Fix - Cursor style not resetting after attribute removal by @devbodaghe in #3113
+* Fix - 'Call to a member function is_taxonomy() on string' error when processing variable products by @devbodaghe in #3155
+
+= 3.4.7 - 2025-04-17 =
+* Tweak - Added external_variant_id to the feed file by @mshymon in #2998
+* Tweak - Added support for syncing product type by @vinkmeta in #3013
+* Tweak - Relocating bulk actions by @SayanPandey in #2943
+* Tweak - Filtration on All Products page | Synced and Not Synced by @SayanPandey in #2999
+* Tweak - Updated PR Template by @vinkmeta in #3019
+* Fix - Null check exceptions by @vinkmeta in #3015
+* Tweak - Relaxing sync validations by @raymon1 in #2969
+* Tweak - Truncates extra characters from title and description by @raymon1 in #3023
+* Tweak - Updated PR template by @vinkmeta in #3053
+* Fix - The item not found error by using filter in the product endpoint @vinkmeta in #3054
+* Fix - Bug where MPN input box had no tooltip by @devbodaghe in #3034
+* Tweak - Investigation: WooCommerce to Facebook Product Attribute Syncing by @devbodaghe in #3033
+* Fix - Add parent product material inheritance for variations by @devbodaghe in #3035
+* Fix - Tooltip Messages for Skirt Length and Sleeve Length by @devbodaghe in #3039
+* Fix - Typo in Admin.php by @SayanPandey in #3063
+* Add - Add separate short_description field to Facebook product data by @devbodaghe in #3029
+* Tweak - Sync short description remove dropdown by @devbodaghe in #3031
+* Tweak - Short Description Fallback by @devbodaghe in #3048
+* Fix - A problem where Purchase event was not firing if thankyou page was not shown or Purchase state updated through Woo dashboard by @vahidkay-meta in #3060
+* Tweak - Remove type casting for gpc to int by @devbodaghe in 3078
+* Tweak - Disable unmapped fields to batch api by @devbodaghe in #3079
+* Fix - Product variation fields not saving correctly by @devbodaghe in #3090
+* Fix - Removed failing test due to merge conflicts @vinkmeta in #3103
+
+= 3.4.6 - 2025-04-04 =
+* Fix - Product availability syncing by @vinkmeta in #3010
+* Fix - Product attribute sort error which prevented product edits in certain scenarios by @iodic in #3012
+
+= 3.4.5 - 2025-04-01 =
+* Tweak - Add new product field external_update_time to measure product update latency by @mshymon in #2973
+* Fix - for 'PHP Warning: Undefined variable $fb_product_parent' by @mshymon in #2976
+* Fix - Updated logic to choose/create the feed for product sync by @mshymon in #2989
+* Add - Facebook Product Data Tab Enhancement by @devbodaghe in #2938
+* Fix - PHP Warning for empty attributes by @vinkmeta in #3001
+
 = 3.4.4 - 2025-03-26 =
 * Add - Create tests for ProductFeedUploads create endpoint by @ajello-meta in #2902
 * Add - Create tests for ProductFeedUploads read endpoint by @ajello-meta in #2903
@@ -25,7 +142,7 @@
 = 3.4.2 - 2025-03-13 =
 * Tweak - Update README.md - Added noification for ownership transfer by @SayanPandey in #2910 and #2916
 
-= 3.4.1 - 2025-02-27 = 
+= 3.4.1 - 2025-02-27 =
 * Tweak - Removed custom field definitions by @devbodaghe in #2876
 * Dev - Improved readability of function prepare_product() in fbproduct.php by @mshymon in #2889
 * Dev - Enabled PHPUnit code coverage report generation by @carterbruce in #2893
@@ -37,13 +154,13 @@
 * Fix - translations loading before the init hook by @iodic in #2866
 * Fix - Fixed feeds by requesting a feed file upload session after feed file is generated and added missing new fields to the feed file by @mshymon in #2841
 
-= 3.3.5 - 2025-02-12 = 
+= 3.3.5 - 2025-02-12 =
 * Add - Rich Text Description to Woo Product Sync with Meta by devbodaghe in #2843
 
 = 3.3.4 - 2025-02-11 =
 * Fix - Fixing the issue with version number
 
-= 3.3.3 - 2025-02-06 = 
+= 3.3.3 - 2025-02-06 =
 * Fix - Use of recommended delete connection endpoint over delete permission endpoint by atuld123 in #2844
 * Add - Expose Brand & MPN to Woocommerce UI by @devbodaghe in #2842
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -80,6 +80,7 @@
 *  Tweak - update product validation logic for checkout by @ajello-meta in #3271
 *  Fix - Adding precautionary bug fix by @SayanPandey in #3275
 *  Add - Added Loading States to WAUM flows by @woo-ardsouza in #3272
+*  Add - Add logging for coupon in checkout by @ajello-meta in #3279
 
 = 3.4.10 - 2025-05-22 =
 * Fix - Disabled the RollOut switch

--- a/changelog.txt
+++ b/changelog.txt
@@ -46,6 +46,7 @@
 *  Add - Add usage logging for enhanced settings tabs by @ajello-meta in #3202
 *  Tweak - Remove UI of a checkbox that controls enablement of the new style feed generation by @mshymon in #3056
 *  Fix - Fix linter errors for ./includes/fbutils.php files by @ajello-meta in #3075
+*  Fix - Hotfix for Rollout Switches by @vinkmeta in #3236
 
 = 3.4.10 - 2025-05-22 =
 * Fix - Disabled the RollOut switch

--- a/changelog.txt
+++ b/changelog.txt
@@ -46,7 +46,29 @@
 *  Add - Add usage logging for enhanced settings tabs by @ajello-meta in #3202
 *  Tweak - Remove UI of a checkbox that controls enablement of the new style feed generation by @mshymon in #3056
 *  Fix - Fix linter errors for ./includes/fbutils.php files by @ajello-meta in #3075
-*  Fix - Hotfix for Rollout Switches by @vinkmeta in #3236
+*  Tweak - Removing Variant Level Sync by @SayanPandey in #2931
+*  Tweak - Removed concept of Product Group Deletion from the plugin by @vinkmeta in #3062
+*  Tweak - Tagging woo all products using a flag by @SayanPandey in #3165
+*  Add - A simple column for Woo All Products sync in feed file by @SayanPandey in #3197
+*  Tweak - Preparation for migrating Batch API to Graph API by @vinkmeta in #3203
+*  Tweak Block Product Group Creation for Simple Products by @vinkmeta in #3204
+*  Fix - Removed html tags from product set description by @mshymon in #3230
+*  Fix - Fix for the rollout Switches by @vinkmeta in #3236
+*  Add - Opt out sync experience. by @SayanPandey in #3220
+*  Fix - Added a transient flag to avoid flooding of product set api requests by @vinkmeta in #3245
+*  Fix - Additional check for the opt-out banner by @SayanPandey in #3259
+*  Fix - Bump up GraphAPI version to 21 by @vahidkay-meta in #3219
+*  Fix - fix linter errors for ./class-wc-facebookcommerce.php by @ajello-meta in #3255
+*  Fix - fix linter errors for ./facebook-commerce-events-tracker.php by @ajello-meta in #3254
+*  Fix - fix linter errors for ./includes/Admin/Settings_Screens/Advertise.php by @ajello-meta in #3237
+*  Fix - fix linter errors for ./includes/Admin/Settings_Screens/Product_Sync.php by @ajello-meta in #3239
+*  Fix - fix function return typing for get_settings() by @ajello-meta in #3257
+*  Tweak - Addition check for opt out by @SayanPandey in #3259
+*  Tweak - Update the GraphAPI version to 21 by @vahidkay-meta in #3219
+*  Fix - Enabled rollout switch only for plugin admins by @vinkmeta in #3242
+*  Add - reset connection functionality by @jczhuoMeta in #3262
+*  Fix - fixing the non static method called as static issue by @SayanPandey in #3263
+*  Fix - Fix linter errors for ./facebook-commerce.php by @ajello-meta in #3251
 
 = 3.4.10 - 2025-05-22 =
 * Fix - Disabled the RollOut switch

--- a/changelog.txt
+++ b/changelog.txt
@@ -78,7 +78,8 @@
 *  Fix - fix linter errors for ./facebook-commerce-pixel-event.php by @ajello-meta in #3248
 *  Fix - fix /variation field persistence & rich text description handling for variants by @devbodaghe in #3269
 *  Tweak - update product validation logic for checkout by @ajello-meta in #3271
-*  Fix - Adding percautionary bug fix by @SayanPandey in #3275
+*  Fix - Adding precautionary bug fix by @SayanPandey in #3275
+*  Add - Added Loading States to WAUM flows by @woo-ardsouza in #3272
 
 = 3.4.10 - 2025-05-22 =
 * Fix - Disabled the RollOut switch

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -111,6 +111,15 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/** @var string the WordPress option name where the merchant access token is stored */
 	const OPTION_MERCHANT_ACCESS_TOKEN = 'wc_facebook_merchant_access_token';
 
+	/** @var string the WordPress option name where the business manager ID is stored */
+	const OPTION_BUSINESS_MANAGER_ID = 'wc_facebook_business_manager_id';
+
+	/** @var string the WordPress option name where the ad account ID is stored */
+	const OPTION_AD_ACCOUNT_ID = 'wc_facebook_ad_account_id';
+
+	/** @var string the WordPress option name where the system user ID is stored */
+	const OPTION_SYSTEM_USER_ID = 'wc_facebook_system_user_id';
+
 	/** @var string the WordPress option name where the commerce merchant settings ID is stored */
 	const OPTION_COMMERCE_MERCHANT_SETTINGS_ID = 'wc_facebook_commerce_merchant_settings_id';
 

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -10,7 +10,7 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 3.4.4
+ * Version: 3.5.0
  * Requires at least: 5.6
  * Requires PHP: 7.4
  * Text Domain: facebook-for-woocommerce
@@ -62,7 +62,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '3.4.4'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '3.5.0'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.4.0';

--- a/includes/API/FBE/Installation/Read/Response.php
+++ b/includes/API/FBE/Installation/Read/Response.php
@@ -95,6 +95,17 @@ class Response extends API\Response {
 		return $this->get_data()['commerce_merchant_settings_id'] ?? '';
 	}
 
+	/**
+	 * Gets the commerce partner integration ID.
+	 *
+	 * @since 3.5.0
+	 *
+	 * @return string
+	 */
+	public function get_commerce_partner_integration_id() {
+		return $this->get_data()['commerce_partner_integration_id'] ?? '';
+	}
+
 
 	/**
 	 * Gets the profiles.

--- a/includes/API/Plugin/Settings/Handler.php
+++ b/includes/API/Plugin/Settings/Handler.php
@@ -191,6 +191,10 @@ class Handler extends AbstractRESTEndpoint {
 			$options[ \WC_Facebookcommerce_Integration::OPTION_PROFILES ] = $params['profiles'];
 		}
 
+		if ( ! empty( $params['business_manager_id'] ) ) {
+			$options[ \WC_Facebookcommerce_Integration::OPTION_BUSINESS_MANAGER_ID ] = $params['business_manager_id'];
+		}
+
 		return $options;
 	}
 
@@ -239,6 +243,10 @@ class Handler extends AbstractRESTEndpoint {
 	private function clear_integration_options() {
 		$options = [
 			\WC_Facebookcommerce_Integration::OPTION_ACCESS_TOKEN,
+			\WC_Facebookcommerce_Integration::OPTION_BUSINESS_MANAGER_ID,
+			\WC_Facebookcommerce_Integration::OPTION_AD_ACCOUNT_ID,
+			\WC_Facebookcommerce_Integration::OPTION_SYSTEM_USER_ID,
+			\WC_Facebookcommerce_Integration::OPTION_FEED_ID,
 			\WC_Facebookcommerce_Integration::OPTION_COMMERCE_MERCHANT_SETTINGS_ID,
 			\WC_Facebookcommerce_Integration::OPTION_COMMERCE_PARTNER_INTEGRATION_ID,
 			\WC_Facebookcommerce_Integration::OPTION_ENABLE_MESSENGER,

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -386,6 +386,10 @@ class Shops extends Abstract_Settings_Screen {
 				const messageEvent = message.event;
 
 				if (messageEvent === 'CommerceExtension::INSTALL' && message.success) {
+					const cms_id = message.installed_features.find( ( f ) => 'fb_shop' === f.feature_type )?.connected_assets?.commerce_merchant_settings_id || 
+						message.installed_features.find( ( f ) => 'ig_shopping' === f.feature_type )?.connected_assets?.commerce_merchant_settings_id || '';
+					const ad_account_id = message.installed_features.find( ( f ) => 'ads' === f.feature_type )?.connected_assets?.ad_account_id || '';
+					
 					const requestBody = {
 						access_token: message.access_token,
 						merchant_access_token: message.access_token,
@@ -394,8 +398,8 @@ class Shops extends Abstract_Settings_Screen {
 						pixel_id: message.pixel_id,
 						page_id: message.page_id,
 						business_manager_id: message.business_manager_id,
-						commerce_merchant_settings_id: message.installed_features.find(f => f.feature_type === 'fb_shop')?.connected_assets?.commerce_merchant_settings_id || '',
-						ad_account_id: message.installed_features.find(f => f.feature_type === 'ads')?.connected_assets?.ad_account_id || '',
+						commerce_merchant_settings_id: cms_id,
+						ad_account_id: ad_account_id,
 						commerce_partner_integration_id: message.commerce_partner_integration_id || '',
 						profiles: message.profiles,
 						installed_features: message.installed_features

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -332,6 +332,12 @@ class Connection {
 		if ( $response->get_commerce_merchant_settings_id() ) {
 			$this->update_commerce_merchant_settings_id( sanitize_text_field( $response->get_commerce_merchant_settings_id() ) );
 		}
+
+		if ( $response->get_commerce_partner_integration_id() ) {
+			$this->update_commerce_partner_integration_id( sanitize_text_field( $response->get_commerce_partner_integration_id() ) );
+		} else {
+			$this->update_commerce_partner_integration_id( "" );
+		}
 	}
 
 

--- a/includes/Handlers/PluginRender.php
+++ b/includes/Handlers/PluginRender.php
@@ -145,7 +145,7 @@ class PluginRender {
 	 * Banner for initmation of WooAllProducts version will show up
 	 * after a week
 	 */
-	public function reset_upcoming_version_banners() {
+	public static function reset_upcoming_version_banners() {
 		set_transient( 'upcoming_woo_all_products_banner_hide', true, 7 * DAY_IN_SECONDS );
 	}
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1729,7 +1729,7 @@ class WC_Facebook_Product {
 				 * If parent's visibility is already marked we know we should assign it to the child/variation as well
 				 */
 				if($parent_product_visibility === "yes"){
-					$product_data["is_woo_all_products_sync"] = !$current_variation_product_visibility;
+					// $product_data["is_woo_all_products_sync"] = !$current_variation_product_visibility;
 					$product_data[ 'visibility' ] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE;
 				}
 				else if ($parent_product_visibility === "no"){
@@ -1760,7 +1760,7 @@ class WC_Facebook_Product {
 					 * But now have visibility published
 					 */
 					if($variation_visibility){
-						$product_data["is_woo_all_products_sync"] = !$current_variation_product_visibility;
+						// $product_data["is_woo_all_products_sync"] = !$current_variation_product_visibility;
 					}
 
 					$product_data[ 'visibility' ] = $variation_visibility ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -387,7 +387,7 @@ class WC_Facebook_Product_Feed {
 		'additional_image_link,sale_price_effective_date,sale_price,condition,' .
 		'visibility,gender,color,size,pattern,google_product_category,default_product,'.
 		'variant,gtin,quantity_to_sell_on_facebook,rich_text_description,internal_label,external_update_time,'.
-		'external_variant_id, is_woo_all_products_sync'. PHP_EOL ;
+		'external_variant_id'. PHP_EOL ;
 	}
 
 
@@ -508,7 +508,7 @@ class WC_Facebook_Product_Feed {
 		}
 
 		// Setting up Woo All Products sync flag
-		$is_woo_all_products_sync = $product_data['is_woo_all_products_sync'] || false;
+		// $is_woo_all_products_sync = $product_data['is_woo_all_products_sync'] || false;
 
 		return $product_data['retailer_id'] . ',' .
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'name' ) ) . ',' .
@@ -541,8 +541,7 @@ class WC_Facebook_Product_Feed {
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'rich_text_description' ) ) . ',' .
 		static::format_internal_labels_for_feed( static::get_value_from_product_data( $product_data, 'internal_label' ) ) . ',' .
 		static::get_value_from_product_data( $product_data, 'external_update_time' ) . ',' .
-		static::get_value_from_product_data( $product_data, 'external_variant_id' ) . ',' .
-		static::format_string_for_feed($is_woo_all_products_sync). PHP_EOL ;
+		static::get_value_from_product_data( $product_data, 'external_variant_id' ) . PHP_EOL ;
 	}
 
 	private static function format_additional_image_url( $product_image_urls ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.4.4",
+  "version": "3.5.0",
   "author": "Facebook",
   "homepage": "https://woocommerce.com/products/facebook/",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -115,5 +115,6 @@ When opening a bug on GitHub, please give us as many details as possible.
 *  Add - Added Loading States to WAUM flows by @woo-ardsouza in #3272
 *  Add - Add logging for coupon in checkout by @ajello-meta in #3279
 *  Fix - fix inconsistency between enhanced and legacy flow by @jczhuoMeta in #3285
+*  Fix - Removing the tag to get rid of warnings by @SayanPandey in #3287
 
 [See changelog for all versions](https://raw.githubusercontent.com/facebook/facebook-for-woocommerce/refs/heads/main/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -102,5 +102,15 @@ When opening a bug on GitHub, please give us as many details as possible.
 *  Add - reset connection functionality by @jczhuoMeta in #3262
 *  Fix - fixing the non static method called as static issue by @SayanPandey in #3263
 *  Fix - Fix linter errors for ./facebook-commerce.php by @ajello-meta in #3251
+*  Fix - updating banners to show the latest version as 3.5.1 by @SayanPandey in #3265
+*  Tweak - enforced product sets functionality for plugin admins by @vinkmeta in #3243
+*  Tweak - removing the product set functionality migration to Admin by @vinkmeta in #3267
+*  Tweak - removing the migration of rollout switch to Admin by @vinkmeta in #3268
+*  Fix - fix to remove html encoding in fb product sets names by @mshymon in #3266
+*  Add - trigger product sets sync in Handler on catalog ID update (new SAOff MBE onboarding flow) by @mshymon in #3270
+*  Fix - fix linter errors for ./facebook-commerce-pixel-event.php by @ajello-meta in #3248
+*  Fix - fix /variation field persistence & rich text description handling for variants by @devbodaghe in #3269
+*  Tweak - update product validation logic for checkout by @ajello-meta in #3271
+*  Fix - Adding percautionary bug fix by @SayanPandey in #3275
 
 [See changelog for all versions](https://raw.githubusercontent.com/facebook/facebook-for-woocommerce/refs/heads/main/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -113,5 +113,6 @@ When opening a bug on GitHub, please give us as many details as possible.
 *  Tweak - update product validation logic for checkout by @ajello-meta in #3271
 *  Fix - Adding precautionary bug fix by @SayanPandey in #3275
 *  Add - Added Loading States to WAUM flows by @woo-ardsouza in #3272
+*  Add - Add logging for coupon in checkout by @ajello-meta in #3279
 
 [See changelog for all versions](https://raw.githubusercontent.com/facebook/facebook-for-woocommerce/refs/heads/main/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -114,5 +114,6 @@ When opening a bug on GitHub, please give us as many details as possible.
 *  Fix - Adding precautionary bug fix by @SayanPandey in #3275
 *  Add - Added Loading States to WAUM flows by @woo-ardsouza in #3272
 *  Add - Add logging for coupon in checkout by @ajello-meta in #3279
+*  Fix - fix inconsistency between enhanced and legacy flow by @jczhuoMeta in #3285
 
 [See changelog for all versions](https://raw.githubusercontent.com/facebook/facebook-for-woocommerce/refs/heads/main/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 *  Fix - fix linter errors for ./facebook-commerce-pixel-event.php by @ajello-meta in #3248
 *  Fix - fix /variation field persistence & rich text description handling for variants by @devbodaghe in #3269
 *  Tweak - update product validation logic for checkout by @ajello-meta in #3271
-*  Fix - Adding percautionary bug fix by @SayanPandey in #3275
+*  Fix - Adding precautionary bug fix by @SayanPandey in #3275
+*  Add - Added Loading States to WAUM flows by @woo-ardsouza in #3272
 
 [See changelog for all versions](https://raw.githubusercontent.com/facebook/facebook-for-woocommerce/refs/heads/main/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -86,5 +86,6 @@ When opening a bug on GitHub, please give us as many details as possible.
 *  Add - Add usage logging for enhanced settings tabs by @ajello-meta in #3202
 *  Tweak - Remove UI of a checkbox that controls enablement of the new style feed generation by @mshymon in #3056
 *  Fix - Fix linter errors for ./includes/fbutils.php files by @ajello-meta in #3075
+*  Fix - Hotfix for Rollout Switches by @vinkmeta in #3236
 
 [See changelog for all versions](https://raw.githubusercontent.com/facebook/facebook-for-woocommerce/refs/heads/main/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -40,18 +40,51 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
-= 3.4.4 - 2025-03-26 =
-* Add - Create tests for ProductFeedUploads create endpoint by @ajello-meta in #2902
-* Add - Create tests for ProductFeedUploads read endpoint by @ajello-meta in #2903
-* Tweak - Remove phpcs:ignoreFile annotation + Enable code coverage report generation with phpunit by @sol-loup in #2897 and #2901
-* Fix - Restores the original dynamic property behavior in the AsyncRequest class by @sol-loup in #2921
-* Tweak - Changing APP to PLUGIN on README.MD by @SayanPandey in #2916
-* Tweak - Update README.md - Added noification for ownership transfer by @SayanPandey in #2910
-* Tweak - Added is_multisite logging to the update_plugin_version_configuration request by @carterbuce in #2955
-* Tweak - Add woo_commerce_retailer_id to products API request by @crisojog in #2958
-* Tweak - Syncing plugin version info by @vinkmeta in #2960
-* Fix - sync products out of stock to meta despite visibility config by @francorisso in #2952
-* Fix - Update woo_commerce_retailer_id to existing field external_variant_id by @crisojog in #2963
-* Tweak - Update readme.txt by @vinkmeta in #2949
+= 3.5.0 - 2025-05-28 =
+*  Add - Create basic checkout permalink w/ products and coupon support by @ajello-meta in #2887
+*  Add - Common Feed Upload Framework by @jmencab in #2875
+*  Fix - Fix bug where templates were not loading correctly by @ajello-meta in #2915
+*  Tweak - Change MICE to use base site url instead of shop url by @carterbuce in #2934
+*  Tweak - Improve custom checkout UI by @ajello-meta in #2930
+*  Tweak - Make custom checkout UI mobile compatible by @ajello-meta in #2942
+*  Fix - Update parsing for Checkout URL Product IDs by @carterbuce in #2935
+*  Add - Implement dummy logging util by @nealweiMeta in #2920
+*  Add - Setup cron job for batch logging with global message queue by @nealweiMeta in #2924
+*  Add - Error log request api activate by @nealweiMeta in #2933
+*  Add - Log locally with debug mode enabled by @nealweiMeta in #2939
+*  Add - Ratings and reviews feed upload by @nrostrow-meta in #2937
+*  Tweak - Feed upload skip logic and logging calls by @nrostrow-meta in #2964
+*  Add - Add function to fetch feed upload instance by @nrostrow-meta in #2970
+*  Tweak - Have feed uploads always use feed generator by @nrostrow-meta in #2971
+*  Tweak - Trigger metadata feed uploads on CPI ID change (post onboarding) by @nrostrow-meta in #2995
+*  Add - Shipping profile feed upload button by @nrostrow-meta in #3140
+*  Add - Navigation menu feed upload logic by @nrostrow-meta in #3159
+*  Fix - Fixing some fclose and logging gaps in the feed upload logic by @nrostrow-meta in #3192
+*  Add - Enabling navigation menu feed upload and adding manual sync button by @nrostrow-meta in #3223
+*  Add - Promotions feed upload by @carterbuce in #2941
+*  Add - Plugin AJAX API Framework by @sol-loup in #2928
+*  Tweak - Test Infrastructure Enhancement by @sol-loup in #2944
+*  Add - Implement telemetry logs api by @nealweiMeta in #2940
+*  Fix -  Make error logging event configurable by @nealweiMeta in #2954
+*  Add - Implement logging toggle by @nealweiMeta in #2959
+*  Fix - auto products sync by @nealweiMeta in #2978
+*  Tweak - Sync products with restriction by @nealweiMeta in #2983
+*  Fix - Fix use_enhanced_onboarding for legacy connections by @carterbuce in #2986
+*  Add - Create enhanced settings UI by @ajello-meta in #2968
+*  Add - Create new troubleshooting drawer from legacy debug settings by @ajello-meta in #2977
+*  Add - Add manual product and coupon sync buttons by @ajello-meta in #2984
+*  Tweak - Make page title in enhanced settings static by @ajello-meta in #2985
+*  Tweak - Align finalized content for logging toggle by @nealweiMeta in #2992
+*  Tweak - Improve local log by @nealweiMeta in #3009
+*  Fix - Fix free shipping coupon sync by @carterbuce in #2993
+*  Tweak - Add logging for feed generation scheduling failure by @carterbuce in #2994
+*  Tweak - Add logging in checkout for coupon code by @ajello-meta in #2991
+*  Tweak - Clean up CSS in enhanced settings UI by @ajello-meta in #2996
+*  Tweak - Remove the "Advertise" tab by @ajello-meta in #3024
+*  Tweak - Sync "Usage Count" in Promos Feed by @carterbuce in #3036
+*  Tweak - Disable mini_shops product capability for unsupported items by @carterbuce in #3084
+*  Add - Add usage logging for enhanced settings tabs by @ajello-meta in #3202
+*  Tweak - Remove UI of a checkbox that controls enablement of the new style feed generation by @mshymon in #3056
+*  Fix - Fix linter errors for ./includes/fbutils.php files by @ajello-meta in #3075
 
 [See changelog for all versions](https://raw.githubusercontent.com/facebook/facebook-for-woocommerce/refs/heads/main/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook
 Tags: meta, facebook, conversions api, catalog sync, ads
 Requires at least: 5.6
 Tested up to: 6.8.1
-Stable tag: 3.4.4
+Stable tag: 3.5.0
 Requires PHP: 7.4
 MySQL: 5.6 or greater
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -87,5 +87,20 @@ When opening a bug on GitHub, please give us as many details as possible.
 *  Tweak - Remove UI of a checkbox that controls enablement of the new style feed generation by @mshymon in #3056
 *  Fix - Fix linter errors for ./includes/fbutils.php files by @ajello-meta in #3075
 *  Fix - Hotfix for Rollout Switches by @vinkmeta in #3236
+*  Add - Opt out sync experience. by @SayanPandey in #3220
+*  Fix - Added a transient flag to avoid flooding of product set api requests by @vinkmeta in #3245
+*  Fix - Additional check for the opt-out banner by @SayanPandey in #3259
+*  Fix - Bump up GraphAPI version to 21 by @vahidkay-meta in #3219
+*  Fix - fix linter errors for ./class-wc-facebookcommerce.php by @ajello-meta in #3255
+*  Fix - fix linter errors for ./facebook-commerce-events-tracker.php by @ajello-meta in #3254
+*  Fix - fix linter errors for ./includes/Admin/Settings_Screens/Advertise.php by @ajello-meta in #3237
+*  Fix - fix linter errors for ./includes/Admin/Settings_Screens/Product_Sync.php by @ajello-meta in #3239
+*  Fix - fix function return typing for get_settings() by @ajello-meta in #3257
+*  Tweak - Addition check for opt out by @SayanPandey in #3259
+*  Tweak - Update the GraphAPI version to 21 by @vahidkay-meta in #3219
+*  Fix - Enabled rollout switch only for plugin admins by @vinkmeta in #3242
+*  Add - reset connection functionality by @jczhuoMeta in #3262
+*  Fix - fixing the non static method called as static issue by @SayanPandey in #3263
+*  Fix - Fix linter errors for ./facebook-commerce.php by @ajello-meta in #3251
 
 [See changelog for all versions](https://raw.githubusercontent.com/facebook/facebook-for-woocommerce/refs/heads/main/changelog.txt).


### PR DESCRIPTION
= 3.5.0 - 2025-05-28 =
*  Add - Create basic checkout permalink w/ products and coupon support by @ajello-meta in #2887
*  Add - Common Feed Upload Framework by @jmencab in #2875
*  Fix - Fix bug where templates were not loading correctly by @ajello-meta in #2915
*  Tweak - Change MICE to use base site url instead of shop url by @carterbuce in #2934
*  Tweak - Improve custom checkout UI by @ajello-meta in #2930
*  Tweak - Make custom checkout UI mobile compatible by @ajello-meta in #2942
*  Fix - Update parsing for Checkout URL Product IDs by @carterbuce in #2935
*  Add - Implement dummy logging util by @nealweiMeta in #2920
*  Add - Setup cron job for batch logging with global message queue by @nealweiMeta in #2924
*  Add - Error log request api activate by @nealweiMeta in #2933
*  Add - Log locally with debug mode enabled by @nealweiMeta in #2939
*  Add - Ratings and reviews feed upload by @nrostrow-meta in #2937
*  Tweak - Feed upload skip logic and logging calls by @nrostrow-meta in #2964
*  Add - Add function to fetch feed upload instance by @nrostrow-meta in #2970
*  Tweak - Have feed uploads always use feed generator by @nrostrow-meta in #2971
*  Tweak - Trigger metadata feed uploads on CPI ID change (post onboarding) by @nrostrow-meta in #2995
*  Add - Shipping profile feed upload button by @nrostrow-meta in #3140
*  Add - Navigation menu feed upload logic by @nrostrow-meta in #3159
*  Fix - Fixing some fclose and logging gaps in the feed upload logic by @nrostrow-meta in #3192
*  Add - Enabling navigation menu feed upload and adding manual sync button by @nrostrow-meta in #3223
*  Add - Promotions feed upload by @carterbuce in #2941
*  Add - Plugin AJAX API Framework by @sol-loup in #2928
*  Tweak - Test Infrastructure Enhancement by @sol-loup in #2944
*  Add - Implement telemetry logs api by @nealweiMeta in #2940
*  Fix -  Make error logging event configurable by @nealweiMeta in #2954
*  Add - Implement logging toggle by @nealweiMeta in #2959
*  Fix - auto products sync by @nealweiMeta in #2978
*  Tweak - Sync products with restriction by @nealweiMeta in #2983
*  Fix - Fix use_enhanced_onboarding for legacy connections by @carterbuce in #2986
*  Add - Create enhanced settings UI by @ajello-meta in #2968
*  Add - Create new troubleshooting drawer from legacy debug settings by @ajello-meta in #2977
*  Add - Add manual product and coupon sync buttons by @ajello-meta in #2984
*  Tweak - Make page title in enhanced settings static by @ajello-meta in #2985
*  Tweak - Align finalized content for logging toggle by @nealweiMeta in #2992
*  Tweak - Improve local log by @nealweiMeta in #3009
*  Fix - Fix free shipping coupon sync by @carterbuce in #2993
*  Tweak - Add logging for feed generation scheduling failure by @carterbuce in #2994
*  Tweak - Add logging in checkout for coupon code by @ajello-meta in #2991
*  Tweak - Clean up CSS in enhanced settings UI by @ajello-meta in #2996
*  Tweak - Remove the "Advertise" tab by @ajello-meta in #3024
*  Tweak - Sync "Usage Count" in Promos Feed by @carterbuce in #3036
*  Tweak - Disable mini_shops product capability for unsupported items by @carterbuce in #3084
*  Add - Add usage logging for enhanced settings tabs by @ajello-meta in #3202
*  Tweak - Remove UI of a checkbox that controls enablement of the new style feed generation by @mshymon in #3056
*  Fix - Fix linter errors for ./includes/fbutils.php files by @ajello-meta in #3075
*  Fix - Hotfix for Rollout Switches by @vinkmeta in #3236
*  Add - Opt out sync experience. by @SayanPandey in #3220
*  Fix - Added a transient flag to avoid flooding of product set api requests by @vinkmeta in #3245
*  Fix - Additional check for the opt-out banner by @SayanPandey in #3259
*  Fix - Bump up GraphAPI version to 21 by @vahidkay-meta in #3219
*  Fix - fix linter errors for ./class-wc-facebookcommerce.php by @ajello-meta in #3255
*  Fix - fix linter errors for ./facebook-commerce-events-tracker.php by @ajello-meta in #3254
*  Fix - fix linter errors for ./includes/Admin/Settings_Screens/Advertise.php by @ajello-meta in #3237
*  Fix - fix linter errors for ./includes/Admin/Settings_Screens/Product_Sync.php by @ajello-meta in #3239
*  Fix - fix function return typing for get_settings() by @ajello-meta in #3257
*  Tweak - Addition check for opt out by @SayanPandey in #3259
*  Tweak - Update the GraphAPI version to 21 by @vahidkay-meta in #3219
*  Fix - Enabled rollout switch only for plugin admins by @vinkmeta in #3242
*  Add - reset connection functionality by @jczhuoMeta in #3262
*  Fix - fixing the non static method called as static issue by @SayanPandey in #3263
*  Fix - Fix linter errors for ./facebook-commerce.php by @ajello-meta in #3251