### PR TITLE
Removed and ignored unused variables

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -242,8 +242,8 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 			new WooCommerce\Facebook\API\Plugin\InitializeRestAPI();
 			$this->connection_handler = new WooCommerce\Facebook\Handlers\Connection( $this );
 			new WooCommerce\Facebook\Handlers\MetaExtension();
-			$this->webhook_handler          = new WooCommerce\Facebook\Handlers\WebHook( $this );
-			$this->whatsapp_webhook_handler = new WooCommerce\Facebook\Handlers\Whatsapp_Webhook( $this );
+			$this->webhook_handler          = new WooCommerce\Facebook\Handlers\WebHook();
+			$this->whatsapp_webhook_handler = new WooCommerce\Facebook\Handlers\Whatsapp_Webhook();
 			$this->tracker                  = new WooCommerce\Facebook\Utilities\Tracker();
 			$this->rollout_switches         = new WooCommerce\Facebook\RolloutSwitches( $this );
 

--- a/includes/Framework/Plugin.php
+++ b/includes/Framework/Plugin.php
@@ -713,6 +713,7 @@ abstract class Plugin {
 	 *        (ie a gateway that supports both credit cards and echecks)
 	 * @return string plugin settings URL
 	 */
+	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
 	public function get_settings_url( $plugin_id = null ) {
 		// stub method
 		return '';

--- a/includes/Handlers/WebHook.php
+++ b/includes/Handlers/WebHook.php
@@ -25,8 +25,6 @@ class WebHook {
 	/**
 	 * Constructs a new WebHook.
 	 *
-	 * @param \WC_Facebookcommerce $plugin Plugin instance.
-	 *
 	 * @since 2.3.0
 	 */
 	public function __construct() {

--- a/includes/Handlers/WebHook.php
+++ b/includes/Handlers/WebHook.php
@@ -29,7 +29,7 @@ class WebHook {
 	 *
 	 * @since 2.3.0
 	 */
-	public function __construct( \WC_Facebookcommerce $plugin ) {
+	public function __construct() {
 		add_action( 'rest_api_init', array( $this, 'init_webhook_endpoint' ) );
 	}
 

--- a/includes/Handlers/Whatsapp_Webhook.php
+++ b/includes/Handlers/Whatsapp_Webhook.php
@@ -26,7 +26,7 @@ class Whatsapp_Webhook {
 	 *
 	 * @since 2.3.0
 	 */
-	public function __construct( \WC_Facebookcommerce $plugin ) {
+	public function __construct() {
 		add_action( 'rest_api_init', array( $this, 'init_whatsapp_webhook_endpoint' ) );
 	}
 

--- a/includes/Handlers/Whatsapp_Webhook.php
+++ b/includes/Handlers/Whatsapp_Webhook.php
@@ -22,8 +22,6 @@ class Whatsapp_Webhook {
 	/**
 	 * Constructs a new Whatsapp WebHook.
 	 *
-	 * @param \WC_Facebookcommerce $plugin Plugin instance.
-	 *
 	 * @since 2.3.0
 	 */
 	public function __construct() {

--- a/includes/ProductSets/ProductSetSync.php
+++ b/includes/ProductSets/ProductSetSync.php
@@ -58,6 +58,7 @@ class ProductSetSync {
 	 * @param int   $tt_id Term taxonomy ID.
 	 * @param array $args Arguments.
 	 */
+	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
 	public function on_create_or_update_product_wc_category_callback( $term_id, $tt_id, $args ) {
 		try {
 			if ( ! $this->is_sync_enabled() ) {
@@ -84,6 +85,7 @@ class ProductSetSync {
 	 * @param WP_Term $deleted_term Copy of the already-deleted term.
 	 * @param array   $object_ids List of term object IDs.
 	 */
+	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
 	public function on_delete_wc_product_category_callback( $term_id, $tt_id, $deleted_term, $object_ids ) {
 		try {
 			if ( ! $this->is_sync_enabled() ) {


### PR DESCRIPTION
## Description

PHPCS report is full of warnings and errors making it difficult to find the issue introduced by our latest changes. I'm starting to cleanup the old issues that we can see in the report.
In this diff I've removed warnings around unused variables. I've removed unused variable sin few cases but in other cases we can't remove it as they are callback functions for WooCommerce library hooks so their signatures can't be changed.

### Type of change

- Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fixed unused variables