### PR TITLE
Fix linter errors for ./includes/Lifecycle.php

### DIFF
--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,7 +10,7 @@
 
 namespace WooCommerce\Facebook;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * The Facebook for WooCommerce plugin lifecycle handler.
@@ -54,7 +53,7 @@ class Lifecycle extends Framework\Lifecycle {
 			'2.4.0',
 			'2.5.0',
 			'3.2.0',
-			'3.4.9'
+			'3.4.9',
 		);
 	}
 
@@ -155,7 +154,7 @@ class Lifecycle extends Framework\Lifecycle {
 			$parsed_time   = ! empty( $autosync_time ) ? strtotime( $autosync_time ) : false;
 			$resync_offset = null;
 			if ( false !== $parsed_time ) {
-				$midnight = ( new \DateTime() )->setTimestamp( $parsed_time )->setTime( 0, 0, 0 );
+				$midnight      = ( new \DateTime() )->setTimestamp( $parsed_time )->setTime( 0, 0, 0 );
 				$resync_offset = $parsed_time - $midnight->getTimestamp();
 			}
 			$new_settings[ \WC_Facebookcommerce_Integration::SETTING_SCHEDULED_RESYNC_OFFSET ] = $resync_offset;
@@ -202,7 +201,8 @@ class Lifecycle extends Framework\Lifecycle {
 	 */
 	protected function upgrade_to_2_0_0() {
 		// handle sync enabled and visible virtual products and variations
-		if ( $handler = $this->get_plugin()->get_background_handle_virtual_products_variations_instance() ) {
+		$handler = $this->get_plugin()->get_background_handle_virtual_products_variations_instance();
+		if ( $handler ) {
 			// create_job() expects an non-empty array of attributes
 			$handler->create_job( array( 'created_at' => current_time( 'mysql' ) ) );
 			$handler->dispatch();
@@ -244,12 +244,14 @@ class Lifecycle extends Framework\Lifecycle {
 		}
 
 		// if an unfinished job is stuck, give the handler a chance to complete it
-		if ( $handler = $this->get_plugin()->get_background_handle_virtual_products_variations_instance() ) {
+		$handler = $this->get_plugin()->get_background_handle_virtual_products_variations_instance();
+		if ( $handler ) {
 			$handler->dispatch();
 		}
 
 		// create a job to remove duplicate visibility meta data entries
-		if ( $handler = $this->get_plugin()->get_background_remove_duplicate_visibility_meta_instance() ) {
+		$handler = $this->get_plugin()->get_background_remove_duplicate_visibility_meta_instance();
+		if ( $handler ) {
 			// create_job() expects an non-empty array of attributes
 			$handler->create_job( array( 'created_at' => current_time( 'mysql' ) ) );
 			$handler->dispatch();
@@ -285,10 +287,13 @@ class Lifecycle extends Framework\Lifecycle {
 	 */
 	protected function upgrade_to_2_0_4() {
 		// if unfinished jobs are stuck, give the handlers a chance to complete them
-		if ( $handler = $this->get_plugin()->get_background_handle_virtual_products_variations_instance() ) {
+		$handler = $this->get_plugin()->get_background_handle_virtual_products_variations_instance();
+		if ( $handler ) {
 			$handler->dispatch();
 		}
-		if ( $handler = $this->get_plugin()->get_background_remove_duplicate_visibility_meta_instance() ) {
+
+		$handler = $this->get_plugin()->get_background_remove_duplicate_visibility_meta_instance();
+		if ( $handler ) {
 			$handler->dispatch();
 		}
 	}
@@ -326,7 +331,7 @@ class Lifecycle extends Framework\Lifecycle {
 	protected function upgrade_to_3_2_0() {
 		// Remove the Messenger deprecation notice.
 		$notice_slug = 'facebook_messenger_deprecation_warning';
-		if( class_exists( 'WC_Admin_Notices' ) && \WC_Admin_Notices::has_notice( $notice_slug ) ) {
+		if ( class_exists( 'WC_Admin_Notices' ) && \WC_Admin_Notices::has_notice( $notice_slug ) ) {
 			\WC_Admin_Notices::remove_notice( $notice_slug );
 		}
 
@@ -345,5 +350,4 @@ class Lifecycle extends Framework\Lifecycle {
 	protected function upgrade_to_3_4_9() {
 		facebook_for_woocommerce()->get_product_sets_sync_handler()->sync_all_product_sets();
 	}
-
 }


### PR DESCRIPTION
## Description
This PR fixes phpcs issues in `./includes/Lifecycle.php`. Comments were also added for several functions. The fixes were made manually (in conjunction with `./vendor/bin/phpcbf`) to ensure that the logic remains the same. Running `./vendor/bin/phpcs`:
```
FILE: /Users/angeloou/Local Sites/test-site-i/app/public/wp-content/plugins/facebook-for-woocommerce/includes/Lifecycle.php
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 11 ERRORS AND 6 WARNINGS AFFECTING 10 LINES
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  13 | ERROR   | [ ] Logical operator "or" is prohibited; use "||" instead (Squiz.Operators.ValidLogicalOperators.NotAllowed)
  56 | ERROR   | [x] There should be a comma after the last array item in a multi-line array. (NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLine)
 157 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 6 spaces but found 1 space (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 204 | WARNING | [ ] Variable assignment found within a condition. Did you mean to do a comparison ? (Generic.CodeAnalysis.AssignmentInCondition.Found)
 204 | ERROR   | [ ] Assignments must be the first block of code on a line (Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure)
 246 | WARNING | [ ] Variable assignment found within a condition. Did you mean to do a comparison ? (Generic.CodeAnalysis.AssignmentInCondition.Found)
 246 | ERROR   | [ ] Assignments must be the first block of code on a line (Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure)
 251 | WARNING | [ ] Variable assignment found within a condition. Did you mean to do a comparison ? (Generic.CodeAnalysis.AssignmentInCondition.Found)
 251 | ERROR   | [ ] Assignments must be the first block of code on a line (Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure)
 287 | WARNING | [ ] Variable assignment found within a condition. Did you mean to do a comparison ? (Generic.CodeAnalysis.AssignmentInCondition.Found)
 287 | ERROR   | [ ] Assignments must be the first block of code on a line (Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure)
 290 | WARNING | [ ] Variable assignment found within a condition. Did you mean to do a comparison ? (Generic.CodeAnalysis.AssignmentInCondition.Found)
 290 | ERROR   | [ ] Assignments must be the first block of code on a line (Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure)
 328 | ERROR   | [x] Space after opening control structure is required (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterStructureOpen)
 328 | ERROR   | [x] No space before opening parenthesis is prohibited (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeOpenParenthesis)
 328 | ERROR   | [x] Expected 1 space after IF keyword; 0 found (Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword)
 348 | ERROR   | [x] The closing brace for the class must go on the next line after the body (PSR2.Classes.ClassDeclaration.CloseBraceAfterBody)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 6 MARKED SNIFF VIOLATIONS AUTOMATICALLY
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected

## Test Plan
1. Run `./vendor/bin/phpcs`, you should get no errors in `./includes/Lifecycle.php`.
2. Run extension and test the basic functionality to ensure everything still works as intended.