### PR TITLE
[WAUM]When token is invalidated because app is uninstalled we want users to be able to disconnect

### DIFF
--- a/assets/js/admin/whatsapp-events.js
+++ b/assets/js/admin/whatsapp-events.js
@@ -190,8 +190,8 @@ jQuery(document).ready(function ($) {
                 console.log('Fetch supported language call succeeded');
             }
             else {
-                console.log('Fetch supported language call failed', response);
-                const message = facebook_for_woocommerce_whatsapp_finish.i18n.generic_error;
+                const errorCode = JSON.parse(response.data.body).error.code;
+                const message = errorCode === 190 ? facebook_for_woocommerce_whatsapp_events.i18n.token_invalidated_error : facebook_for_woocommerce_whatsapp_finish.i18n.generic_error;
                 const errorNoticeHtml = `
                 <div class="notice-error">
                   <p>${message}</p>

--- a/assets/js/admin/whatsapp-events.js
+++ b/assets/js/admin/whatsapp-events.js
@@ -172,6 +172,8 @@ jQuery(document).ready(function ($) {
         });
     });
 
+    const tokenInvalidationErrorCode = 190;
+
     $("#manage-event-language").load(facebook_for_woocommerce_whatsapp_events.ajax_url, function () {
         $.post(facebook_for_woocommerce_whatsapp_events.ajax_url, {
             action: 'wc_facebook_whatsapp_fetch_supported_languages',
@@ -191,7 +193,7 @@ jQuery(document).ready(function ($) {
             }
             else {
                 const errorCode = JSON.parse(response.data.body).error.code;
-                const message = errorCode === 190 ? facebook_for_woocommerce_whatsapp_events.i18n.token_invalidated_error : facebook_for_woocommerce_whatsapp_finish.i18n.generic_error;
+                const message = errorCode === tokenInvalidationErrorCode ? facebook_for_woocommerce_whatsapp_events.i18n.token_invalidated_error : facebook_for_woocommerce_whatsapp_finish.i18n.generic_error;
                 const errorNoticeHtml = `
                 <div class="notice-error">
                   <p>${message}</p>

--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -153,8 +153,9 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				'order_refunded_enabled'   => ! empty( $order_refunded_event_config_id ),
 				'order_refunded_language'  => $order_refunded_language,
 				'i18n'                     => array(
-					'result'        => true,
-					'generic_error' => __( 'Something went wrong. Please try again.', 'facebook-for-woocommerce' ),
+					'result'                  => true,
+					'generic_error'           => __( 'Something went wrong. Please try again.', 'facebook-for-woocommerce' ),
+					'token_invalidated_error' => __( 'Your access token has been invalidated. Please disconnect and reconnect your whatsapp account.', 'facebook-for-woocommerce' ),
 
 				),
 			)

--- a/includes/Handlers/WhatsAppUtilityConnection.php
+++ b/includes/Handlers/WhatsAppUtilityConnection.php
@@ -159,22 +159,22 @@ class WhatsAppUtilityConnection {
 	 * @param string $bisu_token BISU token
 	 */
 	public static function wc_facebook_disconnect_whatsapp( $waba_id, $integration_config_id, $bisu_token ) {
-		$base_url      = array( self::GRAPH_API_BASE_URL, self::API_VERSION, $waba_id, 'disconnect_utility_messages' );
-		$base_url      = esc_url( implode( '/', $base_url ) );
-		$query_params  = array(
+		$base_url           = array( self::GRAPH_API_BASE_URL, self::API_VERSION, $waba_id, 'disconnect_utility_messages' );
+		$base_url           = esc_url( implode( '/', $base_url ) );
+		$query_params       = array(
 			'integration_config_id' => $integration_config_id,
 			'access_token'          => $bisu_token,
 		);
-		$base_url      = add_query_arg( $query_params, $base_url );
-		$options       = array(
+		$base_url           = add_query_arg( $query_params, $base_url );
+		$options            = array(
 			'headers' => array(
 				'Authorization' => $bisu_token,
 			),
 			'body'    => array(),
 			'timeout' => 300, // 5 minutes
 		);
-		$response      = wp_remote_post( $base_url, $options );
-		$response_body = explode( "\n", wp_remote_retrieve_body( $response ) );
+		$response           = wp_remote_post( $base_url, $options );
+		$response_body      = explode( "\n", wp_remote_retrieve_body( $response ) );
 		$response_body_json = json_decode( $response_body[0] );
 		wc_get_logger()->info(
 			sprintf(
@@ -184,7 +184,7 @@ class WhatsAppUtilityConnection {
 			)
 		);
 		// Error code 190 is for invalid token meaning the app was already uninstalled, in this case we can delete the options in DB
-		if ( ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) && ( $response_body_json !== null && $response_body_json->error !== null && $response_body_json->error->code !== 190) ) {
+		if ( ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) && ( null !== $response_body_json && null !== $response_body_json->error && 190 !== $response_body_json->error->code ) ) {
 			$error_object  = json_decode( $response_body[0] );
 			$error_message = $error_object->error->error_user_title ?? $error_object->error->message ?? 'Something went wrong. Please try again later!';
 

--- a/includes/Handlers/WhatsAppUtilityConnection.php
+++ b/includes/Handlers/WhatsAppUtilityConnection.php
@@ -202,7 +202,7 @@ class WhatsAppUtilityConnection {
 			sprintf(
 					/* translators: %s $error_message */
 				__( 'Disconnect Whatsapp Utility Message API Call Response: %1$s ', 'facebook-for-woocommerce' ),
-				wp_json_encode( $response_body_json->error->code ),
+				wp_json_encode( $response ),
 			)
 		);
 		// Error code 190 is for invalid token meaning the app was already uninstalled, in this case we can delete the options in DB

--- a/includes/Handlers/WhatsAppUtilityConnection.php
+++ b/includes/Handlers/WhatsAppUtilityConnection.php
@@ -206,7 +206,7 @@ class WhatsAppUtilityConnection {
 			)
 		);
 		// Error code 190 is for invalid token meaning the app was already uninstalled, in this case we can delete the options in DB
-		if ( null !== $response_body_json && null !== $response_body_json->error && self::WA_INVALID_TOKEN_ERROR_CODE === $response_body_json->error->code ) {
+		if ( null !== $response_body_json && isset( $response_body_json->error ) && self::WA_INVALID_TOKEN_ERROR_CODE === $response_body_json->error->code ) {
 			wc_get_logger()->info(
 				sprintf(
 					__( 'Disconnecting Whatsapp Utility Message since Access token is invalid!!!', 'facebook-for-woocommerce' )

--- a/includes/Handlers/WhatsAppUtilityConnection.php
+++ b/includes/Handlers/WhatsAppUtilityConnection.php
@@ -175,6 +175,7 @@ class WhatsAppUtilityConnection {
 		);
 		$response      = wp_remote_post( $base_url, $options );
 		$response_body = explode( "\n", wp_remote_retrieve_body( $response ) );
+		$response_body_json = json_decode( $response_body[0] );
 		wc_get_logger()->info(
 			sprintf(
 					/* translators: %s $error_message */
@@ -183,7 +184,7 @@ class WhatsAppUtilityConnection {
 			)
 		);
 		// Error code 190 is for invalid token meaning the app was already uninstalled, in this case we can delete the options in DB
-		if ( ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) && json_decode( $response_body[0] )?->error?->code !== 190 ) {
+		if ( ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) && ( $response_body_json !== null && $response_body_json->error !== null && $response_body_json->error->code !== 190) ) {
 			$error_object  = json_decode( $response_body[0] );
 			$error_message = $error_object->error->error_user_title ?? $error_object->error->message ?? 'Something went wrong. Please try again later!';
 


### PR DESCRIPTION
## Description
When token is invalidated because app is uninstalled we want users to be able to disconnect from WooCommerce so that they can re-onboard. The error code from Meta for token invalidation is 190. We check if this is the error and if yes we allow disconnect to delete options from DB so that users can reconnect. We also show this error when fetching the event configs.

### Type of change
- Bug fix (non-breaking change which fixes an issue)


## Changelog entry
When token is invalidated because app is uninstalled we want users to be able to disconnect


## Test Plan


https://github.com/user-attachments/assets/e05fba58-8c30-4268-86e6-38b251fef43c


