### PR TITLE
Updated Feed Loggers

### DIFF
--- a/includes/Feed/AbstractFeed.php
+++ b/includes/Feed/AbstractFeed.php
@@ -13,6 +13,7 @@ namespace WooCommerce\Facebook\Feed;
 use WooCommerce\Facebook\Framework\Helper;
 use WooCommerce\Facebook\Framework\Plugin\Exception as PluginException;
 use WooCommerce\Facebook\Utilities\Heartbeat;
+use WooCommerce\Facebook\Framework\Logger;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -232,7 +233,15 @@ abstract class AbstractFeed {
 	 */
 	public function handle_feed_data_request(): void {
 		$name = static::get_data_stream_name();
-		\WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( "{$name} feed: Meta is requesting feed file." );
+		Logger::log(
+			"{$name} feed: Meta is requesting feed file.",
+			[],
+			array(
+				'should_send_log_to_meta'        => false,
+				'should_save_log_in_woocommerce' => true,
+				'woocommerce_log_level'          => \WC_Log_Levels::DEBUG,
+			)
+		);
 
 		$file_path = $this->feed_writer->get_file_path();
 		$file      = false;
@@ -277,7 +286,15 @@ abstract class AbstractFeed {
 			// fpassthru might be disabled in some hosts (like Flywheel).
 			// phpcs:ignore
 			if ( \WC_Facebookcommerce_Utils::is_fpassthru_disabled() || ! @fpassthru( $file ) ) {
-				\WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( "{$name} feed: fpassthru is disabled: getting file contents." );
+				Logger::log(
+					"{$name} feed: fpassthru is disabled: getting file contents.",
+					[],
+					array(
+						'should_send_log_to_meta'        => false,
+						'should_save_log_in_woocommerce' => true,
+						'woocommerce_log_level'          => \WC_Log_Levels::DEBUG,
+					)
+				);
 				//phpcs:ignore
 				$contents = @stream_get_contents( $file );
 				if ( ! $contents ) {

--- a/includes/Feed/FeedConfigurationDetection.php
+++ b/includes/Feed/FeedConfigurationDetection.php
@@ -12,6 +12,7 @@ use WooCommerce\Facebook\API\Response;
 use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
 use WooCommerce\Facebook\Products\Feed;
 use WooCommerce\Facebook\Utilities\Heartbeat;
+use WooCommerce\Facebook\Framework\Logger;
 
 /**
  * A class responsible detecting feed configuration.
@@ -91,7 +92,15 @@ class FeedConfigurationDetection {
 				$metadata = $this->get_feed_metadata( $feed['id'] );
 			} catch ( Exception $e ) {
 				$message = sprintf( 'There was an error trying to get feed metadata: %s', $e->getMessage() );
-				WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( $message );
+				Logger::log(
+					$message,
+					[],
+					array(
+						'should_send_log_to_meta'        => false,
+						'should_save_log_in_woocommerce' => true,
+						'woocommerce_log_level'          => \WC_Log_Levels::ERROR,
+					)
+				);
 				continue;
 			}
 

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -78,8 +78,15 @@ class WC_Facebook_Product_Feed {
 			do_action('wc_facebook_feed_generation_completed');
 
 		} catch ( \Exception $exception ) {
-
-			\WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( $exception->getMessage() );
+			Logger::log(
+				$exception->getMessage(),
+				[],
+				array(
+					'should_send_log_to_meta'        => false,
+					'should_save_log_in_woocommerce' => true,
+					'woocommerce_log_level'          => \WC_Log_Levels::ERROR,
+				)
+			);
 			// Feed generation failed - clear the generation time to track that there's an issue.
 			facebook_for_woocommerce()->get_tracker()->track_feed_file_generation_time( -1 );
 
@@ -279,7 +286,15 @@ class WC_Facebook_Product_Feed {
 
 		} catch ( Exception $e ) {
 
-			WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( wp_json_encode( $e->getMessage() ) );
+			Logger::log(
+				wp_json_encode( $e->getMessage() ),
+				[],
+				array(
+					'should_send_log_to_meta'        => false,
+					'should_save_log_in_woocommerce' => true,
+					'woocommerce_log_level'          => \WC_Log_Levels::ERROR,
+				)
+			);
 
 			$written = false;
 

--- a/tests/Unit/Feed/ProductFeedTest.php
+++ b/tests/Unit/Feed/ProductFeedTest.php
@@ -8,6 +8,8 @@
  * @package FacebookCommerce
  */
 
+use WooCommerce\Facebook\Framework\Logger;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -43,7 +45,15 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed_Test' ) ) :
 		 */
 		public function log_feed_progress( $msg, $data = array() ) {
 			$msg = empty( $data ) ? $msg : $msg . wp_json_encode( $data );
-			WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( 'Test - ' . $msg );
+			Logger::log(
+				'Test - ' . $msg,
+				[],
+				array(
+					'should_send_log_to_meta'        => false,
+					'should_save_log_in_woocommerce' => true,
+					'woocommerce_log_level'          => \WC_Log_Levels::ERROR,
+				)
+			);
 		}
 	}
 

--- a/tests/Unit/Feed/ProductFeedTest.php
+++ b/tests/Unit/Feed/ProductFeedTest.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed_Test' ) ) :
 				array(
 					'should_send_log_to_meta'        => false,
 					'should_save_log_in_woocommerce' => true,
-					'woocommerce_log_level'          => \WC_Log_Levels::ERROR,
+					'woocommerce_log_level'          => \WC_Log_Levels::DEBUG,
 				)
 			);
 		}


### PR DESCRIPTION

## Description

**Issues**
The current logging architecture within our plugin is disjointed, with multiple logging mechanisms in place, leading to inefficiencies and redundancies:

- Batched Log Transmission to Meta Server: 
    - We recently rolled out process to synchronize logs with the Meta server. However, it also redundantly logs the same information to the advertiser's server. Many of these logs are not pertinent to the advertiser's debugging needs. 
    - Furthermore, the logs sent to the advertiser's server include a plethora of static configuration details, such as commerce_merchant_settings_id, commerce_partner_integration_id, external_business_id, and catalog_id. This results in log saturation, as these details are logged with every entry, offering no substantial value and taking advertiser's server memory. 
    - Additionally, if the Meta logging endpoint encounters an exception, it perpetuates a uniform error message for every log batch it attempts to transmit, potentially leading to hundreds of identical error messages. 
    - In scenarios where exceptions introduce null values into the global message queue, the logging process can become permanently disrupted, failing to process subsequent error logs—an edge case that has not been adequately addressed. 
    - Moreover, all logs sent to the server are currently categorized under the 'Notice' log level, whereas they should be classified as 'Debug' to reflect their nature accurately.

- WooCommerce Server Logging Issues: 
    - Logs are uniformly recorded at the 'Notice' level, which is inappropriate. Ideally, logs should be categorized as 'Debug', 'Warning', or 'Error', depending on their severity. 
    - The creation of multiple log IDs has resulted in the generation of separate log files for different log types, unnecessarily complicating log management. 
    - Additionally, the logging of Items Batch API calls is overwhelming the server logs. 
    - Many logs contain a static error message indicating that the EMS is missing, which is inaccurate, as EMS should never be null once the connection is correctly established.

- Plugin Version Logging: 
    - A distinct API endpoint is invoked daily to log the plugin version and its configuration. 
    - This is redundant, as separate APIs are not required to persist this information.

- Tip Event Logging: 
    - Separate logging APIs are triggered for tip events associated with banners, which is also unnecessary.

**Solution**
To address these issues, we need to implement a centralized logging system. This system should efficiently manage log transmission to the Meta server through a single API and also persist logs in WooCommerce servers applying appropriate log levels. All existing logs should be migrated to utilize this centralized logger.

**This PR**
Updated Feed Loggers and Migrated them to centralised logger

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Changelog entry

Updated Feed Loggers

## Test Plan

Change in Logging
npm run test:php