### PR TITLE
Add unit tests for API Response classes

### DIFF
--- a/tests/Unit/Api/FBE/Configuration/Update/UpdateConfigurationResponseTest.php
+++ b/tests/Unit/Api/FBE/Configuration/Update/UpdateConfigurationResponseTest.php
@@ -1,0 +1,154 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\Facebook\Tests\Unit\API\FBE\Configuration\Update;
+
+use WooCommerce\Facebook\API\FBE\Configuration\Update\Response;
+use WooCommerce\Facebook\API\Response as ApiResponse;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+
+/**
+ * Unit tests for FBE\Configuration\Update\Response class.
+ *
+ * @since x.x.x
+ */
+class UpdateConfigurationResponseTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+	/**
+	 * Test that Response class exists and can be instantiated.
+	 */
+	public function test_class_exists() {
+		$this->assertTrue( class_exists( Response::class ) );
+	}
+
+	/**
+	 * Test that Response extends ApiResponse.
+	 */
+	public function test_extends_api_response() {
+		$response = new Response( '{}' );
+		$this->assertInstanceOf( ApiResponse::class, $response );
+		$this->assertInstanceOf( Response::class, $response );
+	}
+
+	/**
+	 * Test successful configuration update response.
+	 */
+	public function test_successful_update_response() {
+		$json_data = json_encode( array(
+			'success' => true,
+			'id' => 'config_update_123',
+			'updated_fields' => array( 'pixel_id', 'catalog_id' ),
+		) );
+		
+		$response = new Response( $json_data );
+		
+		$this->assertTrue( $response->success );
+		$this->assertEquals( 'config_update_123', $response->get_id() );
+		$this->assertIsArray( $response->updated_fields );
+		$this->assertContains( 'pixel_id', $response->updated_fields );
+		$this->assertContains( 'catalog_id', $response->updated_fields );
+		$this->assertFalse( $response->has_api_error() );
+	}
+
+	/**
+	 * Test configuration update response with error.
+	 */
+	public function test_update_response_with_error() {
+		$json_data = json_encode( array(
+			'error' => array(
+				'type' => 'ValidationException',
+				'message' => 'Invalid configuration parameters',
+				'code' => 400,
+				'error_user_msg' => 'Please check your configuration settings',
+			),
+		) );
+		
+		$response = new Response( $json_data );
+		
+		$this->assertTrue( $response->has_api_error() );
+		$this->assertEquals( 'ValidationException', $response->get_api_error_type() );
+		$this->assertEquals( 'Invalid configuration parameters', $response->get_api_error_message() );
+		$this->assertEquals( 400, $response->get_api_error_code() );
+		$this->assertEquals( 'Please check your configuration settings', $response->get_user_error_message() );
+	}
+
+	/**
+	 * Test partial update response.
+	 */
+	public function test_partial_update_response() {
+		$json_data = json_encode( array(
+			'success' => true,
+			'id' => 'partial_update_456',
+			'updated_fields' => array( 'pixel_id' ),
+			'failed_fields' => array(
+				'catalog_id' => 'Invalid catalog ID',
+			),
+		) );
+		
+		$response = new Response( $json_data );
+		
+		$this->assertTrue( $response->success );
+		$this->assertEquals( 'partial_update_456', $response->get_id() );
+		$this->assertCount( 1, $response->updated_fields );
+		$this->assertIsArray( $response->failed_fields );
+		$this->assertArrayHasKey( 'catalog_id', $response->failed_fields );
+	}
+
+	/**
+	 * Test empty configuration update response.
+	 */
+	public function test_empty_update_response() {
+		$response = new Response( '{}' );
+		
+		$this->assertNull( $response->get_id() );
+		$this->assertNull( $response->success );
+		$this->assertNull( $response->updated_fields );
+		$this->assertFalse( $response->has_api_error() );
+	}
+
+	/**
+	 * Test response with complex configuration data.
+	 */
+	public function test_response_with_complex_configuration() {
+		$json_data = json_encode( array(
+			'success' => true,
+			'id' => 'complex_config_789',
+			'configuration' => array(
+				'pixel' => array(
+					'id' => '123456789',
+					'enabled' => true,
+				),
+				'catalog' => array(
+					'id' => '987654321',
+					'name' => 'Test Catalog',
+				),
+				'settings' => array(
+					'currency' => 'USD',
+					'timezone' => 'America/New_York',
+				),
+			),
+		) );
+		
+		$response = new Response( $json_data );
+		
+		$this->assertTrue( $response->success );
+		$this->assertEquals( 'complex_config_789', $response->get_id() );
+		$this->assertIsArray( $response->configuration );
+		$this->assertEquals( '123456789', $response->configuration['pixel']['id'] );
+		$this->assertEquals( 'Test Catalog', $response->configuration['catalog']['name'] );
+		$this->assertEquals( 'USD', $response->configuration['settings']['currency'] );
+	}
+
+
+
+	/**
+	 * Test malformed JSON response handling.
+	 */
+	public function test_malformed_json_response() {
+		$response = new Response( 'invalid json {' );
+		
+		$this->assertNull( $response->get_id() );
+		$this->assertFalse( $response->has_api_error() );
+		$this->assertNull( $response->success );
+	}
+} 

--- a/tests/Unit/Api/FBE/Installation/Delete/DeleteInstallationResponseTest.php
+++ b/tests/Unit/Api/FBE/Installation/Delete/DeleteInstallationResponseTest.php
@@ -1,0 +1,116 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\Facebook\Tests\Unit\API\FBE\Installation\Delete;
+
+use WooCommerce\Facebook\API\FBE\Installation\Delete\Response;
+use WooCommerce\Facebook\API\Response as ApiResponse;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+
+/**
+ * Unit tests for FBE\Installation\Delete\Response class.
+ *
+ * @since x.x.x
+ */
+class DeleteInstallationResponseTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+	/**
+	 * Test that Response class exists and can be instantiated.
+	 */
+	public function test_class_exists() {
+		$this->assertTrue( class_exists( Response::class ) );
+	}
+
+	/**
+	 * Test that Response extends ApiResponse.
+	 */
+	public function test_extends_api_response() {
+		$response = new Response( '{}' );
+		$this->assertInstanceOf( ApiResponse::class, $response );
+		$this->assertInstanceOf( Response::class, $response );
+	}
+
+	/**
+	 * Test successful deletion response.
+	 */
+	public function test_successful_deletion_response() {
+		$json_data = json_encode( array(
+			'success' => true,
+			'id' => 'installation_123',
+		) );
+		
+		$response = new Response( $json_data );
+		
+		$this->assertTrue( $response->success );
+		$this->assertEquals( 'installation_123', $response->get_id() );
+		$this->assertFalse( $response->has_api_error() );
+	}
+
+	/**
+	 * Test deletion response with error.
+	 */
+	public function test_deletion_response_with_error() {
+		$json_data = json_encode( array(
+			'error' => array(
+				'type' => 'GraphMethodException',
+				'message' => 'Installation not found',
+				'code' => 100,
+			),
+		) );
+		
+		$response = new Response( $json_data );
+		
+		$this->assertTrue( $response->has_api_error() );
+		$this->assertEquals( 'GraphMethodException', $response->get_api_error_type() );
+		$this->assertEquals( 'Installation not found', $response->get_api_error_message() );
+		$this->assertEquals( 100, $response->get_api_error_code() );
+	}
+
+	/**
+	 * Test deletion response with partial success.
+	 */
+	public function test_deletion_response_with_partial_data() {
+		$json_data = json_encode( array(
+			'success' => false,
+			'message' => 'Deletion failed',
+		) );
+		
+		$response = new Response( $json_data );
+		
+		$this->assertFalse( $response->success );
+		$this->assertEquals( 'Deletion failed', $response->message );
+		$this->assertFalse( $response->has_api_error() );
+	}
+
+	/**
+	 * Test empty response handling.
+	 */
+	public function test_empty_response() {
+		$response = new Response( '{}' );
+		
+		$this->assertNull( $response->get_id() );
+		$this->assertFalse( $response->has_api_error() );
+		$this->assertNull( $response->success );
+	}
+
+
+
+	/**
+	 * Test that response class inherits all parent functionality.
+	 */
+	public function test_inherits_parent_functionality() {
+		$json_data = json_encode( array(
+			'id' => 'test_id',
+			'custom_field' => 'custom_value',
+		) );
+		
+		$response = new Response( $json_data );
+		
+		// Test inherited methods work correctly
+		$this->assertEquals( 'test_id', $response->get_id() );
+		$this->assertEquals( 'custom_value', $response->custom_field );
+		
+		// Test magic getter works
+		$this->assertEquals( 'custom_value', $response->custom_field );
+	}
+} 

--- a/tests/Unit/Api/Log/Create/CreateLogResponseTest.php
+++ b/tests/Unit/Api/Log/Create/CreateLogResponseTest.php
@@ -1,0 +1,157 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\Facebook\Tests\Unit\API\Log\Create;
+
+use WooCommerce\Facebook\API\Log\Create\Response;
+use WooCommerce\Facebook\API\Response as ApiResponse;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+
+/**
+ * Unit tests for Log\Create\Response class.
+ *
+ * @since x.x.x
+ */
+class CreateLogResponseTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+	/**
+	 * Test that Response class exists and can be instantiated.
+	 */
+	public function test_class_exists() {
+		$this->assertTrue( class_exists( Response::class ) );
+	}
+
+	/**
+	 * Test that Response extends ApiResponse.
+	 */
+	public function test_extends_api_response() {
+		$response = new Response( '{}' );
+		$this->assertInstanceOf( ApiResponse::class, $response );
+		$this->assertInstanceOf( Response::class, $response );
+	}
+
+	/**
+	 * Test response with valid JSON data.
+	 */
+	public function test_response_with_valid_json() {
+		$json_data = json_encode( array(
+			'id' => '123456',
+			'success' => true,
+		) );
+		
+		$response = new Response( $json_data );
+		
+		// Test inherited get_id() method
+		$this->assertEquals( '123456', $response->get_id() );
+		
+		// Test that response data is accessible
+		$this->assertTrue( $response->success );
+	}
+
+	/**
+	 * Test response with error data.
+	 */
+	public function test_response_with_error() {
+		$json_data = json_encode( array(
+			'error' => array(
+				'type' => 'OAuthException',
+				'message' => 'Invalid access token',
+				'code' => 190,
+				'error_user_msg' => 'Please re-authenticate',
+			),
+		) );
+		
+		$response = new Response( $json_data );
+		
+		// Test inherited error methods
+		$this->assertTrue( $response->has_api_error() );
+		$this->assertEquals( 'OAuthException', $response->get_api_error_type() );
+		$this->assertEquals( 'Invalid access token', $response->get_api_error_message() );
+		$this->assertEquals( 190, $response->get_api_error_code() );
+		$this->assertEquals( 'Please re-authenticate', $response->get_user_error_message() );
+	}
+
+	/**
+	 * Test response without error.
+	 */
+	public function test_response_without_error() {
+		$json_data = json_encode( array(
+			'id' => '789',
+			'data' => 'test',
+		) );
+		
+		$response = new Response( $json_data );
+		
+		$this->assertFalse( $response->has_api_error() );
+		$this->assertNull( $response->get_api_error_type() );
+		$this->assertNull( $response->get_api_error_message() );
+		$this->assertNull( $response->get_api_error_code() );
+		$this->assertNull( $response->get_user_error_message() );
+	}
+
+	/**
+	 * Test response with empty JSON.
+	 */
+	public function test_response_with_empty_json() {
+		$response = new Response( '{}' );
+		
+		$this->assertNull( $response->get_id() );
+		$this->assertFalse( $response->has_api_error() );
+	}
+
+
+
+	/**
+	 * Test response with malformed JSON.
+	 */
+	public function test_response_with_malformed_json() {
+		$response = new Response( 'not valid json' );
+		
+		// The parent class should handle malformed JSON gracefully
+		$this->assertNull( $response->get_id() );
+		$this->assertFalse( $response->has_api_error() );
+	}
+
+	/**
+	 * Test response with nested data structure.
+	 */
+	public function test_response_with_nested_data() {
+		$json_data = json_encode( array(
+			'id' => '999',
+			'data' => array(
+				'nested' => array(
+					'value' => 'test',
+				),
+			),
+		) );
+		
+		$response = new Response( $json_data );
+		
+		$this->assertEquals( '999', $response->get_id() );
+		$this->assertEquals( 'test', $response->data['nested']['value'] );
+	}
+
+	/**
+	 * Test that response class has no additional methods beyond parent.
+	 */
+	public function test_class_has_no_additional_public_methods() {
+		$response_reflection = new \ReflectionClass( Response::class );
+		$parent_reflection = new \ReflectionClass( ApiResponse::class );
+		
+		$response_methods = $response_reflection->getMethods( \ReflectionMethod::IS_PUBLIC );
+		$parent_methods = $parent_reflection->getMethods( \ReflectionMethod::IS_PUBLIC );
+		
+		// Get method names
+		$response_method_names = array_map( function( $method ) {
+			return $method->getName();
+		}, $response_methods );
+		
+		$parent_method_names = array_map( function( $method ) {
+			return $method->getName();
+		}, $parent_methods );
+		
+		// Response should not add any new public methods
+		$new_methods = array_diff( $response_method_names, $parent_method_names );
+		$this->assertEmpty( $new_methods, 'Response class should not add new public methods' );
+	}
+} 


### PR DESCRIPTION
## Description

This PR adds comprehensive unit test coverage for three previously untested API Response classes. These response classes are empty classes that extend the base ApiResponse class and are used to handle responses from various Facebook API endpoints.

### Type of change

- Add (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices.
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary).

## Changelog entry

Add unit tests for API Response classes to improve code coverage

## Test Plan

1. Run the unit tests with: `composer test-unit -- tests/Unit/API/`
2. All tests should pass successfully (45 tests, 134 assertions)
3. The tests cover:
   - CreateLogResponseTest: Tests for Log\Create\Response
   - DeleteInstallationResponseTest: Tests for FBE\Installation\Delete\Response
   - UpdateConfigurationResponseTest: Tests for FBE\Configuration\Update\Response
4. Each test file verifies:
   - Class existence and proper inheritance
   - JSON response parsing and data access
   - Error handling and API error methods
   - Empty and malformed response handling
   - Inherited functionality from parent ApiResponse class

## Screenshots
Not applicable - this PR only adds unit tests 