### PR TITLE
Excluded categories and tags | Bringing back the modal

### DIFF
--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -34,6 +34,12 @@ class AJAX {
 	 * @since 1.10.0
 	 */
 	public function __construct() {
+		// maybe output a modal prompt when toggling product sync in bulk
+		add_action( 'wp_ajax_facebook_for_woocommerce_set_product_sync_bulk_action_prompt', array( $this, 'handle_set_product_sync_bulk_action_prompt' ) );
+
+		// maybe output a modal prompt when setting excluded terms
+		add_action( 'wp_ajax_facebook_for_woocommerce_set_excluded_terms_prompt', array( $this, 'handle_set_excluded_terms_prompt' ) );
+
 		// sync all products via AJAX
 		add_action( 'wp_ajax_wc_facebook_sync_products', array( $this, 'sync_products' ) );
 
@@ -494,5 +500,228 @@ class AJAX {
 			wp_send_json_error( 'Missing request parameters for Event Configs POST API call' );
 		}
 		WhatsAppUtilityConnection::post_whatsapp_utility_messages_event_configs_call( $event, $integration_config_id, $language, $status, $bisu_token );
+	}
+
+	/**
+	 * Maybe triggers a modal warning when the merchant toggles sync enabled status in bulk.
+	 *
+	 * @internal
+	 *
+	 * @since 1.10.0
+	 */
+	public function handle_set_product_sync_bulk_action_prompt() {
+		check_ajax_referer( 'set-product-sync-bulk-action-prompt', 'security' );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$product_ids = isset( $_POST['products'] ) ? (array) wc_clean( wp_unslash( $_POST['products'] ) ) : array();
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$toggle = isset( $_POST['toggle'] ) ? (string) wc_clean( wp_unslash( $_POST['toggle'] ) ) : '';
+
+		if ( ! empty( $product_ids ) && ! empty( $toggle ) && 'facebook_include' === $toggle ) {
+
+			$has_excluded_term = false;
+
+			foreach ( $product_ids as $product_id ) {
+				$product = wc_get_product( $product_id );
+
+				if ( $product instanceof \WC_Product && ! facebook_for_woocommerce()->get_product_sync_validator( $product )->passes_product_terms_check() ) {
+					$has_excluded_term = true;
+					break;
+				}
+			}
+
+			// show modal if there's at least one product that belongs to an excluded term
+			if ( $has_excluded_term ) {
+				ob_start();
+
+				?>
+				<a
+					id="facebook-for-woocommerce-go-to-settings"
+					class="button button-large"
+					href="<?php echo esc_url( add_query_arg( 'tab', Product_Sync::ID, facebook_for_woocommerce()->get_settings_url() ) ); ?>"
+				><?php esc_html_e( 'Go to Settings', 'facebook-for-woocommerce' ); ?></a>
+				<button
+					id="facebook-for-woocommerce-cancel-sync"
+					class="button button-large button-primary"
+					onclick="jQuery( '.modal-close' ).trigger( 'click' )"
+				><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></button>
+				<?php
+
+				$buttons = ob_get_clean();
+
+				wp_send_json_error(
+					array(
+						'message' => __( 'One or more of the selected products belongs to a category or tag that is excluded from the Facebook catalog sync. To sync these products to Facebook, please remove the category or tag exclusion from the plugin settings.', 'facebook-for-woocommerce' ),
+						'buttons' => $buttons,
+					)
+				);
+			}
+		}
+
+		wp_send_json_success();
+	}
+
+
+	/**
+	 * Maybe triggers a modal warning when the merchant adds terms to the excluded terms.
+	 *
+	 * @internal
+	 *
+	 * @since 1.10.0
+	 */
+	public function handle_set_excluded_terms_prompt() {
+		check_ajax_referer( 'set-excluded-terms-prompt', 'security' );
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$posted_categories = isset( $_POST['categories'] ) ? wc_clean( wp_unslash( $_POST['categories'] ) ) : array();
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$posted_tags = isset( $_POST['tags'] ) ? wc_clean( wp_unslash( $_POST['tags'] ) ) : array();
+
+		$new_category_ids = array();
+		$new_tag_ids      = array();
+
+		if ( ! empty( $posted_categories ) ) {
+			foreach ( $posted_categories as $posted_category_id ) {
+				$new_category_ids[] = sanitize_text_field( $posted_category_id );
+			}
+		}
+
+		if ( ! empty( $posted_tags ) ) {
+			foreach ( $posted_tags as $posted_tag_id ) {
+				$new_tag_ids[] = sanitize_text_field( $posted_tag_id );
+			}
+		}
+
+		$products = $this->get_products_to_be_excluded( $new_category_ids, $new_tag_ids );
+		if ( ! empty( $products ) ) {
+
+			ob_start();
+
+			?>
+			<button
+				id="facebook-for-woocommerce-confirm-settings-change"
+				class="button button-large button-primary facebook-for-woocommerce-confirm-settings-change"
+			><?php esc_html_e( 'Exclude Products', 'facebook-for-woocommerce' ); ?></button>
+
+			<button
+				id="facebook-for-woocommerce-cancel-settings-change"
+				class="button button-large button-primary"
+				onclick="jQuery( '.modal-close' ).trigger( 'click' )"
+			><?php esc_html_e( 'Cancel', 'facebook-for-woocommerce' ); ?></button>
+			<?php
+
+			$buttons = ob_get_clean();
+
+			wp_send_json_error(
+				array(
+					'message' => sprintf(
+					/* translators: Placeholder %s - <br/> tags */
+						__( 'The categories and/or tags that you have selected to exclude from sync contain products that are currently synced to Facebook.%sTo exclude these products from the Facebook sync, click Exclude Products. To review the category / tag exclusion settings, click Cancel.', 'facebook-for-woocommerce' ),
+						'<br/><br/>'
+					),
+					'buttons' => $buttons,
+				)
+			);
+
+		} else {
+
+			// the modal should not be displayed
+			wp_send_json_success();
+		}
+	}
+
+
+	/**
+	 * Get the IDs of the products that would be excluded with the new settings.
+	 *
+	 * Queries products with sync enabled, belonging to the added term IDs
+	 * and not belonging to the term IDs that are already stored in the setting.
+	 *
+	 * @since 1.10.0
+	 *
+	 * @param string[] $new_excluded_categories
+	 * @param string[] $new_excluded_tags
+	 * @return int[]
+	 */
+	private function get_products_to_be_excluded( $new_excluded_categories = array(), $new_excluded_tags = array() ) {
+		$sync_enabled_meta_query = array(
+			'relation' => 'OR',
+			array(
+				'key'   => Products::SYNC_ENABLED_META_KEY,
+				'value' => 'yes',
+			),
+			array(
+				'key'     => Products::SYNC_ENABLED_META_KEY,
+				'compare' => 'NOT EXISTS',
+			),
+		);
+
+		$products_query_vars = array(
+			'post_type'  => 'product',
+			'fields'     => 'ids',
+			'meta_query' => $sync_enabled_meta_query,
+		);
+
+		if ( ! empty( $new_excluded_categories ) ) {
+			$categories_tax_query = array(
+				'taxonomy' => 'product_cat',
+				'terms'    => $new_excluded_categories,
+			);
+
+			$integration = facebook_for_woocommerce()->get_integration();
+			if ( $integration ) {
+				$saved_excluded_categories = $integration->get_excluded_product_category_ids();
+				if ( ! empty( $saved_excluded_categories ) ) {
+					$categories_tax_query = array(
+						'relation' => 'AND',
+						$categories_tax_query,
+						array(
+							'taxonomy' => 'product_cat',
+							'terms'    => $saved_excluded_categories,
+							'operator' => 'NOT IN',
+						),
+					);
+				}
+			}
+
+			$products_query_vars['tax_query'] = $categories_tax_query;
+		}
+
+		if ( ! empty( $new_excluded_tags ) ) {
+			$tags_tax_query = array(
+				'taxonomy' => 'product_tag',
+				'terms'    => $new_excluded_tags,
+			);
+
+			$integration = facebook_for_woocommerce()->get_integration();
+			if ( $integration ) {
+				$save_excluded_tags = $integration->get_excluded_product_tag_ids();
+				if ( ! empty( $save_excluded_tags ) ) {
+					$tags_tax_query = array(
+						'relation' => 'AND',
+						$tags_tax_query,
+						array(
+							'taxonomy' => 'product_tag',
+							'terms'    => $save_excluded_tags,
+							'operator' => 'NOT IN',
+						),
+					);
+				}
+			}
+
+			if ( empty( $products_query_vars['tax_query'] ) ) {
+				$products_query_vars['tax_query'] = $tags_tax_query;
+			} else {
+				$products_query_vars['tax_query'] = array(
+					'relation' => 'OR',
+					$products_query_vars,
+					$tags_tax_query,
+				);
+			}
+		}
+
+		$products_query = new \WP_Query( $products_query_vars );
+
+		return $products_query->posts;
 	}
 }


### PR DESCRIPTION
## Description

Due to ongoing changes of rollout switches with all products, we are reverting back with the same old modal to exclude categories and tads.

### Type of change

Fix: Excluded tags and categories not saving for the stuffs.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Test Plan

1.  Go to facebook for woocommerce
2. Now go to product sync tab
3. Now try to remove a tag or a category
4. You should see a popup and then use it to exclude the categories

## Screenshots

### After

![image](https://github.com/user-attachments/assets/2bb9cbb9-4938-44ad-a12d-0f4699bca693)

