### PR TITLE
Fix linter errors for ./includes/Products.php

### DIFF
--- a/includes/Products.php
+++ b/includes/Products.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -15,7 +14,7 @@ use WC_Facebook_Product;
 use WooCommerce\Facebook\Framework\Helper;
 use WooCommerce\Facebook\Framework\Plugin\Exception as PluginException;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Products handler.
@@ -42,7 +41,7 @@ class Products {
 
 	/** @var string product image source option to use the parent product image in Facebook */
 	const PRODUCT_IMAGE_SOURCE_CUSTOM = 'custom';
-	
+
 	/** @var string the meta key used to store the Google product category ID for the product */
 	const GOOGLE_PRODUCT_CATEGORY_META_KEY = '_wc_facebook_google_product_category';
 
@@ -92,10 +91,9 @@ class Products {
 				$product->save_meta_data();
 
 				// Remove excluded product from FB.
-				if ( "no" === $enabled ) {
+				if ( 'no' === $enabled ) {
 					facebook_for_woocommerce()->get_integration()->delete_fb_product( $product );
 				}
-
 			}//end if
 		}//end foreach
 	}
@@ -135,7 +133,7 @@ class Products {
 	 * }
 	 */
 	public static function disable_sync_for_products_with_terms( array $args ) {
-		$args = wp_parse_args(
+		$args     = wp_parse_args(
 			$args,
 			array(
 				'taxonomy' => 'product_cat',
@@ -153,7 +151,7 @@ class Products {
 				)
 			);
 			if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
-				$taxonomy = $args['taxonomy'] === 'product_tag' ? 'tag' : 'category';
+				$taxonomy = 'product_tag' === $args['taxonomy'] ? 'tag' : 'category';
 				$products = wc_get_products(
 					array(
 						$taxonomy => $terms,
@@ -278,12 +276,12 @@ class Products {
 			foreach ( $product->get_children() as $variation ) {
 				$product_variation = wc_get_product( $variation );
 				if ( $product_variation instanceof \WC_Product ) {
-					$product_variation->update_meta_data( self::VISIBILITY_META_KEY, wc_bool_to_string($visibility));
+					$product_variation->update_meta_data( self::VISIBILITY_META_KEY, wc_bool_to_string( $visibility ) );
 					$product_variation->save_meta_data();
 				}
 			}
-		} 
-		
+		}
+
 		$product->update_meta_data( self::VISIBILITY_META_KEY, wc_bool_to_string( $visibility ) );
 		$product->save_meta_data();
 		self::$products_visibility[ $product->get_id() ] = $visibility;
@@ -306,6 +304,8 @@ class Products {
 		}
 		// accounts for a legacy bool value, current should be (string) 'yes' or (string) 'no'
 		if ( ! isset( self::$products_visibility[ $product->get_id() ] ) ) {
+			$meta = $product->get_meta( self::VISIBILITY_META_KEY );
+
 			if ( $product->is_type( 'variable' ) ) {
 				// assume variable products are not visible until a visible child is found
 				$is_visible = false;
@@ -316,7 +316,7 @@ class Products {
 						break;
 					}
 				}
-			} elseif ( $meta = $product->get_meta( self::VISIBILITY_META_KEY ) ) {
+			} elseif ( $meta ) {
 				$is_visible = wc_string_to_bool( $product->get_meta( self::VISIBILITY_META_KEY ) );
 			} else {
 				$is_visible = true;
@@ -335,8 +335,7 @@ class Products {
 	 *
 	 * @since 2.0.0-dev.1
 	 *
-	 * @param int         $price product price in cents
-	 * @param \WC_Product $product product object
+	 * @param \WC_Product $product
 	 * @return int
 	 */
 	public static function get_product_price( \WC_Product $product ) {
@@ -447,12 +446,12 @@ class Products {
 		foreach ( $categories as $category ) {
 			$level           = 0;
 			$parent_category = $category;
-			while ( (int) $parent_category->parent !== 0 ) {
+			while ( 0 !== (int) $parent_category->parent ) {
 				$parent_category = get_term( $parent_category->parent, 'product_cat' );
 				if ( ! $parent_category instanceof \WP_Term ) {
 					break;
 				}
-				$level ++;
+				++$level;
 			}
 			if ( empty( $categories_per_level[ $level ] ) ) {
 				$categories_per_level[ $level ] = array();
@@ -475,7 +474,7 @@ class Products {
 		}
 		if ( ! empty( $categories_per_level ) ) {
 			// get highest level categories
-			$categories = current( $categories_per_level );
+			$categories                 = current( $categories_per_level );
 			$google_product_category_id = '';
 			foreach ( $categories as $category ) {
 				$category_google_product_category_id = Product_Categories::get_google_product_category_id( $category->term_id );
@@ -512,12 +511,12 @@ class Products {
 		foreach ( $categories as $category ) {
 			$level           = 0;
 			$parent_category = $category;
-			while ( (int) $parent_category->parent !== 0 ) {
+			while ( 0 !== (int) $parent_category->parent ) {
 				$parent_category = get_term( $parent_category->parent, 'product_cat' );
 				if ( ! $parent_category instanceof \WP_Term ) {
 					break;
 				}
-				$level ++;
+				++$level;
 			}
 			if ( empty( $categories_per_level[ $level ] ) ) {
 				$categories_per_level[ $level ] = array();
@@ -684,7 +683,7 @@ class Products {
 	 *
 	 * @param \WC_Product $product the product object
 	 * @param string      $attribute_name the attribute to be used to store the color
-	 * @throws PluginException
+	 * @throws PluginException If the provided attribute name does not match any of the available attributes for the product.
 	 */
 	public static function update_product_color_attribute( \WC_Product $product, $attribute_name ) {
 
@@ -693,7 +692,7 @@ class Products {
 			throw new PluginException( "The provided attribute name $attribute_name does not match any of the available attributes for the product {$product->get_name()}" );
 		}
 
-		if ( $attribute_name !== self::get_product_color_attribute( $product ) && in_array( $attribute_name, self::get_distinct_product_attributes( $product ) ) ) {
+		if ( self::get_product_color_attribute( $product ) !== $attribute_name && in_array( $attribute_name, self::get_distinct_product_attributes( $product ) ) ) {
 			throw new PluginException( "The provided attribute $attribute_name is already used for the product {$product->get_name()}" );
 		}
 
@@ -780,7 +779,7 @@ class Products {
 	 *
 	 * @param \WC_Product $product the product object
 	 * @param string      $attribute_name the attribute to be used to store the size
-	 * @throws PluginException
+	 * @throws PluginException If the provided attribute name does not match any of the available attributes for the product.
 	 */
 	public static function update_product_size_attribute( \WC_Product $product, $attribute_name ) {
 
@@ -789,7 +788,7 @@ class Products {
 			throw new PluginException( "The provided attribute name $attribute_name does not match any of the available attributes for the product {$product->get_name()}" );
 		}
 
-		if ( $attribute_name !== self::get_product_size_attribute( $product ) && in_array( $attribute_name, self::get_distinct_product_attributes( $product ) ) ) {
+		if ( self::get_product_size_attribute( $product ) !== $attribute_name && in_array( $attribute_name, self::get_distinct_product_attributes( $product ) ) ) {
 			throw new PluginException( "The provided attribute $attribute_name is already used for the product {$product->get_name()}" );
 		}
 
@@ -876,14 +875,14 @@ class Products {
 	 *
 	 * @param \WC_Product $product the product object
 	 * @param string      $attribute_name the attribute to be used to store the pattern
-	 * @throws PluginException
+	 * @throws PluginException If the provided attribute name does not match any of the available attributes for the product.
 	 */
 	public static function update_product_pattern_attribute( \WC_Product $product, $attribute_name ) {
 		// check if the name matches an available attribute
 		if ( ! empty( $attribute_name ) && ! self::product_has_attribute( $product, $attribute_name ) ) {
 			throw new PluginException( "The provided attribute name $attribute_name does not match any of the available attributes for the product {$product->get_name()}" );
 		}
-		if ( $attribute_name !== self::get_product_pattern_attribute( $product ) && in_array( $attribute_name, self::get_distinct_product_attributes( $product ) ) ) {
+		if ( self::get_product_pattern_attribute( $product ) !== $attribute_name && in_array( $attribute_name, self::get_distinct_product_attributes( $product ) ) ) {
 			throw new PluginException( "The provided attribute $attribute_name is already used for the product {$product->get_name()}" );
 		}
 		$product->update_meta_data( self::PATTERN_ATTRIBUTE_META_KEY, $attribute_name );
@@ -1016,12 +1015,14 @@ class Products {
 	 * @since 2.1.0
 	 *
 	 * @return array associative array
+	 *
+	 * phpcs:disable WordPress.Security.NonceVerification.Missing
 	 */
 	public static function get_enhanced_catalog_attributes_from_request() {
 		$prefix     = Admin\Enhanced_Catalog_Attribute_Fields::FIELD_ENHANCED_CATALOG_ATTRIBUTE_PREFIX;
 		$attributes = array_filter(
 			$_POST,
-			function( $key ) use ( $prefix ) {
+			function ( $key ) use ( $prefix ) {
 				return substr( $key, 0, strlen( $prefix ) ) === $prefix;
 			},
 			ARRAY_FILTER_USE_KEY
@@ -1029,7 +1030,7 @@ class Products {
 
 		return array_reduce(
 			array_keys( $attributes ),
-			function( $attrs, $attr_key ) use ( $prefix ) {
+			function ( $attrs, $attr_key ) use ( $prefix ) {
 				return array_merge(
 					$attrs,
 					array(
@@ -1153,6 +1154,4 @@ class Products {
 
 		return ! empty( $product ) ? $product : null;
 	}
-
-
 }


### PR DESCRIPTION
## Description
This PR fixes phpcs issues in `./includes/Products.php`. Comments were also added for several functions. The fixes were made manually (in conjunction with `./vendor/bin/phpcbf`) to ensure that the logic remains the same. Running `./vendor/bin/phpcs`:
```
FILE: /Users/angeloou/Local Sites/test-site-i/app/public/wp-content/plugins/facebook-for-woocommerce/includes/Products.php
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 25 ERRORS AND 13 WARNINGS AFFECTING 30 LINES
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   17 | ERROR   | [ ] Logical operator "or" is prohibited; use "||" instead (Squiz.Operators.ValidLogicalOperators.NotAllowed)
   94 | ERROR   | [x] String "no" does not require double quotes; use single quotes instead (Squiz.Strings.DoubleQuoteUsage.NotRequired)
   96 | ERROR   | [x] Blank line found after control structure (WordPress.WhiteSpace.ControlStructureSpacing.BlankLineAfterEnd)
  137 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 5 spaces but found 1 space (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  155 | ERROR   | [ ] Use Yoda Condition checks, you must. (WordPress.PHP.YodaConditions.NotYoda)
  280 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket)
  280 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
  280 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
  318 | WARNING | [ ] Variable assignment found within a condition. Did you mean to do a comparison ? (Generic.CodeAnalysis.AssignmentInCondition.Found)
  318 | ERROR   | [ ] Assignments must be the first block of code on a line (Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure)
  337 | ERROR   | [ ] Doc comment for parameter $price does not match actual variable name $product (Squiz.Commenting.FunctionComment.ParamNameNoMatch)
  338 | ERROR   | [ ] Superfluous parameter comment (Squiz.Commenting.FunctionComment.ExtraParamComment)
  341 | ERROR   | [ ] Expected type hint "int"; found "\WC_Product" for $price (Squiz.Commenting.FunctionComment.IncorrectTypeHint)
  449 | ERROR   | [ ] Use Yoda Condition checks, you must. (WordPress.PHP.YodaConditions.NotYoda)
  454 | WARNING | [x] Stand-alone post-increment statement found. Use pre-increment instead: ++$level . (Universal.Operators.DisallowStandalonePostIncrementDecrement.PostIncrementFound)
  454 | ERROR   | [x] Expected no spaces between $level and the increment operator; 1 found (Generic.WhiteSpace.IncrementDecrementSpacing.SpaceAfterIncrement)
  477 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 17 spaces but found 1 space (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  514 | ERROR   | [ ] Use Yoda Condition checks, you must. (WordPress.PHP.YodaConditions.NotYoda)
  519 | WARNING | [x] Stand-alone post-increment statement found. Use pre-increment instead: ++$level . (Universal.Operators.DisallowStandalonePostIncrementDecrement.PostIncrementFound)
  519 | ERROR   | [x] Expected no spaces between $level and the increment operator; 1 found (Generic.WhiteSpace.IncrementDecrementSpacing.SpaceAfterIncrement)
  614 | WARNING | [ ] Not using strict comparison for in_array; supply true for $strict argument. (WordPress.PHP.StrictInArray.MissingTrueStrict)
  686 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
  695 | ERROR   | [ ] Use Yoda Condition checks, you must. (WordPress.PHP.YodaConditions.NotYoda)
  695 | WARNING | [ ] Not using strict comparison for in_array; supply true for $strict argument. (WordPress.PHP.StrictInArray.MissingTrueStrict)
  782 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
  791 | ERROR   | [ ] Use Yoda Condition checks, you must. (WordPress.PHP.YodaConditions.NotYoda)
  791 | WARNING | [ ] Not using strict comparison for in_array; supply true for $strict argument. (WordPress.PHP.StrictInArray.MissingTrueStrict)
  878 | ERROR   | [ ] Comment missing for @throws tag in function comment (Squiz.Commenting.FunctionComment.EmptyThrows)
  885 | ERROR   | [ ] Use Yoda Condition checks, you must. (WordPress.PHP.YodaConditions.NotYoda)
  885 | WARNING | [ ] Not using strict comparison for in_array; supply true for $strict argument. (WordPress.PHP.StrictInArray.MissingTrueStrict)
 1022 | ERROR   | [ ] Processing form data without nonce verification. (WordPress.Security.NonceVerification.Missing)
 1023 | ERROR   | [x] Expected 1 space after FUNCTION keyword; 0 found (Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction)
 1031 | ERROR   | [x] Expected 1 space after FUNCTION keyword; 0 found (Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction)
 1105 | WARNING | [ ] Detected usage of meta_key, possible slow query. (WordPress.DB.SlowDBQuery.slow_db_query_meta_key)
 1106 | WARNING | [ ] Detected usage of meta_value, possible slow query. (WordPress.DB.SlowDBQuery.slow_db_query_meta_value)
 1119 | WARNING | [ ] Detected usage of meta_key, possible slow query. (WordPress.DB.SlowDBQuery.slow_db_query_meta_key)
 1120 | WARNING | [ ] Detected usage of meta_value, possible slow query. (WordPress.DB.SlowDBQuery.slow_db_query_meta_value)
 1157 | ERROR   | [x] The closing brace for the class must go on the next line after the body (PSR2.Classes.ClassDeclaration.CloseBraceAfterBody)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 14 MARKED SNIFF VIOLATIONS AUTOMATICALLY
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected

## Test Plan
1. Run `./vendor/bin/phpcs`, you should get:
```
FILE: /Users/angeloou/Local Sites/test-site-i/app/public/wp-content/plugins/facebook-for-woocommerce/includes/Products.php
----------------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 8 WARNINGS AFFECTING 8 LINES
----------------------------------------------------------------------------------------------------------------------------------------------
  614 | WARNING | Not using strict comparison for in_array; supply true for $strict argument. (WordPress.PHP.StrictInArray.MissingTrueStrict)
  695 | WARNING | Not using strict comparison for in_array; supply true for $strict argument. (WordPress.PHP.StrictInArray.MissingTrueStrict)
  791 | WARNING | Not using strict comparison for in_array; supply true for $strict argument. (WordPress.PHP.StrictInArray.MissingTrueStrict)
  885 | WARNING | Not using strict comparison for in_array; supply true for $strict argument. (WordPress.PHP.StrictInArray.MissingTrueStrict)
 1107 | WARNING | Detected usage of meta_key, possible slow query. (WordPress.DB.SlowDBQuery.slow_db_query_meta_key)
 1108 | WARNING | Detected usage of meta_value, possible slow query. (WordPress.DB.SlowDBQuery.slow_db_query_meta_value)
 1121 | WARNING | Detected usage of meta_key, possible slow query. (WordPress.DB.SlowDBQuery.slow_db_query_meta_key)
 1122 | WARNING | Detected usage of meta_value, possible slow query. (WordPress.DB.SlowDBQuery.slow_db_query_meta_value)
----------------------------------------------------------------------------------------------------------------------------------------------
```
2. Run extension and test the basic functionality to ensure everything still works as intended.