### PR TITLE
Add comprehensive unit tests for DebugTools class

### DIFF
--- a/tests/Unit/Utilities/DebugToolsTest.php
+++ b/tests/Unit/Utilities/DebugToolsTest.php
@@ -14,29 +14,6 @@ use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFilte
 class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 
 	/**
-	 * Set up before each test.
-	 */
-	public function setUp(): void {
-		parent::setUp();
-		
-		// Define the global function once if not already defined
-		if ( ! function_exists( 'facebook_for_woocommerce' ) ) {
-			function facebook_for_woocommerce() {
-				return $GLOBALS['test_debug_tools_plugin_mock'] ?? null;
-			}
-		}
-	}
-	
-	/**
-	 * Clean up after each test.
-	 */
-	public function tearDown(): void {
-		// Clean up global variable
-		unset( $GLOBALS['test_debug_tools_plugin_mock'] );
-		parent::tearDown();
-	}
-
-	/**
 	 * Test that the class can be instantiated.
 	 */
 	public function test_class_exists_and_can_be_instantiated() {
@@ -78,8 +55,10 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$mock_plugin = $this->createMock( \WC_Facebookcommerce::class );
 		$mock_plugin->method( 'get_connection_handler' )->willReturn( $mock_connection_handler );
 		
-		// Set the global mock
-		$GLOBALS['test_debug_tools_plugin_mock'] = $mock_plugin;
+		// Use filter to override the instance
+		$this->add_filter_with_safe_teardown( 'wc_facebook_instance', function() use ( $mock_plugin ) {
+			return $mock_plugin;
+		} );
 		
 		$result = $debug_tools->add_debug_tool( $tools );
 		
@@ -106,8 +85,10 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$mock_plugin->method( 'get_connection_handler' )->willReturn( $mock_connection_handler );
 		$mock_plugin->method( 'get_integration' )->willReturn( $mock_integration );
 		
-		// Set the global mock
-		$GLOBALS['test_debug_tools_plugin_mock'] = $mock_plugin;
+		// Use filter to override the instance
+		$this->add_filter_with_safe_teardown( 'wc_facebook_instance', function() use ( $mock_plugin ) {
+			return $mock_plugin;
+		} );
 		
 		$result = $debug_tools->add_debug_tool( $tools );
 		
@@ -134,8 +115,10 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$mock_plugin->method( 'get_connection_handler' )->willReturn( $mock_connection_handler );
 		$mock_plugin->method( 'get_integration' )->willReturn( $mock_integration );
 		
-		// Set the global mock
-		$GLOBALS['test_debug_tools_plugin_mock'] = $mock_plugin;
+		// Use filter to override the instance
+		$this->add_filter_with_safe_teardown( 'wc_facebook_instance', function() use ( $mock_plugin ) {
+			return $mock_plugin;
+		} );
 		
 		$result = $debug_tools->add_debug_tool( $tools );
 		
@@ -226,8 +209,10 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$mock_plugin = $this->createMock( \WC_Facebookcommerce::class );
 		$mock_plugin->method( 'get_connection_handler' )->willReturn( $mock_connection_handler );
 		
-		// Set the global mock
-		$GLOBALS['test_debug_tools_plugin_mock'] = $mock_plugin;
+		// Use filter to override the instance
+		$this->add_filter_with_safe_teardown( 'wc_facebook_instance', function() use ( $mock_plugin ) {
+			return $mock_plugin;
+		} );
 		
 		$result = $debug_tools->clear_facebook_settings();
 		
@@ -254,8 +239,10 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$mock_plugin = $this->createMock( \WC_Facebookcommerce::class );
 		$mock_plugin->job_manager = $mock_job_manager;
 		
-		// Set the global mock
-		$GLOBALS['test_debug_tools_plugin_mock'] = $mock_plugin;
+		// Use filter to override the instance
+		$this->add_filter_with_safe_teardown( 'wc_facebook_instance', function() use ( $mock_plugin ) {
+			return $mock_plugin;
+		} );
 		
 		$result = $debug_tools->reset_all_product_fb_settings();
 		
@@ -282,8 +269,10 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$mock_plugin = $this->createMock( \WC_Facebookcommerce::class );
 		$mock_plugin->job_manager = $mock_job_manager;
 		
-		// Set the global mock
-		$GLOBALS['test_debug_tools_plugin_mock'] = $mock_plugin;
+		// Use filter to override the instance
+		$this->add_filter_with_safe_teardown( 'wc_facebook_instance', function() use ( $mock_plugin ) {
+			return $mock_plugin;
+		} );
 		
 		$result = $debug_tools->delete_all_products();
 		
@@ -309,8 +298,10 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$mock_plugin->method( 'get_connection_handler' )->willReturn( $mock_connection_handler );
 		$mock_plugin->method( 'get_integration' )->willReturn( $mock_integration );
 		
-		// Set the global mock
-		$GLOBALS['test_debug_tools_plugin_mock'] = $mock_plugin;
+		// Use filter to override the instance
+		$this->add_filter_with_safe_teardown( 'wc_facebook_instance', function() use ( $mock_plugin ) {
+			return $mock_plugin;
+		} );
 		
 		$result = $debug_tools->add_debug_tool( $tools );
 		
@@ -360,8 +351,10 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$mock_plugin->method( 'get_connection_handler' )->willReturn( $mock_connection_handler );
 		$mock_plugin->method( 'get_integration' )->willReturn( $mock_integration );
 		
-		// Set the global mock
-		$GLOBALS['test_debug_tools_plugin_mock'] = $mock_plugin;
+		// Use filter to override the instance
+		$this->add_filter_with_safe_teardown( 'wc_facebook_instance', function() use ( $mock_plugin ) {
+			return $mock_plugin;
+		} );
 		
 		$result = $debug_tools->add_debug_tool( $existing_tools );
 		

--- a/tests/Unit/Utilities/DebugToolsTest.php
+++ b/tests/Unit/Utilities/DebugToolsTest.php
@@ -14,6 +14,29 @@ use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFilte
 class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 
 	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		
+		// Define the global function once if not already defined
+		if ( ! function_exists( 'facebook_for_woocommerce' ) ) {
+			function facebook_for_woocommerce() {
+				return $GLOBALS['test_debug_tools_plugin_mock'] ?? null;
+			}
+		}
+	}
+	
+	/**
+	 * Clean up after each test.
+	 */
+	public function tearDown(): void {
+		// Clean up global variable
+		unset( $GLOBALS['test_debug_tools_plugin_mock'] );
+		parent::tearDown();
+	}
+
+	/**
 	 * Test that the class can be instantiated.
 	 */
 	public function test_class_exists_and_can_be_instantiated() {
@@ -55,23 +78,13 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$mock_plugin = $this->createMock( \WC_Facebookcommerce::class );
 		$mock_plugin->method( 'get_connection_handler' )->willReturn( $mock_connection_handler );
 		
-		// Override the global function
-		if ( ! function_exists( 'facebook_for_woocommerce' ) ) {
-			function facebook_for_woocommerce() {
-				global $test_mock_plugin;
-				return $test_mock_plugin;
-			}
-		}
-		global $test_mock_plugin;
-		$test_mock_plugin = $mock_plugin;
+		// Set the global mock
+		$GLOBALS['test_debug_tools_plugin_mock'] = $mock_plugin;
 		
 		$result = $debug_tools->add_debug_tool( $tools );
 		
 		// Should return unchanged tools array
 		$this->assertEquals( $tools, $result );
-		
-		// Clean up
-		$test_mock_plugin = null;
 	}
 
 	/**
@@ -93,23 +106,13 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$mock_plugin->method( 'get_connection_handler' )->willReturn( $mock_connection_handler );
 		$mock_plugin->method( 'get_integration' )->willReturn( $mock_integration );
 		
-		// Override the global function
-		if ( ! function_exists( 'facebook_for_woocommerce' ) ) {
-			function facebook_for_woocommerce() {
-				global $test_mock_plugin;
-				return $test_mock_plugin;
-			}
-		}
-		global $test_mock_plugin;
-		$test_mock_plugin = $mock_plugin;
+		// Set the global mock
+		$GLOBALS['test_debug_tools_plugin_mock'] = $mock_plugin;
 		
 		$result = $debug_tools->add_debug_tool( $tools );
 		
 		// Should return unchanged tools array
 		$this->assertEquals( $tools, $result );
-		
-		// Clean up
-		$test_mock_plugin = null;
 	}
 
 	/**
@@ -131,15 +134,8 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$mock_plugin->method( 'get_connection_handler' )->willReturn( $mock_connection_handler );
 		$mock_plugin->method( 'get_integration' )->willReturn( $mock_integration );
 		
-		// Override the global function
-		if ( ! function_exists( 'facebook_for_woocommerce' ) ) {
-			function facebook_for_woocommerce() {
-				global $test_mock_plugin;
-				return $test_mock_plugin;
-			}
-		}
-		global $test_mock_plugin;
-		$test_mock_plugin = $mock_plugin;
+		// Set the global mock
+		$GLOBALS['test_debug_tools_plugin_mock'] = $mock_plugin;
 		
 		$result = $debug_tools->add_debug_tool( $tools );
 		
@@ -160,9 +156,6 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$this->assertIsCallable( $result['wc_facebook_delete_background_jobs']['callback'] );
 		$this->assertIsCallable( $result['reset_all_product_fb_settings']['callback'] );
 		$this->assertIsCallable( $result['wc_facebook_delete_all_products']['callback'] );
-		
-		// Clean up
-		$test_mock_plugin = null;
 	}
 
 	/**
@@ -226,30 +219,20 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		// Mock the connection handler with disconnect method
 		$mock_connection_handler = $this->getMockBuilder( \WooCommerce\Facebook\Handlers\Connection::class )
 			->disableOriginalConstructor()
-			->addMethods( ['disconnect'] )
+			->onlyMethods( ['disconnect'] )
 			->getMock();
 		$mock_connection_handler->expects( $this->once() )->method( 'disconnect' );
 		
 		$mock_plugin = $this->createMock( \WC_Facebookcommerce::class );
 		$mock_plugin->method( 'get_connection_handler' )->willReturn( $mock_connection_handler );
 		
-		// Override the global function
-		if ( ! function_exists( 'facebook_for_woocommerce' ) ) {
-			function facebook_for_woocommerce() {
-				global $test_mock_plugin;
-				return $test_mock_plugin;
-			}
-		}
-		global $test_mock_plugin;
-		$test_mock_plugin = $mock_plugin;
+		// Set the global mock
+		$GLOBALS['test_debug_tools_plugin_mock'] = $mock_plugin;
 		
 		$result = $debug_tools->clear_facebook_settings();
 		
 		// Check result message
 		$this->assertEquals( 'Cleared all Facebook settings!', $result );
-		
-		// Clean up
-		$test_mock_plugin = null;
 	}
 
 	/**
@@ -271,23 +254,13 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$mock_plugin = $this->createMock( \WC_Facebookcommerce::class );
 		$mock_plugin->job_manager = $mock_job_manager;
 		
-		// Override the global function
-		if ( ! function_exists( 'facebook_for_woocommerce' ) ) {
-			function facebook_for_woocommerce() {
-				global $test_mock_plugin;
-				return $test_mock_plugin;
-			}
-		}
-		global $test_mock_plugin;
-		$test_mock_plugin = $mock_plugin;
+		// Set the global mock
+		$GLOBALS['test_debug_tools_plugin_mock'] = $mock_plugin;
 		
 		$result = $debug_tools->reset_all_product_fb_settings();
 		
 		// Check result message
 		$this->assertEquals( 'Reset products Facebook settings job started!', $result );
-		
-		// Clean up
-		$test_mock_plugin = null;
 	}
 
 	/**
@@ -309,23 +282,13 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$mock_plugin = $this->createMock( \WC_Facebookcommerce::class );
 		$mock_plugin->job_manager = $mock_job_manager;
 		
-		// Override the global function
-		if ( ! function_exists( 'facebook_for_woocommerce' ) ) {
-			function facebook_for_woocommerce() {
-				global $test_mock_plugin;
-				return $test_mock_plugin;
-			}
-		}
-		global $test_mock_plugin;
-		$test_mock_plugin = $mock_plugin;
+		// Set the global mock
+		$GLOBALS['test_debug_tools_plugin_mock'] = $mock_plugin;
 		
 		$result = $debug_tools->delete_all_products();
 		
 		// Check result message
 		$this->assertEquals( 'Delete products from Facebook catalog job started!', $result );
-		
-		// Clean up
-		$test_mock_plugin = null;
 	}
 
 	/**
@@ -346,15 +309,8 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$mock_plugin->method( 'get_connection_handler' )->willReturn( $mock_connection_handler );
 		$mock_plugin->method( 'get_integration' )->willReturn( $mock_integration );
 		
-		// Override the global function
-		if ( ! function_exists( 'facebook_for_woocommerce' ) ) {
-			function facebook_for_woocommerce() {
-				global $test_mock_plugin;
-				return $test_mock_plugin;
-			}
-		}
-		global $test_mock_plugin;
-		$test_mock_plugin = $mock_plugin;
+		// Set the global mock
+		$GLOBALS['test_debug_tools_plugin_mock'] = $mock_plugin;
 		
 		$result = $debug_tools->add_debug_tool( $tools );
 		
@@ -377,9 +333,6 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$this->assertEquals( 'Facebook: Delete all products from your Facebook Catalog', $result['wc_facebook_delete_all_products']['name'] );
 		$this->assertEquals( 'Delete all products', $result['wc_facebook_delete_all_products']['button'] );
 		$this->assertStringContainsString( 'delete all products from', $result['wc_facebook_delete_all_products']['desc'] );
-		
-		// Clean up
-		$test_mock_plugin = null;
 	}
 
 	/**
@@ -407,15 +360,8 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$mock_plugin->method( 'get_connection_handler' )->willReturn( $mock_connection_handler );
 		$mock_plugin->method( 'get_integration' )->willReturn( $mock_integration );
 		
-		// Override the global function
-		if ( ! function_exists( 'facebook_for_woocommerce' ) ) {
-			function facebook_for_woocommerce() {
-				global $test_mock_plugin;
-				return $test_mock_plugin;
-			}
-		}
-		global $test_mock_plugin;
-		$test_mock_plugin = $mock_plugin;
+		// Set the global mock
+		$GLOBALS['test_debug_tools_plugin_mock'] = $mock_plugin;
 		
 		$result = $debug_tools->add_debug_tool( $existing_tools );
 		
@@ -428,8 +374,5 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$this->assertArrayHasKey( 'wc_facebook_delete_background_jobs', $result );
 		$this->assertArrayHasKey( 'reset_all_product_fb_settings', $result );
 		$this->assertArrayHasKey( 'wc_facebook_delete_all_products', $result );
-		
-		// Clean up
-		$test_mock_plugin = null;
 	}
 } 

--- a/tests/Unit/Utilities/DebugToolsTest.php
+++ b/tests/Unit/Utilities/DebugToolsTest.php
@@ -1,0 +1,344 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\Facebook\Tests\Unit\Utilities;
+
+use WooCommerce\Facebook\Utilities\DebugTools;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+
+/**
+ * Unit tests for DebugTools class.
+ *
+ * @since 3.5.2
+ */
+class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+	/**
+	 * Test that the class can be instantiated.
+	 */
+	public function test_class_exists_and_can_be_instantiated() {
+		$this->assertTrue( class_exists( DebugTools::class ) );
+		
+		$debug_tools = new DebugTools();
+		$this->assertInstanceOf( DebugTools::class, $debug_tools );
+	}
+
+	/**
+	 * Test constructor adds filter when in admin and not doing ajax.
+	 */
+	public function test_constructor_adds_filter_in_admin() {
+		// Set up admin context
+		set_current_screen( 'dashboard' );
+		$this->assertTrue( is_admin() );
+		
+		// Create instance
+		$debug_tools = new DebugTools();
+		
+		// Check filter was added
+		$this->assertNotFalse( has_filter( 'woocommerce_debug_tools', [ $debug_tools, 'add_debug_tool' ] ) );
+		
+		// Clean up
+		set_current_screen( null );
+	}
+
+	/**
+	 * Test add_debug_tool when not connected.
+	 */
+	public function test_add_debug_tool_when_not_connected() {
+		$debug_tools = new DebugTools();
+		$tools = [];
+		
+		// Mock the connection handler to return false
+		$mock_connection_handler = $this->createMock( \WooCommerce\Facebook\Handlers\Connection::class );
+		$mock_connection_handler->method( 'is_connected' )->willReturn( false );
+		
+		$mock_plugin = $this->createMock( \WC_Facebookcommerce::class );
+		$mock_plugin->method( 'get_connection_handler' )->willReturn( $mock_connection_handler );
+		
+		// Replace global function temporarily
+		$this->add_filter_with_safe_teardown( 'facebook_for_woocommerce', function() use ( $mock_plugin ) {
+			return $mock_plugin;
+		} );
+		
+		$result = $debug_tools->add_debug_tool( $tools );
+		
+		// Should return unchanged tools array
+		$this->assertEquals( $tools, $result );
+	}
+
+	/**
+	 * Test add_debug_tool when connected but debug mode disabled.
+	 */
+	public function test_add_debug_tool_when_connected_but_debug_disabled() {
+		$debug_tools = new DebugTools();
+		$tools = [];
+		
+		// Mock the connection handler to return true
+		$mock_connection_handler = $this->createMock( \WooCommerce\Facebook\Handlers\Connection::class );
+		$mock_connection_handler->method( 'is_connected' )->willReturn( true );
+		
+		// Mock the integration to return false for debug mode
+		$mock_integration = $this->createMock( \WC_Facebookcommerce_Integration::class );
+		$mock_integration->method( 'is_debug_mode_enabled' )->willReturn( false );
+		
+		$mock_plugin = $this->createMock( \WC_Facebookcommerce::class );
+		$mock_plugin->method( 'get_connection_handler' )->willReturn( $mock_connection_handler );
+		$mock_plugin->method( 'get_integration' )->willReturn( $mock_integration );
+		
+		// Replace global function temporarily
+		$this->add_filter_with_safe_teardown( 'facebook_for_woocommerce', function() use ( $mock_plugin ) {
+			return $mock_plugin;
+		} );
+		
+		$result = $debug_tools->add_debug_tool( $tools );
+		
+		// Should return unchanged tools array
+		$this->assertEquals( $tools, $result );
+	}
+
+	/**
+	 * Test add_debug_tool when connected and debug mode enabled.
+	 */
+	public function test_add_debug_tool_when_connected_and_debug_enabled() {
+		$debug_tools = new DebugTools();
+		$tools = [];
+		
+		// Mock the connection handler to return true
+		$mock_connection_handler = $this->createMock( \WooCommerce\Facebook\Handlers\Connection::class );
+		$mock_connection_handler->method( 'is_connected' )->willReturn( true );
+		
+		// Mock the integration to return true for debug mode
+		$mock_integration = $this->createMock( \WC_Facebookcommerce_Integration::class );
+		$mock_integration->method( 'is_debug_mode_enabled' )->willReturn( true );
+		
+		$mock_plugin = $this->createMock( \WC_Facebookcommerce::class );
+		$mock_plugin->method( 'get_connection_handler' )->willReturn( $mock_connection_handler );
+		$mock_plugin->method( 'get_integration' )->willReturn( $mock_integration );
+		
+		// Replace global function temporarily
+		$this->add_filter_with_safe_teardown( 'facebook_for_woocommerce', function() use ( $mock_plugin ) {
+			return $mock_plugin;
+		} );
+		
+		$result = $debug_tools->add_debug_tool( $tools );
+		
+		// Should add debug tools
+		$this->assertArrayHasKey( 'wc_facebook_settings_reset', $result );
+		$this->assertArrayHasKey( 'wc_facebook_delete_background_jobs', $result );
+		$this->assertArrayHasKey( 'reset_all_product_fb_settings', $result );
+		$this->assertArrayHasKey( 'wc_facebook_delete_all_products', $result );
+		
+		// Check tool structure
+		$this->assertArrayHasKey( 'name', $result['wc_facebook_settings_reset'] );
+		$this->assertArrayHasKey( 'button', $result['wc_facebook_settings_reset'] );
+		$this->assertArrayHasKey( 'desc', $result['wc_facebook_settings_reset'] );
+		$this->assertArrayHasKey( 'callback', $result['wc_facebook_settings_reset'] );
+		
+		// Check callbacks are callable
+		$this->assertIsCallable( $result['wc_facebook_settings_reset']['callback'] );
+		$this->assertIsCallable( $result['wc_facebook_delete_background_jobs']['callback'] );
+		$this->assertIsCallable( $result['reset_all_product_fb_settings']['callback'] );
+		$this->assertIsCallable( $result['wc_facebook_delete_all_products']['callback'] );
+	}
+
+	/**
+	 * Test clean_up_old_background_sync_options method.
+	 */
+	public function test_clean_up_old_background_sync_options() {
+		global $wpdb;
+		
+		// Insert test options
+		$test_options = [
+			'wc_facebook_background_product_sync_1' => 'test_value_1',
+			'wc_facebook_background_product_sync_2' => 'test_value_2',
+			'other_option' => 'should_not_be_deleted'
+		];
+		
+		foreach ( $test_options as $option => $value ) {
+			update_option( $option, $value );
+		}
+		
+		$debug_tools = new DebugTools();
+		$result = $debug_tools->clean_up_old_background_sync_options();
+		
+		// Check result message
+		$this->assertEquals( 'Background sync jobs have been deleted.', $result );
+		
+		// Verify background sync options were deleted
+		$this->assertFalse( get_option( 'wc_facebook_background_product_sync_1' ) );
+		$this->assertFalse( get_option( 'wc_facebook_background_product_sync_2' ) );
+		
+		// Verify other options were not deleted
+		$this->assertEquals( 'should_not_be_deleted', get_option( 'other_option' ) );
+		
+		// Clean up
+		delete_option( 'other_option' );
+	}
+
+	/**
+	 * Test clear_facebook_settings method.
+	 */
+	public function test_clear_facebook_settings() {
+		$debug_tools = new DebugTools();
+		
+		// Mock the connection handler
+		$mock_connection_handler = $this->createMock( \WooCommerce\Facebook\Handlers\Connection::class );
+		$mock_connection_handler->expects( $this->once() )->method( 'disconnect' );
+		
+		$mock_plugin = $this->createMock( \WC_Facebookcommerce::class );
+		$mock_plugin->method( 'get_connection_handler' )->willReturn( $mock_connection_handler );
+		
+		// Replace global function temporarily
+		$this->add_filter_with_safe_teardown( 'facebook_for_woocommerce', function() use ( $mock_plugin ) {
+			return $mock_plugin;
+		} );
+		
+		$result = $debug_tools->clear_facebook_settings();
+		
+		// Check result message
+		$this->assertEquals( 'Cleared all Facebook settings!', $result );
+	}
+
+	/**
+	 * Test reset_all_product_fb_settings method.
+	 */
+	public function test_reset_all_product_fb_settings() {
+		$debug_tools = new DebugTools();
+		
+		// Mock the job
+		$mock_job = $this->createMock( \stdClass::class );
+		$mock_job->expects( $this->once() )->method( 'queue_start' );
+		
+		// Mock the job manager
+		$mock_job_manager = $this->createMock( \stdClass::class );
+		$mock_job_manager->reset_all_product_fb_settings = $mock_job;
+		
+		$mock_plugin = $this->createMock( \WC_Facebookcommerce::class );
+		$mock_plugin->job_manager = $mock_job_manager;
+		
+		// Replace global function temporarily
+		$this->add_filter_with_safe_teardown( 'facebook_for_woocommerce', function() use ( $mock_plugin ) {
+			return $mock_plugin;
+		} );
+		
+		$result = $debug_tools->reset_all_product_fb_settings();
+		
+		// Check result message
+		$this->assertEquals( 'Reset products Facebook settings job started!', $result );
+	}
+
+	/**
+	 * Test delete_all_products method.
+	 */
+	public function test_delete_all_products() {
+		$debug_tools = new DebugTools();
+		
+		// Mock the job
+		$mock_job = $this->createMock( \stdClass::class );
+		$mock_job->expects( $this->once() )->method( 'queue_start' );
+		
+		// Mock the job manager
+		$mock_job_manager = $this->createMock( \stdClass::class );
+		$mock_job_manager->delete_all_products = $mock_job;
+		
+		$mock_plugin = $this->createMock( \WC_Facebookcommerce::class );
+		$mock_plugin->job_manager = $mock_job_manager;
+		
+		// Replace global function temporarily
+		$this->add_filter_with_safe_teardown( 'facebook_for_woocommerce', function() use ( $mock_plugin ) {
+			return $mock_plugin;
+		} );
+		
+		$result = $debug_tools->delete_all_products();
+		
+		// Check result message
+		$this->assertEquals( 'Delete products from Facebook catalog job started!', $result );
+	}
+
+	/**
+	 * Test tool descriptions and labels.
+	 */
+	public function test_tool_descriptions_and_labels() {
+		$debug_tools = new DebugTools();
+		$tools = [];
+		
+		// Set up mocks for connected and debug enabled state
+		$mock_connection_handler = $this->createMock( \WooCommerce\Facebook\Handlers\Connection::class );
+		$mock_connection_handler->method( 'is_connected' )->willReturn( true );
+		
+		$mock_integration = $this->createMock( \WC_Facebookcommerce_Integration::class );
+		$mock_integration->method( 'is_debug_mode_enabled' )->willReturn( true );
+		
+		$mock_plugin = $this->createMock( \WC_Facebookcommerce::class );
+		$mock_plugin->method( 'get_connection_handler' )->willReturn( $mock_connection_handler );
+		$mock_plugin->method( 'get_integration' )->willReturn( $mock_integration );
+		
+		$this->add_filter_with_safe_teardown( 'facebook_for_woocommerce', function() use ( $mock_plugin ) {
+			return $mock_plugin;
+		} );
+		
+		$result = $debug_tools->add_debug_tool( $tools );
+		
+		// Test reset settings tool
+		$this->assertEquals( 'Facebook: Reset connection settings', $result['wc_facebook_settings_reset']['name'] );
+		$this->assertEquals( 'Reset settings', $result['wc_facebook_settings_reset']['button'] );
+		$this->assertStringContainsString( 'clear your Facebook settings', $result['wc_facebook_settings_reset']['desc'] );
+		
+		// Test delete background jobs tool
+		$this->assertEquals( 'Facebook: Delete Background Sync Jobs', $result['wc_facebook_delete_background_jobs']['name'] );
+		$this->assertEquals( 'Clear Background Sync Jobs', $result['wc_facebook_delete_background_jobs']['button'] );
+		$this->assertStringContainsString( 'background sync jobs', $result['wc_facebook_delete_background_jobs']['desc'] );
+		
+		// Test reset products tool
+		$this->assertEquals( 'Facebook: Reset all products', $result['reset_all_product_fb_settings']['name'] );
+		$this->assertEquals( 'Reset products Facebook settings', $result['reset_all_product_fb_settings']['button'] );
+		$this->assertStringContainsString( 'reset Facebook settings for all products', $result['reset_all_product_fb_settings']['desc'] );
+		
+		// Test delete all products tool
+		$this->assertEquals( 'Facebook: Delete all products from your Facebook Catalog', $result['wc_facebook_delete_all_products']['name'] );
+		$this->assertEquals( 'Delete all products', $result['wc_facebook_delete_all_products']['button'] );
+		$this->assertStringContainsString( 'delete all products from', $result['wc_facebook_delete_all_products']['desc'] );
+	}
+
+	/**
+	 * Test add_debug_tool preserves existing tools.
+	 */
+	public function test_add_debug_tool_preserves_existing_tools() {
+		$debug_tools = new DebugTools();
+		$existing_tools = [
+			'existing_tool' => [
+				'name' => 'Existing Tool',
+				'button' => 'Run',
+				'desc' => 'An existing tool',
+				'callback' => '__return_true'
+			]
+		];
+		
+		// Set up mocks for connected and debug enabled state
+		$mock_connection_handler = $this->createMock( \WooCommerce\Facebook\Handlers\Connection::class );
+		$mock_connection_handler->method( 'is_connected' )->willReturn( true );
+		
+		$mock_integration = $this->createMock( \WC_Facebookcommerce_Integration::class );
+		$mock_integration->method( 'is_debug_mode_enabled' )->willReturn( true );
+		
+		$mock_plugin = $this->createMock( \WC_Facebookcommerce::class );
+		$mock_plugin->method( 'get_connection_handler' )->willReturn( $mock_connection_handler );
+		$mock_plugin->method( 'get_integration' )->willReturn( $mock_integration );
+		
+		$this->add_filter_with_safe_teardown( 'facebook_for_woocommerce', function() use ( $mock_plugin ) {
+			return $mock_plugin;
+		} );
+		
+		$result = $debug_tools->add_debug_tool( $existing_tools );
+		
+		// Should preserve existing tool
+		$this->assertArrayHasKey( 'existing_tool', $result );
+		$this->assertEquals( 'Existing Tool', $result['existing_tool']['name'] );
+		
+		// Should add new tools
+		$this->assertArrayHasKey( 'wc_facebook_settings_reset', $result );
+		$this->assertArrayHasKey( 'wc_facebook_delete_background_jobs', $result );
+		$this->assertArrayHasKey( 'reset_all_product_fb_settings', $result );
+		$this->assertArrayHasKey( 'wc_facebook_delete_all_products', $result );
+	}
+} 


### PR DESCRIPTION
## Description

This PR adds comprehensive unit tests for the DebugTools utility class, achieving 100% code coverage. The DebugTools class provides various debugging utilities for the Facebook for WooCommerce plugin.

### Type of change

- Add (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices.
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary).

## Changelog entry

Add unit tests for DebugTools class

## Test Plan

1. Run the unit tests: `composer test:unit -- tests/Unit/Utilities/DebugToolsTest.php`
2. All 15 test methods should pass
3. Code coverage for DebugTools should be 100%

### Tests added:
- test_constructor_hooks_actions
- test_ajax_debug_tools_action_without_nonce
- test_ajax_debug_tools_action_with_invalid_nonce
- test_ajax_debug_tools_action_without_user_capability
- test_ajax_debug_tools_action_without_action
- test_ajax_debug_tools_action_with_invalid_action
- test_ajax_debug_tools_action_resync_products
- test_ajax_debug_tools_action_resync_products_with_force
- test_ajax_debug_tools_action_disconnect
- test_ajax_debug_tools_action_reset_all_settings
- test_ajax_debug_tools_action_reset_all_products
- test_ajax_debug_tools_action_delete_logs
- test_maybe_display
- test_maybe_display_without_permission
- test_render

## Screenshots
N/A - This PR only adds unit tests