### PR TITLE
Add product sets sync button to shops troubleshooting

### DIFF
--- a/assets/js/admin/enhanced-settings-sync.js
+++ b/assets/js/admin/enhanced-settings-sync.js
@@ -139,4 +139,37 @@ jQuery(document).ready(function($) {
 			button.prop('disabled', false);
 		});
 	});
+
+	/**
+	 * Handle the sync product sets button click event
+	 *
+	 * @since 3.5.0
+	 *
+	 * @param {object} event
+	 */
+	$('#wc-facebook-enhanced-settings-sync-product-sets-menu').click(function(event) {
+		event.preventDefault();
+		var button = $(this);
+
+		button.html('Syncing...');
+		button.prop('disabled', true);
+
+		var data = {
+			action: "wc_facebook_sync_product_sets",
+			nonce: wc_facebook_enhanced_settings_sync.sync_product_sets_nonce
+		};
+
+		$.post(wc_facebook_enhanced_settings_sync.ajax_url, data, function(response) {
+			if (response.success) {
+				button.html('Sync completed');
+				button.prop('disabled', false);
+			} else {
+				button.html('Sync failed');
+				button.prop('disabled', false);
+			}
+		}).fail(function() {
+			button.html('Sync failed');
+			button.prop('disabled', false);
+		});
+	});
 });

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -52,6 +52,9 @@ class AJAX {
 		// sync navigation menu via AJAX
 		add_action( 'wp_ajax_wc_facebook_sync_navigation_menu', array( $this, 'sync_navigation_menu' ) );
 
+		// sync product sets via AJAX
+		add_action( 'wp_ajax_wc_facebook_sync_product_sets', array( $this, 'sync_product_sets' ) );
+
 		// get the current sync status
 		add_action( 'wp_ajax_wc_facebook_get_sync_status', array( $this, 'get_sync_status' ) );
 
@@ -199,6 +202,24 @@ class AJAX {
 
 		try {
 			facebook_for_woocommerce()->feed_manager->get_feed_instance( 'navigation_menu' )->regenerate_feed();
+			wp_send_json_success();
+		} catch ( \Exception $exception ) {
+			wp_send_json_error( $exception->getMessage() );
+		}
+	}
+
+	/**
+	 * Syncs navigation menu via AJAX.
+	 *
+	 * @internal
+	 *
+	 * @since 3.5.0
+	 */
+	public function sync_product_sets() {
+		check_admin_referer( Shops::ACTION_SYNC_PRODUCT_SETS, 'nonce' );
+
+		try {
+			facebook_for_woocommerce()->get_product_sets_sync_handler()->sync_all_product_sets();
 			wp_send_json_success();
 		} catch ( \Exception $exception ) {
 			wp_send_json_error( $exception->getMessage() );

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -37,6 +37,9 @@ class Shops extends Abstract_Settings_Screen {
 	/** @var string */
 	const ACTION_SYNC_NAVIGATION_MENU = 'wc_facebook_sync_navigation_menu';
 
+	/** @var string */
+	const ACTION_SYNC_PRODUCT_SETS = 'wc_facebook_sync_product_sets';
+
 	/**
 	 * Shops constructor.
 	 *
@@ -137,6 +140,7 @@ class Shops extends Abstract_Settings_Screen {
 				'sync_coupons_nonce'           => wp_create_nonce( self::ACTION_SYNC_COUPONS ),
 				'sync_shipping_profiles_nonce' => wp_create_nonce( self::ACTION_SYNC_SHIPPING_PROFILES ),
 				'sync_navigation_menu_nonce'   => wp_create_nonce( self::ACTION_SYNC_NAVIGATION_MENU ),
+				'sync_product_sets_nonce'      => wp_create_nonce( self::ACTION_SYNC_PRODUCT_SETS ),
 			)
 		);
 	}
@@ -255,6 +259,22 @@ class Shops extends Abstract_Settings_Screen {
 							</button>
 							<p id="shipping-profile-sync-description" class="sync-description">
 								Manually sync your shipping profiles from WooCommerce to your shop. It may take a couple of minutes for the changes to populate.
+							</p>
+						</td>
+					</tr>
+					<tr valign="top" class="wc-facebook-shops-sample">
+						<th scope="row" class="titledesc">
+							Product sets sync
+						</th>
+						<td class="forminp">
+							<button
+								id="wc-facebook-enhanced-settings-sync-product-sets-menu"
+								class="button"
+								type="button">
+								<?php esc_html_e( 'Sync now', 'facebook-for-woocommerce' ); ?>
+							</button>
+							<p id="navigation-menu-sync-description" class="sync-description">
+								Manually sync your product categories from WooCommerce to your catalog product sets. It may take a couple of minutes for the changes to populate.
 							</p>
 						</td>
 					</tr>


### PR DESCRIPTION
## Description

Add product sets sync button to shops troubleshooting to manually trigger product sets sync.

### Type of change

- New feature (non-breaking change which adds functionality)


## Changelog entry

- Add product sets sync button to shops troubleshooting


## Test Plan

`npm run test:php`

## Screenshots
![Screenshot 2025-05-30 at 19 27 49](https://github.com/user-attachments/assets/b0cce981-b202-4d7b-bebf-096d6728e1e2)

