### PR TITLE
[WAUM]Fix whatsapp consent checkbox enable for classic checkout

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -189,7 +189,8 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 		add_action( 'init', array( $this, 'get_integration' ) );
 		add_action( 'init', array( $this, 'register_custom_taxonomy' ) );
 		add_action( 'add_meta_boxes_product', array( $this, 'remove_product_fb_product_set_metabox' ), 50 );
-		add_action( 'woocommerce_init', array( $this, 'add_whatsapp_consent_checkout_fields' ) );
+		add_action( 'woocommerce_init', array( $this, 'add_whatsapp_consent_block_checkout_fields' ) );
+		add_filter( 'woocommerce_checkout_fields', array( $this, 'add_whatsapp_consent_classic_checkout_fields' ) );
 		add_filter( 'fb_product_set_row_actions', array( $this, 'product_set_links' ) );
 		add_filter( 'manage_edit-fb_product_set_columns', array( $this, 'manage_fb_product_set_columns' ) );
 
@@ -951,7 +952,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	}
 
 	/**
-	 * Add checkout fields to collect whatsapp consent if consent collection is enabled
+	 * Add blocks checkout fields to collect whatsapp consent if consent collection is enabled
 	 *
 	 * @since 2.3.0
 	 *
@@ -959,7 +960,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	 *
 	 * @return array
 	 */
-	public function add_whatsapp_consent_checkout_fields( $fields ) {
+	public function add_whatsapp_consent_block_checkout_fields( $fields ) {
 		if ( get_option( 'wc_facebook_whatsapp_consent_collection_setting_status', 'disabled' ) === 'enabled' ) {
 			woocommerce_register_additional_checkout_field(
 				array(
@@ -970,6 +971,37 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 					'optionalLabel' => esc_html( 'Get order updates on WhatsApp' ),
 				)
 			);
+		}
+		return $fields;
+	}
+
+	/**
+	 * Add classic checkout fields to collect whatsapp consent if consent collection is enabled
+	 *
+	 * @since 2.3.0
+	 *
+	 * @param array $fields
+	 *
+	 * @return array
+	 */
+	public function add_whatsapp_consent_classic_checkout_fields( $fields ) {
+		if ( get_option( 'wc_facebook_whatsapp_consent_collection_setting_status', 'disabled' ) === 'enabled' ) {
+				$fields['billing']['billing_whatsapp_consent']   = array(
+					'label'    => esc_html( 'Get order updates on WhatsApp' ),
+					'type'     => 'checkbox',
+					'required' => false,
+					'class'    => array( 'form-row-wide' ),
+					'default'  => true,
+					'priority' => 101,
+				);
+				$fields['shipping']['shipping_whatsapp_consent'] = array(
+					'label'    => esc_html( 'Get order updates on WhatsApp' ),
+					'type'     => 'checkbox',
+					'required' => false,
+					'class'    => array( 'form-row-wide' ),
+					'default'  => true,
+					'priority' => 101,
+				);
 		}
 		return $fields;
 	}

--- a/facebook-commerce-whatsapp-utility-event.php
+++ b/facebook-commerce-whatsapp-utility-event.php
@@ -85,14 +85,16 @@ class WC_Facebookcommerce_Whatsapp_Utility_Event {
 		}
 
 		$order = wc_get_order( $order_id );
-		// Check WhatsApp Consent Checkbox is selected in shipping and billing
-		$billing_consent_value  = $order->get_meta( '_wc_billing/wc_facebook/whatsapp_consent_checkbox' );
-		$shipping_consent_value = $order->get_meta( '_wc_shipping/wc_facebook/whatsapp_consent_checkbox' );
-		$has_whatsapp_consent   = $billing_consent_value && $shipping_consent_value;
+		// Check WhatsApp Consent Checkbox is selected in shipping or billing
+		$user_wa_consent             = $this->has_billing_or_shipping_number_whatsapp_consent( $order );
+		$wa_billing_consent_enabled  = $user_wa_consent['has_user_consented_to_wa_billing_number_notif'];
+		$wa_shipping_consent_enabled = $user_wa_consent['has_user_consented_to_wa_shipping_number_notif'];
+
+		$has_whatsapp_consent = $wa_billing_consent_enabled || $wa_shipping_consent_enabled;
 		// Get WhatsApp Phone number from entered Billing and Shipping phone number
 		$billing_phone_number  = $order->get_billing_phone();
 		$shipping_phone_number = $order->get_shipping_phone();
-		$phone_number          = ( isset( $billing_phone_number ) && $billing_consent_value ) ? $billing_phone_number : $shipping_phone_number;
+		$phone_number          = ( isset( $billing_phone_number ) && $wa_billing_consent_enabled ) ? $billing_phone_number : $shipping_phone_number;
 		// Get Customer first name
 		$first_name = $order->get_billing_first_name();
 		// Get Total Refund Amount for Order Refunded event
@@ -127,5 +129,45 @@ class WC_Facebookcommerce_Whatsapp_Utility_Event {
 			return;
 		}
 		WhatsAppUtilityConnection::post_whatsapp_utility_messages_events_call( $event, $event_config_id, $language_code, $wacs_id, $order_id, $phone_number, $first_name, $refund_amount, $currency, $bisu_token );
+	}
+
+	/**
+	 * Determines if WhatsApp Consent is Enabled for a user either for Billing or Shipping Phone Number for Blocks or Classic Flows
+	 *
+	 * @since 2.3.0
+	 *
+	 * @return array
+	 */
+	private function has_billing_or_shipping_number_whatsapp_consent( $order ) {
+		$block_billing_consent_value    = $order->get_meta( '_wc_billing/wc_facebook/whatsapp_consent_checkbox' );
+		$block_shipping_consent_value   = $order->get_meta( '_wc_shipping/wc_facebook/whatsapp_consent_checkbox' );
+		$classic_billing_consent_value  = $order->get_meta( '_billing_whatsapp_consent' );
+		$classic_shipping_consent_value = $order->get_meta( '_shipping_whatsapp_consent' );
+
+		$has_user_consented_to_wa_billing_number_notif  = false;
+		$has_user_consented_to_wa_shipping_number_notif = false;
+		if ( $block_billing_consent_value || $classic_billing_consent_value ) {
+			$has_user_consented_to_wa_billing_number_notif = true;
+		}
+
+		if ( $block_shipping_consent_value || $classic_shipping_consent_value ) {
+			$has_user_consented_to_wa_shipping_number_notif = true;
+		}
+
+		wc_get_logger()->info(
+			sprintf(
+				/* translators: %s consent for billing and shipping */
+				__( 'WhatsApp Consent info for user  $block_billing_consent_value: %1$s, $block_shipping_consent_value: %2$s, $classic_billing_consent_value: %3$s, $classic_shipping_consent_value: %4$s', 'facebook-for-woocommerce' ),
+				$block_billing_consent_value,
+				$block_shipping_consent_value,
+				$classic_billing_consent_value,
+				$classic_shipping_consent_value
+			)
+		);
+
+		return array(
+			'has_user_consented_to_wa_billing_number_notif' => $has_user_consented_to_wa_billing_number_notif,
+			'has_user_consented_to_wa_shipping_number_notif' => $has_user_consented_to_wa_shipping_number_notif,
+		);
 	}
 }

--- a/facebook-commerce-whatsapp-utility-event.php
+++ b/facebook-commerce-whatsapp-utility-event.php
@@ -134,6 +134,7 @@ class WC_Facebookcommerce_Whatsapp_Utility_Event {
 	/**
 	 * Determines if WhatsApp Consent is Enabled for a user either for Billing or Shipping Phone Number for Blocks or Classic Flows
 	 *
+	 * @param \WC_Order $order Order object
 	 * @since 2.3.0
 	 *
 	 * @return array


### PR DESCRIPTION
## Description
The whatsapp consent checkbox was not visible for classic checkout flow for certain woocommerce businesses. Thsi PR fixes this to enable consent checkbox even for classic checkout flows.

### Type of change
- Fix (non-breaking change which fixes an issue)


## Changelog entry
Fix whatsapp consent checkbox enable for classic checkout


## Test Plan
## Screenshots
### Before
![Screenshot 2025-06-20 at 4 08 17 PM](https://github.com/user-attachments/assets/070a8c19-b522-49a5-82e9-1bd8b3f18c94)

### After
![Screenshot 2025-06-20 at 4 10 49 PM](https://github.com/user-attachments/assets/c62bd95f-5f30-4f1c-bb83-456ed6bb8080)
Able to receive message:
![Screenshot 2025-06-20 at 4 11 32 PM](https://github.com/user-attachments/assets/1e4bc5fe-c1e1-46b1-8574-e217a89e5c2e)

