### PR TITLE
[WAUM] Make content updates on WA onboarding screen suggested by legal team

### DIFF
--- a/includes/Admin/Settings_Screens/Whatsapp_Utility.php
+++ b/includes/Admin/Settings_Screens/Whatsapp_Utility.php
@@ -271,7 +271,24 @@ class Whatsapp_Utility extends Abstract_Settings_Screen {
 				<div id="wc-fb-whatsapp-connect-inprogress" class="custom-dashicon-halfcircle fbwa-hidden-element"></div>
 				<div class="card-content">
 					<h2><?php esc_html_e( 'Connect your WhatApp Business account', 'facebook-for-woocommerce' ); ?></h2>
-					<p id="wc-fb-whatsapp-onboarding-subcontent"><?php esc_html_e( 'Allows WooCommerce to connect to your WhatsApp account. ', 'facebook-for-woocommerce' ); ?></p>
+					<p id="wc-fb-whatsapp-onboarding-subcontent">
+						<p>
+							<?php esc_html_e( 'Allows WooCommerce to connect to your WhatsApp account. By connecting your account, you agree to the ', 'facebook-for-woocommerce' ); ?>
+							<a
+								href="https://www.facebook.com/legal/Meta-Hosting-Terms-Cloud-API"
+								id="wc-whatsapp-about-pricing"
+								target="_blank"
+							><?php esc_html_e( 'Cloud API Terms', 'facebook-for-woocommerce' ); ?>
+							</a>
+							<?php esc_html_e( 'and ', 'facebook-for-woocommerce' ); ?>
+							<a
+								href="https://www.whatsapp.com/legal/meta-terms-whatsapp-business"
+								id="wc-whatsapp-about-pricing"
+								target="_blank"
+							><?php esc_html_e( ' Meta Terms for WhatsApp Business.', 'facebook-for-woocommerce' ); ?>
+							</a>
+						</p>
+					</p>
 				</div>
 			</div>
 			<div id="wc-fb-whatsapp-onboarding-button-wrapper" class="whatsapp-onboarding-button">


### PR DESCRIPTION
 Make content updates on WA onboarding screen suggested by legal team

## Description
Make content updates on onboarding screen suggested by legal team to add links to Cloud API Terms and Meta Terms for WhatsApp Business.

##Figma
<img width="1434" alt="Screenshot 2025-06-18 at 5 03 43 PM" src="https://github.com/user-attachments/assets/991d72a3-ddbd-448d-be10-40a11b201988" />

### Type of change
- Add (non-breaking change which adds functionality)


## Changelog entry
Make content updates on WA onboarding screen suggested by legal team


## Test Plan
## Screenshots
### Before
<img width="790" alt="Screenshot 2025-06-18 at 5 05 01 PM" src="https://github.com/user-attachments/assets/319c678f-d315-443a-8077-7fe5ba54f17b" />

### After

https://github.com/user-attachments/assets/160e76e3-e137-4b57-88cd-e5ccf25f9c68


