### PR TITLE
Add unit tests for Framework Plugin Exception class

### DIFF
--- a/tests/Unit/Framework/Plugin/PluginExceptionTest.php
+++ b/tests/Unit/Framework/Plugin/PluginExceptionTest.php
@@ -1,0 +1,155 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\Facebook\Tests\Unit\Framework\Plugin;
+
+use WooCommerce\Facebook\Framework\Plugin\Exception;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+
+/**
+ * Unit tests for Framework Plugin Exception class.
+ *
+ * @since x.x.x
+ */
+class PluginExceptionTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+	/**
+	 * Test that the Exception class exists and can be instantiated.
+	 */
+	public function test_exception_class_exists() {
+		$this->assertTrue( class_exists( Exception::class ) );
+	}
+
+	/**
+	 * Test that Exception extends the base PHP Exception class.
+	 */
+	public function test_exception_extends_base_exception() {
+		$exception = new Exception();
+		$this->assertInstanceOf( \Exception::class, $exception );
+	}
+
+	/**
+	 * Test exception instantiation with message.
+	 */
+	public function test_exception_with_message() {
+		$message = 'Test exception message';
+		$exception = new Exception( $message );
+		
+		$this->assertEquals( $message, $exception->getMessage() );
+	}
+
+	/**
+	 * Test exception instantiation with message and code.
+	 */
+	public function test_exception_with_message_and_code() {
+		$message = 'Test exception message';
+		$code = 123;
+		$exception = new Exception( $message, $code );
+		
+		$this->assertEquals( $message, $exception->getMessage() );
+		$this->assertEquals( $code, $exception->getCode() );
+	}
+
+	/**
+	 * Test exception instantiation with message, code, and previous exception.
+	 */
+	public function test_exception_with_previous_exception() {
+		$previousMessage = 'Previous exception';
+		$previousException = new \Exception( $previousMessage );
+		
+		$message = 'Current exception';
+		$code = 456;
+		$exception = new Exception( $message, $code, $previousException );
+		
+		$this->assertEquals( $message, $exception->getMessage() );
+		$this->assertEquals( $code, $exception->getCode() );
+		$this->assertSame( $previousException, $exception->getPrevious() );
+		$this->assertEquals( $previousMessage, $exception->getPrevious()->getMessage() );
+	}
+
+	/**
+	 * Test throwing and catching the exception.
+	 */
+	public function test_exception_can_be_thrown_and_caught() {
+		$message = 'Thrown exception';
+		$code = 789;
+		
+		try {
+			throw new Exception( $message, $code );
+		} catch ( Exception $e ) {
+			$this->assertEquals( $message, $e->getMessage() );
+			$this->assertEquals( $code, $e->getCode() );
+			return;
+		}
+		
+		$this->fail( 'Exception was not thrown' );
+	}
+
+	/**
+	 * Test exception with empty message.
+	 */
+	public function test_exception_with_empty_message() {
+		$exception = new Exception( '' );
+		$this->assertEquals( '', $exception->getMessage() );
+	}
+
+	/**
+	 * Test exception with zero code.
+	 */
+	public function test_exception_with_zero_code() {
+		$exception = new Exception( 'Message', 0 );
+		$this->assertEquals( 0, $exception->getCode() );
+	}
+
+	/**
+	 * Test exception with negative code.
+	 */
+	public function test_exception_with_negative_code() {
+		$exception = new Exception( 'Message', -1 );
+		$this->assertEquals( -1, $exception->getCode() );
+	}
+
+	/**
+	 * Test exception with special characters in message.
+	 */
+	public function test_exception_with_special_characters() {
+		$message = "Special chars: !@#$%^&*()_+{}[]|\\:\";<>?,./~`\n\t";
+		$exception = new Exception( $message );
+		$this->assertEquals( $message, $exception->getMessage() );
+	}
+
+	/**
+	 * Test exception with Unicode characters in message.
+	 */
+	public function test_exception_with_unicode_characters() {
+		$message = 'Unicode: 你好世界 🌍 émojis';
+		$exception = new Exception( $message );
+		$this->assertEquals( $message, $exception->getMessage() );
+	}
+
+	/**
+	 * Test exception trace contains expected information.
+	 */
+	public function test_exception_trace() {
+		$exception = new Exception( 'Test trace' );
+		$trace = $exception->getTrace();
+		
+		$this->assertIsArray( $trace );
+		$this->assertNotEmpty( $trace );
+		$this->assertArrayHasKey( 'file', $trace[0] );
+		$this->assertArrayHasKey( 'line', $trace[0] );
+		$this->assertArrayHasKey( 'function', $trace[0] );
+	}
+
+	/**
+	 * Test exception string representation.
+	 */
+	public function test_exception_string_representation() {
+		$message = 'String representation test';
+		$exception = new Exception( $message );
+		$string = (string) $exception;
+		
+		$this->assertStringContainsString( Exception::class, $string );
+		$this->assertStringContainsString( $message, $string );
+	}
+} 


### PR DESCRIPTION
## Description

This PR adds comprehensive unit test coverage for the `Framework\Plugin\Exception` class, which previously had 0% test coverage.

The Framework Plugin Exception class is the base exception class for the plugin, extending PHP's base Exception class. It serves as the parent for all plugin-specific exceptions and provides a foundation for the exception hierarchy used throughout the codebase.

### Type of change

- Add (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices.
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary).

## Changelog entry

Add unit tests for Framework Plugin Exception class to improve code coverage

## Test Plan

1. Run the unit tests with:
   ```bash
   composer test-unit -- tests/Unit/Framework/Plugin/PluginExceptionTest.php
   ```

2. All 13 tests should pass successfully (23 assertions)

3. The tests cover:
   - **Class existence and instantiation**: Verify the class exists and can be instantiated
   - **Inheritance from base Exception**: Test proper extension of PHP's Exception class
   - **Constructor parameters**: Test with message, code, and previous exception
   - **Exception chaining**: Verify previous exception handling
   - **Throwing and catching**: Test exception can be thrown and caught properly
   - **Edge cases**: Empty messages, zero/negative codes, special characters, Unicode
   - **Exception trace**: Verify trace contains expected information
   - **String representation**: Test exception converts to string properly

## Screenshots
Not applicable - this PR only adds unit tests 