### PR TITLE
Removing the tag to get rid of warnings

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1729,7 +1729,7 @@ class WC_Facebook_Product {
 				 * If parent's visibility is already marked we know we should assign it to the child/variation as well
 				 */
 				if($parent_product_visibility === "yes"){
-					$product_data["is_woo_all_products_sync"] = !$current_variation_product_visibility;
+					// $product_data["is_woo_all_products_sync"] = !$current_variation_product_visibility;
 					$product_data[ 'visibility' ] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE;
 				}
 				else if ($parent_product_visibility === "no"){
@@ -1760,7 +1760,7 @@ class WC_Facebook_Product {
 					 * But now have visibility published
 					 */
 					if($variation_visibility){
-						$product_data["is_woo_all_products_sync"] = !$current_variation_product_visibility;
+						// $product_data["is_woo_all_products_sync"] = !$current_variation_product_visibility;
 					}
 
 					$product_data[ 'visibility' ] = $variation_visibility ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -387,7 +387,7 @@ class WC_Facebook_Product_Feed {
 		'additional_image_link,sale_price_effective_date,sale_price,condition,' .
 		'visibility,gender,color,size,pattern,google_product_category,default_product,'.
 		'variant,gtin,quantity_to_sell_on_facebook,rich_text_description,internal_label,external_update_time,'.
-		'external_variant_id, is_woo_all_products_sync'. PHP_EOL ;
+		'external_variant_id'. PHP_EOL ;
 	}
 
 
@@ -508,7 +508,7 @@ class WC_Facebook_Product_Feed {
 		}
 
 		// Setting up Woo All Products sync flag
-		$is_woo_all_products_sync = $product_data['is_woo_all_products_sync'] || false;
+		// $is_woo_all_products_sync = $product_data['is_woo_all_products_sync'] || false;
 
 		return $product_data['retailer_id'] . ',' .
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'name' ) ) . ',' .
@@ -541,8 +541,7 @@ class WC_Facebook_Product_Feed {
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'rich_text_description' ) ) . ',' .
 		static::format_internal_labels_for_feed( static::get_value_from_product_data( $product_data, 'internal_label' ) ) . ',' .
 		static::get_value_from_product_data( $product_data, 'external_update_time' ) . ',' .
-		static::get_value_from_product_data( $product_data, 'external_variant_id' ) . ',' .
-		static::format_string_for_feed($is_woo_all_products_sync). PHP_EOL ;
+		static::get_value_from_product_data( $product_data, 'external_variant_id' ) . PHP_EOL ;
 	}
 
 	private static function format_additional_image_url( $product_image_urls ) {


### PR DESCRIPTION
## Description

A new tag is failing to be ingested in the backend and therefore removing it form feeds and sync.

### Type of change

Code change

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).
