### PR TITLE
Fixing logs for excluded categories and tags

### DIFF
--- a/includes/ExternalVersionUpdate/Update.php
+++ b/includes/ExternalVersionUpdate/Update.php
@@ -80,8 +80,8 @@ class Update {
 				'extra_data' => [
 					'is_multisite'                => is_multisite(),
 					'is_product_sync_enabled'     => facebook_for_woocommerce()->get_integration()->is_product_sync_enabled(),
-					'excluded_product_categories' => json_encode($excluded_product_categories),
-					'excluded_product_tags'       => json_encode($excluded_product_tags),
+					'excluded_product_categories' => json_encode( $excluded_product_categories ),
+					'excluded_product_tags'       => json_encode( $excluded_product_tags ),
 					'published_product_count'     => facebook_for_woocommerce()->get_integration()->get_product_count(),
 					'opted_out_woo_all_products'  => get_option( self::MASTER_SYNC_OPT_OUT_TIME ),
 				],


### PR DESCRIPTION
## Description

The logging is not good to include excluded categories and tags as they are dicts.
Using json encode to keep it in string format for easy logging.

### Type of change

Fix: adding json encode to the dicts of excluded tags and categories to convert it into string.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Test Plan

It is a improvement.
Now the data will be in string format.

