### PR TITLE
Updated loggers for Feeds

### DIFF
--- a/includes/API/Plugin/Settings/Handler.php
+++ b/includes/API/Plugin/Settings/Handler.php
@@ -13,6 +13,7 @@ namespace WooCommerce\Facebook\API\Plugin\Settings;
 use WooCommerce\Facebook\API\Plugin\AbstractRESTEndpoint;
 use WooCommerce\Facebook\API\Plugin\Settings\Update\Request as UpdateRequest;
 use WooCommerce\Facebook\API\Plugin\Settings\Uninstall\Request as UninstallRequest;
+use WooCommerce\Facebook\Framework\Logger;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -283,12 +284,17 @@ class Handler extends AbstractRESTEndpoint {
 				if ( facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
 					facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_all_products();
 				} else {
-					\WC_Facebookcommerce_Utils::log_to_meta(
+					Logger::log(
 						'Initial full product sync disabled by filter hook `facebook_for_woocommerce_allow_full_batch_api_sync`',
 						[
 							'flow_name' => 'product_sync',
 							'flow_step' => 'initial_sync',
-						]
+						],
+						array(
+							'should_send_log_to_meta' => true,
+							'should_save_log_in_woocommerce' => true,
+							'woocommerce_log_level'   => \WC_Log_Levels::DEBUG,
+						)
 					);
 				}
 			}

--- a/includes/Feed/ShippingProfiles/ShippingProfilesFeed.php
+++ b/includes/Feed/ShippingProfiles/ShippingProfilesFeed.php
@@ -13,6 +13,7 @@ defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\ActionSchedulerJobFramework\Proxies\ActionScheduler;
 use WC_Shipping_Zones;
+use WooCommerce\Facebook\Framework\Logger;
 
 /**
  * Ratings and Reviews Feed class
@@ -294,7 +295,7 @@ class ShippingProfilesFeed extends AbstractFeed {
 	}
 
 	private static function log_map_shipping_method_issue_to_meta( array $zone, array $shipping_method, string $message, string $flow_step ): void {
-		\WC_Facebookcommerce_Utils::log_to_meta(
+		Logger::log(
 			$message,
 			array(
 				'flow_name'  => FeedUploadUtils::SHIPPING_PROFILES_SYNC_LOGGING_FLOW_NAME,
@@ -304,6 +305,11 @@ class ShippingProfilesFeed extends AbstractFeed {
 					'zone_name' => $zone['zone_name'],
 					'method_id' => $shipping_method['instance_id'],
 				],
+			),
+			array(
+				'should_send_log_to_meta'        => true,
+				'should_save_log_in_woocommerce' => true,
+				'woocommerce_log_level'          => \WC_Log_Levels::DEBUG,
 			)
 		);
 	}

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -18,6 +18,7 @@ use WC_Facebookcommerce_Utils;
 use WooCommerce\Facebook\Framework\Helper;
 use WooCommerce\Facebook\Utilities\Heartbeat;
 use WooCommerce\Facebook\Framework\Plugin\Exception as PluginException;
+use WooCommerce\Facebook\Framework\Logger;
 
 /**
  * The main product feed handler.
@@ -179,11 +180,16 @@ class Feed {
 			} elseif ( ! $store_allows_feed ) {
 				$message = 'Store does not allow feed.';
 			}
-			WC_Facebookcommerce_Utils::log_to_meta(
+			Logger::log(
 				sprintf( 'Product feed scheduling failed: %s', $message ),
 				array(
 					'flow_name' => 'product_feed',
 					'flow_step' => 'schedule_feed_generation',
+				),
+				array(
+					'should_send_log_to_meta'        => true,
+					'should_save_log_in_woocommerce' => true,
+					'woocommerce_log_level'          => \WC_Log_Levels::DEBUG,
 				)
 			);
 			return;


### PR DESCRIPTION
## Description

**Issues**
The current logging architecture within our plugin is disjointed, with multiple logging mechanisms in place, leading to inefficiencies and redundancies:

- Batched Log Transmission to Meta Server: 
    - We recently rolled out process to synchronize logs with the Meta server. However, it also redundantly logs the same information to the advertiser's server. Many of these logs are not pertinent to the advertiser's debugging needs. 
    - Furthermore, the logs sent to the advertiser's server include a plethora of static configuration details, such as commerce_merchant_settings_id, commerce_partner_integration_id, external_business_id, and catalog_id. This results in log saturation, as these details are logged with every entry, offering no substantial value and taking advertiser's server memory. 
    - Additionally, if the Meta logging endpoint encounters an exception, it perpetuates a uniform error message for every log batch it attempts to transmit, potentially leading to hundreds of identical error messages. 
    - In scenarios where exceptions introduce null values into the global message queue, the logging process can become permanently disrupted, failing to process subsequent error logs—an edge case that has not been adequately addressed. 
    - Moreover, all logs sent to the server are currently categorized under the 'Notice' log level, whereas they should be classified as 'Debug' to reflect their nature accurately.

- WooCommerce Server Logging Issues: 
    - Logs are uniformly recorded at the 'Notice' level, which is inappropriate. Ideally, logs should be categorized as 'Debug', 'Warning', or 'Error', depending on their severity. 
    - The creation of multiple log IDs has resulted in the generation of separate log files for different log types, unnecessarily complicating log management. 
    - Additionally, the logging of Items Batch API calls is overwhelming the server logs. 
    - Many logs contain a static error message indicating that the EMS is missing, which is inaccurate, as EMS should never be null once the connection is correctly established.

- Plugin Version Logging: 
    - A distinct API endpoint is invoked daily to log the plugin version and its configuration. 
    - This is redundant, as separate APIs are not required to persist this information.

- Tip Event Logging: 
    - Separate logging APIs are triggered for tip events associated with banners, which is also unnecessary.

**Solution**
To address these issues, we need to implement a centralized logging system. This system should efficiently manage log transmission to the Meta server through a single API and also persist logs in WooCommerce servers applying appropriate log levels. All existing logs should be migrated to utilize this centralized logger.

**This PR**
Migrating Feed logs to centralised logger

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Changelog entry

Updated loggers for Feeds

## Test Plan

Change in Logging
npm run test:php