### PR TITLE
[Rollout Switches] Product sync tab deprecation

### DIFF
--- a/includes/Admin/Enhanced_Settings.php
+++ b/includes/Admin/Enhanced_Settings.php
@@ -79,15 +79,17 @@ class Enhanced_Settings {
 
 		if ( $is_connected ) {
 			if ( $is_woo_all_products_sync_enbaled ) {
-				// TODO: Remove Product sync and Product sets tab once catalog changes are complete
 				$screens = array(
 					Settings_Screens\Shops::ID        => new Settings_Screens\Shops(),
-					Settings_Screens\Product_Sync::ID => new Settings_Screens\Product_Sync(),
 					Settings_Screens\Product_Sets::ID => new Settings_Screens\Product_Sets(),
 				);
 			} else {
+				/**
+				 * If not enabled then the product sync tab should show itself
+				 */
 				$screens = array(
 					Settings_Screens\Shops::ID        => new Settings_Screens\Shops(),
+					Settings_Screens\Product_Sync::ID => new Settings_Screens\Product_Sync(),
 					Settings_Screens\Product_Sets::ID => new Settings_Screens\Product_Sets(),
 				);
 			}

--- a/includes/Admin/Enhanced_Settings.php
+++ b/includes/Admin/Enhanced_Settings.php
@@ -72,15 +72,25 @@ class Enhanced_Settings {
 	 * @return array
 	 */
 	public function build_menu_item_array(): array {
-		$is_connected = $this->plugin->get_connection_handler()->is_connected();
+		$is_connected                     = $this->plugin->get_connection_handler()->is_connected();
+		$is_woo_all_products_sync_enbaled = $this->plugin->get_rollout_switches()->is_switch_enabled(
+			RolloutSwitches::SWITCH_WOO_ALL_PRODUCTS_SYNC_ENABLED
+		);
 
 		if ( $is_connected ) {
-			// TODO: Remove Product sync and Product sets tab once catalog changes are complete
-			$screens = array(
-				Settings_Screens\Shops::ID        => new Settings_Screens\Shops(),
-				Settings_Screens\Product_Sync::ID => new Settings_Screens\Product_Sync(),
-				Settings_Screens\Product_Sets::ID => new Settings_Screens\Product_Sets(),
-			);
+			if ( $is_woo_all_products_sync_enbaled ) {
+				// TODO: Remove Product sync and Product sets tab once catalog changes are complete
+				$screens = array(
+					Settings_Screens\Shops::ID        => new Settings_Screens\Shops(),
+					Settings_Screens\Product_Sync::ID => new Settings_Screens\Product_Sync(),
+					Settings_Screens\Product_Sets::ID => new Settings_Screens\Product_Sets(),
+				);
+			} else {
+				$screens = array(
+					Settings_Screens\Shops::ID        => new Settings_Screens\Shops(),
+					Settings_Screens\Product_Sets::ID => new Settings_Screens\Product_Sets(),
+				);
+			}
 		} else {
 			$screens = [ Settings_Screens\Shops::ID => new Settings_Screens\Shops() ];
 		}
@@ -193,9 +203,9 @@ class Enhanced_Settings {
 				'flow_step' => $current_tab . '_tab_rendered',
 			),
 			array(
-				'should_send_log_to_meta' => true,
+				'should_send_log_to_meta'        => true,
 				'should_save_log_in_woocommerce' => true,
-				'woocommerce_log_level'   => \WC_Log_Levels::DEBUG,
+				'woocommerce_log_level'          => \WC_Log_Levels::DEBUG,
 			)
 		);
 

--- a/includes/Admin/Enhanced_Settings.php
+++ b/includes/Admin/Enhanced_Settings.php
@@ -78,6 +78,7 @@ class Enhanced_Settings {
 			// TODO: Remove Product sync and Product sets tab once catalog changes are complete
 			$screens = array(
 				Settings_Screens\Shops::ID        => new Settings_Screens\Shops(),
+				Settings_Screens\Product_Sync::ID => new Settings_Screens\Product_Sync(),
 				Settings_Screens\Product_Sets::ID => new Settings_Screens\Product_Sets(),
 			);
 		} else {

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -198,10 +198,10 @@ class Settings {
 						break;
 					case Settings_Screens\Product_Sync::ID:
 						/**
-						 * If all proudcts sync not enabled 
+						 * If all proudcts sync not enabled
 						 * Show the product sync tab
 						 */
-						if ( !$is_woo_all_products_sync_enbaled ) {
+						if ( ! $is_woo_all_products_sync_enbaled ) {
 							$crumbs[] = __( 'Product sync', 'facebook-for-woocommerce' );
 						}
 						break;

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -77,7 +77,6 @@ class Settings {
 		$last         = ( $is_connected ) ? $connection : $advertise;
 
 		$screens = array(
-			Settings_Screens\Product_Sync::ID => new Settings_Screens\Product_Sync(),
 			Settings_Screens\Product_Sets::ID => new Settings_Screens\Product_Sets(),
 		);
 
@@ -90,6 +89,13 @@ class Settings {
 		$is_whatsapp_utility_messaging_enabled = $rollout_switches->is_switch_enabled( RolloutSwitches::WHATSAPP_UTILITY_MESSAGING );
 		if ( true === $is_connected && true === $is_whatsapp_utility_messaging_enabled ) {
 			$this->screens[ Settings_Screens\Whatsapp_Utility::ID ] = new Settings_Screens\Whatsapp_Utility();
+		}
+
+		$is_woo_all_products_sync_enbaled = $this->plugin->get_rollout_switches()->is_switch_enabled(
+			RolloutSwitches::SWITCH_WOO_ALL_PRODUCTS_SYNC_ENABLED
+		);
+		if ( true === $is_connected && true === $is_woo_all_products_sync_enbaled ) {
+			$this->screens[ Settings_Screens\Product_Sync::ID ] = new Settings_Screens\Product_Sync();
 		}
 	}
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -94,7 +94,10 @@ class Settings {
 		$is_woo_all_products_sync_enbaled = $this->plugin->get_rollout_switches()->is_switch_enabled(
 			RolloutSwitches::SWITCH_WOO_ALL_PRODUCTS_SYNC_ENABLED
 		);
-		if ( true === $is_connected && true === $is_woo_all_products_sync_enbaled ) {
+		/**
+		 * If all products sync is not enabled should show the Product sync tab
+		 */
+		if ( true === $is_connected && false === $is_woo_all_products_sync_enbaled ) {
 			$this->screens[ Settings_Screens\Product_Sync::ID ] = new Settings_Screens\Product_Sync();
 		}
 	}
@@ -194,7 +197,11 @@ class Settings {
 						$crumbs[] = __( 'Connection', 'facebook-for-woocommerce' );
 						break;
 					case Settings_Screens\Product_Sync::ID:
-						if ( $is_woo_all_products_sync_enbaled ) {
+						/**
+						 * If all proudcts sync not enabled 
+						 * Show the product sync tab
+						 */
+						if ( !$is_woo_all_products_sync_enbaled ) {
 							$crumbs[] = __( 'Product sync', 'facebook-for-woocommerce' );
 						}
 						break;

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -172,6 +172,10 @@ class Settings {
 	 * @param string $screen_id the ID to connect to
 	 */
 	private function connect_to_enhanced_admin( $screen_id ) {
+		$is_woo_all_products_sync_enbaled = $this->plugin->get_rollout_switches()->is_switch_enabled(
+			RolloutSwitches::SWITCH_WOO_ALL_PRODUCTS_SYNC_ENABLED
+		);
+
 		if ( is_callable( 'wc_admin_connect_page' ) ) {
 			$crumbs = array(
 				__( 'Facebook for WooCommerce', 'facebook-for-woocommerce' ),
@@ -184,7 +188,9 @@ class Settings {
 						$crumbs[] = __( 'Connection', 'facebook-for-woocommerce' );
 						break;
 					case Settings_Screens\Product_Sync::ID:
-						$crumbs[] = __( 'Product sync', 'facebook-for-woocommerce' );
+						if ( $is_woo_all_products_sync_enbaled ) {
+							$crumbs[] = __( 'Product sync', 'facebook-for-woocommerce' );
+						}
 						break;
 					case Settings_Screens\Advertise::ID:
 						$crumbs[] = __( 'Advertise', 'facebook-for-woocommerce' );

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -77,6 +77,7 @@ class Settings {
 		$last         = ( $is_connected ) ? $connection : $advertise;
 
 		$screens = array(
+			Settings_Screens\Product_Sync::ID => new Settings_Screens\Product_Sync(),
 			Settings_Screens\Product_Sets::ID => new Settings_Screens\Product_Sets(),
 		);
 
@@ -181,6 +182,9 @@ class Settings {
 				switch ( $_GET['tab'] ) {
 					case Connection::ID:
 						$crumbs[] = __( 'Connection', 'facebook-for-woocommerce' );
+						break;
+					case Settings_Screens\Product_Sync::ID:
+						$crumbs[] = __( 'Product sync', 'facebook-for-woocommerce' );
 						break;
 					case Settings_Screens\Advertise::ID:
 						$crumbs[] = __( 'Advertise', 'facebook-for-woocommerce' );

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -20,10 +20,6 @@ use WooCommerce\Facebook\Products\Sync;
 
 /**
  * The Product Sync settings screen object.
- *
- * @deprecated
- * From version 3.5.1 onwards product sync tab will no longer be used across the app and should be
- * removed from existence after WooAllProducts happen.
  */
 class Product_Sync extends Abstract_Settings_Screen {
 

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -20,6 +20,11 @@ use WooCommerce\Facebook\Products\Sync;
 
 /**
  * The Product Sync settings screen object.
+ * *
+ *
+ * @deprecated
+ * From version 3.5.3 onwards product sync tab will no longer be used across the app and should be
+ * removed from existence after WooAllProducts happen.
  */
 class Product_Sync extends Abstract_Settings_Screen {
 

--- a/includes/RolloutSwitches.php
+++ b/includes/RolloutSwitches.php
@@ -24,15 +24,17 @@ class RolloutSwitches {
 	/** @var \WC_Facebookcommerce commerce handler */
 	private \WC_Facebookcommerce $plugin;
 
-	public const SWITCH_ROLLOUT_FEATURES          = 'rollout_enabled';
-	public const WHATSAPP_UTILITY_MESSAGING       = 'whatsapp_utility_messages_enabled';
-	public const SWITCH_PRODUCT_SETS_SYNC_ENABLED = 'product_sets_sync_enabled';
-	private const SETTINGS_KEY                    = 'wc_facebook_for_woocommerce_rollout_switches';
+	public const SWITCH_ROLLOUT_FEATURES              = 'rollout_enabled';
+	public const WHATSAPP_UTILITY_MESSAGING           = 'whatsapp_utility_messages_enabled';
+	public const SWITCH_PRODUCT_SETS_SYNC_ENABLED     = 'product_sets_sync_enabled';
+	public const SWITCH_WOO_ALL_PRODUCTS_SYNC_ENABLED = 'woo_all_products_sync_enabled';
+	private const SETTINGS_KEY                        = 'wc_facebook_for_woocommerce_rollout_switches';
 
 	private const ACTIVE_SWITCHES = array(
 		self::SWITCH_ROLLOUT_FEATURES,
 		self::WHATSAPP_UTILITY_MESSAGING,
 		self::SWITCH_PRODUCT_SETS_SYNC_ENABLED,
+		self::SWITCH_WOO_ALL_PRODUCTS_SYNC_ENABLED,
 	);
 
 	public function __construct( \WC_Facebookcommerce $plugin ) {
@@ -82,13 +84,13 @@ class RolloutSwitches {
 			Logger::log(
 				$e->getMessage(),
 				array(
-					'flow_name'  => 'rollout_switches',
-					'flow_step'  => 'init',
+					'flow_name' => 'rollout_switches',
+					'flow_step' => 'init',
 				),
 				array(
-					'should_send_log_to_meta' => true,
+					'should_send_log_to_meta'        => true,
 					'should_save_log_in_woocommerce' => true,
-					'woocommerce_log_level'   => \WC_Log_Levels::ERROR,
+					'woocommerce_log_level'          => \WC_Log_Levels::ERROR,
 				)
 			);
 		}


### PR DESCRIPTION
## Description

We are providing Roll out switches to Product sync tab deprecation.
This way we would selectively roll out the changes to our advertisers.

### Type of change

Improvement: Adding roll out switches

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Test Plan

1. If roll out switch is enabled -> No product sync tab
2. If roll out switch is disabled -> Product sync tab visible
