### PR TITLE
Add flags for feed intervals to avoid multiple feed generations

### DIFF
--- a/includes/Feed/FeedConfigurationDetection.php
+++ b/includes/Feed/FeedConfigurationDetection.php
@@ -36,6 +36,11 @@ class FeedConfigurationDetection {
 	 * @return void
 	 */
 	public function track_data_source_feed_tracker_info() {
+		$flag_name = '_wc_facebook_for_woocommerce_track_data_source_feed_tracker_info';
+		if ( 'yes' === get_transient( $flag_name ) ) {
+			return;
+		}
+		set_transient( $flag_name, 'yes', DAY_IN_SECONDS );
 		try {
 			$info = $this->get_data_source_feed_tracker_info();
 			facebook_for_woocommerce()->get_tracker()->track_facebook_feed_config( $info );

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -161,6 +161,11 @@ class Feed {
 	 * @since 1.11.0
 	 */
 	public function schedule_feed_generation() {
+		$flag_name = '_wc_facebook_for_woocommerce_schedule_feed_generation';
+		if ( 'yes' === get_transient( $flag_name ) ) {
+			return;
+		}
+		set_transient( $flag_name, 'yes', HOUR_IN_SECONDS );
 		$integration   = facebook_for_woocommerce()->get_integration();
 		$configured_ok = $integration && $integration->is_configured();
 		// Only schedule feed job if store has not opted out of product sync.


### PR DESCRIPTION
## Description

Add flags for feed intervals to avoid multiple feed generations

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Add flags for feed intervals to avoid multiple feed generations