### PR TITLE
Migrated Product Feed Progress Logging Mechanism

### DIFF
--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -15,6 +15,7 @@ use WooCommerce\Facebook\Framework\Plugin\Exception as PluginException;
 use WooCommerce\Facebook\Products;
 use WooCommerce\Facebook\Products\Feed;
 use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
+use WooCommerce\Facebook\Framework\Logger;
 
 
 /**
@@ -45,7 +46,15 @@ class WC_Facebook_Product_Feed {
 		$profiling_logger = facebook_for_woocommerce()->get_profiling_logger();
 		$profiling_logger->start( 'generate_feed' );
 
-		\WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( 'Generating a fresh product feed file' );
+		Logger::log(
+			'Generating a fresh product feed file',
+			[],
+			array(
+				'should_send_log_to_meta'        => false,
+				'should_save_log_in_woocommerce' => true,
+				'woocommerce_log_level'          => \WC_Log_Levels::DEBUG,
+			)
+		);
 
 		try {
 
@@ -56,7 +65,15 @@ class WC_Facebook_Product_Feed {
 			$generation_time = microtime( true ) - $start_time;
 			facebook_for_woocommerce()->get_tracker()->track_feed_file_generation_time( $generation_time );
 
-			\WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( 'Product feed file generated' );
+			Logger::log(
+				'Product feed file generated',
+				[],
+				array(
+					'should_send_log_to_meta'        => false,
+					'should_save_log_in_woocommerce' => true,
+					'woocommerce_log_level'          => \WC_Log_Levels::DEBUG,
+				)
+			);
 
 			do_action('wc_facebook_feed_generation_completed');
 
@@ -652,6 +669,14 @@ class WC_Facebook_Product_Feed {
 	public function log_feed_progress( $msg, $object = array() ) {
 		WC_Facebookcommerce_Utils::fblog( $msg, $object );
 		$msg = empty( $object ) ? $msg : $msg . wp_json_encode( $object );
-		WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( $msg );
+		Logger::log(
+			$msg,
+			[],
+			array(
+				'should_send_log_to_meta'        => false,
+				'should_save_log_in_woocommerce' => true,
+				'woocommerce_log_level'          => \WC_Log_Levels::DEBUG,
+			)
+		);
 	}
 }


### PR DESCRIPTION
## Description

**Issues**
The current logging architecture within our plugin is disjointed, with multiple logging mechanisms in place, leading to inefficiencies and redundancies:

- Batched Log Transmission to Meta Server: 
    - We recently rolled out process to synchronize logs with the Meta server. However, it also redundantly logs the same information to the advertiser's server. Many of these logs are not pertinent to the advertiser's debugging needs. 
    - Furthermore, the logs sent to the advertiser's server include a plethora of static configuration details, such as commerce_merchant_settings_id, commerce_partner_integration_id, external_business_id, and catalog_id. This results in log saturation, as these details are logged with every entry, offering no substantial value and taking advertiser's server memory. 
    - Additionally, if the Meta logging endpoint encounters an exception, it perpetuates a uniform error message for every log batch it attempts to transmit, potentially leading to hundreds of identical error messages. 
    - In scenarios where exceptions introduce null values into the global message queue, the logging process can become permanently disrupted, failing to process subsequent error logs—an edge case that has not been adequately addressed. 
    - Moreover, all logs sent to the server are currently categorized under the 'Notice' log level, whereas they should be classified as 'Debug' to reflect their nature accurately.

- WooCommerce Server Logging Issues: 
    - Logs are uniformly recorded at the 'Notice' level, which is inappropriate. Ideally, logs should be categorized as 'Debug', 'Warning', or 'Error', depending on their severity. 
    - The creation of multiple log IDs has resulted in the generation of separate log files for different log types, unnecessarily complicating log management. 
    - Additionally, the logging of Items Batch API calls is overwhelming the server logs. 
    - Many logs contain a static error message indicating that the EMS is missing, which is inaccurate, as EMS should never be null once the connection is correctly established.

- Plugin Version Logging: 
    - A distinct API endpoint is invoked daily to log the plugin version and its configuration. 
    - This is redundant, as separate APIs are not required to persist this information.

- Tip Event Logging: 
    - Separate logging APIs are triggered for tip events associated with banners, which is also unnecessary.

**Solution**
To address these issues, we need to implement a centralized logging system. This system should efficiently manage log transmission to the Meta server through a single API and also persist logs in WooCommerce servers applying appropriate log levels. All existing logs should be migrated to utilize this centralized logger.

**This PR**
Migrated Product Feed Progress logging to centralised logger.

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Changelog entry

Migrated Product Feed Progress Logging Mechanism

## Test Plan

Change in Logging
npm run test:php