### PR TITLE
Restoring the product sync tagging with integers

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1734,7 +1734,9 @@ class WC_Facebook_Product {
 				 * If parent's visibility is already marked we know we should assign it to the child/variation as well
 				 */
 				if($parent_product_visibility === "yes"){
-					// $product_data["is_woo_all_products_sync"] = !$current_variation_product_visibility;
+					if( !$current_variation_product_visibility){
+						$product_data["is_woo_all_products_sync"] = 1;
+					}
 					$product_data[ 'visibility' ] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE;
 				}
 				else if ($parent_product_visibility === "no"){
@@ -1764,8 +1766,8 @@ class WC_Facebook_Product {
 					 * Tagging those products who were previously having visibility hidden
 					 * But now have visibility published
 					 */
-					if($variation_visibility){
-						// $product_data["is_woo_all_products_sync"] = !$current_variation_product_visibility;
+					if($variation_visibility && !$current_variation_product_visibility){
+						$product_data["is_woo_all_products_sync"] = 1;
 					}
 
 					$product_data[ 'visibility' ] = $variation_visibility ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;


### PR DESCRIPTION
## Description

Due to limitation in ingestion framework, the tagging was showing issues by manifesting itself in form of debug logs in the wordpress logging.

### Type of change

Backend fixes have been made with integer support and now tagging is enabled with integers

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).



## Test Plan

Check in the logs if there are any warnings