### PR TITLE
Add logging for coupon in checkout

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1610,7 +1610,7 @@ class Admin {
 		}
 
 		// ALWAYS save Facebook field data (this fixes the PR #2931 breaking change)
-		$posted_param    = 'variable_' . \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION;
+		$posted_param = 'variable_' . \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION;
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Intentionally getting raw value to apply different sanitization methods below
 		$description_raw = isset( $_POST[ $posted_param ][ $index ] ) ? wp_unslash( $_POST[ $posted_param ][ $index ] ) : null;
 

--- a/includes/Checkout.php
+++ b/includes/Checkout.php
@@ -84,7 +84,7 @@ class Checkout {
 				$products = explode( ',', $products_param );
 
 				foreach ( $products as $product ) {
-					list($product_id, $quantity) = explode( ':', $product );
+					list( $product_id, $quantity ) = explode( ':', $product );
 
 					// Parse the product ID. The input is sent in the Retailer ID format (see get_fb_retailer_id())
 					// The Retailer ID format is: {product_sku}_{product_id}, so we need to extract the product_id
@@ -93,32 +93,44 @@ class Checkout {
 						$product_id = end( $parts );
 					}
 
-					// Validate and add the product to the cart
-					if ( is_numeric( $product_id ) && is_numeric( $quantity ) && $quantity > 0 ) {
-						try {
-							WC()->cart->add_to_cart( $product_id, $quantity );
-						} catch ( \Exception $e ) {
-							\WC_Facebookcommerce_Utils::log_exception_immediately_to_meta(
-								$e,
+					$product_obj = wc_get_product( $product_id );
+
+					if (
+					$product_obj &&
+					$product_obj->is_purchasable() &&
+					is_numeric( $quantity ) &&
+					$quantity > 0
+					) {
+						$added = WC()->cart->add_to_cart( $product_id, $quantity );
+						if ( ! $added ) {
+							$error_message = sprintf(
+								'WC add_to_cart() failed: product_id=%s, quantity=%s',
+								$product_id,
+								$quantity
+							);
+
+							\WC_Facebookcommerce_Utils::log_to_meta(
+								$error_message,
 								array(
-									'event'           => 'checkout',
-									'event_type'      => 'checkout_permalink_template_exception',
-									'incoming_params' => array(
-										'products_param' => $products_param,
-										'product_id'     => $product_id,
-									),
+									'flow_name'       => 'checkout',
+									'flow_step'       => 'add_to_cart',
+									'extra_data'   => [ 'products_param' => $products_param, 'product_id' => $product_id, 'quantity' => $quantity, ],
 								)
 							);
 						}
 					} else {
+						$error_message = sprintf(
+							'Invalid product or quantity: product_id=%s, quantity=%s',
+							$product_id,
+							$quantity
+						);
+
 						\WC_Facebookcommerce_Utils::log_to_meta(
-							'Failed to add product to cart',
+							$error_message,
 							array(
 								'flow_name'       => 'checkout',
-								'incoming_params' => array(
-									'products_param' => $products_param,
-									'product_id'     => $product_id,
-								),
+								'flow_step'       => 'product_quantity_validation',
+								'extra_data'   => [ 'products_param' => $products_param, 'product_id' => $product_id, 'quantity' => $quantity, ],
 							)
 						);
 					}
@@ -152,33 +164,33 @@ class Checkout {
 
 			$checkout_url = wc_get_checkout_url();
 			echo '<!DOCTYPE html>
-				<html lang="en">
-				<head>
-						<meta charset="UTF-8">
-						<meta name="viewport" content="width=device-width, initial-scale=1">
-						<title>Checkout</title>
-						<style>
-								body, html {
-										margin: 0;
-										padding: 0;
-										height: 100%;
-										overflow: hidden;
-								}
-								iframe {
-										width: 100%;
-										height: 100vh;
-										border: none;
-										display: block;
-										max-width: 100%;
-										max-height: 100%;
-										box-sizing: border-box;
-								}
-						</style>
-				</head>
-				<body>
-						<iframe src="' . esc_url( $checkout_url ) . '"></iframe>
-				</body>
-				</html>';
+			<html lang="en">
+			<head>
+				<meta charset="UTF-8">
+				<meta name="viewport" content="width=device-width, initial-scale=1">
+				<title>Checkout</title>
+				<style>
+					body, html {
+						margin: 0;
+						padding: 0;
+						height: 100%;
+						overflow: hidden;
+					}
+					iframe {
+						width: 100%;
+						height: 100vh;
+						border: none;
+						display: block;
+						max-width: 100%;
+						max-height: 100%;
+						box-sizing: border-box;
+					}
+				</style>
+			</head>
+			<body>
+				<iframe src="' . esc_url( $checkout_url ) . '"></iframe>
+			</body>
+			</html>';
 
 			exit;
 		}

--- a/includes/Checkout.php
+++ b/includes/Checkout.php
@@ -112,9 +112,13 @@ class Checkout {
 							\WC_Facebookcommerce_Utils::log_to_meta(
 								$error_message,
 								array(
-									'flow_name'       => 'checkout',
-									'flow_step'       => 'add_to_cart',
-									'extra_data'   => [ 'products_param' => $products_param, 'product_id' => $product_id, 'quantity' => $quantity, ],
+									'flow_name'  => 'checkout',
+									'flow_step'  => 'add_to_cart',
+									'extra_data' => [
+										'products_param' => $products_param,
+										'product_id'     => $product_id,
+										'quantity'       => $quantity,
+									],
 								)
 							);
 						}
@@ -128,9 +132,13 @@ class Checkout {
 						\WC_Facebookcommerce_Utils::log_to_meta(
 							$error_message,
 							array(
-								'flow_name'       => 'checkout',
-								'flow_step'       => 'product_quantity_validation',
-								'extra_data'   => [ 'products_param' => $products_param, 'product_id' => $product_id, 'quantity' => $quantity, ],
+								'flow_name'  => 'checkout',
+								'flow_step'  => 'product_quantity_validation',
+								'extra_data' => [
+									'products_param' => $products_param,
+									'product_id'     => $product_id,
+									'quantity'       => $quantity,
+								],
 							)
 						);
 					}

--- a/includes/Checkout.php
+++ b/includes/Checkout.php
@@ -84,7 +84,7 @@ class Checkout {
 				$products = explode( ',', $products_param );
 
 				foreach ( $products as $product ) {
-					list( $product_id, $quantity ) = explode( ':', $product );
+					list($product_id, $quantity) = explode( ':', $product );
 
 					// Parse the product ID. The input is sent in the Retailer ID format (see get_fb_retailer_id())
 					// The Retailer ID format is: {product_sku}_{product_id}, so we need to extract the product_id
@@ -93,52 +93,32 @@ class Checkout {
 						$product_id = end( $parts );
 					}
 
-					$product_obj = wc_get_product( $product_id );
-
-					if (
-					$product_obj &&
-					$product_obj->is_purchasable() &&
-					is_numeric( $quantity ) &&
-					$quantity > 0
-					) {
-						$added = WC()->cart->add_to_cart( $product_id, $quantity );
-						if ( ! $added ) {
-							$error_message = sprintf(
-								'WC add_to_cart() failed: product_id=%s, quantity=%s',
-								$product_id,
-								$quantity
-							);
-
-							\WC_Facebookcommerce_Utils::log_to_meta(
-								$error_message,
+					// Validate and add the product to the cart
+					if ( is_numeric( $product_id ) && is_numeric( $quantity ) && $quantity > 0 ) {
+						try {
+							WC()->cart->add_to_cart( $product_id, $quantity );
+						} catch ( \Exception $e ) {
+							\WC_Facebookcommerce_Utils::log_exception_immediately_to_meta(
+								$e,
 								array(
-									'flow_name'  => 'checkout',
-									'flow_step'  => 'add_to_cart',
-									'extra_data' => [
+									'event'           => 'checkout',
+									'event_type'      => 'checkout_permalink_template_exception',
+									'incoming_params' => array(
 										'products_param' => $products_param,
 										'product_id'     => $product_id,
-										'quantity'       => $quantity,
-									],
+									),
 								)
 							);
 						}
 					} else {
-						$error_message = sprintf(
-							'Invalid product or quantity: product_id=%s, quantity=%s',
-							$product_id,
-							$quantity
-						);
-
 						\WC_Facebookcommerce_Utils::log_to_meta(
-							$error_message,
+							'Failed to add product to cart',
 							array(
-								'flow_name'  => 'checkout',
-								'flow_step'  => 'product_quantity_validation',
-								'extra_data' => [
+								'flow_name'       => 'checkout',
+								'incoming_params' => array(
 									'products_param' => $products_param,
 									'product_id'     => $product_id,
-									'quantity'       => $quantity,
-								],
+								),
 							)
 						);
 					}
@@ -147,38 +127,58 @@ class Checkout {
 
 			$coupon_code = get_query_var( 'coupon' );
 			if ( $coupon_code ) {
-				WC()->cart->apply_coupon( sanitize_text_field( $coupon_code ) );
+				$coupon_code_sanitized = sanitize_text_field( $coupon_code );
+				WC()->cart->apply_coupon( $coupon_code_sanitized );
+
+				if ( ! in_array( $coupon_code_sanitized, WC()->cart->get_applied_coupons(), true ) ) {
+					$error_message = sprintf(
+						'Failed to apply coupon: %s',
+						$coupon_code_sanitized
+					);
+
+					\WC_Facebookcommerce_Utils::log_to_meta(
+						$error_message,
+						array(
+							'flow_name'  => 'checkout',
+							'flow_step'  => 'apply_coupon',
+							'extra_data' => [
+								'coupon_param' => $coupon_code,
+								'coupon_code'  => $coupon_code_sanitized,
+							],
+						)
+					);
+				}
 			}
 
 			$checkout_url = wc_get_checkout_url();
 			echo '<!DOCTYPE html>
-			<html lang="en">
-			<head>
-				<meta charset="UTF-8">
-				<meta name="viewport" content="width=device-width, initial-scale=1">
-				<title>Checkout</title>
-				<style>
-					body, html {
-						margin: 0;
-						padding: 0;
-						height: 100%;
-						overflow: hidden;
-					}
-					iframe {
-						width: 100%;
-						height: 100vh;
-						border: none;
-						display: block;
-						max-width: 100%;
-						max-height: 100%;
-						box-sizing: border-box;
-					}
-				</style>
-			</head>
-			<body>
-				<iframe src="' . esc_url( $checkout_url ) . '"></iframe>
-			</body>
-			</html>';
+				<html lang="en">
+				<head>
+						<meta charset="UTF-8">
+						<meta name="viewport" content="width=device-width, initial-scale=1">
+						<title>Checkout</title>
+						<style>
+								body, html {
+										margin: 0;
+										padding: 0;
+										height: 100%;
+										overflow: hidden;
+								}
+								iframe {
+										width: 100%;
+										height: 100vh;
+										border: none;
+										display: block;
+										max-width: 100%;
+										max-height: 100%;
+										box-sizing: border-box;
+								}
+						</style>
+				</head>
+				<body>
+						<iframe src="' . esc_url( $checkout_url ) . '"></iframe>
+				</body>
+				</html>';
 
 			exit;
 		}


### PR DESCRIPTION
## Description
This PR adds logging for coupon codes in `Checkout.php`. The `WC()->cart->apply_coupon( $coupon_code )` function does not throw an exception when the coupon is invalid. The updated logic adds a conditional check that verifies the coupon is correctly applied to the cart, or logs the error if not correctly applied to the cart.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Test Plan
1. Go to `http://test-site-i.local/fb-checkout?products=<ID>:<#>&coupon=<code>`. Fill in the "ID" and/or "#" with valid inputs. Fill in "code" with an invalid input.
3. Check Meta side logging to ensure that the error logs are visible for `flow_name=checkout` and `flow_step=apply_coupon`.
