### PR TITLE
Flush rewrite rules on upgrade to v3.5.3

### DIFF
--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -54,6 +54,7 @@ class Lifecycle extends Framework\Lifecycle {
 			'2.5.0',
 			'3.2.0',
 			'3.4.9',
+			'3.5.3',
 		);
 	}
 

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -350,4 +350,14 @@ class Lifecycle extends Framework\Lifecycle {
 	protected function upgrade_to_3_4_9() {
 		facebook_for_woocommerce()->get_product_sets_sync_handler()->sync_all_product_sets();
 	}
+
+	/**
+	 * Trigger flush of rewrite rules to update with checkout URL
+	 *
+	 * @since 3.5.3
+	 */
+	protected function upgrade_to_3_5_3() {
+		add_rewrite_rule( '^fb-checkout/?$', 'index.php?fb_checkout=1', 'top' );
+		flush_rewrite_rules();
+	}
 }


### PR DESCRIPTION
## Description
This PR will flush the rewrite rules on upgrade to `v3.5.3`. This ensures that the `/fb-checkout` endpoint is working correctly on the seller's website.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Test Plan
1. Install an older version of the extension.
2. Upgrade to `v3.5.3` and ensure rewrite rules were flushed.

## Screenshots
1. https://github.com/user-attachments/assets/d2c13108-3d00-44e2-b921-5b845a9ca34a
2. https://github.com/user-attachments/assets/923011b8-e719-4490-8087-794eba87ab57

