### PR TITLE
Fix non-static method reset_upcoming_version_banners called by WP Hook

### DIFF
--- a/includes/Handlers/PluginRender.php
+++ b/includes/Handlers/PluginRender.php
@@ -145,7 +145,7 @@ class PluginRender {
 	 * Banner for initmation of WooAllProducts version will show up
 	 * after a week
 	 */
-	public function reset_upcoming_version_banners() {
+	public static function reset_upcoming_version_banners() {
 		set_transient( 'upcoming_woo_all_products_banner_hide', true, 7 * DAY_IN_SECONDS );
 	}
 


### PR DESCRIPTION
## Description

We got an report from QA of an error log being surfaced due to this non-static method being called in a static way. This is similar to some other errors we've seen and fixed recently. Updating the method to be static to resolve the error.

https://privatebin.net/?7272b8875ee5971f#9fkC642u6APEjm6TQsYoD6jLrW1MEvrkGQDvwUaQJuYZ

### Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [] I have commented my code, particularly in hard-to-understand areas.
- [] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fix non-static method reset_upcoming_version_banners called by WP Hook

