### PR TITLE
fix/select-attr: check if `fieldId` is `undefined`

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -2014,7 +2014,7 @@ class Admin {
 				$('.woocommerce_options_panel select').on('change', function() {
 					var fieldId = $(this).attr('id');
 					for (var key in syncedBadgeState) {
-						if (fieldId.includes(key)) {
+						if (fieldId && fieldId.includes(key)) {
 							manualValues[key] = $(this).val();
 							// When manually selecting a value, mark as not synced
 							syncedFields[key] = false;


### PR DESCRIPTION
## Description

Not all `<select />` elements on the page will have an `id` attribute on them. Running a `fieldId.includes(key)` on `undefined` throws error.

### Type of change

- Break (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [] I have commented my code, particularly in hard-to-understand areas, if any.
- [] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

- Fixes bug when storing manual selection values for select fields.
