### PR TITLE
Fix Select2 Compatibility Issues 

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1795,7 +1795,7 @@ class Admin {
 									// For Google Product Category fields, preserve options but clear selection
 									$field.val('').trigger('change');
 								} else if ($field.hasClass('wc-product-search') || 
-								    $field.closest('.wc-product-bundles').length) {
+									$field.closest('.wc-product-bundles').length) {
 									// For Product Bundle fields, use empty() and trigger change
 									$field.empty().trigger('change');
 								} else {


### PR DESCRIPTION
# Fix Select2 Compatibility Issues 

## Description

This PR addresses a critical compatibility issue between the Facebook for WooCommerce plugin and WooCommerce Product Bundles plugin, specifically related to Select2 field functionality. 

The key changes include:
1. Refactoring the `cleanupAllUIElements()` function to only target specific Facebook attribute fields
2. Implementing a more precise approach using an array of specific field IDs
3. Preserving functionality of the Google Product Category field while maintaining cleanup for Facebook-specific fields

### Type of change

- [x] Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices.
- [x] I have completed dogfooding and QA testing to ensure that it does not break existing functionality.

## Changelog entry

Fixed Select2 compatibility issues with Product Bundles plugin affecting Google Product Category field functionality.

## Test Plan

### Prerequisites
- WooCommerce 7.0+
- Facebook for WooCommerce plugin
- WooCommerce Product Bundles plugin

### Test Steps
1. Create a new product or edit an existing one
2. Verify that the Google Product Category field works correctly:
   - Field should populate with options when typing
   - "No results found" should only appear for invalid searches
3. Verify that Facebook attribute fields (material, color, size, etc.) work as expected:
   - Fields should be properly cleared when necessary
   - Dropdown fields (age_group, gender, condition) should maintain functionality
4. Test with Product Bundles:
   - Create a product bundle
   - Verify that bundle-specific Select2 fields work correctly
   - Confirm no interference with Facebook fields

Fixes https://github.com/facebook/facebook-for-woocommerce/issues/3184 & https://github.com/facebook/facebook-for-woocommerce/issues/3325 