### PR TITLE
[WAUM] Added Loading States for API flows

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
+++ b/assets/css/admin/facebook-for-woocommerce-whatsapp-utility.css
@@ -200,8 +200,10 @@
 }
 /* Modal footer */
 .warning-modal-footer {
+    display: flex;
+    flex-direction: row-reverse;
+    gap: 10px;
     padding: 10px 0;
-    text-align: right;
 }
 /* Close button */
 .warning-modal-close {
@@ -250,4 +252,27 @@
 .disconnect-footer {
     display: flex;
     position: relative;
+}
+.fbwa-spinner {
+    width: 8px;
+    height: 8px;
+    border: 2px solid white;
+    border-top: 2px solid transparent;
+    border-radius: 50%;
+    margin-right: 4px;
+    animation: spin 0.6s linear infinite;
+}
+@keyframes spin {
+    100% {
+        transform: rotate(360deg);
+    }
+}
+.fbwa-button {
+    display: flex !important; /* Overrides wordpress button flex property */
+    flex-direction: row;
+    align-items: center;
+}
+.fbwa-button-disabled {
+    cursor: not-allowed !important; /* Overrides wordpress cursor property */
+    opacity: 0.7;
 }

--- a/assets/js/admin/whatsapp-disconnect.js
+++ b/assets/js/admin/whatsapp-disconnect.js
@@ -32,6 +32,12 @@ jQuery( document ).ready( function( $ ) {
     if (confirmButton) {
         // Handle confirm action
         confirmButton.onclick = function() {
+            var spinnerState = $('#wc-fb-disconnect-warning-modal-confirm-loading-state');
+            var disconnectButton =  $('#wc-fb-disconnect-warning-modal-confirm');
+            var disconnectCancelBtn = $('#wc-fb-disconnect-warning-modal-cancel');
+            spinnerState.show();
+            disconnectButton.addClass('fbwa-button-disabled');
+            disconnectCancelBtn.addClass('fbwa-button-disabled');
             $.post( facebook_for_woocommerce_whatsapp_disconnect.ajax_url, {
                 action: 'wc_facebook_disconnect_whatsapp',
                 nonce:  facebook_for_woocommerce_whatsapp_disconnect.nonce
@@ -44,12 +50,14 @@ jQuery( document ).ready( function( $ ) {
                     window.location.href = url.toString();
                     console.log( 'Whatsapp Disconnect Success', response );
                 } else {
+                    spinnerState.hide();
+                    disconnectButton.removeClass('fbwa-button-disabled');
+                    disconnectCancelBtn.removeClass('fbwa-button-disabled');
                     console.log("Whatsapp Disconnect Failure!!!",response);
                 }
+                // Close the modal
+                modal.style.display = "none";
             } );
-
-            // Close the modal
-            modal.style.display = "none";
         };
     }
 

--- a/assets/js/admin/whatsapp-events.js
+++ b/assets/js/admin/whatsapp-events.js
@@ -44,6 +44,9 @@ jQuery(document).ready(function ($) {
         orderRefundedInactiveStatus.show();
     }
 
+    var saveEventBtn = $('#woocommerce-whatsapp-save-order-confirmation');
+    var cancelEventBtn = $('#woocommerce-whatsapp-cancel-order-confirmation');
+
     $('#woocommerce-whatsapp-manage-order-placed, #woocommerce-whatsapp-manage-order-fulfilled, #woocommerce-whatsapp-manage-order-refunded').click(function (event) {
         var clickedButtonId = $(event.target).attr("id");
         let view = clickedButtonId.replace("woocommerce-whatsapp-", "");
@@ -131,10 +134,13 @@ jQuery(document).ready(function ($) {
         });
     });
 
-    $('#woocommerce-whatsapp-save-order-confirmation').click(function (event) {
+    saveEventBtn.click(function (event) {
         var languageValue = $("#manage-event-language").val();
         var statusValue = $('input[name="template-status"]:checked').val();
-        console.log('Save confirmation clicked: ', languageValue, statusValue);
+        var spinnerState = $('#woocommerce-whatsapp-save-loading-state');
+        saveEventBtn.addClass('fbwa-button-disabled');
+        cancelEventBtn.addClass('fbwa-button-disabled');
+        spinnerState.show();
         $.post(facebook_for_woocommerce_whatsapp_events.ajax_url, {
             action: 'wc_facebook_whatsapp_upsert_event_config',
             nonce: facebook_for_woocommerce_whatsapp_events.nonce,
@@ -151,6 +157,9 @@ jQuery(document).ready(function ($) {
                 console.log('Whatsapp Event Config has been updated', response);
             }
             else {
+                spinnerState.hide();
+                saveEventBtn.removeClass('fbwa-button-disabled');
+                cancelEventBtn.removeClass('fbwa-button-disabled');
                 console.log('Whatsapp Event Config Update failure', response);
                 const message = facebook_for_woocommerce_whatsapp_finish.i18n.generic_error;
                 const errorNoticeHtml = `

--- a/assets/js/admin/whatsapp-finish.js
+++ b/assets/js/admin/whatsapp-finish.js
@@ -8,8 +8,13 @@
  */
 
 jQuery( document ).ready( function( $ ) {
+    var doneBtn = $('#wc-whatsapp-onboarding-finish');
+
     // handle the whatsapp finish button click
-	$( '#wc-whatsapp-onboarding-finish' ).click( function( event ) {
+	doneBtn.click( function( event ) {
+        var spinnerState = $('#wc-whatsapp-onboarding-finish-loading-state');
+        doneBtn.addClass('fbwa-button-disabled');
+        spinnerState.show();
         // call the connect API to create configs and check payment
         $.post( facebook_for_woocommerce_whatsapp_finish.ajax_url, {
 			action: 'wc_facebook_whatsapp_finish_onboarding',
@@ -46,6 +51,8 @@ jQuery( document ).ready( function( $ ) {
                       </div>
                     `;
                 $( '#payment-method-error-notice' ).html( errorNoticeHtml ).show();
+                spinnerState.hide();
+                doneBtn.removeClass('fbwa-button-disabled');
             }
 		} );
     });

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -335,10 +335,12 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 		<div id="whatsapp-onboarding-done-button" class="card-item">
 			<div class="whatsapp-onboarding-done-button">
 				<a
-					class="button button-primary"
+					class="button button-primary fbwa-button"
 					id="wc-whatsapp-onboarding-finish"
-					href="#"
-				><?php esc_html_e( 'Done', 'facebook-for-woocommerce' ); ?></a>
+					href="#">
+					<div id="wc-whatsapp-onboarding-finish-loading-state" class="fbwa-spinner fbwa-hidden-element"></div>
+					<span><?php esc_html_e( 'Done', 'facebook-for-woocommerce' ); ?></span>
+				</a>
 			</div>
 		</div>
 	</div>
@@ -518,8 +520,11 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 						<?php esc_html_e( 'Your WhatsApp Business account will be disconnected from WooCommerce, resulting in the loss of messaging features. To reconnect in the future, you\'ll need to set up the connection again. However, you can still view your old insights in WhatsApp Manager. ', 'facebook-for-woocommerce' ); ?>
 					</div>
 					<div class="warning-modal-footer">
-						<button id="wc-fb-disconnect-warning-modal-cancel" class="button"><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></button>
-						<button id="wc-fb-disconnect-warning-modal-confirm" class="button button-primary"><?php esc_html_e( 'Disconnect', 'facebook-for-woocommerce' ); ?></button>
+						<a id="wc-fb-disconnect-warning-modal-cancel" class="button fbwa-button" href="#"><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></a>
+						<a id="wc-fb-disconnect-warning-modal-confirm" class="button button-primary fbwa-button" href="#">
+							<div id="wc-fb-disconnect-warning-modal-confirm-loading-state" class="fbwa-spinner fbwa-hidden-element"></div>
+							<span><?php esc_html_e( 'Disconnect', 'facebook-for-woocommerce' ); ?></span>
+						</a>
 					</div>
 				</div>
 			</div>
@@ -648,14 +653,16 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<div class="manage-event-button">
 					<a
 						id="woocommerce-whatsapp-save-order-confirmation"
-						class="button button-primary"
-						href="#"><?php esc_html_e( 'Save', 'facebook-for-woocommerce' ); ?>
+						class="button button-primary fbwa-button"
+						href="#">
+							<div id="woocommerce-whatsapp-save-loading-state" class="fbwa-spinner fbwa-hidden-element"></div>
+							<span><?php esc_html_e( 'Save', 'facebook-for-woocommerce' ); ?></span>
 					</a>
 				</div>
 				<div class="manage-event-button">
 					<a
 						id="woocommerce-whatsapp-cancel-order-confirmation"
-						class="button"
+						class="button fbwa-button"
 						href="<?php echo esc_html( admin_url( 'admin.php?page=' . self::PAGE_ID . '&tab=' . self::ID . '&view=utility_settings' ) ); ?>"><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></a>
 				</div>
 			</div>


### PR DESCRIPTION
## Description
In this PR, I added loading state to the Connect, Disconnect, Event Configs creation flow to prevent multiple clicks and to update the end-user on the status of the API call.

### Type of change
- New feature (non-breaking change which adds functionality)



## Changelog entry
Added Loading States to WAUM flows

## Test Plan
1. Open WhatsApp Utility tab
2. Connect WhatsApp Account by clicking Done in the Onboarding view.
3. Create Event Config by clicking Save in the Manage Event view.
4. Disconnect WhatsApp Account by clicking Disconnect in the confirmation modal. 
5. Validate Spinner appears for the clicked button and the buttons are not clickable

## Screen Recording
https://github.com/user-attachments/assets/96381fc1-0d07-47c1-8327-a26b16b92403


