### PR TITLE
Deprecating Product Sync tab

### DIFF
--- a/includes/Admin/Enhanced_Settings.php
+++ b/includes/Admin/Enhanced_Settings.php
@@ -79,7 +79,6 @@ class Enhanced_Settings {
 			// TODO: Remove Product sync and Product sets tab once catalog changes are complete
 			$screens = array(
 				Settings_Screens\Shops::ID        => new Settings_Screens\Shops(),
-				Settings_Screens\Product_Sync::ID => new Settings_Screens\Product_Sync(),
 				Settings_Screens\Product_Sets::ID => new Settings_Screens\Product_Sets(),
 			);
 		} else {

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -77,7 +77,6 @@ class Settings {
 		$last         = ( $is_connected ) ? $connection : $advertise;
 
 		$screens = array(
-			Settings_Screens\Product_Sync::ID => new Settings_Screens\Product_Sync(),
 			Settings_Screens\Product_Sets::ID => new Settings_Screens\Product_Sets(),
 		);
 
@@ -182,9 +181,6 @@ class Settings {
 				switch ( $_GET['tab'] ) {
 					case Connection::ID:
 						$crumbs[] = __( 'Connection', 'facebook-for-woocommerce' );
-						break;
-					case Settings_Screens\Product_Sync::ID:
-						$crumbs[] = __( 'Product sync', 'facebook-for-woocommerce' );
 						break;
 					case Settings_Screens\Advertise::ID:
 						$crumbs[] = __( 'Advertise', 'facebook-for-woocommerce' );

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -20,6 +20,9 @@ use WooCommerce\Facebook\Products\Sync;
 
 /**
  * The Product Sync settings screen object.
+ * @deprecated
+ * From version 3.5.1 onwards product sync tab will no longer be used across the app and should be
+ * removed from existence after WooAllProducts happen.
  */
 class Product_Sync extends Abstract_Settings_Screen {
 


### PR DESCRIPTION
## Description

Since most important  Sync controls are there in MICE, the product sync tab has no use.
The excluded categories and tags has also been removed in last PR.

### Type of change

Please delete options that are not relevant.

Few code deprecation.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Test Plan

Go to marketing tab and click facebook, you should not see any Product Sync tab

## Screenshots
### Before

<img width="776" alt="Screenshot 2025-05-29 at 9 04 20 pm" src="https://github.com/user-attachments/assets/e1ee2be2-c195-4150-b1d1-31a91e600d0e" />


### After
<img width="1082" alt="Screenshot 2025-05-29 at 9 04 42 pm" src="https://github.com/user-attachments/assets/cec254ec-c225-4e76-bdf7-e8066271690a" />
