### PR TITLE
Removing delete on stock check

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1172,26 +1172,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	}
 
 	/**
-	 * If the user has opt-in to remove products that are out of stock,
-	 * this function will delete the product from FB Page as well.
-	 *
-	 * @param int        $wp_id
-	 * @param WC_Product $woo_product
-	 *
-	 * @return bool
-	 */
-	public function delete_on_out_of_stock( int $wp_id, WC_Product $woo_product ): bool {
-		if ( Products::product_should_be_deleted( $woo_product ) ) {
-			$product = wc_get_product( $wp_id );
-			$this->delete_fb_product( $product );
-
-			return true;
-		}
-
-		return false;
-	}
-
-	/**
 	 * Syncs product to Facebook when saving a variable product.
 	 *
 	 * @param int                      $wp_id product post ID
@@ -1200,10 +1180,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	public function on_variable_product_publish( $wp_id, $woo_product = null ) {
 		if ( ! $woo_product instanceof \WC_Facebook_Product ) {
 			$woo_product = new \WC_Facebook_Product( $wp_id );
-		}
-
-		if ( $this->delete_on_out_of_stock( $wp_id, $woo_product->woo_product ) ) {
-			return;
 		}
 
 		if ( ! $this->product_should_be_synced( $woo_product->woo_product ) ) {
@@ -1226,7 +1202,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		// scheduled update for each variation that should be synced
 		foreach ( $woo_product->get_children() as $variation_id ) {
 			$variation = wc_get_product( $variation_id );
-			if ( $variation instanceof WC_Product && $this->product_should_be_synced( $variation ) && ! $this->delete_on_out_of_stock( $variation_id, $variation ) ) {
+			if ( $variation instanceof WC_Product && $this->product_should_be_synced( $variation ) ) {
 				$variation_ids[] = $variation_id;
 			}
 		}
@@ -1246,10 +1222,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	public function on_simple_product_publish( $wp_id, $woo_product = null, &$parent_product = null ) {
 		if ( ! $woo_product instanceof \WC_Facebook_Product ) {
 			$woo_product = new \WC_Facebook_Product( $wp_id, $parent_product );
-		}
-
-		if ( $this->delete_on_out_of_stock( $wp_id, $woo_product->woo_product ) ) {
-			return;
 		}
 
 		if ( ! $this->product_should_be_synced( $woo_product->woo_product ) ) {

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -875,67 +875,7 @@ class WCFacebookCommerceIntegrationTest extends \WooCommerce\Facebook\Tests\Abst
 
 		$this->integration->on_product_publish( $product->get_id() );
 	}
-
-	/**
-	 * Sunny day test. Tests deletion of out of stock simple product item.
-	 *
-	 * @return void
-	 */
-	public function test_delete_on_out_of_stock_deletes_simple_product() {
-		$product = WC_Helper_Product::create_simple_product();
-
-		update_option( 'woocommerce_hide_out_of_stock_items', 'yes' );
-		$product->set_stock_status( 'outofstock' );
-
-		add_post_meta( $product->get_id(), WC_Facebookcommerce_Integration::FB_PRODUCT_ITEM_ID, 'facebook-product-item-id' );
-
-		$this->api->expects( $this->never() )
-			->method( 'delete_product_item' )
-			->with( 'facebook-product-item-id' );
-
-		$result = $this->integration->delete_on_out_of_stock( $product->get_id(), $product );
-
-		$this->assertFalse( $result );
-	}
-
-	/**
-	 * Tests deletion of out of stock simple product item not performed due to WC settings set to 'no'.
-	 *
-	 * @return void
-	 */
-	public function test_delete_on_out_of_stock_does_not_delete_simple_product_with_wc_settings_off() {
-		$product = WC_Helper_Product::create_simple_product();
-
-		update_option( 'woocommerce_hide_out_of_stock_items', 'no' );
-		$product->set_stock_status( 'outofstock' );
-
-		$this->api->expects( $this->never() )
-			->method( 'delete_product_item' );
-
-		$result = $this->integration->delete_on_out_of_stock( $product->get_id(), $product );
-
-		$this->assertFalse( $result );
-	}
-
-	/**
-	 * Tests deletion of in-stock variation product item not performed.
-	 *
-	 * @return void
-	 */
-	public function test_delete_on_out_of_stock_does_not_delete_in_stock_simple_product() {
-		$product = WC_Helper_Product::create_variation_product();
-
-		update_option( 'woocommerce_hide_out_of_stock_items', 'yes' );
-		$product->set_stock_status( 'instock' );
-
-		$this->api->expects( $this->never() )
-			->method( 'delete_product_item' );
-
-		$result = $this->integration->delete_on_out_of_stock( $product->get_id(), $product );
-
-		$this->assertFalse( $result );
-	}
-
+	
 	/**
 	 * Tests update of existing variable product.
 	 *


### PR DESCRIPTION
## Description

In order to make code better we are removing unused check for delte_product_on_empty stocks

### Type of change

Unused code removal

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).



## Test Plan

Dead code removal
