### PR TITLE
Adding tags on excluded categories and tags

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1695,6 +1695,8 @@ class WC_Facebook_Product {
 		}
 
 		$categories = WC_Facebookcommerce_Utils::get_product_categories( $id );
+		$category_ids =  array_map('strval', WC_Facebookcommerce_Utils::get_product_category_ids( $id ));
+		$tags_ids = array_map('strval',  WC_Facebookcommerce_Utils::get_excluded_product_tags_ids($id));
 
 		// Determine if this is an API call where we should convert pipe-separated values to arrays
 		$is_api_call = ($type_to_prepare_for === self::PRODUCT_PREP_TYPE_ITEMS_BATCH);
@@ -1795,6 +1797,26 @@ class WC_Facebook_Product {
 			 */
 			 $product_data["is_woo_all_products_sync"] = 1;
 		 }
+
+		 /*
+		 * If a category was previously excluded that meant that it was not getting synced
+		 * 3.5.3 changes will make sure these categories are no longer kept from syncing
+		 * So we are tagging them as well since they are now synced with us
+		 */
+		$deprecated_excluded_category_ids = get_option('wc_facebook_excluded_product_category_ids');
+
+		if($deprecated_excluded_category_ids && $category_ids && !empty(array_intersect($deprecated_excluded_category_ids, $category_ids))){
+			$product_data["is_woo_all_products_sync"] = 1;	
+		}
+
+		/**
+		 * Doing same tagging for proudct tags exclusion
+		*/
+		$deprecated_excluded_tag_ids = get_option('wc_facebook_excluded_product_tag_ids');
+
+		if($deprecated_excluded_tag_ids && $tags_ids && !empty(array_intersect($deprecated_excluded_tag_ids, $tags_ids))){
+			$product_data["is_woo_all_products_sync"] = 1;	
+		}
 
 
 		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -234,6 +234,38 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		}
 
 		/**
+		 * Returns the category ids for products/pixel.
+		 *
+		 * @param int $wpid
+		 * @return Array
+		 */
+		public static function get_product_category_ids( $wpid ) {
+			$product = wc_get_product( $wpid );
+
+			if ( ! $product ) {
+				return 'Invalid product ID';
+			}
+
+			return $product->get_category_ids();
+		}
+
+		/**
+		 * Returns the category ids for products/pixel.
+		 *
+		 * @param int $wpid
+		 * @return Array
+		 */
+		public static function get_excluded_product_tags_ids( $wpid ) {
+			$product = wc_get_product( $wpid );
+
+			if ( ! $product ) {
+				return [];
+			}
+
+			return $product->get_tag_ids();
+		}
+
+		/**
 		 * Returns the content ID to match on for Pixel fires.
 		 *
 		 * @param WC_Product $woo_product


### PR DESCRIPTION
## Description

Adding tagging support for excluded tags and categories

### Type of change

Adding a simple tag on products that were previously excluded from tags and categories.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Test Plan

No UI change
but should see a tag in API params when making a request for a product
tagged with excluded category or tag
