### PR TITLE
Release plugin workflow

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -1,0 +1,165 @@
+name: Release Plugin
+
+on:
+  push:
+    branches:
+      - 'release/current'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    environment: Deployment
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get NPM Version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@v1.3.1
+
+      - name: Validate Git tag
+        run: |
+          if [ $(git tag -l "v${{ steps.package-version.outputs.current-version}}") ]; then
+            echo "Git tag exist" 1>&2
+            exit 1
+          fi
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache-dependency-path: './package-lock.json'
+          cache: 'npm'
+      
+      - name: Install dependencies
+        run: |
+          npm ci || npm install
+          composer install
+      
+      - name: Build plugin
+        run: |
+          npm run build
+          if [ -f "facebook-for-woocommerce.zip" ]; then
+            echo "build_success=true" >> $GITHUB_OUTPUT
+            echo "filesize=$(du -h facebook-for-woocommerce.zip | cut -f1)" >> $GITHUB_OUTPUT
+          else
+            echo "build_success=false" >> $GITHUB_OUTPUT
+            echo "Build error" 1>&2
+            exit 1
+          fi
+
+      - name: Extract Release Notes
+        id: extract_release_notes
+        run: |
+          readme_file="readme.txt"
+          found_changelog=0
+          echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
+          while IFS= read -r line || [[ -n $line ]]; do
+              clean_line=$(echo "$line" | tr -d '\r' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+              if [[ $found_changelog -eq 0 ]]; then
+                  if [[ "$clean_line" == "== Changelog ==" ]]; then
+                      found_changelog=1
+                  fi
+              else
+                  if [[ "$clean_line" == \** ]]; then
+                      echo "$clean_line" >> $GITHUB_ENV
+                  fi
+              fi
+          done < "$readme_file"
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Store built plugin
+        uses: actions/upload-artifact@master
+        continue-on-error: true
+        with:
+          name: facebook-for-woocommerce
+          path: facebook-for-woocommerce.zip
+
+      - name: Install SVN
+        run: sudo apt-get install subversion -y
+
+      - name: Checkout SVN Repository
+        run: svn co https://plugins.svn.wordpress.org/facebook-for-woocommerce/ woocommerce_svn --quiet --non-interactive
+
+      - name: Validate SVN tag
+        run: |
+          if [ -d "woocommerce_svn/tags/${{ steps.package-version.outputs.current-version}}" ]; then
+            echo "SVN tag directory exist" 1>&2
+            exit 1
+          fi
+
+      - name: Commit to SVN
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        run: |
+          cd woocommerce_svn
+          rm -rf trunk
+          cp ../facebook-for-woocommerce.zip ./
+          echo "Unzipping the atrifact"
+          unzip facebook-for-woocommerce.zip
+          mv facebook-for-woocommerce trunk
+          rm facebook-for-woocommerce.zip
+          svn add --force .
+          svn st | grep ^! | awk '{print $2}' | xargs -r svn rm
+          svn status
+          echo "Tagging version ${{ steps.package-version.outputs.current-version}}"
+          svn cp trunk "tags/${{ steps.package-version.outputs.current-version}}"
+          echo "Status:"
+          svn status
+          svn commit -m "Deploy new version ${{ steps.package-version.outputs.current-version}}" --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --no-auth-cache --non-interactive
+
+      - name: Create a new release on GitHub
+        uses: actions/github-script@v7
+        env:
+          VERSION: ${{ steps.package-version.outputs.current-version}}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const version = process.env.VERSION;
+            const releaseNotes = process.env.RELEASE_NOTES;
+            const release = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: `v${version}`,
+              target_commitish: 'release/current',
+              name: `Release ${version}`,
+              body: releaseNotes,
+              draft: true,
+            });
+            const maxRetries = 5;
+            const fileName = 'facebook-for-woocommerce.zip'
+            const filePath = path.join(process.env.GITHUB_WORKSPACE, fileName);
+            const source = fs.readFileSync(filePath);
+            for (let retry = 0; retry < maxRetries; retry++) {
+              try {
+                await github.rest.repos.uploadReleaseAsset({
+                  owner: context.repo.owner, 
+                  repo: context.repo.repo, 
+                  release_id: release.data.id,
+                  name: fileName, 
+                  headers: {'Content-Type': 'application/x-xz'}, 
+                  data: source
+                });
+                break;
+              } catch (error) {
+                  console.log(`Failed to upload (status ${error.status}, retry: ${retry})`);
+                  if (error.status != 500) {
+                      throw error;
+                  }
+              }
+            }
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner, 
+              repo: context.repo.repo, 
+              release_id: release.data.id,
+              draft: false,
+              prerelease: true,
+            });


### PR DESCRIPTION
This workflow deploys the plugin to Wordpress SVN and creates a new GitHub release.
It is using the Deployment environment and will only deploy when pushing to release/current branch which is a protected branch.
It uses the package.json version to get the latest version.
On SVN it replaces trunk with the contents of the built package and creates a new tag based on the version.
It also creates a new GitHub prerelease using the readme.txt changelog.

It currently validates both git and svn tags before moving forward with the release process.

**It does not set the "Stable tag" on readme.txt**


Succesful test run:
https://github.com/facebook/facebook-for-woocommerce/actions/runs/15544252114

