### PR TITLE
Updating banners to show latest version as 3.5.1

### DIFF
--- a/includes/Handlers/PluginRender.php
+++ b/includes/Handlers/PluginRender.php
@@ -26,7 +26,7 @@ class PluginRender {
 	private \WC_Facebookcommerce $plugin;
 
 	/** @var string opt out plugin version action */
-	const ALL_PRODUCTS_PLUGIN_VERSION = '3.4.12';
+	const ALL_PRODUCTS_PLUGIN_VERSION = '3.5.1';
 
 	/** @var string opt out sync action */
 	const ACTION_OPT_OUT_OF_SYNC = 'wc_facebook_opt_out_of_sync';
@@ -88,7 +88,7 @@ class PluginRender {
 		$current_version = $this->plugin->get_version();
 		/**
 		 * Case when current version is less or equal to latest
-		 * but latest is below 3.4.12
+		 * but latest is below 3.5.1
 		 * Should show the opt in/ opt out banner
 		 */
 		if ( version_compare( $current_version, self::ALL_PRODUCTS_PLUGIN_VERSION, '<' ) ) {


### PR DESCRIPTION
## Description

Due to recent changes the Woo All Products version will be changed to 3.5.1 from 3.4.12

### Type of change

Please delete options that are not relevant.

Simple text change

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- []x I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Test Plan

Upgrade to the latest plugin and observe the banner
