### PR TITLE
Fix inconsistency between enhanced and legacy flow

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -113,7 +113,13 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 	/** @var string the WordPress option name where the business manager ID is stored */
 	const OPTION_BUSINESS_MANAGER_ID = 'wc_facebook_business_manager_id';
-	
+
+	/** @var string the WordPress option name where the ad account ID is stored */
+	const OPTION_AD_ACCOUNT_ID = 'wc_facebook_ad_account_id';
+
+	/** @var string the WordPress option name where the system user ID is stored */
+	const OPTION_SYSTEM_USER_ID = 'wc_facebook_system_user_id';
+
 	/** @var string the WordPress option name where the commerce merchant settings ID is stored */
 	const OPTION_COMMERCE_MERCHANT_SETTINGS_ID = 'wc_facebook_commerce_merchant_settings_id';
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -111,6 +111,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/** @var string the WordPress option name where the merchant access token is stored */
 	const OPTION_MERCHANT_ACCESS_TOKEN = 'wc_facebook_merchant_access_token';
 
+	/** @var string the WordPress option name where the business manager ID is stored */
+	const OPTION_BUSINESS_MANAGER_ID = 'wc_facebook_business_manager_id';
+	
 	/** @var string the WordPress option name where the commerce merchant settings ID is stored */
 	const OPTION_COMMERCE_MERCHANT_SETTINGS_ID = 'wc_facebook_commerce_merchant_settings_id';
 

--- a/includes/API/FBE/Installation/Read/Response.php
+++ b/includes/API/FBE/Installation/Read/Response.php
@@ -95,6 +95,17 @@ class Response extends API\Response {
 		return $this->get_data()['commerce_merchant_settings_id'] ?? '';
 	}
 
+	/**
+	 * Gets the commerce partner integration ID.
+	 *
+	 * @since 3.5.0
+	 *
+	 * @return string
+	 */
+	public function get_commerce_partner_integration_id() {
+		return $this->get_data()['commerce_partner_integration_id'] ?? '';
+	}
+
 
 	/**
 	 * Gets the profiles.

--- a/includes/API/Plugin/Settings/Handler.php
+++ b/includes/API/Plugin/Settings/Handler.php
@@ -239,6 +239,7 @@ class Handler extends AbstractRESTEndpoint {
 	private function clear_integration_options() {
 		$options = [
 			\WC_Facebookcommerce_Integration::OPTION_ACCESS_TOKEN,
+			\WC_Facebookcommerce_Integration::OPTION_BUSINESS_MANAGER_ID,
 			\WC_Facebookcommerce_Integration::OPTION_COMMERCE_MERCHANT_SETTINGS_ID,
 			\WC_Facebookcommerce_Integration::OPTION_COMMERCE_PARTNER_INTEGRATION_ID,
 			\WC_Facebookcommerce_Integration::OPTION_ENABLE_MESSENGER,

--- a/includes/API/Plugin/Settings/Handler.php
+++ b/includes/API/Plugin/Settings/Handler.php
@@ -244,6 +244,9 @@ class Handler extends AbstractRESTEndpoint {
 		$options = [
 			\WC_Facebookcommerce_Integration::OPTION_ACCESS_TOKEN,
 			\WC_Facebookcommerce_Integration::OPTION_BUSINESS_MANAGER_ID,
+			\WC_Facebookcommerce_Integration::OPTION_AD_ACCOUNT_ID,
+			\WC_Facebookcommerce_Integration::OPTION_SYSTEM_USER_ID,
+			\WC_Facebookcommerce_Integration::OPTION_FEED_ID,
 			\WC_Facebookcommerce_Integration::OPTION_COMMERCE_MERCHANT_SETTINGS_ID,
 			\WC_Facebookcommerce_Integration::OPTION_COMMERCE_PARTNER_INTEGRATION_ID,
 			\WC_Facebookcommerce_Integration::OPTION_ENABLE_MESSENGER,

--- a/includes/API/Plugin/Settings/Handler.php
+++ b/includes/API/Plugin/Settings/Handler.php
@@ -191,6 +191,10 @@ class Handler extends AbstractRESTEndpoint {
 			$options[ \WC_Facebookcommerce_Integration::OPTION_PROFILES ] = $params['profiles'];
 		}
 
+		if ( ! empty( $params['business_manager_id'] ) ) {
+			$options[ \WC_Facebookcommerce_Integration::OPTION_BUSINESS_MANAGER_ID ] = $params['business_manager_id'];
+		}
+
 		return $options;
 	}
 

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -386,6 +386,10 @@ class Shops extends Abstract_Settings_Screen {
 				const messageEvent = message.event;
 
 				if (messageEvent === 'CommerceExtension::INSTALL' && message.success) {
+					const cms_id = message.installed_features.find( ( f ) => 'fb_shop' === f.feature_type )?.connected_assets?.cms_id || 
+						message.installed_features.find( ( f ) => 'ig_shopping' === f.feature_type )?.connected_assets?.commerce_merchant_settings_id || '';
+					const ad_account_id = message.installed_features.find( ( f ) => 'ads' === f.feature_type )?.connected_assets?.ad_account_id || '';
+					
 					const requestBody = {
 						access_token: message.access_token,
 						merchant_access_token: message.access_token,
@@ -394,8 +398,8 @@ class Shops extends Abstract_Settings_Screen {
 						pixel_id: message.pixel_id,
 						page_id: message.page_id,
 						business_manager_id: message.business_manager_id,
-						commerce_merchant_settings_id: message.installed_features.find(f => f.feature_type === 'fb_shop')?.connected_assets?.commerce_merchant_settings_id || '',
-						ad_account_id: message.installed_features.find(f => f.feature_type === 'ads')?.connected_assets?.ad_account_id || '',
+						commerce_merchant_settings_id: cms_id,
+						ad_account_id: ad_account_id,
 						commerce_partner_integration_id: message.commerce_partner_integration_id || '',
 						profiles: message.profiles,
 						installed_features: message.installed_features

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -386,7 +386,7 @@ class Shops extends Abstract_Settings_Screen {
 				const messageEvent = message.event;
 
 				if (messageEvent === 'CommerceExtension::INSTALL' && message.success) {
-					const cms_id = message.installed_features.find( ( f ) => 'fb_shop' === f.feature_type )?.connected_assets?.cms_id || 
+					const cms_id = message.installed_features.find( ( f ) => 'fb_shop' === f.feature_type )?.connected_assets?.commerce_merchant_settings_id || 
 						message.installed_features.find( ( f ) => 'ig_shopping' === f.feature_type )?.connected_assets?.commerce_merchant_settings_id || '';
 					const ad_account_id = message.installed_features.find( ( f ) => 'ads' === f.feature_type )?.connected_assets?.ad_account_id || '';
 					

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -530,6 +530,7 @@ class Connection {
 		$this->update_instagram_business_id( '' );
 		$this->update_commerce_merchant_settings_id( '' );
 		$this->update_external_business_id( '' );
+		$this->update_commerce_partner_integration_id( '' );
 		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, '' );
 		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, '' );
 		facebook_for_woocommerce()->get_integration()->update_product_catalog_id( '' );

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -332,6 +332,12 @@ class Connection {
 		if ( $response->get_commerce_merchant_settings_id() ) {
 			$this->update_commerce_merchant_settings_id( sanitize_text_field( $response->get_commerce_merchant_settings_id() ) );
 		}
+
+		if ( $response->get_commerce_partner_integration_id() ) {
+			$this->update_commerce_partner_integration_id( sanitize_text_field( $response->get_commerce_partner_integration_id() ) );
+		} else {
+			$this->update_commerce_partner_integration_id( "" );
+		}
 	}
 
 


### PR DESCRIPTION
## TL;DR
We found some issue caused by the inconsistency between the legacy and enhanced flow. The real world uses are unlikely to have the same serious issues. This PR put out a graceful fix it them.

## Description
During dogfooding and QA testing, we get reports of:
1. Should show legacy view but rendered with BROKEN MiCE page
2. Used the enhanced flow onboard but seeing the legacy view after onboarding.

The causes has been identified as:
1. The CPI ID didn't get cleared out when off boarding using legacy flow.
This has been fixed in https://github.com/facebook/facebook-for-woocommerce/pull/3262/files but for existing instances off boarded before the fix landed, it's still experience problems
2. Some fields(e.g. business id) were missed during saving the onboarding result, causing MiCE failed to render.

### Issue 1
It's mainly impacting QA and internal users, for public users, the only chance they have a stale CPI ID and seeing this issue only if the performed the exact actions:
1. They upgraded to 3.4.8, the CPI was repaired in the background.
2. They disconnected their shop, staled CPI stay in their DB
3. They reconnected their shop
4. They upgraded 3.5.0, staled CPI causing their MiCE rendering to be all broken

However, since this will cause broken MiCE page, this PR introduces graceful and robust logic to ensure the CPI is correct:
a. Using MBE response as source of truth, if the response from Meta does not have CPI ID, then clear the local CPI ID. This ensures no stale CPI ID.
b. The CPI repair endpoint will fetch or repair, get the correct CPI ID
The logic is implemented in refresh_installation_data heartbeat will fix the data inconsistency automatically.

### Issue 2
It wasn't surfaced frequently as the refresh_installation_data is also repairing the missing IDs in the background. This PR added the saving action of those missing fields.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fix onboarding and offboarding data inconsistency between legacy and enhanced connection view.

## Test Plan
No unit test can cover it since it's caused by a sequence of actions.
All existing tests passes:

Time: 00:28.917, Memory: 121.00 MB
OK (324 tests, 859 assertions)

### Manual test it to cover all the cases.
#### Before
Verify on 3.5.0 branch, the business manager id was missing:
<img width="1004" alt="image" src="https://github.com/user-attachments/assets/3f153d93-8d01-415e-bd15-ffef00ef7230" />

The cpi id exists:
<img width="807" alt="image" src="https://github.com/user-attachments/assets/6b2abf18-bf61-4151-9168-2a97593bd6c6" />
and should be cleaned during uninstall since current 3.5.0 already included the cleanup fix(https://github.com/facebook/facebook-for-woocommerce/pull/3262/files), however, still manually make a copy so we can verify a lingering cpi_id won't break things.

#### After
Disconnect and switch to the current branch:
After onboarding, we now have business ID populated:
<img width="955" alt="image" src="https://github.com/user-attachments/assets/c9e16e73-1334-4e12-a50d-4249e70a9a96" />

Now use the wrong CPI id to make sure the installation can recover:
1. Use the previously saved, 2153153801813487 to overwrite wc_facebook_commerce_partner_integration_id, 729123966146427, intentionally put a stall cpi_id in the field.
<img width="799" alt="image" src="https://github.com/user-attachments/assets/3a511552-7513-452f-a53f-0c0a43cda2b1" />

6. Go to Meta side and manually delete the correct CPI 729123966146427
The Overview page broken as expected, mimicking the staled CPI ID cases
<img width="944" alt="image" src="https://github.com/user-attachments/assets/a4c507df-e0bb-417b-941b-1817545b7c44" />

7. Run update_installation_data
<img width="575" alt="image" src="https://github.com/user-attachments/assets/2efe2ec6-e313-4d2b-85d6-9dd1f4fc2905" />
<img width="780" alt="image" src="https://github.com/user-attachments/assets/8f7bfd4b-d7d1-4be4-926a-47bdca6aadd2" />
This removed staled CPI ID

<img width="952" alt="image" src="https://github.com/user-attachments/assets/3a43875d-4bfc-4a8b-a5d3-0afba7df7173" />
The legacy view is showing as expected

8. Run repair to create a new CPI
<img width="655" alt="image" src="https://github.com/user-attachments/assets/7b8f9809-4276-4a5d-8af9-554dd9dfda3c" />
<img width="936" alt="image" src="https://github.com/user-attachments/assets/85ec3fff-f260-443f-9377-19ba5b8584c9" />
Now the MiCE is rendering poperly
