### PR TITLE
Fix to remove html encoding in fb product sets names

### DIFF
--- a/includes/ProductSets/ProductSetSync.php
+++ b/includes/ProductSets/ProductSetSync.php
@@ -167,8 +167,8 @@ class ProductSetSync {
 	}
 
 	protected function build_fb_product_set_data( $wc_category ) {
-		$wc_category_name          = get_term_field( 'name', $wc_category, self::WC_PRODUCT_CATEGORY_TAXONOMY );
-		$wc_category_description   = get_term_field( 'description', $wc_category, self::WC_PRODUCT_CATEGORY_TAXONOMY );
+		$wc_category_name          = WC_Facebookcommerce_Utils::clean_string( get_term_field( 'name', $wc_category, self::WC_PRODUCT_CATEGORY_TAXONOMY ) );
+		$wc_category_description   = WC_Facebookcommerce_Utils::clean_string( get_term_field( 'description', $wc_category, self::WC_PRODUCT_CATEGORY_TAXONOMY ) );
 		$wc_category_url           = get_term_link( $wc_category, self::WC_PRODUCT_CATEGORY_TAXONOMY );
 		$wc_category_thumbnail_id  = get_term_meta( $wc_category, 'thumbnail_id', true );
 		$wc_category_thumbnail_url = wp_get_attachment_image_src( $wc_category_thumbnail_id );
@@ -178,7 +178,7 @@ class ProductSetSync {
 			$fb_product_set_metadata['cover_image_url'] = $wc_category_thumbnail_url;
 		}
 		if ( ! empty( $wc_category_description ) ) {
-			$fb_product_set_metadata['description'] = WC_Facebookcommerce_Utils::clean_string( $wc_category_description );
+			$fb_product_set_metadata['description'] = $wc_category_description;
 		}
 		if ( ! empty( $wc_category_url ) ) {
 			$fb_product_set_metadata['external_url'] = $wc_category_url;

--- a/tests/Unit/ProductSets/ProductSetSyncTest.php
+++ b/tests/Unit/ProductSets/ProductSetSyncTest.php
@@ -20,7 +20,7 @@ class ProductSetSyncTest extends WP_UnitTestCase {
     const FB_PRODUCT_SET_ID = "3720002385";
 
     const WC_CATEGORY_NAME_1 =  'Test Category 1';
-    const WC_CATEGORY_NAME_2 =  'Test Category 2';
+    const WC_CATEGORY_NAME_2 =  'Test Category 2 (with special characters: &^%$#@!~|)';
 
 	/* ------------------ Test Methods ------------------ */
 


### PR DESCRIPTION
## Description

If the category name contains special characters it is by default comes in the special html format.
For example: "Clothing (v1 & v2)" becomes "Clothing (v1 &amp; v2)".
This PR is a fix to remove the html encoding before string is passed to Meta as a product set name. 

### Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Changelog entry

- Fix to remove html encoding in fb product sets names


## Test Plan

`npm run test:php`

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before
<img width="1587" alt="Screenshot 2025-05-29 at 11 06 57" src="https://github.com/user-attachments/assets/f33251a7-5d6f-479c-a7e7-1cbdc12ba352" />


### After
<img width="1576" alt="Screenshot 2025-05-29 at 11 05 34" src="https://github.com/user-attachments/assets/66bf269c-f090-43fb-ad34-5a3c235bc46b" />
