### PR TITLE
Adding links to updated banner

### DIFF
--- a/includes/Handlers/PluginRender.php
+++ b/includes/Handlers/PluginRender.php
@@ -181,7 +181,7 @@ class PluginRender {
 					echo '<div id="plugin_updated_successfully_but_master_sync_off" class="notice notice-success is-dismissible ' . esc_html( $plugin_updated_but_not_master_sync_on ) . '"" style="">
 					<h4>You’ve updated to the latest plugin version</h4>   
 						<p>
-							To see all the changes, view the changelog. Since you’ve opted out of automatically syncing all your products, some of your products are not yet on Meta. We recommend turning on auto syncing to help drive your sales and improve ad performance. About syncing products to Meta
+							To see all the changes, view the changelog. Since you’ve opted out of automatically syncing all your products, some of your products are not yet on Meta. We recommend turning on auto syncing to help drive your sales and improve ad performance.<a href="https://www.facebook.com/business/help/4049935305295468"> About syncing products to Meta </a>
 						</p>
 						<p>
 							<a href="javascript:void(0);" class="button wc-forward" id="sync_all_products">


### PR DESCRIPTION
## Description

Earlier there was no link in updated banner for meta help centre. 

Bug fix : Adding link to the banner for meta help center

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Test Plan

1. Make sure you are on latest version > 3.5.3.
2. Now go to facebook tab under marketing.
3. Should see a banner and you can see the link 

## Screenshots
### After

![image](https://github.com/user-attachments/assets/739d0433-075c-4639-ae3c-44c1975744f6)

