### PR TITLE
Tracking error messages being displayed to Admins

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -2865,7 +2865,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 					],
 				),
 				array(
-					'should_send_log_to_meta'        => true,
+					'should_send_log_to_meta' => true,
 				)
 			);
 		}

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -2855,10 +2855,18 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			echo $this->get_message_html( $message );
 			delete_transient( 'facebook_plugin_api_error' );
-			WC_Facebookcommerce_Utils::fblog(
-				$error_msg,
-				[],
-				true
+			Logger::log(
+				'Error message displayed to Admins',
+				array(
+					'flow_name'  => 'display_admin_message',
+					'flow_step'  => 'display_admin_error_message',
+					'extra_data' => [
+						'displayed_message' => $error_msg,
+					],
+				),
+				array(
+					'should_send_log_to_meta'        => true,
+				)
 			);
 		}
 		$warning_msg = get_transient( 'facebook_plugin_api_warning' );


### PR DESCRIPTION
## Description

Tracking error messages being displayed to Admins

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Tracking error messages being displayed to Admins
