### PR TITLE
Strict comparisons wherever it was missing in the plugin

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -839,7 +839,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			$purchase_tracked_flag = '_wc_' . facebook_for_woocommerce()->get_id() . '_purchase_tracked_' . $order_id;
 
 			// Return if this Purchase event has already been tracked
-			if ( 'yes' === get_transient( $purchase_tracked_flag ) || $order->meta_exists( '_meta_purchase_tracked' ) || ! in_array( $order_state, $valid_purchase_order_states ) ) {
+			if ( 'yes' === get_transient( $purchase_tracked_flag ) || $order->meta_exists( '_meta_purchase_tracked' ) || ! in_array( $order_state, $valid_purchase_order_states, true ) ) {
 				return;
 			}
 
@@ -1124,7 +1124,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			// The fields contain country, so we do not need to add a condition
 			foreach ( $user_data as $field => $value ) {
 				if ( null === $value || '' === $value ||
-					! in_array( $field, $this->aam_settings->get_enabled_automatic_matching_fields() )
+					! in_array( $field, $this->aam_settings->get_enabled_automatic_matching_fields(), true )
 				) {
 					unset( $user_data[ $field ] );
 				}

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1610,7 +1610,7 @@ class Admin {
 		}
 
 		// ALWAYS save Facebook field data (this fixes the PR #2931 breaking change)
-		$posted_param    = 'variable_' . \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION;
+		$posted_param = 'variable_' . \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION;
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Intentionally getting raw value to apply different sanitization methods below
 		$description_raw = isset( $_POST[ $posted_param ][ $index ] ) ? wp_unslash( $_POST[ $posted_param ][ $index ] ) : null;
 
@@ -2323,7 +2323,7 @@ class Admin {
 			}
 
 			// If we found a match and haven't processed this field yet
-			if ( $matched_facebook_field && ! in_array( $field_name, $processed_fields ) ) {
+			if ( $matched_facebook_field && ! in_array( $field_name, $processed_fields, true ) ) {
 				$values = [];
 
 				if ( $attribute->is_taxonomy() ) {

--- a/includes/Framework/AdminMessageHandler.php
+++ b/includes/Framework/AdminMessageHandler.php
@@ -103,7 +103,7 @@ class AdminMessageHandler {
 	 */
 	public function load_messages() {
 		$message_id_get_name = isset( $_GET[ self::MESSAGE_ID_GET_NAME ] ) ? wc_clean( wp_unslash( $_GET[ self::MESSAGE_ID_GET_NAME ] ) ) : false;
-		if ( $message_id_get_name && $this->get_message_id() == $message_id_get_name ) {
+		if ( $message_id_get_name && $this->get_message_id() === $message_id_get_name ) {
 			$memo = get_transient( self::MESSAGE_TRANSIENT_PREFIX . $message_id_get_name );
 			if ( isset( $memo['errors'] ) ) {
 				$this->errors = $memo['errors'];

--- a/includes/Framework/Plugin.php
+++ b/includes/Framework/Plugin.php
@@ -477,7 +477,7 @@ abstract class Plugin {
 		$messages   = [];
 		$messages[] = isset( $data['uri'] ) && $data['uri'] ? 'Request' : 'Response';
 		foreach ( (array) $data as $key => $value ) {
-			$messages[] = trim( sprintf( '%s: %s', $key, is_array( $value ) || ( is_object( $value ) && 'stdClass' == get_class( $value ) ) ? print_r( (array) $value, true ) : $value ) );
+			$messages[] = trim( sprintf( '%s: %s', $key, is_array( $value ) || ( is_object( $value ) && 'stdClass' === get_class( $value ) ) ? print_r( (array) $value, true ) : $value ) );
 		}
 		return implode( "\n", $messages ) . "\n";
 	}

--- a/includes/Products/FBCategories.php
+++ b/includes/Products/FBCategories.php
@@ -83,9 +83,9 @@ class FBCategories {
 		// TODO: can perform more validations here.
 		switch ( $attribute['type'] ) {
 			case 'enum':
-				return in_array( strtolower( $value ), $attribute['enum_values'] );
+				return in_array( strtolower( $value ), $attribute['enum_values'], true );
 			case 'boolean':
-				return in_array( $value, array( 'yes', 'no' ) );
+				return in_array( $value, array( 'yes', 'no' ), true );
 			default:
 				return true;
 		}

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -357,7 +357,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 				// Each field that is not present in AAM settings or is empty is deleted from user data
 				foreach ( $user_data as $field => $value ) {
 					if ( null === $value || '' === $value
-						|| ! in_array( $field, $aam_settings->get_enabled_automatic_matching_fields() )
+						|| ! in_array( $field, $aam_settings->get_enabled_automatic_matching_fields(), true )
 					) {
 						unset( $user_data[ $field ] );
 					}
@@ -621,7 +621,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 				$parent_product_ids[ $parent_id ] = true;
 
 				// Include variations with published parents only.
-				if ( in_array( $parent_id, $product_ids ) ) {
+				if ( in_array( $parent_id, $product_ids, true ) ) {
 					$product_ids[] = $post_id;
 				}
 			}


### PR DESCRIPTION
## Description

PHPCS report is full of warnings and errors making it difficult to find the issue introduced by our latest changes. I'm starting to cleanup the old issues that we can see in the report.
In this diff, I've added Strict comparisons wherever it was missing in the plugin.

### Type of change

- Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Strict comparisons wherever it was missing in the plugin

