### PR TITLE
Fixed linting for WC_Facebookcommerce_Background_Process

### DIFF
--- a/includes/fbbackground.php
+++ b/includes/fbbackground.php
@@ -22,22 +22,22 @@ if ( ! class_exists( 'WP_Background_Process', false ) ) {
  */
 class WC_Facebookcommerce_Background_Process extends WP_Background_Process {
 
-		/**
-		 * @var WC_Facebookcommerce_Integration instance.
-		 */
-		private $commerce;
+	/**
+	 * @var WC_Facebookcommerce_Integration instance.
+	 */
+	private $commerce;
 
 	public function __construct( $commerce ) {
 		$this->commerce = $commerce; // Full WC_Facebookcommerce_Integration obj
 	}
 
-		/**
-		 * __get method for backward compatibility.
-		 *
-		 * @param string $key property name
-		 * @return mixed
-		 * @since 3.0.32
-		 */
+	/**
+	 * __get method for backward compatibility.
+	 *
+	 * @param string $key property name
+	 * @return mixed
+	 * @since 3.0.32
+	 */
 	public function __get( $key ) {
 		// Add warning for private properties.
 		if ( 'commerce' === $key ) {
@@ -49,10 +49,10 @@ class WC_Facebookcommerce_Background_Process extends WP_Background_Process {
 		return null;
 	}
 
-		/**
-		 * @var string
-		 */
-		protected $action = 'fb_commerce_background_process';
+	/**
+	 * @var string
+	 */
+	protected $action = 'fb_commerce_background_process';
 
 	public function dispatch() {
 		$commerce   = $this->commerce;
@@ -73,12 +73,12 @@ class WC_Facebookcommerce_Background_Process extends WP_Background_Process {
 		return (int) get_transient( $commerce::FB_SYNC_REMAINING );
 	}
 
-		/**
-		 * Handle cron healthcheck
-		 *
-		 * Restart the background process if not already running
-		 * and data exists in the queue.
-		 */
+	/**
+	 * Handle cron healthcheck
+	 *
+	 * Restart the background process if not already running
+	 * and data exists in the queue.
+	 */
 	public function handle_cron_healthcheck() {
 		$commerce = $this->commerce;
 		if ( $this->is_process_running() ) {
@@ -97,9 +97,9 @@ class WC_Facebookcommerce_Background_Process extends WP_Background_Process {
 		return true;
 	}
 
-		/**
-		 * Schedule fallback event.
-		 */
+	/**
+	 * Schedule fallback event.
+	 */
 	protected function schedule_event() {
 		if ( ! wp_next_scheduled( $this->cron_hook_identifier ) ) {
 			wp_schedule_event(
@@ -110,34 +110,34 @@ class WC_Facebookcommerce_Background_Process extends WP_Background_Process {
 		}
 	}
 
-		/**
-		 * Is the processor updating?
-		 *
-		 * @return boolean
-		 */
+	/**
+	 * Is the processor updating?
+	 *
+	 * @return boolean
+	 */
 	public function is_updating() {
 		return false === $this->is_queue_empty();
 	}
 
-		/**
-		 * Is the processor running?
-		 *
-		 * @return boolean
-		 */
+	/**
+	 * Is the processor running?
+	 *
+	 * @return boolean
+	 */
 	public function is_running() {
 		return $this->is_process_running();
 	}
 
-		/**
-		 * Process individual product
-		 *
-		 * Returns false to remove the item from the queue
-		 * (would return item if it needed additional processing).
-		 *
-		 * @param mixed $item Queue item to iterate over
-		 *
-		 * @return mixed
-		 */
+	/**
+	 * Process individual product
+	 *
+	 * Returns false to remove the item from the queue
+	 * (would return item if it needed additional processing).
+	 *
+	 * @param mixed $item Queue item to iterate over
+	 *
+	 * @return mixed
+	 */
 	protected function task( $item ) {
 		$commerce      = $this->commerce;  // PHP5 compatibility for static access
 		$remaining     = $this->get_item_count();
@@ -163,12 +163,12 @@ class WC_Facebookcommerce_Background_Process extends WP_Background_Process {
 		return false;
 	}
 
-		/**
-		 * Complete
-		 *
-		 * Override if applicable, but ensure that the below actions are
-		 * performed, or, call parent::complete().
-		 */
+	/**
+	 * Complete
+	 *
+	 * Override if applicable, but ensure that the below actions are
+	 * performed, or, call parent::complete().
+	 */
 	protected function complete() {
 		$commerce = $this->commerce;  // PHP5 compatibility for static access
 		delete_transient( $commerce::FB_SYNC_IN_PROGRESS );


### PR DESCRIPTION
## Description

Fixed linting for WC_Facebookcommerce_Background_Process

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fixed linting for WC_Facebookcommerce_Background_Process


## Test Plan

Lint fix only
npm run test:php