### PR TITLE
Fix linter errors for ./includes/API.php

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 use WooCommerce\Facebook\API\Exceptions\Request_Limit_Reached;
 use WooCommerce\Facebook\API\Request;
@@ -49,7 +48,7 @@ class API extends Base {
 	 * @param string $access_token access token to use for API requests
 	 */
 	public function __construct( $access_token ) {
-		$this->access_token = $access_token;
+		$this->access_token    = $access_token;
 		$this->request_headers = array(
 			'Authorization' => "Bearer {$access_token}",
 		);
@@ -87,7 +86,7 @@ class API extends Base {
 	 *
 	 * @param API\Request $request request object
 	 * @return API\Response
-	 * @throws API\Exceptions\Request_Limit_Reached|ApiException
+	 * @throws API\Exceptions\Request_Limit_Reached|ApiException In case of a general API error or rate limit error.
 	 */
 	protected function perform_request( $request ): API\Response {
 		$rate_limit_id   = $request::get_rate_limit_id();
@@ -108,14 +107,16 @@ class API extends Base {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @throws ApiException
+	 * @throws ApiException In case of an invalid token error.
+	 * @throws API\Exceptions\Request_Limit_Reached In case of a rate limit error.
 	 */
 	protected function do_post_parse_response_validation() {
 		/** @var API\Response $response */
 		$response = $this->get_response();
 		$request  = $this->get_request();
 		if ( $response && $response->has_api_error() ) {
-			$code    = $response->get_api_error_code();
+			$code = $response->get_api_error_code();
+			// phpcs:ignore Universal.Operators.DisallowShortTernary.Found
 			$message = sprintf( '%s: %s', $response->get_api_error_type(), $response->get_user_error_message() ?: $response->get_api_error_message() );
 			/**
 			 * Graph API
@@ -176,7 +177,7 @@ class API extends Base {
 	 *
 	 * @param string $rate_limit_id ID for the API request
 	 * @param int    $timestamp timestamp until the delay is over
-	 * @throws API\Exceptions\Request_Limit_Reached
+	 * @throws API\Exceptions\Request_Limit_Reached In case of a rate limit error.
 	 */
 	private function handle_throttled_request( $rate_limit_id, $timestamp ) {
 		if ( time() > $timestamp ) {
@@ -195,7 +196,7 @@ class API extends Base {
 	 *
 	 * @param string $external_business_id External business id.
 	 * @return API\Response|API\FBE\Installation\Read\Response
-	 * @throws ApiException
+	 * @throws ApiException In case of a general API error or rate limit error.
 	 */
 	public function get_installation_ids( string $external_business_id ): API\FBE\Installation\Read\Response {
 		$request = new API\FBE\Installation\Read\Request( $external_business_id );
@@ -211,7 +212,7 @@ class API extends Base {
 	 *
 	 * @param string $page_id page ID
 	 * @return API\Response|API\Pages\Read\Response
-	 * @throws ApiException
+	 * @throws ApiException In case of a general API error or rate limit error.
 	 */
 	public function get_page( $page_id ): API\Pages\Read\Response {
 		$request = new API\Pages\Read\Request( $page_id );
@@ -225,7 +226,7 @@ class API extends Base {
 	 *
 	 * @param string $catalog_id Facebook catalog id.
 	 * @return API\Response|API\Catalog\Response
-	 * @throws ApiException
+	 * @throws ApiException In case of a general API error or rate limit error.
 	 */
 	public function get_catalog( string $catalog_id ): API\Catalog\Response {
 		$request = new API\Catalog\Request( $catalog_id );
@@ -239,7 +240,7 @@ class API extends Base {
 	 *
 	 * @param string $user_id user ID. Defaults to the currently authenticated user
 	 * @return API\Response|API\User\Response
-	 * @throws ApiException
+	 * @throws ApiException In case of a general API error or rate limit error.
 	 */
 	public function get_user( string $user_id = '' ): API\User\Response {
 		$request = new API\User\Request( $user_id );
@@ -255,10 +256,10 @@ class API extends Base {
 	 *
 	 * @param string $external_business_id external business ID
 	 * @return API\Response|API\FBE\Installation\Delete\Response
-	 * @throws ApiException
+	 * @throws ApiException In case of a general API error or rate limit error.
 	 */
-	public function delete_mbe_connection( string $external_business_id): API\FBE\Installation\Delete\Response {
-		$request = new API\FBE\Installation\Delete\Request( $external_business_id);
+	public function delete_mbe_connection( string $external_business_id ): API\FBE\Installation\Delete\Response {
+		$request = new API\FBE\Installation\Delete\Request( $external_business_id );
 		$this->set_response_handler( API\FBE\Installation\Delete\Response::class );
 		return $this->perform_request( $request );
 	}
@@ -269,13 +270,13 @@ class API extends Base {
 	 *
 	 * @param string $external_business_id external business ID
 	 * @param string $access_token Optional access token to use for this request. If not provided, will use the instance token.
-	 * @param array $fields Optional. Fields to request from the API. Default empty array returns all fields.
+	 * @param array  $fields Optional. Fields to request from the API. Default empty array returns all fields.
 	 * @return API\Response|API\FBE\Configuration\Read\Response
-	 * @throws ApiException
+	 * @throws ApiException In case of a general API error or rate limit error.
 	 */
 	public function get_business_configuration( $external_business_id, $access_token = '', $fields = [] ) {
 		$request = new API\FBE\Configuration\Request( $external_business_id, 'GET' );
-		$params = [];
+		$params  = [];
 		// Use provided access token or fall back to the instance token
 		if ( ! empty( $access_token ) ) {
 			$params['access_token'] = $access_token;
@@ -295,20 +296,20 @@ class API extends Base {
 	/**
 	 * Gets rollout switches
 	 *
-	 * @param string  $external_business_id
+	 * @param string $external_business_id
 	 * @return API\FBE\RolloutSwitches\Response
-	 * @throws ApiException
+	 * @throws ApiException In case of a general API error or rate limit error.
 	 */
 	public function get_rollout_switches( string $external_business_id ) {
-		if(!$this->get_access_token()) {
+		if ( ! $this->get_access_token() ) {
 			return null;
 		}
 
 		$request = new API\FBE\RolloutSwitches\Request( $external_business_id );
 		$request->set_params(
 			array(
-				'access_token' => $this->get_access_token(),
-				'fbe_external_business_id'=> $external_business_id
+				'access_token'             => $this->get_access_token(),
+				'fbe_external_business_id' => $external_business_id,
 			)
 		);
 		$this->set_response_handler( API\FBE\RolloutSwitches\Response::class );
@@ -319,18 +320,18 @@ class API extends Base {
 	 * Updates the plugin version configuration.
 	 *
 	 * @param string $external_business_id external business ID
+	 * @param bool   $is_opted_out The plugin version.
 	 * @param string $plugin_version The plugin version.
-	 * @param bool is_opted_out The plugin version.
 	 * @return Response|API\FBE\Configuration\Update\Response
-	 * @throws ApiException
+	 * @throws ApiException In case of a general API error or rate limit error.
 	 */
 	public function update_plugin_version_configuration( string $external_business_id, bool $is_opted_out, string $plugin_version ): API\FBE\Configuration\Update\Response {
 		$request = new API\FBE\Configuration\Update\Request( $external_business_id );
 		$request->set_external_client_metadata(
 			array(
-				'version_id' => $plugin_version,
-				'is_multisite'   => is_multisite(),
-				'is_woo_all_products_opted_out' => $is_opted_out
+				'version_id'                    => $plugin_version,
+				'is_multisite'                  => is_multisite(),
+				'is_woo_all_products_opted_out' => $is_opted_out,
 			)
 		);
 		$this->set_response_handler( API\FBE\Configuration\Update\Response::class );
@@ -346,7 +347,7 @@ class API extends Base {
 	 * @param string $facebook_product_catalog_id Facebook Product Catalog ID.
 	 * @param array  $requests array of prefixed product IDs to create, update or remove.
 	 * @return API\Response|API\ProductCatalog\ItemsBatch\Create\Response
-	 * @throws ApiException
+	 * @throws ApiException In case of a general API error or rate limit error.
 	 */
 	public function send_item_updates( string $facebook_product_catalog_id, array $requests ) {
 		$request = new API\ProductCatalog\ItemsBatch\Create\Request( $facebook_product_catalog_id, $requests );
@@ -361,7 +362,7 @@ class API extends Base {
 	 * @param string $product_catalog_id Facebook Product Catalog ID.
 	 * @param array  $data Facebook Product Group Data.
 	 * @return API\Response|API\ProductCatalog\ProductGroups\Create\Response
-	 * @throws ApiException
+	 * @throws ApiException In case of a general API error or rate limit error.
 	 */
 	public function create_product_group( string $product_catalog_id, array $data ): API\ProductCatalog\ProductGroups\Create\Response {
 		$request = new API\ProductCatalog\ProductGroups\Create\Request( $product_catalog_id, $data );
@@ -376,10 +377,10 @@ class API extends Base {
 	 * @param string $product_group_id Facebook Product Group ID.
 	 * @param array  $data Facebook Product Group Data.
 	 * @return API\ProductCatalog\ProductGroups\Update\Response
-	 * @throws ApiException
+	 * @throws ApiException In case of a general API error or rate limit error.
 	 */
 	public function update_product_group( string $product_group_id, array $data ): API\ProductCatalog\ProductGroups\Update\Response {
-		$request = new API\ProductCatalog\ProductGroups\Update\Request( $product_group_id , $data );
+		$request = new API\ProductCatalog\ProductGroups\Update\Request( $product_group_id, $data );
 		$this->set_response_handler( API\ProductCatalog\ProductGroups\Update\Response::class );
 		return $this->perform_request( $request );
 	}
@@ -391,7 +392,7 @@ class API extends Base {
 	 * @param string $product_group_id product group ID
 	 * @param int    $limit max number of results returned per page of data
 	 * @return API\Response|API\ProductCatalog\ProductGroups\Read\Response
-	 * @throws ApiException
+	 * @throws ApiException In case of a general API error or rate limit error.
 	 */
 	public function get_product_group_products( string $product_group_id, int $limit = 1000 ): API\ProductCatalog\ProductGroups\Read\Response {
 		$request = new API\ProductCatalog\ProductGroups\Read\Request( $product_group_id, $limit );
@@ -453,7 +454,7 @@ class API extends Base {
 	 * @param string $facebook_retailer_id
 	 * @return API\Response|API\ProductCatalog\Products\Id\Response
 	 * @throws ApiException In case of network request error.
-	 * @throws API\Exceptions\Request_Limit_Reached
+	 * @throws API\Exceptions\Request_Limit_Reached In case of rate limit error.
 	 */
 	public function get_product_facebook_ids( string $facebook_product_catalog_id, string $facebook_retailer_id ): API\ProductCatalog\Products\Id\Response {
 		$request = new API\ProductCatalog\Products\Id\Request( $facebook_product_catalog_id, $facebook_retailer_id );
@@ -464,10 +465,10 @@ class API extends Base {
 
 	/**
 	 * @param string $product_catalog_id
-	 * @param array $data
+	 * @param array  $data
 	 * @return API\Response|API\ProductCatalog\ProductSets\Create\Response
-	 * @throws ApiException
-	 * @throws API\Exceptions\Request_Limit_Reached
+	 * @throws ApiException In case of network request error.
+	 * @throws API\Exceptions\Request_Limit_Reached In case of rate limit error.
 	 */
 	public function create_product_set_item( string $product_catalog_id, array $data ): API\ProductCatalog\ProductSets\Create\Response {
 		$request = new API\ProductCatalog\ProductSets\Create\Request( $product_catalog_id, $data );
@@ -478,10 +479,10 @@ class API extends Base {
 
 	/**
 	 * @param string $product_set_id
-	 * @param array $data
+	 * @param array  $data
 	 * @return API\Response|API\ProductCatalog\ProductSets\Update\Response
-	 * @throws ApiException
-	 * @throws API\Exceptions\Request_Limit_Reached
+	 * @throws ApiException In case of network request error.
+	 * @throws API\Exceptions\Request_Limit_Reached In case of rate limit error.
 	 */
 	public function update_product_set_item( string $product_set_id, array $data ): API\ProductCatalog\ProductSets\Update\Response {
 		$request = new API\ProductCatalog\ProductSets\Update\Request( $product_set_id, $data );
@@ -494,8 +495,8 @@ class API extends Base {
 	 * @param string $product_set_id Facebook Product Set ID.
 	 * @param bool   $allow_live_deletion Allow live Facebook Product Set Deletion.
 	 * @return API\Response|API\ProductCatalog\ProductSets\Delete\Response
-	 * @throws ApiException
-	 * @throws API\Exceptions\Request_Limit_Reached
+	 * @throws ApiException In case of network request error.
+	 * @throws API\Exceptions\Request_Limit_Reached In case of rate limit error.
 	 */
 	public function delete_product_set_item( string $product_set_id, bool $allow_live_deletion ): API\ProductCatalog\ProductSets\Delete\Response {
 		$request = new API\ProductCatalog\ProductSets\Delete\Request( $product_set_id, $allow_live_deletion );
@@ -504,11 +505,11 @@ class API extends Base {
 	}
 
 	/**
-	 * @param string $product_catalog_id
-	 * @param array $data
+	 * @param string $product_catalog_id Facebook Product Catalog ID.
+	 * @param string $retailer_id Facebook Product Set Retailer ID.
 	 * @return API\Response|API\ProductCatalog\ProductSets\Read\Response
-	 * @throws ApiException
-	 * @throws API\Exceptions\Request_Limit_Reached
+	 * @throws ApiException In case of network request error.
+	 * @throws API\Exceptions\Request_Limit_Reached In case of rate limit error.
 	 */
 	public function read_product_set_item( string $product_catalog_id, string $retailer_id ): API\ProductCatalog\ProductSets\Read\Response {
 		$request = new API\ProductCatalog\ProductSets\Read\Request( $product_catalog_id, $retailer_id );
@@ -519,8 +520,8 @@ class API extends Base {
 	/**
 	 * @param string $product_catalog_id
 	 * @return API\Response|API\ProductCatalog\ProductFeeds\ReadAll\Response
-	 * @throws ApiException
-	 * @throws API\Exceptions\Request_Limit_Reached
+	 * @throws ApiException In case of network request error.
+	 * @throws API\Exceptions\Request_Limit_Reached In case of rate limit error.
 	 */
 	public function read_feeds( string $product_catalog_id ): API\ProductCatalog\ProductFeeds\ReadAll\Response {
 		$request = new API\ProductCatalog\ProductFeeds\ReadAll\Request( $product_catalog_id );
@@ -532,8 +533,8 @@ class API extends Base {
 	/**
 	 * @param string $product_feed_id Facebook Product Feed ID.
 	 * @return Response
-	 * @throws ApiException
-	 * @throws API\Exceptions\Request_Limit_Reached
+	 * @throws ApiException In case of network request error.
+	 * @throws API\Exceptions\Request_Limit_Reached In case of rate limit error.
 	 */
 	public function read_feed( string $product_feed_id ) {
 		$request = new API\ProductCatalog\ProductFeeds\Read\Request( $product_feed_id );
@@ -543,9 +544,10 @@ class API extends Base {
 
 	/**
 	 * @param string $product_catalog_id Facebook Product Catalog ID.
+	 * @param array  $data Product Feed Data.
 	 * @return Response
-	 * @throws ApiException
-	 * @throws API\Exceptions\Request_Limit_Reached
+	 * @throws ApiException In case of network request error.
+	 * @throws API\Exceptions\Request_Limit_Reached In case of rate limit error.
 	 */
 	public function create_feed( string $product_catalog_id, array $data ) {
 		$request = new API\ProductCatalog\ProductFeeds\Create\Request( $product_catalog_id, $data );
@@ -557,8 +559,8 @@ class API extends Base {
 	/**
 	 * @param string $product_feed_upload_id
 	 * @return Response
-	 * @throws ApiException
-	 * @throws API\Exceptions\Request_Limit_Reached
+	 * @throws ApiException In case of network request error.
+	 * @throws API\Exceptions\Request_Limit_Reached In case of rate limit error.
 	 */
 	public function read_upload( string $product_feed_upload_id ) {
 		$request = new API\ProductCatalog\ProductFeedUploads\Read\Request( $product_feed_upload_id );
@@ -568,9 +570,10 @@ class API extends Base {
 
 	/**
 	 * @param string $product_feed_id Facebook Product Feed ID.
+	 * @param array  $data Product Feed Data.
 	 * @return Response
-	 * @throws ApiException
-	 * @throws API\Exceptions\Request_Limit_Reached
+	 * @throws ApiException In case of network request error.
+	 * @throws API\Exceptions\Request_Limit_Reached In case of rate limit error.
 	 */
 	public function create_product_feed_upload( string $product_feed_id, array $data ): Response {
 		$request = new API\ProductCatalog\ProductFeedUploads\Create\Request( $product_feed_id, $data );
@@ -580,11 +583,11 @@ class API extends Base {
 
 	/**
 	 * @param string $cpi_id The commerce partner integration id.
-	 * @param array $data The json body for the Generic Feed Upload endpoint.
+	 * @param array  $data The json body for the Generic Feed Upload endpoint.
 	 *
 	 * @return Response
-	 * @throws Request_Limit_Reached
-	 * @throws ApiException
+	 * @throws Request_Limit_Reached In case of rate limit error.
+	 * @throws ApiException In case of network request error.
 	 */
 	public function create_common_data_feed_upload( string $cpi_id, array $data ): Response {
 		$request = new API\CommonFeedUploads\Create\Request( $cpi_id, $data );
@@ -596,8 +599,8 @@ class API extends Base {
 	/**
 	 * @param string $external_merchant_settings_id
 	 * @return API\Response|API\Tip\Read\Response
-	 * @throws ApiException
-	 * @throws API\Exceptions\Request_Limit_Reached
+	 * @throws ApiException In case of network request error.
+	 * @throws API\Exceptions\Request_Limit_Reached In case of rate limit error.
 	 */
 	public function get_tip_info( string $external_merchant_settings_id ): API\Tip\Read\Response {
 		$request = new API\Tip\Read\Request( $external_merchant_settings_id );
@@ -619,8 +622,8 @@ class API extends Base {
 		return $this->perform_request( $request );
 	}
 
-	public function log_to_meta( $context) {
-		if(!facebook_for_woocommerce()->get_integration()->is_meta_diagnosis_enabled()) {
+	public function log_to_meta( $context ) {
+		if ( ! facebook_for_woocommerce()->get_integration()->is_meta_diagnosis_enabled() ) {
 			return;
 		}
 		$request = new API\MetaLog\Request( $context );
@@ -636,7 +639,7 @@ class API extends Base {
 	 * @param string  $pixel_id pixel ID
 	 * @param Event[] $events events to send
 	 * @return Response
-	 * @throws ApiException
+	 * @throws ApiException In case of a general API error or rate limit error.
 	 */
 	public function send_pixel_events( $pixel_id, array $events ) {
 		$request = new API\Pixel\Events\Request( $pixel_id, $events );
@@ -644,17 +647,17 @@ class API extends Base {
 		return $this->perform_request( $request );
 	}
 
-    /**
-     * @return Response
-     * @throws ApiException
-     * @throws API\Exceptions\Request_Limit_Reached
-     */
-    public function get_public_key( string $key_project ): Response
-    {
-        $request = new API\PublicKeyGet\Request( $key_project );
-        $this->set_response_handler( API\Response::class );
-        return $this->perform_request( $request );
-    }
+	/**
+	 * @param string $key_project The key project.
+	 * @return Response
+	 * @throws ApiException In case of network request error.
+	 * @throws API\Exceptions\Request_Limit_Reached In case of rate limit error.
+	 */
+	public function get_public_key( string $key_project ): Response {
+		$request = new API\PublicKeyGet\Request( $key_project );
+		$this->set_response_handler( API\Response::class );
+		return $this->perform_request( $request );
+	}
 
 	/**
 	 * Gets the next page of results for a paginated response.
@@ -664,14 +667,14 @@ class API extends Base {
 	 * @param API\Response $response previous response object
 	 * @param int          $additional_pages number of additional pages of results to retrieve
 	 * @return API\Response|null
-	 * @throws ApiException
+	 * @throws ApiException In case of a general API error or rate limit error.
 	 */
 	public function next( API\Response $response, int $additional_pages = 0 ) {
 		$next_response = null;
 		// get the next page if we haven't reached the limit of pages to retrieve and the endpoint for the next page is available
 		if ( ( 0 === $additional_pages || $response->get_pages_retrieved() <= $additional_pages ) && $response->get_next_page_endpoint() ) {
 			$components = parse_url( str_replace( $this->request_uri, '', $response->get_next_page_endpoint() ) );
-			$request = $this->get_new_request(
+			$request    = $this->get_new_request(
 				[
 					'path'   => $components['path'] ?? '',
 					'method' => 'GET',
@@ -707,8 +710,8 @@ class API extends Base {
 			'method' => 'GET',
 			'params' => [],
 		);
-		$args    = wp_parse_args( $args, $defaults );
-		$request = new Request( $args['path'], $args['method'] );
+		$args     = wp_parse_args( $args, $defaults );
+		$request  = new Request( $args['path'], $args['method'] );
 		if ( $args['params'] ) {
 			$request->set_params( $args['params'] );
 		}
@@ -736,7 +739,7 @@ class API extends Base {
 	 * @param string $extension_version The version of the Facebook for WooCommerce extension
 	 *
 	 * @return API\Response|API\CommerceIntegration\Repair\Response
-	 * @throws ApiException
+	 * @throws ApiException In case of a general API error or rate limit error.
 	 */
 	public function repair_commerce_integration( string $fbe_external_business_id, string $shop_domain, string $admin_url, string $extension_version ): API\CommerceIntegration\Repair\Response {
 		$request = new API\CommerceIntegration\Repair\RepairRequest( $fbe_external_business_id, $shop_domain, $admin_url, $extension_version );
@@ -747,16 +750,16 @@ class API extends Base {
 	/**
 	 * Updates the commerce integration configuration.
 	 *
-	 * @param string $commerce_integration_id The ID of the commerce integration to update
+	 * @param string      $commerce_integration_id The ID of the commerce integration to update
 	 * @param string|null $extension_version The version of the Facebook for WooCommerce extension
 	 * @param string|null $admin_url The admin URL of the WooCommerce site
 	 * @param string|null $country_code ISO2 country code
 	 * @param string|null $currency ISO currency code
 	 * @param string|null $platform_store_id The ID of the current website on a multisite setup
-	 * @param string $commerce_partner_seller_platform_type The type of commerce partner platform
-	 * @param string $installation_status The installation status of the integration
+	 * @param string      $commerce_partner_seller_platform_type The type of commerce partner platform
+	 * @param string      $installation_status The installation status of the integration
 	 * @return API\Response|API\CommerceIntegration\Configuration\Update\Response
-	 * @throws ApiException
+	 * @throws ApiException In case of a general API error or rate limit error.
 	 */
 	public function update_commerce_integration(
 		string $commerce_integration_id,
@@ -778,7 +781,7 @@ class API extends Base {
 			$commerce_partner_seller_platform_type,
 			$installation_status
 		);
-		$this->set_response_handler(API\CommerceIntegration\Configuration\Update\Response::class);
-		return $this->perform_request($request);
+		$this->set_response_handler( API\CommerceIntegration\Configuration\Update\Response::class );
+		return $this->perform_request( $request );
 	}
 }

--- a/includes/Handlers/WhatsAppUtilityConnection.php
+++ b/includes/Handlers/WhatsAppUtilityConnection.php
@@ -224,7 +224,7 @@ class WhatsAppUtilityConnection {
 
 			wp_send_json_success( $response, 'Disconnect Whatsapp Success with Invalid Access Token' );
 
-		} else if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		} elseif ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			$error_object  = json_decode( $response_body[0] );
 			$error_message = $error_object->error->error_user_title ?? $error_object->error->message ?? 'Something went wrong. Please try again later!';
 


### PR DESCRIPTION
## Description
This PR fixes phpcs issues in `./includes/API.php`. Comments were also added for several functions. The fixes were made manually (in conjunction with `./vendor/bin/phpcbf`) to ensure that the logic remains the same. Running `./vendor/bin/phpcs`:
```
FILE: /Users/angeloou/Local Sites/test-site-i/app/public/wp-content/plugins/facebook-for-woocommerce/includes/API.php
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 105 ERRORS AND 12 WARNINGS AFFECTING 95 LINES
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  13 | ERROR   | [ ] Logical operator "or" is prohibited; use "||" instead (Squiz.Operators.ValidLogicalOperators.NotAllowed)
  51 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 4 spaces but found 1 space (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  89 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 110 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 111 | ERROR   | [ ] Expected 2 @throws tag(s) in function comment; 1 found (Squiz.Commenting.FunctionCommentThrowTag.WrongNumber)
 118 | ERROR   | [ ] Using short ternaries is not allowed as they are rarely used correctly (Universal.Operators.DisallowShortTernary.Found)
 152 | WARNING | [ ] Not using strict comparison for in_array; supply true for $strict argument. (WordPress.PHP.StrictInArray.FoundNonStrictFalse)
 159 | WARNING | [ ] Not using strict comparison for in_array; supply true for $strict argument. (WordPress.PHP.StrictInArray.FoundNonStrictFalse)
 178 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 197 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 213 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 227 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 241 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 257 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 259 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeClose)
 260 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
 271 | ERROR   | [x] Expected 2 spaces after parameter type; 1 found (Squiz.Commenting.FunctionComment.SpacingAfterParamType)
 273 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 277 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 2 spaces but found 1 space (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 297 | ERROR   | [x] Expected 1 spaces after parameter type; 2 found (Squiz.Commenting.FunctionComment.SpacingAfterParamType)
 299 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 302 | ERROR   | [x] Space after opening control structure is required (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterStructureOpen)
 302 | ERROR   | [x] No space before opening parenthesis is prohibited (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeOpenParenthesis)
 302 | ERROR   | [x] No space after opening parenthesis is prohibited (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis)
 302 | ERROR   | [x] Expected 1 space after IF keyword; 0 found (Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword)
 302 | ERROR   | [x] Expected 1 space before "!"; 0 found (WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore)
 302 | ERROR   | [x] Expected 1 space after "!"; 0 found (WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter)
 302 | ERROR   | [x] No space before closing parenthesis is prohibited (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeCloseParenthesis)
 309 | WARNING | [x] Array double arrow not aligned correctly; expected 13 space(s) between "'access_token'" and double arrow, but found 1.
     |         |     (WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned)
 310 | WARNING | [x] Array double arrow not aligned correctly; expected 1 space(s) between "'fbe_external_business_id'" and double arrow, but found 0.
     |         |     (WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned)
 310 | ERROR   | [x] Expected 1 space before "=>"; 0 found (WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore)
 310 | ERROR   | [x] There should be a comma after the last array item in a multi-line array. (NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLine)
 317 | ERROR   | [ ] Doc comment for parameter "$is_opted_out" missing (Squiz.Commenting.FunctionComment.MissingParamTag)
 320 | ERROR   | [x] Expected 31 spaces after parameter type; 1 found (Squiz.Commenting.FunctionComment.SpacingAfterParamType)
 321 | ERROR   | [x] Expected 31 spaces after parameter type; 1 found (Squiz.Commenting.FunctionComment.SpacingAfterParamType)
 321 | ERROR   | [ ] Doc comment for parameter $plugin_version does not match actual variable name $is_opted_out (Squiz.Commenting.FunctionComment.ParamNameNoMatch)
 322 | ERROR   | [ ] Missing parameter name (Squiz.Commenting.FunctionComment.MissingParamName)
 324 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 326 | ERROR   | [ ] Expected type hint "string"; found "bool" for $plugin_version (Squiz.Commenting.FunctionComment.IncorrectTypeHint)
 330 | WARNING | [x] Array double arrow not aligned correctly; expected 20 space(s) between "'version_id'" and double arrow, but found 1.
     |         |     (WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned)
 331 | WARNING | [x] Array double arrow not aligned correctly; expected 18 space(s) between "'is_multisite'" and double arrow, but found 3.
     |         |     (WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned)
 332 | ERROR   | [x] There should be a comma after the last array item in a multi-line array. (NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLine)
 348 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 363 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 378 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 381 | ERROR   | [x] Space found before comma in argument list (Generic.Functions.FunctionCallArgumentSpacing.SpaceBeforeComma)
 393 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 455 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 466 | ERROR   | [x] Expected 2 spaces after parameter type; 1 found (Squiz.Commenting.FunctionComment.SpacingAfterParamType)
 468 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 469 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 480 | ERROR   | [x] Expected 2 spaces after parameter type; 1 found (Squiz.Commenting.FunctionComment.SpacingAfterParamType)
 482 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 483 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 496 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 497 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 505 | ERROR   | [ ] Doc comment for parameter "$retailer_id" missing (Squiz.Commenting.FunctionComment.MissingParamTag)
 507 | ERROR   | [x] Expected 2 spaces after parameter type; 1 found (Squiz.Commenting.FunctionComment.SpacingAfterParamType)
 507 | ERROR   | [ ] Doc comment for parameter $data does not match actual variable name $retailer_id (Squiz.Commenting.FunctionComment.ParamNameNoMatch)
 509 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 510 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 512 | ERROR   | [ ] Expected type hint "array"; found "string" for $data (Squiz.Commenting.FunctionComment.IncorrectTypeHint)
 521 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 522 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 534 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 535 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 543 | ERROR   | [ ] Doc comment for parameter "$data" missing (Squiz.Commenting.FunctionComment.MissingParamTag)
 546 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 547 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 559 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 560 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 568 | ERROR   | [ ] Doc comment for parameter "$data" missing (Squiz.Commenting.FunctionComment.MissingParamTag)
 571 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 572 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 582 | ERROR   | [x] Expected 2 spaces after parameter type; 1 found (Squiz.Commenting.FunctionComment.SpacingAfterParamType)
 585 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 586 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 598 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 599 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 621 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeClose)
 622 | ERROR   | [x] Space after opening control structure is required (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterStructureOpen)
 622 | ERROR   | [x] No space before opening parenthesis is prohibited (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeOpenParenthesis)
 622 | ERROR   | [x] No space after opening parenthesis is prohibited (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis)
 622 | ERROR   | [x] Expected 1 space after IF keyword; 0 found (Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword)
 622 | ERROR   | [x] Expected 1 space before "!"; 0 found (WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore)
 622 | ERROR   | [x] Expected 1 space after "!"; 0 found (WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter)
 622 | ERROR   | [x] No space before closing parenthesis is prohibited (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeCloseParenthesis)
 638 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 646 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 646 | ERROR   | [ ] Doc comment for parameter "$key_project" missing (Squiz.Commenting.FunctionComment.MissingParamTag)
 647 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 648 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 648 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 649 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 649 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 650 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 651 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 652 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 652 | ERROR   | [x] Opening brace should be on the same line as the declaration (Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine)
 653 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 654 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 655 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 656 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
 666 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 672 | WARNING | [ ] parse_url() is discouraged because of inconsistency in the output across PHP versions; use wp_parse_url() instead. (WordPress.WP.AlternativeFunctions.parse_url_parse_url)
 673 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 4 spaces but found 1 space (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 709 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 5 spaces but found 4 spaces (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 710 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 2 spaces but found 1 space (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 738 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 749 | ERROR   | [x] Expected 6 spaces after parameter type; 1 found (Squiz.Commenting.FunctionComment.SpacingAfterParamType)
 755 | ERROR   | [x] Expected 6 spaces after parameter type; 1 found (Squiz.Commenting.FunctionComment.SpacingAfterParamType)
 756 | ERROR   | [x] Expected 6 spaces after parameter type; 1 found (Squiz.Commenting.FunctionComment.SpacingAfterParamType)
 758 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
 780 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket)
 780 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
 781 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket)
 781 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 57 MARKED SNIFF VIOLATIONS AUTOMATICALLY
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected

## Test Plan
1. Run `./vendor/bin/phpcs`, you should get:
```
FILE: /Users/angeloou/Local Sites/test-site-i/app/public/wp-content/plugins/facebook-for-woocommerce/includes/API.php
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 3 WARNINGS AFFECTING 3 LINES
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 154 | WARNING | Not using strict comparison for in_array; supply true for $strict argument. (WordPress.PHP.StrictInArray.FoundNonStrictFalse)
 161 | WARNING | Not using strict comparison for in_array; supply true for $strict argument. (WordPress.PHP.StrictInArray.FoundNonStrictFalse)
 676 | WARNING | parse_url() is discouraged because of inconsistency in the output across PHP versions; use wp_parse_url() instead. (WordPress.WP.AlternativeFunctions.parse_url_parse_url)
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
2. Run extension and test the basic functionality to ensure everything still works as intended.