### PR TITLE
Changed json_encode to wp_json_encode to avoid phpcs issues

### DIFF
--- a/bin/GenerateCategoryAttributeMapping.php
+++ b/bin/GenerateCategoryAttributeMapping.php
@@ -33,7 +33,7 @@ class GenerateCategoryAttributeMapping {
 			foreach ( $category['attributes'] as &$attr ) {
 
 				// hash the attribute array to determine unique entries
-				$hash = md5( json_encode( $attr ) );
+				$hash = md5( wp_json_encode( $attr ) );
 
 				if ( ! isset( $unique_fields[ $hash ] ) ) {
 					$this->field_export[ $hash ] = $attr;
@@ -45,8 +45,8 @@ class GenerateCategoryAttributeMapping {
 			$this->category_export[ $category_id ] = $category;
 		}
 
-		file_put_contents( $plugin_root . $this::EXPORT_CATEGORIES_FILE_NAME, json_encode( $this->category_export ) );
-		file_put_contents( $plugin_root . $this::EXPORT_FIELDS_FILE_NAME, json_encode( $this->field_export ) );
+		file_put_contents( $plugin_root . $this::EXPORT_CATEGORIES_FILE_NAME, wp_json_encode( $this->category_export ) );
+		file_put_contents( $plugin_root . $this::EXPORT_FIELDS_FILE_NAME, wp_json_encode( $this->field_export ) );
 
 		echo sprintf(
 			"Files successfully generated: \n %s \n %s \n",

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -228,7 +228,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				'custom_data' => array(
 					'content_name'     => $category->name,
 					'content_category' => $category->name,
-					'content_ids'      => json_encode( array_slice( $product_ids, 0, 10 ) ),
+					'content_ids'      => wp_json_encode( array_slice( $product_ids, 0, 10 ) ),
 					'content_type'     => $content_type,
 					'contents'         => $contents,
 				),
@@ -453,7 +453,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 					'event_name'  => 'Search',
 					'custom_data' => array(
 						'content_type'  => $content_type,
-						'content_ids'   => json_encode( array_slice( $product_ids, 0, 10 ) ),
+						'content_ids'   => wp_json_encode( array_slice( $product_ids, 0, 10 ) ),
 						'contents'      => $contents,
 						'search_string' => get_search_query(),
 						'value'         => Helper::number_format( $total_value ),

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -126,8 +126,8 @@ class WC_Facebookcommerce_Pixel {
 			sprintf(
 				"fbq('init', '%s', %s, %s);\n",
 				esc_js( self::get_pixel_id() ),
-				json_encode( $this->user_info, JSON_PRETTY_PRINT | JSON_FORCE_OBJECT ),
-				json_encode( array( 'agent' => $agent_string ), JSON_PRETTY_PRINT | JSON_FORCE_OBJECT )
+				wp_json_encode( $this->user_info, JSON_PRETTY_PRINT | JSON_FORCE_OBJECT ),
+				wp_json_encode( array( 'agent' => $agent_string ), JSON_PRETTY_PRINT | JSON_FORCE_OBJECT )
 			)
 		);
 	}
@@ -166,7 +166,7 @@ class WC_Facebookcommerce_Pixel {
 
 			<?php echo $this->get_pixel_init_code(); ?>
 
-				fbq( 'track', 'PageView', <?php echo json_encode( self::build_params( [], 'PageView' ), JSON_PRETTY_PRINT | JSON_FORCE_OBJECT ); ?> );
+				fbq( 'track', 'PageView', <?php echo wp_json_encode( self::build_params( [], 'PageView' ), JSON_PRETTY_PRINT | JSON_FORCE_OBJECT ); ?> );
 
 				document.addEventListener( 'DOMContentLoaded', function() {
 					// Insert placeholder for events injected when a product is added to the cart through AJAX.
@@ -460,8 +460,8 @@ class WC_Facebookcommerce_Pixel {
 				self::get_pixel_id(),
 				esc_js( $method ),
 				esc_js( $event_name ),
-				json_encode( self::build_params( $params, $event_name ), JSON_PRETTY_PRINT | JSON_FORCE_OBJECT ),
-				json_encode( array( 'eventID' => $event_id ), JSON_PRETTY_PRINT | JSON_FORCE_OBJECT )
+				wp_json_encode( self::build_params( $params, $event_name ), JSON_PRETTY_PRINT | JSON_FORCE_OBJECT ),
+				wp_json_encode( array( 'eventID' => $event_id ), JSON_PRETTY_PRINT | JSON_FORCE_OBJECT )
 			);
 
 		} else {
@@ -475,7 +475,7 @@ class WC_Facebookcommerce_Pixel {
 				self::get_pixel_id(),
 				esc_js( $method ),
 				esc_js( $event_name ),
-				json_encode( self::build_params( $params, $event_name ), JSON_PRETTY_PRINT | JSON_FORCE_OBJECT )
+				wp_json_encode( self::build_params( $params, $event_name ), JSON_PRETTY_PRINT | JSON_FORCE_OBJECT )
 			);
 		}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -563,7 +563,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				'background' => false,
 			];
 		}
-		printf( json_encode( $response ) );
+		printf( wp_json_encode( $response ) );
 		wp_die();
 	}
 
@@ -1735,7 +1735,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			'connected' => true,
 			'status'    => 'complete',
 		];
-		printf( json_encode( $response ) );
+		printf( wp_json_encode( $response ) );
 		wp_die();
 	}
 
@@ -1786,7 +1786,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		} else {
 			$response = [ 'connected' => false ];
 		}
-		printf( json_encode( $response ) );
+		printf( wp_json_encode( $response ) );
 		wp_die();
 	}
 
@@ -2015,7 +2015,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		wp_reset_postdata();
 		ob_end_clean();
 
-		return json_encode( [ $items ] );
+		return wp_json_encode( [ $items ] );
 	}
 
 	/**
@@ -3009,7 +3009,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			delete_transient( 'facebook_plugin_test_stack_trace' );
 		}
 		delete_option( 'fb_test_pass' );
-		printf( json_encode( $response ) );
+		printf( wp_json_encode( $response ) );
 		wp_die();
 	}
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -479,7 +479,7 @@ class Connection {
 			if ( json_last_error() === JSON_ERROR_NONE ) {
 				// If error is the first key we want to use just the body to simplify the message.
 				$decoded_message = isset( $decoded_message->error ) ? $decoded_message->error : $decoded_message;
-				$message         = json_encode( $decoded_message, JSON_PRETTY_PRINT );
+				$message         = wp_json_encode( $decoded_message, JSON_PRETTY_PRINT );
 			}
 			return $message;
 	}
@@ -1039,7 +1039,7 @@ class Connection {
 				'display'       => 'page',
 				'response_type' => 'code',
 				'scope'         => implode( ',', $this->get_scopes() ),
-				'extras'        => json_encode( $this->get_connect_parameters_extras() ),
+				'extras'        => wp_json_encode( $this->get_connect_parameters_extras() ),
 			)
 		);
 	}

--- a/includes/fbinfobanner.php
+++ b/includes/fbinfobanner.php
@@ -169,7 +169,7 @@ class WC_Facebookcommerce_Info_Banner {
 			update_option(
 				'fb_info_banner_last_best_tip',
 				is_object( $tip_info ) || is_array( $tip_info )
-				? json_encode( $tip_info ) : $tip_info
+				? wp_json_encode( $tip_info ) : $tip_info
 			);
 		}
 

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -262,7 +262,7 @@ class WC_Facebook_Product_Feed {
 
 		} catch ( Exception $e ) {
 
-			WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( json_encode( $e->getMessage() ) );
+			WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( wp_json_encode( $e->getMessage() ) );
 
 			$written = false;
 
@@ -628,7 +628,7 @@ class WC_Facebook_Product_Feed {
 			$result        = facebook_for_woocommerce()->get_api()->read_upload( $upload_id );
 
 			if ( is_wp_error( $result ) || ! isset( $result['body'] ) ) {
-				$this->log_feed_progress( json_encode( $result ) );
+				$this->log_feed_progress( wp_json_encode( $result ) );
 				return $upload_status;
 			}
 
@@ -650,7 +650,7 @@ class WC_Facebook_Product_Feed {
 	// Log progress in local log file and FB.
 	public function log_feed_progress( $msg, $object = array() ) {
 		WC_Facebookcommerce_Utils::fblog( $msg, $object );
-		$msg = empty( $object ) ? $msg : $msg . json_encode( $object );
+		$msg = empty( $object ) ? $msg : $msg . wp_json_encode( $object );
 		WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( $msg );
 	}
 }

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -394,7 +394,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 				$obj['plugin_version'] = self::PLUGIN_VERSION;
 				$obj['php_version']    = phpversion();
 			}
-			$message = json_encode(
+			$message = wp_json_encode(
 				array(
 					'message' => $message,
 					'object'  => $obj,
@@ -1020,7 +1020,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 			}
 
 			if ( is_array( $message ) || is_object( $message ) ) {
-				$message = json_encode( $message );
+				$message = wp_json_encode( $message );
 			} else {
 				$message = sanitize_textarea_field( $message );
 			}

--- a/tests/Unit/Handlers/MetaExtensionTest.php
+++ b/tests/Unit/Handlers/MetaExtensionTest.php
@@ -72,7 +72,7 @@ class MetaExtensionTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilt
                         'code' => 200,
                         'message' => 'OK',
                     ],
-                    'body' => json_encode([
+                    'body' => wp_json_encode([
                         'commerce_extension' => [
                             'uri' => $expected_url
                         ]

--- a/tests/Unit/RolloutSwitchesTest.php
+++ b/tests/Unit/RolloutSwitchesTest.php
@@ -91,7 +91,7 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 		$prop_api->setAccessible( true );
 		$mock_api = $this->getMockBuilder( API::class )->disableOriginalConstructor()->setMethods( array( 'do_remote_request' ) )->getMock();
 		$mock_api->expects( $this->any() )->method( 'do_remote_request' )->willReturn(
-			array('body' => json_encode(array(
+			array('body' => wp_json_encode(array(
 				'data' => array(
 					array('switch' => 'switch_a','enabled' => '1'),
 					array('switch' => 'switch_b', 'enabled' => ''),
@@ -149,7 +149,7 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 		$prop_api->setAccessible( true );
 		$mock_api = $this->getMockBuilder( API::class )->disableOriginalConstructor()->setMethods( array( 'do_remote_request' ) )->getMock();
 		$mock_api->expects( $this->any() )->method( 'do_remote_request' )->willReturn(
-			array('body' => json_encode(array())));
+			array('body' => wp_json_encode(array())));
 		$prop_api->setValue( $plugin, $mock_api );
 
 		$switch_mock = $this->getMockBuilder(RolloutSwitches::class)

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -289,7 +289,7 @@ class WCFacebookCommerceIntegrationTest extends \WooCommerce\Facebook\Tests\Abst
 		}
 		/* From Product Meta or FB API. */
 		$facebook_product_group_id = 'some-facebook-product-group-id';
-		$facebook_response         = new API\ProductCatalog\ProductGroups\Read\Response( json_encode( [ 'data' => $facebook_output ] ) );
+		$facebook_response         = new API\ProductCatalog\ProductGroups\Read\Response( wp_json_encode( [ 'data' => $facebook_output ] ) );
 
 		$this->api->expects( $this->once() )
 			->method( 'get_product_group_products' )
@@ -325,7 +325,7 @@ class WCFacebookCommerceIntegrationTest extends \WooCommerce\Facebook\Tests\Abst
 		}
 		/* From Product Meta or FB API. */
 		$facebook_product_group_id = 'some-facebook-product-group-id';
-		$facebook_response         = new API\ProductCatalog\ProductGroups\Read\Response( json_encode( [ 'data' => $facebook_output ] ) );
+		$facebook_response         = new API\ProductCatalog\ProductGroups\Read\Response( wp_json_encode( [ 'data' => $facebook_output ] ) );
 
 		$this->api->expects( $this->once() )
 			->method( 'get_product_group_products' )


### PR DESCRIPTION
## Description

Changed json_encode to wp_json_encode to avoid phpcs issues

### Type of change

- Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Changed json_encode to wp_json_encode to avoid phpcs issues


## Test Plan
npm run test:php

./vendor/bin/phpcs  won't show json_encode warnings anymore