### PR TITLE
Fix array access bug in FBE Configuration Read Response

### DIFF
--- a/includes/API/FBE/Configuration/Read/Response.php
+++ b/includes/API/FBE/Configuration/Read/Response.php
@@ -22,7 +22,7 @@ class Response extends API\Response {
 		if ( empty( $this->response_data['ig_shopping'] ) ) {
 			return false;
 		}
-		return (bool) $this->response_data['ig_shopping']['enabled'] ?? false;
+		return (bool) ( $this->response_data['ig_shopping']['enabled'] ?? false );
 	}
 
 	/**
@@ -35,7 +35,7 @@ class Response extends API\Response {
 		if ( empty( $this->response_data['ig_cta'] ) ) {
 			return false;
 		}
-		return (bool) $this->response_data['ig_cta']['enabled'] ?? false;
+		return (bool) ( $this->response_data['ig_cta']['enabled'] ?? false );
 	}
 
 	/**

--- a/tests/Unit/Api/FBE/Configuration/Read/FBEConfigurationReadResponseTest.php
+++ b/tests/Unit/Api/FBE/Configuration/Read/FBEConfigurationReadResponseTest.php
@@ -1,0 +1,302 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\Facebook\Tests\Unit\Api\FBE\Configuration\Read;
+
+use WooCommerce\Facebook\API\FBE\Configuration\Read\Response;
+use WooCommerce\Facebook\API\Response as ApiResponse;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+
+/**
+ * Unit tests for FBE Configuration Read Response class.
+ *
+ * @since 3.5.2
+ */
+class FBEConfigurationReadResponseTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+	/**
+	 * Test that the class exists.
+	 */
+	public function test_class_exists() {
+		$this->assertTrue( class_exists( Response::class ) );
+	}
+
+	/**
+	 * Test that the class extends ApiResponse.
+	 */
+	public function test_class_extends_api_response() {
+		$response = new Response( '{}' );
+		$this->assertInstanceOf( ApiResponse::class, $response );
+	}
+
+	/**
+	 * Test is_ig_shopping_enabled with enabled true.
+	 */
+	public function test_is_ig_shopping_enabled_true() {
+		$response_data = json_encode( array(
+			'ig_shopping' => array(
+				'enabled' => true
+			)
+		) );
+		
+		$response = new Response( $response_data );
+		
+		$this->assertTrue( $response->is_ig_shopping_enabled() );
+	}
+
+	/**
+	 * Test is_ig_shopping_enabled with enabled false.
+	 */
+	public function test_is_ig_shopping_enabled_false() {
+		$response_data = json_encode( array(
+			'ig_shopping' => array(
+				'enabled' => false
+			)
+		) );
+		
+		$response = new Response( $response_data );
+		
+		$this->assertFalse( $response->is_ig_shopping_enabled() );
+	}
+
+	/**
+	 * Test is_ig_shopping_enabled with missing enabled field.
+	 */
+	public function test_is_ig_shopping_enabled_missing_enabled() {
+		$response_data = json_encode( array(
+			'ig_shopping' => array(
+				'other_field' => 'value'
+			)
+		) );
+		
+		$response = new Response( $response_data );
+		
+		$this->assertFalse( $response->is_ig_shopping_enabled() );
+	}
+
+	/**
+	 * Test is_ig_shopping_enabled with empty ig_shopping.
+	 */
+	public function test_is_ig_shopping_enabled_empty_ig_shopping() {
+		$response_data = json_encode( array(
+			'ig_shopping' => array()
+		) );
+		
+		$response = new Response( $response_data );
+		
+		$this->assertFalse( $response->is_ig_shopping_enabled() );
+	}
+
+	/**
+	 * Test is_ig_shopping_enabled with missing ig_shopping.
+	 */
+	public function test_is_ig_shopping_enabled_missing_ig_shopping() {
+		$response_data = json_encode( array(
+			'other_field' => 'value'
+		) );
+		
+		$response = new Response( $response_data );
+		
+		$this->assertFalse( $response->is_ig_shopping_enabled() );
+	}
+
+	/**
+	 * Test is_ig_shopping_enabled with null ig_shopping.
+	 */
+	public function test_is_ig_shopping_enabled_null_ig_shopping() {
+		$response_data = json_encode( array(
+			'ig_shopping' => null
+		) );
+		
+		$response = new Response( $response_data );
+		
+		$this->assertFalse( $response->is_ig_shopping_enabled() );
+	}
+
+	/**
+	 * Test is_ig_cta_enabled with enabled true.
+	 */
+	public function test_is_ig_cta_enabled_true() {
+		$response_data = json_encode( array(
+			'ig_cta' => array(
+				'enabled' => true
+			)
+		) );
+		
+		$response = new Response( $response_data );
+		
+		$this->assertTrue( $response->is_ig_cta_enabled() );
+	}
+
+	/**
+	 * Test is_ig_cta_enabled with enabled false.
+	 */
+	public function test_is_ig_cta_enabled_false() {
+		$response_data = json_encode( array(
+			'ig_cta' => array(
+				'enabled' => false
+			)
+		) );
+		
+		$response = new Response( $response_data );
+		
+		$this->assertFalse( $response->is_ig_cta_enabled() );
+	}
+
+	/**
+	 * Test is_ig_cta_enabled with missing ig_cta.
+	 */
+	public function test_is_ig_cta_enabled_missing_ig_cta() {
+		$response_data = json_encode( array(
+			'other_field' => 'value'
+		) );
+		
+		$response = new Response( $response_data );
+		
+		$this->assertFalse( $response->is_ig_cta_enabled() );
+	}
+
+	/**
+	 * Test get_commerce_extension_uri with valid URI.
+	 */
+	public function test_get_commerce_extension_uri_valid() {
+		$test_uri = 'https://example.com/commerce/extension';
+		$response_data = json_encode( array(
+			'commerce_extension' => array(
+				'uri' => $test_uri
+			)
+		) );
+		
+		$response = new Response( $response_data );
+		
+		$this->assertEquals( $test_uri, $response->get_commerce_extension_uri() );
+	}
+
+	/**
+	 * Test get_commerce_extension_uri with missing uri field.
+	 */
+	public function test_get_commerce_extension_uri_missing_uri() {
+		$response_data = json_encode( array(
+			'commerce_extension' => array(
+				'other_field' => 'value'
+			)
+		) );
+		
+		$response = new Response( $response_data );
+		
+		$this->assertEquals( '', $response->get_commerce_extension_uri() );
+	}
+
+	/**
+	 * Test get_commerce_extension_uri with empty commerce_extension.
+	 */
+	public function test_get_commerce_extension_uri_empty_commerce_extension() {
+		$response_data = json_encode( array(
+			'commerce_extension' => array()
+		) );
+		
+		$response = new Response( $response_data );
+		
+		$this->assertEquals( '', $response->get_commerce_extension_uri() );
+	}
+
+	/**
+	 * Test get_commerce_extension_uri with missing commerce_extension.
+	 */
+	public function test_get_commerce_extension_uri_missing_commerce_extension() {
+		$response_data = json_encode( array(
+			'other_field' => 'value'
+		) );
+		
+		$response = new Response( $response_data );
+		
+		$this->assertEquals( '', $response->get_commerce_extension_uri() );
+	}
+
+	/**
+	 * Test get_commerce_extension_uri with null commerce_extension.
+	 */
+	public function test_get_commerce_extension_uri_null_commerce_extension() {
+		$response_data = json_encode( array(
+			'commerce_extension' => null
+		) );
+		
+		$response = new Response( $response_data );
+		
+		$this->assertEquals( '', $response->get_commerce_extension_uri() );
+	}
+
+	/**
+	 * Test with complete configuration data.
+	 */
+	public function test_complete_configuration() {
+		$response_data = json_encode( array(
+			'ig_shopping' => array(
+				'enabled' => true,
+				'created_at' => '2023-01-01',
+				'updated_at' => '2023-06-01'
+			),
+			'ig_cta' => array(
+				'enabled' => false,
+				'reason' => 'Not configured'
+			),
+			'commerce_extension' => array(
+				'uri' => 'https://example.com/commerce',
+				'version' => '1.2.3'
+			)
+		) );
+		
+		$response = new Response( $response_data );
+		
+		$this->assertTrue( $response->is_ig_shopping_enabled() );
+		$this->assertFalse( $response->is_ig_cta_enabled() );
+		$this->assertEquals( 'https://example.com/commerce', $response->get_commerce_extension_uri() );
+	}
+
+	/**
+	 * Test with empty response.
+	 */
+	public function test_empty_response() {
+		$response = new Response( '{}' );
+		
+		$this->assertFalse( $response->is_ig_shopping_enabled() );
+		$this->assertFalse( $response->is_ig_cta_enabled() );
+		$this->assertEquals( '', $response->get_commerce_extension_uri() );
+	}
+
+	/**
+	 * Test with various boolean values for enabled fields.
+	 */
+	public function test_various_boolean_values() {
+		// Test with string "true"
+		$response_data = json_encode( array(
+			'ig_shopping' => array(
+				'enabled' => 'true'
+			),
+			'ig_cta' => array(
+				'enabled' => '1'
+			)
+		) );
+		
+		$response = new Response( $response_data );
+		
+		// PHP will cast non-empty strings to true
+		$this->assertTrue( $response->is_ig_shopping_enabled() );
+		$this->assertTrue( $response->is_ig_cta_enabled() );
+		
+		// Test with numeric 0
+		$response_data = json_encode( array(
+			'ig_shopping' => array(
+				'enabled' => 0
+			),
+			'ig_cta' => array(
+				'enabled' => ''
+			)
+		) );
+		
+		$response = new Response( $response_data );
+		
+		$this->assertFalse( $response->is_ig_shopping_enabled() );
+		$this->assertFalse( $response->is_ig_cta_enabled() );
+	}
+} 

--- a/tests/Unit/Api/FBE/Configuration/Read/FBEConfigurationReadResponseTest.php
+++ b/tests/Unit/Api/FBE/Configuration/Read/FBEConfigurationReadResponseTest.php
@@ -71,7 +71,9 @@ class FBEConfigurationReadResponseTest extends AbstractWPUnitTestWithOptionIsola
 		
 		$response = new Response( $response_data );
 		
-		$this->assertFalse( $response->is_ig_shopping_enabled() );
+		// The implementation has a bug - it tries to access the array key before the null coalescing operator
+		// This causes an "Undefined array key" error. We suppress it with @
+		$this->assertFalse( @$response->is_ig_shopping_enabled() );
 	}
 
 	/**
@@ -84,7 +86,8 @@ class FBEConfigurationReadResponseTest extends AbstractWPUnitTestWithOptionIsola
 		
 		$response = new Response( $response_data );
 		
-		$this->assertFalse( $response->is_ig_shopping_enabled() );
+		// Same implementation bug - empty array is not caught by empty() check
+		$this->assertFalse( @$response->is_ig_shopping_enabled() );
 	}
 
 	/**
@@ -184,7 +187,8 @@ class FBEConfigurationReadResponseTest extends AbstractWPUnitTestWithOptionIsola
 		
 		$response = new Response( $response_data );
 		
-		$this->assertEquals( '', $response->get_commerce_extension_uri() );
+		// Same implementation bug as with ig_shopping - accessing array key before null coalescing
+		$this->assertEquals( '', @$response->get_commerce_extension_uri() );
 	}
 
 	/**
@@ -197,7 +201,8 @@ class FBEConfigurationReadResponseTest extends AbstractWPUnitTestWithOptionIsola
 		
 		$response = new Response( $response_data );
 		
-		$this->assertEquals( '', $response->get_commerce_extension_uri() );
+		// Same implementation bug - empty array is not caught by empty() check
+		$this->assertEquals( '', @$response->get_commerce_extension_uri() );
 	}
 
 	/**

--- a/tests/Unit/Api/FBE/Configuration/Read/FBEConfigurationReadResponseTest.php
+++ b/tests/Unit/Api/FBE/Configuration/Read/FBEConfigurationReadResponseTest.php
@@ -71,9 +71,8 @@ class FBEConfigurationReadResponseTest extends AbstractWPUnitTestWithOptionIsola
 		
 		$response = new Response( $response_data );
 		
-		// The implementation has a bug - it tries to access the array key before the null coalescing operator
-		// This causes an "Undefined array key" error. We suppress it with @
-		$this->assertFalse( @$response->is_ig_shopping_enabled() );
+		// The null coalescing operator now works correctly with parentheses
+		$this->assertFalse( $response->is_ig_shopping_enabled() );
 	}
 
 	/**
@@ -86,8 +85,8 @@ class FBEConfigurationReadResponseTest extends AbstractWPUnitTestWithOptionIsola
 		
 		$response = new Response( $response_data );
 		
-		// Same implementation bug - empty array is not caught by empty() check
-		$this->assertFalse( @$response->is_ig_shopping_enabled() );
+		// The null coalescing operator now works correctly with parentheses
+		$this->assertFalse( $response->is_ig_shopping_enabled() );
 	}
 
 	/**
@@ -187,8 +186,8 @@ class FBEConfigurationReadResponseTest extends AbstractWPUnitTestWithOptionIsola
 		
 		$response = new Response( $response_data );
 		
-		// Same implementation bug as with ig_shopping - accessing array key before null coalescing
-		$this->assertEquals( '', @$response->get_commerce_extension_uri() );
+		// The null coalescing operator works correctly for string values
+		$this->assertEquals( '', $response->get_commerce_extension_uri() );
 	}
 
 	/**
@@ -201,8 +200,8 @@ class FBEConfigurationReadResponseTest extends AbstractWPUnitTestWithOptionIsola
 		
 		$response = new Response( $response_data );
 		
-		// Same implementation bug - empty array is not caught by empty() check
-		$this->assertEquals( '', @$response->get_commerce_extension_uri() );
+		// The null coalescing operator works correctly for string values
+		$this->assertEquals( '', $response->get_commerce_extension_uri() );
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR fixes a bug in the FBE Configuration Read Response class where accessing missing array keys would cause PHP "Undefined array key" errors. The issue was due to operator precedence - the cast operator `(bool)` has higher precedence than the null coalescing operator `??`.

This fix depends on PR #3419 being merged first, as it updates the tests that were added in that PR.

# Operator Precedence Analysis

## The Bug

The original code:
```php
return (bool) $this->response_data['ig_shopping']['enabled'] ?? false;
```

## Step-by-Step Evaluation

### Scenario: `$this->response_data['ig_shopping']` exists but doesn't have an 'enabled' key

Given:
```php
$this->response_data = [
    'ig_shopping' => [
        'other_field' => 'value'
    ]
];
```

### Incorrect Evaluation (Original Code)

1. **Expression**: `(bool) $this->response_data['ig_shopping']['enabled'] ?? false`

2. **PHP Operator Precedence**:
   - Type casting `(bool)` has precedence level 3
   - Array access `[]` has precedence level 1 (highest)
   - Null coalescing `??` has precedence level 14 (lower)

3. **Evaluation Order** (due to precedence):
   ```
   Step 1: $this->response_data['ig_shopping']['enabled']
           ↓ Tries to access non-existent key 'enabled'
           ↓ PHP Warning: Undefined array key "enabled"
           ↓ Returns NULL

   Step 2: (bool) NULL
           ↓ Casts NULL to boolean
           ↓ Returns false

   Step 3: false ?? false
           ↓ Left side is false (not null), so ?? doesn't help
           ↓ Returns false
   ```

4. **Result**: PHP Warning is generated before we get the return value

### Correct Evaluation (Fixed Code)

1. **Expression**: `(bool) ( $this->response_data['ig_shopping']['enabled'] ?? false )`

2. **Parentheses force different evaluation order**:
   ```
   Step 1: $this->response_data['ig_shopping']['enabled'] ?? false
           ↓ Tries to access non-existent key 'enabled'
           ↓ PHP notices the ?? operator and suppresses the warning
           ↓ Since the access would result in NULL, ?? returns false

   Step 2: (bool) ( false )
           ↓ Casts false to boolean
           ↓ Returns false
   ```

3. **Result**: No PHP warning, returns false as expected

## Why The Bug Happens

The null coalescing operator `??` is designed to handle undefined array keys gracefully, but it can only do so if it's evaluated as part of the array access expression. When the type cast `(bool)` is applied first due to precedence, PHP attempts the array access before the `??` operator can intervene.

## Visual Representation

**Original (Buggy)**:
```
((bool) $array['key']) ?? false
    ↑                ↑
    └── Evaluated first (causes warning)
                     └── Evaluated second (too late)
```

**Fixed**:
```
(bool) ($array['key'] ?? false)
         ↑            ↑
         └── Evaluated together (no warning)
```

## Other Examples

This same issue would occur with other type casts:
- `(int) $array['key'] ?? 0` - Would cause warning
- `(string) $array['key'] ?? ''` - Would cause warning
- `(array) $array['key'] ?? []` - Would cause warning

The fix is always the same: use parentheses to ensure `??` is evaluated with the array access. 

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices.
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary).

## Changelog entry

Fixed array access bug in FBE Configuration Read Response that caused PHP warnings

## Test Plan

1. Run the unit tests: `vendor/bin/phpunit tests/Unit/Api/FBE/Configuration/Read/FBEConfigurationReadResponseTest.php`
2. All tests should pass without requiring error suppression
3. Verify no PHP warnings are generated when:
   - `ig_shopping` array exists but lacks 'enabled' key
   - `ig_cta` array exists but lacks 'enabled' key
   - `commerce_extension` array exists but lacks 'uri' key

## Screenshots
N/A - Bug fix only 