### PR TITLE
Fixing R&R query logic and tests for R&R and promotion feed upload

### DIFF
--- a/includes/Feed/RatingsAndReviews/RatingsAndReviewsFeedGenerator.php
+++ b/includes/Feed/RatingsAndReviews/RatingsAndReviewsFeedGenerator.php
@@ -37,9 +37,11 @@ class RatingsAndReviewsFeedGenerator extends FeedGenerator {
 		$offset       = ( $batch_number - 1 ) * $batch_size;
 
 		$query_args = array(
-			'number' => $batch_size,
-			'offset' => $offset,
-			'status' => 'approve',
+			'number'       => $batch_size,
+			'offset'       => $offset,
+			'status'       => 'approve',
+			'post_type'    => 'product',
+			'comment_type' => 'review',
 		);
 
 		return FeedUploadUtils::get_ratings_and_reviews_data( $query_args );

--- a/includes/Feed/RatingsAndReviews/RatingsAndReviewsFeedHandler.php
+++ b/includes/Feed/RatingsAndReviews/RatingsAndReviewsFeedHandler.php
@@ -39,7 +39,9 @@ class RatingsAndReviewsFeedHandler extends AbstractFeedHandler {
 	 */
 	public function get_feed_data(): array {
 		$query_args = array(
-			'status' => 'approve',
+			'status'       => 'approve',
+			'post_type'    => 'product',
+			'comment_type' => 'review',
 		);
 
 		return FeedUploadUtils::get_ratings_and_reviews_data( $query_args );

--- a/tests/Unit/Feed/FeedUploadUtilsTest.php
+++ b/tests/Unit/Feed/FeedUploadUtilsTest.php
@@ -29,6 +29,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 		// Create a review comment.
 		$comment_id = self::factory()->comment->create( [
 			'comment_post_ID' => $product_id,
+			'comment_type'    => 'review',
 			'comment_date'    => '2023-10-01 10:00:00',
 			'comment_content' => 'Awesome product!',
 			'comment_author'  => 'John Doe',
@@ -36,7 +37,14 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 		] );
 		update_comment_meta( $comment_id, 'rating', 5 );
 
-		$result = \WooCommerce\Facebook\Feed\FeedUploadUtils::get_ratings_and_reviews_data( [] );
+		//Query arguments to fetch R&R data
+		$query_args = array(
+			'status'       => 'approve',
+			'post_type'    => 'product',
+			'comment_type' => 'review',
+		);
+
+		$result = \WooCommerce\Facebook\Feed\FeedUploadUtils::get_ratings_and_reviews_data( $query_args );
 
 		$expected_review = [
 			'aggregator'                      => 'woocommerce',
@@ -83,7 +91,14 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 		] );
 		update_comment_meta( $comment_id, 'rating', 4 );
 
-		$result = \WooCommerce\Facebook\Feed\FeedUploadUtils::get_ratings_and_reviews_data( [] );
+		//Query arguments to fetch R&R data
+		$query_args = array(
+			'status'       => 'approve',
+			'post_type'    => 'product',
+			'comment_type' => 'review',
+		);
+
+		$result = \WooCommerce\Facebook\Feed\FeedUploadUtils::get_ratings_and_reviews_data( $query_args );
 		$this->assertEmpty( $result, 'Expected no review for a non-product comment.' );
 	}
 
@@ -100,13 +115,21 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 		// Create a comment without a valid rating.
 		$comment_id = self::factory()->comment->create( [
 			'comment_post_ID' => $product_id,
+			'comment_type'    => 'review',
 			'comment_date'    => '2023-10-01 10:00:00',
 			'comment_content' => 'I did not rate this product.',
 			'comment_author'  => 'Alice',
 			'user_id'         => 3,
 		] );
 
-		$result = \WooCommerce\Facebook\Feed\FeedUploadUtils::get_ratings_and_reviews_data( [] );
+		//Query arguments to fetch R&R data
+		$query_args = array(
+			'status'       => 'approve',
+			'post_type'    => 'product',
+			'comment_type' => 'review',
+		);
+
+		$result = \WooCommerce\Facebook\Feed\FeedUploadUtils::get_ratings_and_reviews_data( $query_args );
 		$this->assertEmpty( $result, 'Expected no review when rating is missing.' );
 	}
 
@@ -115,6 +138,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 		$invalid_product_id = 999999;
 		$comment_id         = self::factory()->comment->create( [
 			'comment_post_ID' => $invalid_product_id,
+			'comment_type'    => 'review',
 			'comment_date'    => '2023-10-01 12:00:00',
 			'comment_content' => 'Product does not exist.',
 			'comment_author'  => 'Bob',
@@ -122,7 +146,14 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 		] );
 		update_comment_meta( $comment_id, 'rating', 3 );
 
-		$result = \WooCommerce\Facebook\Feed\FeedUploadUtils::get_ratings_and_reviews_data( [] );
+		//Query arguments to fetch R&R data
+		$query_args = array(
+			'status'       => 'approve',
+			'post_type'    => 'product',
+			'comment_type' => 'review',
+		);
+
+		$result = \WooCommerce\Facebook\Feed\FeedUploadUtils::get_ratings_and_reviews_data( $query_args );
 		$this->assertEmpty( $result, 'Expected no review for comment with invalid product.' );
 	}
 
@@ -168,7 +199,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 		// Build the expected coupon shape according to how FeedUploadUtils outputs the data.
 		$expected_coupon = [
 			'offer_id'                              => $coupon_id,              // coupon ID as an integer
-			'title'                                 => 'coupon-code-1',         // lowercased coupon post title
+			'title'                                 => 'COUPON-CODE-1',         // uppercase coupon post title
 			'value_type'                            => 'PERCENTAGE',
 			'percent_off'                           => '15',                    // as a string
 			'fixed_amount_off'                      => '',                      // empty string output
@@ -178,7 +209,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 			'target_selection'                      => 'SPECIFIC_PRODUCTS',
 			'start_date_time'                       => $coupon_data['start_date_time'], // use the output from the coupon post date/time
 			'end_date_time'                         => '',
-			'coupon_codes'                          => ['coupon-code-1'],
+			'coupon_codes'                          => ['COUPON-CODE-1'],
 			'public_coupon_code'                    => '',
 			'target_filter'                         => '{"or":[{"retailer_id":{"eq":"product-sku-1_'.$product1->get_id().'"}}]}',
 			'target_product_retailer_ids'           => '',
@@ -234,7 +265,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 		// Build the expected coupon shape according to how FeedUploadUtils outputs the data.
 		$expected_coupon = [
 			'offer_id'                              => $coupon_id,              // coupon ID as an integer
-			'title'                                 => 'coupon-code-1',         // lowercased coupon post title
+			'title'                                 => 'COUPON-CODE-1',         // uppercase coupon post title
 			'value_type'                            => 'PERCENTAGE',
 			'fixed_amount_off'                      => '0',                      // empty string output
 			'percent_off'                           => '100',                    // as a string
@@ -244,7 +275,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 			'target_selection'                      => 'ALL_CATALOG_PRODUCTS',
 			'start_date_time'                       => $coupon_data['start_date_time'], // use the output from the coupon post date/time
 			'end_date_time'                         => '',
-			'coupon_codes'                          => ['coupon-code-1'],
+			'coupon_codes'                          => ['COUPON-CODE-1'],
 			'public_coupon_code'                    => '',
 			'target_filter'                         => '',
 			'target_product_retailer_ids'           => '',
@@ -326,7 +357,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 		// Build the expected coupon shape.
 		$expected_coupon = [
 			'offer_id'                              => $coupon_id,                          // coupon ID as an integer
-			'title'                                 => 'coupon-incl-excl',                  // lowercased coupon post title
+			'title'                                 => 'COUPON-INCL-EXCL',                  // uppercase coupon post title
 			'value_type'                            => 'PERCENTAGE',
 			'percent_off'                           => '20',                                // as a string
 			'fixed_amount_off'                      => '',                                  // empty string output
@@ -336,7 +367,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 			'target_selection'                      => 'SPECIFIC_PRODUCTS',
 			'start_date_time'                       => $coupon_data['start_date_time'],     // use the generated start date/time
 			'end_date_time'                         => '',
-			'coupon_codes'                          => ['coupon-incl-excl'],                // coupon_codes as an array containing the title
+			'coupon_codes'                          => ['COUPON-INCL-EXCL'],                // coupon_codes as an array containing the title
 			'public_coupon_code'                    => '',
 			'target_filter'                         => '{"and":[{"or":[{"retailer_id":{"eq":"product-sku-1_'.$product1->get_id().'"}},{"retailer_id":{"eq":"product-sku-2_'.$product2->get_id().'"}}]},{"and":[{"retailer_id":{"neq":"product-sku-3_'.$product3->get_id().'"}}]}]}',
 			'target_product_retailer_ids'           => '',
@@ -435,8 +466,8 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 
 		// Build the expected coupon shape.
 		$expected_coupon = [
-			'offer_id'                              => $coupon_id,                           // coupon ID as an integer
-			'title'                                 => 'coupon-cat-only',                   // lowercased coupon post title
+			'offer_id'                              => $coupon_id,                          // coupon ID as an integer
+			'title'                                 => 'COUPON-CAT-ONLY',                   // uppercase coupon post title
 			'value_type'                            => 'PERCENTAGE',
 			'percent_off'                           => '15',                                // as a string
 			'fixed_amount_off'                      => '',                                  // empty string output
@@ -446,7 +477,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 			'target_selection'                      => 'SPECIFIC_PRODUCTS',
 			'start_date_time'                       => $coupon_data['start_date_time'],     // generated start date/time
 			'end_date_time'                         => '',
-			'coupon_codes'                          => ['coupon-cat-only'],                 // coupon_codes as an array containing the code
+			'coupon_codes'                          => ['COUPON-CAT-ONLY'],                 // coupon_codes as an array containing the code
 			'public_coupon_code'                    => '',
 			'target_filter'                         => $expected_target_filter,
 			'target_product_retailer_ids'           => '',


### PR DESCRIPTION
## Description

This PR fixes the query logic used to fetch the ratings and reviews data for the feed upload. There were some changes part of the WooCommerce 9.9.3 update that tweaked how to query this data. Previously you didn't have to specify the post_type/comment_type and could just fetch all comments. This PR updates where we setup the query arguments to set post_type and comment_type to fetch product ratings and reviews data.

This PR also updates the ratings and reviews tests to factor in this logic change and fixed some failing promotions feed upload tests.

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Updated ratings and reviews query logic and fixed tests in FeedUploadUtilsTest

## Test Plan
1. Pushed code without these changes to lightsail
2. Updated WooCommerce to 9.9.3
3. Triggered R&R feed upload and verified that the feed upload being sent to us was empty (due to changes in WooCommerce 9.9.3)
4. Pushed code with these changes to lightsail
5. Triggered R&R feed upload again and verified that this time the feed upload being sent to us included the expected reviews
![Screenshot 2025-06-09 at 4 07 54 PM](https://github.com/user-attachments/assets/d15095cc-5915-4695-b8c8-017db5e8d22a)
6. Ran all tests locally in FeedUploadUtilsTest.php and verified they all passed
![Screenshot 2025-06-09 at 4 03 33 PM](https://github.com/user-attachments/assets/e9237589-bb2b-48e8-a0fd-99c479c777c1)