### PR TITLE
Migrated Feed Logger

### DIFF
--- a/includes/ExternalVersionUpdate/Update.php
+++ b/includes/ExternalVersionUpdate/Update.php
@@ -15,6 +15,7 @@ defined( 'ABSPATH' ) || exit;
 use Exception;
 use WC_Facebookcommerce_Utils;
 use WooCommerce\Facebook\Utilities\Heartbeat;
+use WooCommerce\Facebook\Framework\Logger;
 
 /**
  * Facebook for WooCommerce External Plugin Version Update.
@@ -90,7 +91,15 @@ class Update {
 			}
 			return update_option( self::LATEST_VERSION_SENT, WC_Facebookcommerce_Utils::PLUGIN_VERSION );
 		} catch ( Exception $e ) {
-			WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( $e->getMessage() );
+			Logger::log(
+				$e->getMessage(),
+				[],
+				array(
+					'should_send_log_to_meta'        => false,
+					'should_save_log_in_woocommerce' => true,
+					'woocommerce_log_level'          => \WC_Log_Levels::ERROR,
+				)
+			);
 			// If the request fails, we should retry it in the next heartbeat.
 			return false;
 		}

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -82,7 +82,15 @@ class Feed {
 	 * @throws PluginException If the feed secret is invalid, file is not readable, or other errors occur.
 	 */
 	public function handle_feed_data_request() {
-		\WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( 'Facebook is requesting the product feed.' );
+		Logger::log(
+			'Facebook is requesting the product feed.',
+			[],
+			array(
+				'should_send_log_to_meta'        => false,
+				'should_save_log_in_woocommerce' => true,
+				'woocommerce_log_level'          => \WC_Log_Levels::DEBUG,
+			)
+		);
 		facebook_for_woocommerce()->get_tracker()->track_feed_file_requested();
 
 		$feed_handler = new \WC_Facebook_Product_Feed();
@@ -120,7 +128,15 @@ class Feed {
 
 			// fpassthru might be disabled in some hosts (like Flywheel)
 			if ( $this->is_fpassthru_disabled() || ! @fpassthru( $file ) ) {
-				\WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( 'fpassthru is disabled: getting file contents' );
+				Logger::log(
+					'fpassthru is disabled: getting file contents',
+					[],
+					array(
+						'should_send_log_to_meta'        => false,
+						'should_save_log_in_woocommerce' => true,
+						'woocommerce_log_level'          => \WC_Log_Levels::DEBUG,
+					)
+				);
 				$contents = @stream_get_contents( $file );
 				if ( ! $contents ) {
 					throw new PluginException( 'Could not get feed file contents.', 500 );
@@ -128,7 +144,15 @@ class Feed {
 				echo $contents; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 		} catch ( \Exception $exception ) {
-			\WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( 'Could not serve product feed. ' . $exception->getMessage() . ' (' . $exception->getCode() . ')' );
+			Logger::log(
+				'Could not serve product feed. ' . $exception->getMessage() . ' (' . $exception->getCode() . ')',
+				[],
+				array(
+					'should_send_log_to_meta'        => false,
+					'should_save_log_in_woocommerce' => true,
+					'woocommerce_log_level'          => \WC_Log_Levels::ERROR,
+				)
+			);
 			status_header( $exception->getCode() );
 		}
 		exit;
@@ -189,7 +213,7 @@ class Feed {
 				array(
 					'should_send_log_to_meta'        => true,
 					'should_save_log_in_woocommerce' => true,
-					'woocommerce_log_level'          => \WC_Log_Levels::DEBUG,
+					'woocommerce_log_level'          => \WC_Log_Levels::WARNING,
 				)
 			);
 			return;
@@ -218,7 +242,15 @@ class Feed {
 	public function send_request_to_upload_feed() {
 		$feed_id = self::retrieve_or_create_integration_feed_id();
 		if ( empty( $feed_id ) ) {
-			WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( 'Feed: integration feed ID is null or empty, feed will not be uploaded.' );
+			Logger::log(
+				'Feed: integration feed ID is null or empty, feed will not be uploaded.',
+				[],
+				array(
+					'should_send_log_to_meta'        => false,
+					'should_save_log_in_woocommerce' => true,
+					'woocommerce_log_level'          => \WC_Log_Levels::WARNING,
+				)
+			);
 			return;
 		}
 
@@ -245,7 +277,15 @@ class Feed {
 		$feed_id = self::request_and_filter_integration_feed_id();
 		if ( $feed_id ) {
 			facebook_for_woocommerce()->get_integration()->update_feed_id( $feed_id );
-			WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( 'Feed: feed_id = ' . $feed_id . ', queried and selected from Meta API.' );
+			Logger::log(
+				'Feed: feed_id = ' . $feed_id . ', queried and selected from Meta API.',
+				[],
+				array(
+					'should_send_log_to_meta'        => false,
+					'should_save_log_in_woocommerce' => true,
+					'woocommerce_log_level'          => \WC_Log_Levels::DEBUG,
+				)
+			);
 			return $feed_id;
 		}
 
@@ -253,7 +293,15 @@ class Feed {
 		$feed_id = self::create_feed_id();
 		if ( $feed_id ) {
 			facebook_for_woocommerce()->get_integration()->update_feed_id( $feed_id );
-			WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( 'Feed: feed_id = ' . $feed_id . ', created a new feed via Meta API.' );
+			Logger::log(
+				'Feed: feed_id = ' . $feed_id . ', created a new feed via Meta API.',
+				[],
+				array(
+					'should_send_log_to_meta'        => false,
+					'should_save_log_in_woocommerce' => true,
+					'woocommerce_log_level'          => \WC_Log_Levels::DEBUG,
+				)
+			);
 			return $feed_id;
 		}
 
@@ -278,7 +326,15 @@ class Feed {
 			$feed_nodes = facebook_for_woocommerce()->get_api()->read_feeds( $catalog_id )->data;
 		} catch ( Exception $e ) {
 			$message = sprintf( 'There was an error trying to get feed nodes for catalog: %s', $e->getMessage() );
-			WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( $message );
+			Logger::log(
+				$message,
+				[],
+				array(
+					'should_send_log_to_meta'        => false,
+					'should_save_log_in_woocommerce' => true,
+					'woocommerce_log_level'          => \WC_Log_Levels::ERROR,
+				)
+			);
 			return '';
 		}
 
@@ -298,7 +354,15 @@ class Feed {
 				$feed_metadata = facebook_for_woocommerce()->get_api()->read_feed( $feed['id'] );
 			} catch ( Exception $e ) {
 				$message = sprintf( 'There was an error trying to get feed metadata: %s', $e->getMessage() );
-				WC_Facebookcommerce_Utils::log_with_debug_mode_enabled( $message );
+				Logger::log(
+					$message,
+					[],
+					array(
+						'should_send_log_to_meta'        => false,
+						'should_save_log_in_woocommerce' => true,
+						'woocommerce_log_level'          => \WC_Log_Levels::ERROR,
+					)
+				);
 				continue;
 			}
 


### PR DESCRIPTION
## Description

**Issues**
The current logging architecture within our plugin is disjointed, with multiple logging mechanisms in place, leading to inefficiencies and redundancies:

- Batched Log Transmission to Meta Server: 
    - We recently rolled out process to synchronize logs with the Meta server. However, it also redundantly logs the same information to the advertiser's server. Many of these logs are not pertinent to the advertiser's debugging needs. 
    - Furthermore, the logs sent to the advertiser's server include a plethora of static configuration details, such as commerce_merchant_settings_id, commerce_partner_integration_id, external_business_id, and catalog_id. This results in log saturation, as these details are logged with every entry, offering no substantial value and taking advertiser's server memory. 
    - Additionally, if the Meta logging endpoint encounters an exception, it perpetuates a uniform error message for every log batch it attempts to transmit, potentially leading to hundreds of identical error messages. 
    - In scenarios where exceptions introduce null values into the global message queue, the logging process can become permanently disrupted, failing to process subsequent error logs—an edge case that has not been adequately addressed. 
    - Moreover, all logs sent to the server are currently categorized under the 'Notice' log level, whereas they should be classified as 'Debug' to reflect their nature accurately.

- WooCommerce Server Logging Issues: 
    - Logs are uniformly recorded at the 'Notice' level, which is inappropriate. Ideally, logs should be categorized as 'Debug', 'Warning', or 'Error', depending on their severity. 
    - The creation of multiple log IDs has resulted in the generation of separate log files for different log types, unnecessarily complicating log management. 
    - Additionally, the logging of Items Batch API calls is overwhelming the server logs. 
    - Many logs contain a static error message indicating that the EMS is missing, which is inaccurate, as EMS should never be null once the connection is correctly established.

- Plugin Version Logging: 
    - A distinct API endpoint is invoked daily to log the plugin version and its configuration. 
    - This is redundant, as separate APIs are not required to persist this information.

- Tip Event Logging: 
    - Separate logging APIs are triggered for tip events associated with banners, which is also unnecessary.

**Solution**
To address these issues, we need to implement a centralized logging system. This system should efficiently manage log transmission to the Meta server through a single API and also persist logs in WooCommerce servers applying appropriate log levels. All existing logs should be migrated to utilize this centralized logger.

**This PR**
Migrated Feed Logger

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Changelog entry

Migrated Feed Logger

## Test Plan

Change in Logging
npm run test:php