### PR TITLE
[Product Sync tab] Removing deprecated tag

### DIFF
--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -20,11 +20,6 @@ use WooCommerce\Facebook\Products\Sync;
 
 /**
  * The Product Sync settings screen object.
- * *
- *
- * @deprecated
- * From version 3.5.3 onwards product sync tab will no longer be used across the app and should be
- * removed from existence after WooAllProducts happen.
  */
 class Product_Sync extends Abstract_Settings_Screen {
 


### PR DESCRIPTION
## Description

In order to not drastically change the experience to the users, we are putting back the product sync tab and not longer marking it deprecated. This tab will show up for the users who are not rolled out for the woo all products change.

### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Test Plan

No testing required

