### PR TITLE
Woo All Products | All Products Sync on Opt in

### DIFF
--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -647,11 +647,11 @@ class AJAX {
 		$sync_enabled_meta_query = array(
 			'relation' => 'OR',
 			array(
-				'key'   => Products::SYNC_ENABLED_META_KEY,
+				'key'   => Products::get_product_sync_meta_key(),
 				'value' => 'yes',
 			),
 			array(
-				'key'     => Products::SYNC_ENABLED_META_KEY,
+				'key'     => Products::get_product_sync_meta_key(),
 				'compare' => 'NOT EXISTS',
 			),
 		);

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -608,7 +608,7 @@ class Admin {
 						'post_type'  => 'product',
 						'meta_query' => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 							array(
-								'key'   => Products::SYNC_ENABLED_META_KEY,
+								'key'   => Products::get_product_sync_meta_key(),
 								'value' => 'no',
 							),
 						),
@@ -623,7 +623,7 @@ class Admin {
 						'post_type'  => 'product_variation',
 						'meta_query' => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 							array(
-								'key'   => Products::SYNC_ENABLED_META_KEY,
+								'key'   => Products::get_product_sync_meta_key(),
 								'value' => 'no',
 							),
 						),
@@ -677,11 +677,11 @@ class Admin {
 		$meta_query = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			'relation' => 'OR',
 			array(
-				'key'   => Products::SYNC_ENABLED_META_KEY,
+				'key'   => Products::get_product_sync_meta_key(),
 				'value' => 'yes',
 			),
 			array(
-				'key'     => Products::SYNC_ENABLED_META_KEY,
+				'key'     => Products::get_product_sync_meta_key(),
 				'compare' => 'NOT EXISTS',
 			),
 		);
@@ -1100,7 +1100,7 @@ class Admin {
 		global $post;
 
 		// all products have sync enabled unless explicitly disabled
-		$sync_enabled = 'no' !== get_post_meta( $post->ID, Products::SYNC_ENABLED_META_KEY, true );
+		$sync_enabled = 'no' !== get_post_meta( $post->ID, Products::get_product_sync_meta_key(), true );
 		$visibility   = get_post_meta( $post->ID, Products::VISIBILITY_META_KEY, true );
 		$is_visible   = $visibility ? wc_string_to_bool( $visibility ) : true;
 		$product      = wc_get_product( $post );

--- a/includes/Handlers/PluginRender.php
+++ b/includes/Handlers/PluginRender.php
@@ -135,7 +135,7 @@ class PluginRender {
 		}
 	}
 
-	public function opt_out_of_sync_clicked() {
+	public static function opt_out_of_sync_clicked() {
 			$latest_date = gmdate( 'Y-m-d H:i:s' );
 			update_option( self::MASTER_SYNC_OPT_OUT_TIME, $latest_date );
 			wp_send_json_success( 'Opted out successfully' );
@@ -145,7 +145,7 @@ class PluginRender {
 	 * Banner for initmation of WooAllProducts version will show up
 	 * after a week
 	 */
-	public function reset_upcoming_version_banners() {
+	public static function reset_upcoming_version_banners() {
 		set_transient( 'upcoming_woo_all_products_banner_hide', true, 7 * DAY_IN_SECONDS );
 	}
 

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -20,14 +20,6 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) {
  * @since 2.5.0
  */
 class ProductValidator {
-
-	/**
-	 * The meta key used to flag whether a product should be synced in Facebook
-	 *
-	 * @var string
-	 */
-	public const SYNC_ENABLED_META_KEY = '_wc_facebook_sync_enabled';
-
 	/**
 	 * Maximum allowed attributes in a variation;
 	 *
@@ -328,7 +320,7 @@ class ProductValidator {
 		if ( $this->product->is_type( 'variable' ) ) {
 			foreach ( $this->product->get_children() as $child_id ) {
 				$child_product = wc_get_product( $child_id );
-				if ( $child_product && 'no' !== $child_product->get_meta( self::SYNC_ENABLED_META_KEY ) ) {
+				if ( $child_product && 'no' !== $child_product->get_meta( Products::get_product_sync_meta_key() ) ) {
 					// At least one product is "sync-enabled" so bail before exception.
 					return;
 				}
@@ -340,7 +332,7 @@ class ProductValidator {
 			/**
 			 * This check will run for background jobs like sync all and feeds
 			 */
-			$parent_sync = $this->product_parent->get_meta( self::SYNC_ENABLED_META_KEY ) || null;
+			$parent_sync = $this->product_parent->get_meta( Products::get_product_sync_meta_key() ) || null;
 
 			if ( 'yes' === $parent_sync ) {
 				return;
@@ -350,7 +342,7 @@ class ProductValidator {
 				$variation_sync = false;
 				foreach ( $this->product_parent->get_children() as $child_id ) {
 					$child_product = wc_get_product( $child_id );
-					if ( $child_product && 'no' !== $child_product->get_meta( self::SYNC_ENABLED_META_KEY ) ) {
+					if ( $child_product && 'no' !== $child_product->get_meta( Products::get_product_sync_meta_key() ) ) {
 						// At least one product is "sync-enabled" so bail before exception.
 						$variation_sync = true;
 						break;
@@ -361,7 +353,7 @@ class ProductValidator {
 				 * Updating parent level sync for UI issues and
 				 * Future variation checks for sync
 				 */
-				update_post_meta( $this->product_parent->get_id(), self::SYNC_ENABLED_META_KEY, $variation_sync ? 'yes' : 'no' );
+				update_post_meta( $this->product_parent->get_id(), Products::get_product_sync_meta_key(), $variation_sync ? 'yes' : 'no' );
 				if ( $variation_sync ) {
 					return;
 				}
@@ -369,7 +361,7 @@ class ProductValidator {
 
 			// Variable product has no variations with sync enabled so it shouldn't be synced.
 			throw $invalid_exception;
-		} elseif ( 'no' === $this->product->get_meta( self::SYNC_ENABLED_META_KEY ) ) {
+		} elseif ( 'no' === $this->product->get_meta( Products::get_product_sync_meta_key() ) ) {
 				throw $invalid_exception;
 		}
 	}

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -14,6 +14,7 @@ namespace WooCommerce\Facebook;
 use WC_Facebook_Product;
 use WooCommerce\Facebook\Framework\Helper;
 use WooCommerce\Facebook\Framework\Plugin\Exception as PluginException;
+use WooCommerce\Facebook\Handlers\PluginRender;
 
 defined( 'ABSPATH' ) or exit;
 
@@ -26,6 +27,9 @@ class Products {
 
 	/** @var string the meta key used to flag whether a product should be synced in Facebook */
 	const SYNC_ENABLED_META_KEY = '_wc_facebook_sync_enabled';
+
+	/** @var string the meta key used to flag whether a product should be synced in Facebook for woo all products opted in users */
+	const OPTEN_IN_SYNC_ENABLED_META_KEY = '_wc_facebook_sync_enabled_v2';
 
 	// TODO probably we'll want to run some upgrade routine or somehow move meta keys to follow the same patter e.g. _wc_facebook_visibility {FN 2020-01-17}
 	/** @var string the meta key used to flag whether a product should be visible in Facebook */
@@ -75,20 +79,22 @@ class Products {
 	 */
 	private static function set_sync_for_products( array $products, $enabled ) {
 		$enabled = wc_bool_to_string( $enabled );
+		$product_sync_meta_key = self::get_product_sync_meta_key();
+
 		foreach ( $products as $product ) {
 			if ( $product instanceof \WC_Product ) {
 				if ( $product->is_type( 'variable' ) ) {
 					foreach ( $product->get_children() as $variation ) {
 						$product_variation = wc_get_product( $variation );
 						if ( $product_variation instanceof \WC_Product ) {
-							$product_variation->update_meta_data( self::SYNC_ENABLED_META_KEY, $enabled );
+							$product_variation->update_meta_data( $product_sync_meta_key, $enabled );
 							$product_variation->save_meta_data();
 						}
 					}
 				}
 
 				// Adding sync mode settings to simple product as well as main product for variants.
-				$product->update_meta_data( self::SYNC_ENABLED_META_KEY, $enabled );
+				$product->update_meta_data( $product_sync_meta_key, $enabled );
 				$product->save_meta_data();
 
 				// Remove excluded product from FB.
@@ -98,6 +104,23 @@ class Products {
 
 			}//end if
 		}//end foreach
+	}
+
+	/**
+	 * Chooses a particular key for product sync
+	 * based on user opt in status for Woo all products
+	 *
+	 * @since 3.5.1
+	 *
+	 * @param \WC_Product[] $products an array of product objects
+	 */
+	public static function get_product_sync_meta_key() {
+		if(PluginRender::is_master_sync_on()){
+			return self::SYNC_ENABLED_META_KEY;
+		}
+		else {
+			return self::OPTEN_IN_SYNC_ENABLED_META_KEY;
+		}
 	}
 
 	/**

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1708,9 +1708,18 @@ class WC_Facebook_Product {
 		// $product_data[ 'unmapped_attributes' ] = $this->get_unmapped_attributes();
 		$product_data[ 'disabled_capabilities' ] = $this->get_disabled_capabilities();
 
+
+		/**
+		 * As part of Woo All Products if user was not syncing a product before and currently is syncing
+		 * That will be tagged as well
+		 * If code has reached this point sync is enabled
+		*/
+		$previous_sync_status = 'yes' === $this->get_meta( Products::SYNC_ENABLED_META_KEY);
+
 		if($this->get_type() === "variation"){
 			$parent_id = $this->woo_product->get_parent_id();	
 			$parent_product =  wc_get_product( $parent_id );
+			$previous_sync_status = 'yes' === $parent_product->get_meta( Products::SYNC_ENABLED_META_KEY);
 
 			if( $parent_product ){
 				$parent_product_visibility =  $parent_product->get_meta( Products::VISIBILITY_META_KEY );
@@ -1764,6 +1773,10 @@ class WC_Facebook_Product {
 					update_post_meta($parent_id,Products::VISIBILITY_META_KEY, $variation_visibility ? "yes" : "no");
 				}
 			}
+		}
+
+		if(!$previous_sync_status){
+			$product_data["is_woo_all_products_sync"] = true;
 		}
 
 		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {


### PR DESCRIPTION
## Description

If user has opted in for Woo All Products after ver 3.5.0,
We will sync all the products.

### Type of change

This is a feature where we introduce a new field so that when user opts in to the change we keep syncing the products.

## Checklist

- [] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

One liner entry to be surfaced in changelog.txt


## Test Plan

Upgrade to plugin 3.5.0, don't opt out then upgrade again to 3.5.1
Your products should start syncing.

## Screenshots
N/A
