### PR TITLE
Updated loggers for checkout flow

### DIFF
--- a/includes/Admin/Enhanced_Settings.php
+++ b/includes/Admin/Enhanced_Settings.php
@@ -12,11 +12,10 @@ namespace WooCommerce\Facebook\Admin;
 
 use Automattic\WooCommerce\Admin\Features\Features as WooAdminFeatures;
 use WooCommerce\Facebook\Admin\Settings_Screens;
-use WooCommerce\Facebook\Admin\Settings_Screens\Shops;
 use WooCommerce\Facebook\Framework\Helper;
 use WooCommerce\Facebook\Framework\Plugin\Exception as PluginException;
-use WooCommerce\Facebook\Admin\Settings_Screens\Whatsapp_Utility;
 use WooCommerce\Facebook\RolloutSwitches;
+use WooCommerce\Facebook\Framework\Logger;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -186,11 +185,16 @@ class Enhanced_Settings {
 		$current_tab = $this->get_current_tab();
 		$screen      = $this->get_screen( $current_tab );
 
-		\WC_Facebookcommerce_Utils::log_to_meta(
+		Logger::log(
 			'User visited the Facebook for WooCommerce settings' . $current_tab . 'tab',
 			array(
 				'flow_name' => 'settings',
 				'flow_step' => $current_tab . '_tab_rendered',
+			),
+			array(
+				'should_send_log_to_meta' => true,
+				'should_save_log_in_woocommerce' => true,
+				'woocommerce_log_level'   => \WC_Log_Levels::DEBUG,
 			)
 		);
 

--- a/includes/Checkout.php
+++ b/includes/Checkout.php
@@ -12,6 +12,8 @@ namespace WooCommerce\Facebook;
 
 defined( 'ABSPATH' ) || exit;
 
+use WooCommerce\Facebook\Framework\Logger;
+
 /**
  * The checkout permalink.
  *
@@ -109,7 +111,7 @@ class Checkout {
 								$quantity
 							);
 
-							\WC_Facebookcommerce_Utils::log_to_meta(
+							Logger::log(
 								$error_message,
 								array(
 									'flow_name'  => 'checkout',
@@ -119,6 +121,11 @@ class Checkout {
 										'product_id'     => $product_id,
 										'quantity'       => $quantity,
 									],
+								),
+								array(
+									'should_send_log_to_meta'        => true,
+									'should_save_log_in_woocommerce' => true,
+									'woocommerce_log_level'          => \WC_Log_Levels::ERROR,
 								)
 							);
 						}
@@ -129,7 +136,7 @@ class Checkout {
 							$quantity
 						);
 
-						\WC_Facebookcommerce_Utils::log_to_meta(
+						Logger::log(
 							$error_message,
 							array(
 								'flow_name'  => 'checkout',
@@ -139,6 +146,11 @@ class Checkout {
 									'product_id'     => $product_id,
 									'quantity'       => $quantity,
 								],
+							),
+							array(
+								'should_send_log_to_meta' => true,
+								'should_save_log_in_woocommerce' => true,
+								'woocommerce_log_level'   => \WC_Log_Levels::ERROR,
 							)
 						);
 					}
@@ -156,7 +168,7 @@ class Checkout {
 						$coupon_code_sanitized
 					);
 
-					\WC_Facebookcommerce_Utils::log_to_meta(
+					Logger::log(
 						$error_message,
 						array(
 							'flow_name'  => 'checkout',
@@ -165,6 +177,11 @@ class Checkout {
 								'coupon_param' => $coupon_code,
 								'coupon_code'  => $coupon_code_sanitized,
 							],
+						),
+						array(
+							'should_send_log_to_meta' => true,
+							'should_save_log_in_woocommerce' => true,
+							'woocommerce_log_level'   => \WC_Log_Levels::ERROR,
 						)
 					);
 				}


### PR DESCRIPTION
## Description

**Issues**
The current logging architecture within our plugin is disjointed, with multiple logging mechanisms in place, leading to inefficiencies and redundancies:

- Batched Log Transmission to Meta Server: 
    - We recently rolled out process to synchronize logs with the Meta server. However, it also redundantly logs the same information to the advertiser's server. Many of these logs are not pertinent to the advertiser's debugging needs. 
    - Furthermore, the logs sent to the advertiser's server include a plethora of static configuration details, such as commerce_merchant_settings_id, commerce_partner_integration_id, external_business_id, and catalog_id. This results in log saturation, as these details are logged with every entry, offering no substantial value and taking advertiser's server memory. 
    - Additionally, if the Meta logging endpoint encounters an exception, it perpetuates a uniform error message for every log batch it attempts to transmit, potentially leading to hundreds of identical error messages. 
    - In scenarios where exceptions introduce null values into the global message queue, the logging process can become permanently disrupted, failing to process subsequent error logs—an edge case that has not been adequately addressed. 
    - Moreover, all logs sent to the server are currently categorized under the 'Notice' log level, whereas they should be classified as 'Debug' to reflect their nature accurately.

- WooCommerce Server Logging Issues: 
    - Logs are uniformly recorded at the 'Notice' level, which is inappropriate. Ideally, logs should be categorized as 'Debug', 'Warning', or 'Error', depending on their severity. 
    - The creation of multiple log IDs has resulted in the generation of separate log files for different log types, unnecessarily complicating log management. 
    - Additionally, the logging of Items Batch API calls is overwhelming the server logs. 
    - Many logs contain a static error message indicating that the EMS is missing, which is inaccurate, as EMS should never be null once the connection is correctly established.

- Plugin Version Logging: 
    - A distinct API endpoint is invoked daily to log the plugin version and its configuration. 
    - This is redundant, as separate APIs are not required to persist this information.

- Tip Event Logging: 
    - Separate logging APIs are triggered for tip events associated with banners, which is also unnecessary.

**Solution**
To address these issues, we need to implement a centralized logging system. This system should efficiently manage log transmission to the Meta server through a single API and also persist logs in WooCommerce servers applying appropriate log levels. All existing logs should be migrated to utilize this centralized logger.

**This PR**
Migrating Checkout flow logs to centralised logger

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Changelog entry

Updated loggers for checkout flow

## Test Plan

Change in Logging
npm run test:php