### PR TITLE
Update product validation logic for checkout

### DIFF
--- a/includes/Checkout.php
+++ b/includes/Checkout.php
@@ -112,13 +112,13 @@ class Checkout {
 							\WC_Facebookcommerce_Utils::log_to_meta(
 								$error_message,
 								array(
-									'flow_name'       => 'checkout',
-									'flow_step'       => 'add_to_cart',
-									'incoming_params' => array(
+									'flow_name'  => 'checkout',
+									'flow_step'  => 'add_to_cart',
+									'extra_data' => [
 										'products_param' => $products_param,
 										'product_id'     => $product_id,
 										'quantity'       => $quantity,
-									),
+									],
 								)
 							);
 						}
@@ -132,13 +132,13 @@ class Checkout {
 						\WC_Facebookcommerce_Utils::log_to_meta(
 							$error_message,
 							array(
-								'flow_name'       => 'checkout',
-								'flow_step'       => 'product_quantity_validation',
-								'incoming_params' => array(
+								'flow_name'  => 'checkout',
+								'flow_step'  => 'product_quantity_validation',
+								'extra_data' => [
 									'products_param' => $products_param,
 									'product_id'     => $product_id,
 									'quantity'       => $quantity,
-								),
+								],
 							)
 						);
 					}

--- a/includes/Checkout.php
+++ b/includes/Checkout.php
@@ -84,7 +84,7 @@ class Checkout {
 				$products = explode( ',', $products_param );
 
 				foreach ( $products as $product ) {
-					list($product_id, $quantity) = explode( ':', $product );
+					list( $product_id, $quantity ) = explode( ':', $product );
 
 					// Parse the product ID. The input is sent in the Retailer ID format (see get_fb_retailer_id())
 					// The Retailer ID format is: {product_sku}_{product_id}, so we need to extract the product_id
@@ -93,31 +93,51 @@ class Checkout {
 						$product_id = end( $parts );
 					}
 
-					// Validate and add the product to the cart
-					if ( is_numeric( $product_id ) && is_numeric( $quantity ) && $quantity > 0 ) {
-						try {
-							WC()->cart->add_to_cart( $product_id, $quantity );
-						} catch ( \Exception $e ) {
-							\WC_Facebookcommerce_Utils::log_exception_immediately_to_meta(
-								$e,
+					$product_obj = wc_get_product( $product_id );
+
+					if (
+					$product_obj &&
+					$product_obj->is_purchasable() &&
+					is_numeric( $quantity ) &&
+					$quantity > 0
+					) {
+						$added = WC()->cart->add_to_cart( $product_id, $quantity );
+						if ( ! $added ) {
+							$error_message = sprintf(
+								'WC add_to_cart() failed: product_id=%s, quantity=%s',
+								$product_id,
+								$quantity
+							);
+
+							\WC_Facebookcommerce_Utils::log_to_meta(
+								$error_message,
 								array(
-									'event'           => 'checkout',
-									'event_type'      => 'checkout_permalink_template_exception',
+									'flow_name'       => 'checkout',
+									'flow_step'       => 'add_to_cart',
 									'incoming_params' => array(
 										'products_param' => $products_param,
 										'product_id'     => $product_id,
+										'quantity'       => $quantity,
 									),
 								)
 							);
 						}
 					} else {
+						$error_message = sprintf(
+							'Invalid product or quantity: product_id=%s, quantity=%s',
+							$product_id,
+							$quantity
+						);
+
 						\WC_Facebookcommerce_Utils::log_to_meta(
-							'Failed to add product to cart',
+							$error_message,
 							array(
 								'flow_name'       => 'checkout',
+								'flow_step'       => 'product_quantity_validation',
 								'incoming_params' => array(
 									'products_param' => $products_param,
 									'product_id'     => $product_id,
+									'quantity'       => $quantity,
 								),
 							)
 						);
@@ -132,33 +152,33 @@ class Checkout {
 
 			$checkout_url = wc_get_checkout_url();
 			echo '<!DOCTYPE html>
-				<html lang="en">
-				<head>
-						<meta charset="UTF-8">
-						<meta name="viewport" content="width=device-width, initial-scale=1">
-						<title>Checkout</title>
-						<style>
-								body, html {
-										margin: 0;
-										padding: 0;
-										height: 100%;
-										overflow: hidden;
-								}
-								iframe {
-										width: 100%;
-										height: 100vh;
-										border: none;
-										display: block;
-										max-width: 100%;
-										max-height: 100%;
-										box-sizing: border-box;
-								}
-						</style>
-				</head>
-				<body>
-						<iframe src="' . esc_url( $checkout_url ) . '"></iframe>
-				</body>
-				</html>';
+			<html lang="en">
+			<head>
+				<meta charset="UTF-8">
+				<meta name="viewport" content="width=device-width, initial-scale=1">
+				<title>Checkout</title>
+				<style>
+					body, html {
+						margin: 0;
+						padding: 0;
+						height: 100%;
+						overflow: hidden;
+					}
+					iframe {
+						width: 100%;
+						height: 100vh;
+						border: none;
+						display: block;
+						max-width: 100%;
+						max-height: 100%;
+						box-sizing: border-box;
+					}
+				</style>
+			</head>
+			<body>
+				<iframe src="' . esc_url( $checkout_url ) . '"></iframe>
+			</body>
+			</html>';
 
 			exit;
 		}


### PR DESCRIPTION
## Description
This PR updates product validation logic in `Checkout.php`. The `WC()->cart->add_to_cart( $product_id, $quantity )` function does not throw an exception when the product ID (or quantity) is invalid. It also does not throw an exception when a product fails to be added to the cart. The updated logic (1) uses `wc_get_product( $product_id )` to retrieve the product and validate it's existence and availability and (2) verifies that `WC()->cart->add_to_cart( $product_id, $quantity )` returns `true`.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Test Plan
1. Go to `http://test-site-i.local/fb-checkout?products=<ID>:<#>`. Fill in the "ID" and/or "#" with invalid inputs.
3. Check Meta side logging to ensure that the error logs are visible.
