### PR TITLE
Add unit tests for ProductExcludedException and ProductInvalidException

### DIFF
--- a/tests/Unit/ProductSync/ProductExcludedExceptionTest.php
+++ b/tests/Unit/ProductSync/ProductExcludedExceptionTest.php
@@ -1,0 +1,133 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\Facebook\Tests\Unit\ProductSync;
+
+use WooCommerce\Facebook\ProductSync\ProductExcludedException;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+use Exception;
+
+/**
+ * Unit tests for ProductExcludedException class.
+ *
+ * @since x.x.x
+ */
+class ProductExcludedExceptionTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+	/**
+	 * Test that ProductExcludedException exists and can be instantiated.
+	 */
+	public function test_class_exists() {
+		$this->assertTrue( class_exists( ProductExcludedException::class ) );
+	}
+
+	/**
+	 * Test that ProductExcludedException extends Exception.
+	 */
+	public function test_extends_exception() {
+		$exception = new ProductExcludedException();
+		$this->assertInstanceOf( Exception::class, $exception );
+		$this->assertInstanceOf( ProductExcludedException::class, $exception );
+	}
+
+	/**
+	 * Test throwing and catching exception with message.
+	 */
+	public function test_throw_with_message() {
+		$message = 'Product is excluded from Facebook sync';
+		
+		try {
+			throw new ProductExcludedException( $message );
+		} catch ( ProductExcludedException $e ) {
+			$this->assertEquals( $message, $e->getMessage() );
+			$this->assertInstanceOf( ProductExcludedException::class, $e );
+		}
+	}
+
+	/**
+	 * Test throwing exception with custom code.
+	 */
+	public function test_throw_with_code() {
+		$message = 'Product excluded';
+		$code = 100;
+		
+		try {
+			throw new ProductExcludedException( $message, $code );
+		} catch ( ProductExcludedException $e ) {
+			$this->assertEquals( $message, $e->getMessage() );
+			$this->assertEquals( $code, $e->getCode() );
+		}
+	}
+
+	/**
+	 * Test exception chaining.
+	 */
+	public function test_exception_chaining() {
+		$previousException = new Exception( 'Previous error' );
+		$message = 'Product excluded due to previous error';
+		
+		try {
+			throw new ProductExcludedException( $message, 0, $previousException );
+		} catch ( ProductExcludedException $e ) {
+			$this->assertEquals( $message, $e->getMessage() );
+			$this->assertSame( $previousException, $e->getPrevious() );
+			$this->assertEquals( 'Previous error', $e->getPrevious()->getMessage() );
+		}
+	}
+
+	/**
+	 * Test default exception values.
+	 */
+	public function test_default_values() {
+		$exception = new ProductExcludedException();
+		
+		$this->assertEquals( '', $exception->getMessage() );
+		$this->assertEquals( 0, $exception->getCode() );
+		$this->assertNull( $exception->getPrevious() );
+	}
+
+	/**
+	 * Test exception with empty message.
+	 */
+	public function test_empty_message() {
+		$exception = new ProductExcludedException( '' );
+		$this->assertEquals( '', $exception->getMessage() );
+	}
+
+	/**
+	 * Test exception with special characters in message.
+	 */
+	public function test_special_characters_in_message() {
+		$message = "Product 'Test & Demo' <excluded> due to \"special\" characters!";
+		$exception = new ProductExcludedException( $message );
+		$this->assertEquals( $message, $exception->getMessage() );
+	}
+
+	/**
+	 * Test that exception can be caught as base Exception.
+	 */
+	public function test_catch_as_base_exception() {
+		$caught = false;
+		
+		try {
+			throw new ProductExcludedException( 'Test' );
+		} catch ( Exception $e ) {
+			$caught = true;
+			$this->assertInstanceOf( ProductExcludedException::class, $e );
+		}
+		
+		$this->assertTrue( $caught );
+	}
+
+	/**
+	 * Test exception trace functionality.
+	 */
+	public function test_exception_trace() {
+		$exception = new ProductExcludedException( 'Test trace' );
+		
+		$this->assertIsArray( $exception->getTrace() );
+		$this->assertNotEmpty( $exception->getTraceAsString() );
+		$this->assertStringContainsString( __FILE__, $exception->getFile() );
+		$this->assertIsInt( $exception->getLine() );
+	}
+} 

--- a/tests/Unit/ProductSync/ProductExcludedExceptionTest.php
+++ b/tests/Unit/ProductSync/ProductExcludedExceptionTest.php
@@ -10,7 +10,7 @@ use Exception;
 /**
  * Unit tests for ProductExcludedException class.
  *
- * @since x.x.x
+ * @since 3.5.2
  */
 class ProductExcludedExceptionTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 

--- a/tests/Unit/ProductSync/ProductInvalidExceptionTest.php
+++ b/tests/Unit/ProductSync/ProductInvalidExceptionTest.php
@@ -10,7 +10,7 @@ use Exception;
 /**
  * Unit tests for ProductInvalidException class.
  *
- * @since x.x.x
+ * @since 3.5.2
  */
 class ProductInvalidExceptionTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 

--- a/tests/Unit/ProductSync/ProductInvalidExceptionTest.php
+++ b/tests/Unit/ProductSync/ProductInvalidExceptionTest.php
@@ -1,0 +1,161 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\Facebook\Tests\Unit\ProductSync;
+
+use WooCommerce\Facebook\ProductSync\ProductInvalidException;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+use Exception;
+
+/**
+ * Unit tests for ProductInvalidException class.
+ *
+ * @since x.x.x
+ */
+class ProductInvalidExceptionTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+	/**
+	 * Test that ProductInvalidException exists and can be instantiated.
+	 */
+	public function test_class_exists() {
+		$this->assertTrue( class_exists( ProductInvalidException::class ) );
+	}
+
+	/**
+	 * Test that ProductInvalidException extends Exception.
+	 */
+	public function test_extends_exception() {
+		$exception = new ProductInvalidException();
+		$this->assertInstanceOf( Exception::class, $exception );
+		$this->assertInstanceOf( ProductInvalidException::class, $exception );
+	}
+
+	/**
+	 * Test throwing and catching exception with message.
+	 */
+	public function test_throw_with_message() {
+		$message = 'Product configuration is invalid for Facebook sync';
+		
+		try {
+			throw new ProductInvalidException( $message );
+		} catch ( ProductInvalidException $e ) {
+			$this->assertEquals( $message, $e->getMessage() );
+			$this->assertInstanceOf( ProductInvalidException::class, $e );
+		}
+	}
+
+	/**
+	 * Test throwing exception with custom code.
+	 */
+	public function test_throw_with_code() {
+		$message = 'Invalid product configuration';
+		$code = 200;
+		
+		try {
+			throw new ProductInvalidException( $message, $code );
+		} catch ( ProductInvalidException $e ) {
+			$this->assertEquals( $message, $e->getMessage() );
+			$this->assertEquals( $code, $e->getCode() );
+		}
+	}
+
+	/**
+	 * Test exception chaining.
+	 */
+	public function test_exception_chaining() {
+		$previousException = new Exception( 'Validation failed' );
+		$message = 'Product invalid due to validation failure';
+		
+		try {
+			throw new ProductInvalidException( $message, 0, $previousException );
+		} catch ( ProductInvalidException $e ) {
+			$this->assertEquals( $message, $e->getMessage() );
+			$this->assertSame( $previousException, $e->getPrevious() );
+			$this->assertEquals( 'Validation failed', $e->getPrevious()->getMessage() );
+		}
+	}
+
+	/**
+	 * Test default exception values.
+	 */
+	public function test_default_values() {
+		$exception = new ProductInvalidException();
+		
+		$this->assertEquals( '', $exception->getMessage() );
+		$this->assertEquals( 0, $exception->getCode() );
+		$this->assertNull( $exception->getPrevious() );
+	}
+
+	/**
+	 * Test exception with empty message.
+	 */
+	public function test_empty_message() {
+		$exception = new ProductInvalidException( '' );
+		$this->assertEquals( '', $exception->getMessage() );
+	}
+
+	/**
+	 * Test exception with special characters in message.
+	 */
+	public function test_special_characters_in_message() {
+		$message = "Product 'Test & Demo' <invalid> due to \"configuration\" errors!";
+		$exception = new ProductInvalidException( $message );
+		$this->assertEquals( $message, $exception->getMessage() );
+	}
+
+	/**
+	 * Test that exception can be caught as base Exception.
+	 */
+	public function test_catch_as_base_exception() {
+		$caught = false;
+		
+		try {
+			throw new ProductInvalidException( 'Test' );
+		} catch ( Exception $e ) {
+			$caught = true;
+			$this->assertInstanceOf( ProductInvalidException::class, $e );
+		}
+		
+		$this->assertTrue( $caught );
+	}
+
+	/**
+	 * Test exception trace functionality.
+	 */
+	public function test_exception_trace() {
+		$exception = new ProductInvalidException( 'Test trace' );
+		
+		$this->assertIsArray( $exception->getTrace() );
+		$this->assertNotEmpty( $exception->getTraceAsString() );
+		$this->assertStringContainsString( __FILE__, $exception->getFile() );
+		$this->assertIsInt( $exception->getLine() );
+	}
+
+	/**
+	 * Test different error scenarios for invalid products.
+	 */
+	public function test_product_validation_scenarios() {
+		// Missing required fields
+		try {
+			throw new ProductInvalidException( 'Product missing required fields' );
+		} catch ( ProductInvalidException $e ) {
+			$this->assertEquals( 'Product missing required fields', $e->getMessage() );
+		}
+
+		// Invalid price
+		try {
+			throw new ProductInvalidException( 'Product price is invalid', 301 );
+		} catch ( ProductInvalidException $e ) {
+			$this->assertEquals( 'Product price is invalid', $e->getMessage() );
+			$this->assertEquals( 301, $e->getCode() );
+		}
+
+		// Invalid category
+		try {
+			throw new ProductInvalidException( 'Product category not supported by Facebook', 302 );
+		} catch ( ProductInvalidException $e ) {
+			$this->assertEquals( 'Product category not supported by Facebook', $e->getMessage() );
+			$this->assertEquals( 302, $e->getCode() );
+		}
+	}
+} 


### PR DESCRIPTION
## Description

This PR adds comprehensive unit test coverage for two previously untested exception classes in the ProductSync namespace. These exception classes are used to handle specific error conditions during Facebook product synchronization.

### Type of change

- Add (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices.
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary).

## Changelog entry

Add unit tests for ProductExcludedException and ProductInvalidException to improve code coverage

## Test Plan

1. Run the unit tests with: `composer test-unit -- tests/Unit/ProductSync/`
2. All 21 tests should pass successfully
3. The tests cover:
   - Class existence and inheritance verification
   - Exception throwing and catching with messages
   - Exception codes and chaining
   - Default values and edge cases
   - Special character handling in messages
   - Exception trace functionality

## Screenshots
Not applicable - this PR only adds unit tests 