### PR TITLE
Adding warning fix - Woo all products key unavailable in an array

### DIFF
--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -543,7 +543,11 @@ class WC_Facebook_Product_Feed {
 		}
 
 		// Setting up Woo All Products sync flag
-		$is_woo_all_products_sync = isset($product_data['is_woo_all_products_sync']) ? $product_data['is_woo_all_products_sync'] : 0;
+		if ( ! isset( $product_data['is_woo_all_products_sync'] ) ) {
+			$is_woo_all_products_sync = 0;
+		} else {
+			$is_woo_all_products_sync = $product_data['is_woo_all_products_sync'];
+		}
 
 		return $product_data['retailer_id'] . ',' .
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'name' ) ) . ',' .


### PR DESCRIPTION
## Description

There was a log that suggeted woo_all_products key missing in array.
It happened because many products might not have woo_all_products field present.

### Type of change

Fix: adding a simple null check

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- x[] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Test Plan

1. You need to have some products
2. Try to run feeds via the status in WooCommerce panel
3. now check the logs in the same panel
4. It should not show this particular log:  `Undefined array key "is_woo_all_products_sync"`