### PR TITLE
Enable video sync at variable product level

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1200,8 +1200,6 @@ class Admin {
 					)
 				);
 
-				$this->render_facebook_product_video_field( $video_urls );
-
 				woocommerce_wp_text_input(
 					array(
 						'id'          => \WC_Facebook_Product::FB_PRODUCT_PRICE,
@@ -1250,6 +1248,9 @@ class Admin {
 			</script>
 
 			<?php
+				// Render the Facebook Product Video field at Product level
+				$this->render_facebook_product_video_field( $video_urls );
+
 				woocommerce_wp_text_input(
 					array(
 						'id'          => \WC_Facebook_Product::FB_MPN,

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -416,19 +416,24 @@ class WC_Facebook_Product {
 	 *
 	 * @return array
 	 */
-	public function get_all_video_urls() {
+	public function get_all_video_urls( $parent_id = null ) {
 
 		$video_urls = array();
-
+		$product = $this->woo_product;
+		
+		if($parent_id !== null) {
+			$product = wc_get_product( $parent_id );
+		}
+	
 		$attached_videos = get_attached_media( 'video', $this->id );
 
-			$custom_video_urls = $this->woo_product->get_meta( self::FB_PRODUCT_VIDEO );
+		$custom_video_urls = $product->get_meta( self::FB_PRODUCT_VIDEO );
 
 		if ( empty( $attached_videos ) && empty( $custom_video_urls ) ) {
 			return $video_urls;
 		}
 
-			// Add custom video URLs to the list
+		// Add custom video URLs to the list
 		if ( ! empty( $custom_video_urls ) && is_array( $custom_video_urls ) ) {
 			foreach ( $custom_video_urls as $custom_url ) {
 				$custom_url = trim( $custom_url );
@@ -438,7 +443,7 @@ class WC_Facebook_Product {
 			}
 		}
 
-			// Add attached video URLs to the list, excluding duplicates from custom video URLs
+		// Add attached video URLs to the list, excluding duplicates from custom video URLs
 		if ( ! empty( $attached_videos ) ) {
 			$custom_video_url_set = array_flip( array_column( $video_urls, 'url' ) );
 			foreach ( $attached_videos as $video ) {
@@ -1418,7 +1423,7 @@ class WC_Facebook_Product {
 				$value = $attribute_values[0];
 				// Clean and truncate the value directly for simple products
 				return mb_substr(WC_Facebookcommerce_Utils::clean_string($value), 0, 200);
-			}
+			}		
 		} else {
 			// For variable/variation products, keep all values
 			$joined_values = implode(' | ', $attribute_values);
@@ -1807,6 +1812,13 @@ class WC_Facebook_Product {
 		}//end if
 
 		$video_urls = $this->get_all_video_urls();
+		
+		// If this is a variable product, get the video URLs from the parent product and add them to variations.
+		if($this->get_type() === "variation"){
+			$parent_id = $this->woo_product->get_parent_id();
+			$video_urls = $this->get_all_video_urls($parent_id);
+		}
+
 		if ( ! empty( $video_urls ) && self::PRODUCT_PREP_TYPE_NORMAL !== $type_to_prepare_for ) {
 			$product_data['video'] = $video_urls;
 		}


### PR DESCRIPTION
## Description
Earlier, we introduced video sync at simple product level in #2874.

This PR brings enabling the video sync at variable product level.

### Type of change
- New feature (non-breaking change which adds functionality)


## Checklist

- [] I have commented my code, particularly in hard-to-understand areas.
- [] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

 - enable video sync at variable product level.


## Test Plan

1. Run all tests : `npm run test:php`
<img width="541" alt="image" src="https://github.com/user-attachments/assets/8456d111-9f7b-4e6a-9575-bf7ac5ff3b09" />

2. Lint: `./vendor/bin/phpcs`
3. Run test `./vendor/bin/phpunit --filter test_prepare_product_videos`
4. **E2E Tests**
   - Single Product Update
       * Go to individual product. Upload a video using FB product video form field.
       * Click Publish->Update
       * Outcome : Video Synced to facebook
       
   - Batch API Update
      * Disconnect from facebook
      * Connect back and create a new catalog
      * Products are synced with batch API flow
      * Outcomes : New catalog created on facebook, with Videos synced at product level.

### test
| **video sync simple product**  | **video sync variable product** |
| -------- | ------- |
| https://pxl.cl/7nr6V | https://pxl.cl/7nrB1  |


## Screenshots
| **Before** | **After**|
| -------- | ------- |
| <img width="2256" alt="Screenshot 2025-06-03 at 16 52 14" src="https://github.com/user-attachments/assets/3ab146f7-40cd-4a6c-9109-bf7ac9322336" /> | <img width="2256" alt="Screenshot 2025-06-03 at 16 50 02" src="https://github.com/user-attachments/assets/7c608cc0-4f4a-4773-8f9b-3bb6af550d70" /> |




