### PR TITLE
Fix JavaScript TypeError With Upsells

### DIFF
--- a/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
+++ b/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
@@ -152,7 +152,7 @@ class Enhanced_Catalog_Attribute_Fields {
 		}
 		$selector_value      = $this->get_value( self::OPTIONAL_SELECTOR_KEY, $category_id );
 		$is_showing_optional = 'on' === $selector_value;
-// 
+
 		// Only show the selector if we have natural recommendations
 		if ( $should_render_checkbox ) {
 			$this->render_selector_checkbox( $is_showing_optional );


### PR DESCRIPTION
## Description

This PR fixes JavaScript `TypeError: Cannot read properties of undefined (reading 'includes')` errors that occur when the Facebook for WooCommerce plugin is enabled alongside third-party plugins that have search input fields without `id` or `class` attributes.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Changelog entry

Fix JavaScript TypeError when interacting with third-party plugin search boxes

## Test Plan

**Test Environment:**
- WordPress with Facebook for WooCommerce v3.4.5+
- Third-party plugin with search input fields (e.g., upsell plugins)
- Browser developer console open

**Steps to Reproduce Original Issue:**
1. Install Facebook for WooCommerce plugin v3.4.5+
2. Install any plugin with search input boxes that don't have `id` attributes
3. Open browser developer console
4. Type in the search boxes
5. Observe JavaScript errors: `TypeError: Cannot read properties of undefined (reading 'includes')`

**Steps to Verify Fix:**
1. Apply this patch
2. Repeat steps 1-4 above
3. Confirm no JavaScript errors appear in console
4. Verify Facebook plugin functionality still works:
   - Product tab switching works correctly
   - Facebook sync attributes function properly
   - Manual input values are stored correctly

**Additional Testing:**
- Test with elements that have no `class` attribute
- Test with elements that have no `id` attribute  
- Test with elements that have both attributes
- Verify no regression in existing Facebook plugin features

## Screenshots

### Before
<img width="532" alt="Screenshot 2025-06-17 at 15 19 09" src="https://github.com/user-attachments/assets/8e84b285-3a3f-4c54-9d38-59449af57246" />

*Console shows TypeError when typing in search boxes*

### After
<img width="691" alt="Screenshot 2025-06-17 at 15 17 43" src="https://github.com/user-attachments/assets/48564fcc-bd43-4f67-ad2f-062e8db75a6f" />

*Console remains clean when typing in search boxes*