### PR TITLE
Redundant api calls reduction

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -995,7 +995,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		$product_id = $product->get_id();
 
-		if ( $product->is_type( 'variation' ) || $product->is_type('simple')) {
+		if ( $product->is_type( 'variation' ) || $product->is_type( 'simple' ) ) {
 			$retailer_id = \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product );
 			// enqueue variation to be deleted in the background
 			$this->facebook_for_woocommerce->get_products_sync_handler()->delete_products( [ $retailer_id ] );
@@ -1195,7 +1195,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		if ( ! $this->product_should_be_synced( $woo_product->woo_product ) ) {
 			return;
 		}
-		
+
 		return $this->create_product_simple( $woo_product );  // new product
 	}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -323,8 +323,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 					[ $this, 'on_quick_and_bulk_edit_save' ]
 				);
 
-				add_action( 'add_meta_boxes_product', [ $this, 'display_batch_api_completed' ], 10, 2 );
-
 				add_action(
 					'wp_ajax_ajax_fb_toggle_visibility',
 					array( $this, 'ajax_fb_toggle_visibility' )

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1278,7 +1278,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 * @deprecated as we are no longer calling an update
 	 * We create everytime and it will be handled in the backend
 	 * TO_BE_DELETED
-	 * 
+	 *
 	 * @param WC_Facebook_Product $woo_product
 	 **/
 	public function update_product_group( WC_Facebook_Product $woo_product ) {
@@ -2713,7 +2713,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		}
 
 		$should_set_visible = self::FB_SHOP_PRODUCT_VISIBLE === $visibility;
-		if ( $product->is_type( 'variation' ) || $product->is_type( 'simple' )) {
+		if ( $product->is_type( 'variation' ) || $product->is_type( 'simple' ) ) {
 			Products::set_product_visibility( $product, $should_set_visible );
 			$this->facebook_for_woocommerce->get_products_sync_handler()->create_or_update_products( [ $product->get_id() ] );
 		} elseif ( $product->is_type( 'variable' ) ) {

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1195,7 +1195,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		if ( ! $this->product_should_be_synced( $woo_product->woo_product ) ) {
 			return;
 		}
-
 		return $this->create_product_simple( $woo_product );  // new product
 	}
 
@@ -1276,6 +1275,10 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/**
 	 * Update existing product group (variant data only)
 	 *
+	 * @deprecated as we are no longer calling an update
+	 * We create everytime and it will be handled in the backend
+	 * TO_BE_DELETED
+	 * 
 	 * @param WC_Facebook_Product $woo_product
 	 **/
 	public function update_product_group( WC_Facebook_Product $woo_product ) {
@@ -2710,7 +2713,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		}
 
 		$should_set_visible = self::FB_SHOP_PRODUCT_VISIBLE === $visibility;
-		if ( $product->is_type( 'variation' ) ) {
+		if ( $product->is_type( 'variation' ) || $product->is_type( 'simple' )) {
 			Products::set_product_visibility( $product, $should_set_visible );
 			$this->facebook_for_woocommerce->get_products_sync_handler()->create_or_update_products( [ $product->get_id() ] );
 		} elseif ( $product->is_type( 'variable' ) ) {
@@ -2731,24 +2734,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			}
 			// sync product with all variations
 			$this->facebook_for_woocommerce->get_products_sync_handler()->create_or_update_products( $product_ids );
-		} else {
-			try {
-				$set_visibility = $this->facebook_for_woocommerce->get_api()->update_product_item( $fb_product_item_id, [ 'visibility' => $visibility ] );
-				if ( $set_visibility->success ) {
-					Products::set_product_visibility( $product, $should_set_visible );
-				}
-			} catch ( ApiException $e ) {
-				$message = sprintf( 'There was an error trying to update product item: %s', $e->getMessage() );
-				Logger::log(
-					$message,
-					[],
-					array(
-						'should_send_log_to_meta'        => false,
-						'should_save_log_in_woocommerce' => true,
-						'woocommerce_log_level'          => \WC_Log_Levels::ERROR,
-					)
-				);
-			}
 		}
 	}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -995,7 +995,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		$product_id = $product->get_id();
 
-		if ( $product->is_type( 'variation' ) ) {
+		if ( $product->is_type( 'variation' ) || $product->is_type('simple')) {
 			$retailer_id = \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product );
 			// enqueue variation to be deleted in the background
 			$this->facebook_for_woocommerce->get_products_sync_handler()->delete_products( [ $retailer_id ] );
@@ -1010,9 +1010,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			}
 			// enqueue variations to be deleted in the background
 			$this->facebook_for_woocommerce->get_products_sync_handler()->delete_products( $retailer_ids );
-		} else {
-
-			$this->delete_product_item( $product_id );
 		}
 
 		// clear out both item and group IDs
@@ -2713,6 +2710,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	}
 
 	/**
+	 * @deprecated
 	 * Delete product item by id.
 	 *
 	 * @param int $wp_id


### PR DESCRIPTION
## Description

A lot of redundant API calls were fired for no reason. 
All because of showing redundant information to the user like fbid.
This fbid was then fetched every time a product was created or updated or even deleted.

### Type of change

Improvement: A wide improvement in reducing the number of API calls while making CRUD operations. Removal of not required fbid get/fetch calls and deprecating functions that are not required.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Test Plan

The test is very simle:
1. Make a product and check the number of API calls should be 1.

## Screenshots

No UI change
