### PR TITLE
Introducing centralised logger

### DIFF
--- a/includes/Logger/Logger.php
+++ b/includes/Logger/Logger.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace WooCommerce\Facebook\Framework;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Centralised Logger class for the plugin
+ *
+ * @since 3.5.3
+ */
+class Logger {
+
+	/** @var string the "debug mode" setting ID */
+	const SETTING_ENABLE_DEBUG_MODE = 'wc_facebook_enable_debug_mode';
+	/** @var string the "meta diagnosis" setting ID */
+	const SETTING_ENABLE_META_DIAGNOSIS = 'wc_facebook_enable_meta_diagnosis';
+	/** @var string the message queue for this plugin handled in BatchLogHandler class */
+	const LOGGING_MESSAGE_QUEUE = 'global_logging_message_queue';
+
+	/**
+	 * Centralised Logger function for the plugin
+	 *
+	 * @since 3.5.3
+	 *
+	 * @param string    $message log message
+	 * @param array     $context optional body of log with whole context
+	 * @param array     $log_options optional options for logging place and levels
+	 */
+	public static function log($message, $context = [], $log_options = [
+		'should_send_log_to_meta'        => false,
+		'should_save_log_in_woocommerce' => false,
+		'woocommerce_log_level'          => \WC_Log_Levels::DEBUG,
+	]) {
+		$is_debug_mode_enabled = 'yes' === get_option( self::SETTING_ENABLE_META_DIAGNOSIS );
+		if ( $is_debug_mode_enabled && $log_options['should_save_log_in_woocommerce'] ) {
+			facebook_for_woocommerce()->log( $message . ' : ' . wp_json_encode( $context ), null, $log_options['woocommerce_log_level'] );
+		}
+
+		$is_meta_diagnosis_enabled = (bool) ( 'yes' === get_option( self::SETTING_ENABLE_META_DIAGNOSIS ) );
+		if ( $log_options['should_send_log_to_meta'] && $is_meta_diagnosis_enabled ) {
+
+			$extra_data            = $context['extra_data'] ?? [];
+			$extra_data['message'] = $message;
+			$context['extra_data'] = $extra_data;
+
+			$logs = get_transient( self::LOGGING_MESSAGE_QUEUE );
+			if ( ! $logs ) {
+				$logs = [];
+			}
+			$logs[] = $context;
+			set_transient( self::LOGGING_MESSAGE_QUEUE, $logs, HOUR_IN_SECONDS );
+		}
+	}
+}

--- a/includes/Logger/Logger.php
+++ b/includes/Logger/Logger.php
@@ -31,9 +31,9 @@ class Logger {
 	 *
 	 * @since 3.5.3
 	 *
-	 * @param string    $message log message
-	 * @param array     $context optional body of log with whole context
-	 * @param array     $log_options optional options for logging place and levels
+	 * @param string $message log message
+	 * @param array  $context optional body of log with whole context
+	 * @param array  $log_options optional options for logging place and levels
 	 */
 	public static function log($message, $context = [], $log_options = [
 		'should_send_log_to_meta'        => false,


### PR DESCRIPTION
## Description

**Issues**
The current logging architecture within our plugin is disjointed, with multiple logging mechanisms in place, leading to inefficiencies and redundancies:

- Batched Log Transmission to Meta Server: 
    - We recently rolled out process to synchronize logs with the Meta server. However, it also redundantly logs the same information to the advertiser's server. Many of these logs are not pertinent to the advertiser's debugging needs. 
    - Furthermore, the logs sent to the advertiser's server include a plethora of static configuration details, such as commerce_merchant_settings_id, commerce_partner_integration_id, external_business_id, and catalog_id. This results in log saturation, as these details are logged with every entry, offering no substantial value and taking advertiser's server memory. 
    - Additionally, if the Meta logging endpoint encounters an exception, it perpetuates a uniform error message for every log batch it attempts to transmit, potentially leading to hundreds of identical error messages. 
    - In scenarios where exceptions introduce null values into the global message queue, the logging process can become permanently disrupted, failing to process subsequent error logs—an edge case that has not been adequately addressed. 
    - Moreover, all logs sent to the server are currently categorized under the 'Notice' log level, whereas they should be classified as 'Debug' to reflect their nature accurately.

- WooCommerce Server Logging Issues: 
    - Logs are uniformly recorded at the 'Notice' level, which is inappropriate. Ideally, logs should be categorized as 'Debug', 'Warning', or 'Error', depending on their severity. 
    - The creation of multiple log IDs has resulted in the generation of separate log files for different log types, unnecessarily complicating log management. 
    - Additionally, the logging of Items Batch API calls is overwhelming the server logs. 
    - Many logs contain a static error message indicating that the EMS is missing, which is inaccurate, as EMS should never be null once the connection is correctly established.

- Plugin Version Logging: 
    - A distinct API endpoint is invoked daily to log the plugin version and its configuration. 
    - This is redundant, as separate APIs are not required to persist this information.

- Tip Event Logging: 
    - Separate logging APIs are triggered for tip events associated with banners, which is also unnecessary.

**Solution**
To address these issues, we need to implement a centralized logging system. This system should efficiently manage log transmission to the Meta server through a single API and also persist logs in WooCommerce servers applying appropriate log levels. All existing logs should be migrated to utilize this centralized logger.

**This PR**
In this pull request, I have introduced a centralized Logger to streamline and enhance our logging processes.

### Type of change

- Add (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Introducing centralised logger
