### PR TITLE
Fixed an error with the foreach statement

### DIFF
--- a/includes/Events/Event.php
+++ b/includes/Events/Event.php
@@ -151,7 +151,7 @@ class Event {
 			if ( is_array( $user_data['external_id'] ) ) {
 				$external_ids = array();
 				foreach ( $user_data['external_id'] as $id ) {
-					$external_ids[] = hash( 'sha256', $user_data['external_id'][ $id ], false );
+					$external_ids[] = hash( 'sha256', $id, false );
 				}
 				$user_data['external_id'] = $external_ids;
 			} else {

--- a/includes/Events/Event.php
+++ b/includes/Events/Event.php
@@ -151,7 +151,9 @@ class Event {
 			if ( is_array( $user_data['external_id'] ) ) {
 				$external_ids = array();
 				foreach ( $user_data['external_id'] as $id ) {
-					$external_ids[] = hash( 'sha256', $id, false );
+					if ( $id ) {
+						$external_ids[] = hash( 'sha256', $id, false );
+					}
 				}
 				$user_data['external_id'] = $external_ids;
 			} else {


### PR DESCRIPTION
Fix for the warning message:
18-Jun-2025 10:50:44 UTC] PHP Warning:  Undefined array key 3 in /home/wooderson/web/[wooderson.websitetotal.com/public_html/wp-content/plugins/facebook-for-woocommerce/includes/Events/Event.php](http://wooderson.websitetotal.com/public_html/wp-content/plugins/facebook-for-woocommerce/includes/Events/Event.php) on line 154
[18-Jun-2025 10:50:44 UTC] PHP Deprecated:  hash(): Passing null to parameter #2 ($data) of type string is deprecated in /home/wooderson/web/[wooderson.websitetotal.com/public_html/wp-content/plugins/facebook-for-woocommerce/includes/Events/Event.php](http://wooderson.websitetotal.com/public_html/wp-content/plugins/facebook-for-woocommerce/includes/Events/Event.php) on line 154
