### PR TITLE
Tzahgr/build artifact on push

### DIFF
--- a/.github/workflows/build-plugin-artifact.yml
+++ b/.github/workflows/build-plugin-artifact.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - release/*
-      - tzahgr/*
 
 jobs:
   build-and-upload:

--- a/.github/workflows/build-plugin-artifact.yml
+++ b/.github/workflows/build-plugin-artifact.yml
@@ -3,6 +3,10 @@ name: Build Plugin Artifact
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - release/*
+      - tzahgr/*
 
 jobs:
   build-and-upload:
@@ -23,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version-file: 'package.json'
           cache-dependency-path: './package-lock.json'
           cache: 'npm'
       

--- a/.github/workflows/build-plugin-artifact.yml
+++ b/.github/workflows/build-plugin-artifact.yml
@@ -60,6 +60,7 @@ jobs:
         run: echo "⬇️ Scroll to the bottom of this page and download the 'facebook-for-woocommerce' artifact to get the latest plugin build." > $GITHUB_STEP_SUMMARY
         
       - name: Post build info comment on PR
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

- Update build-plugin-artifact workflow to execute on release branch push
- Change node version to file package.json
- Change 'Post build info comment on PR' step to run only on PR

### Type of change

Please delete options that are not relevant

- Tweak (non-breaking change which fixes code modularity, linting or phpcs issues)

## Checklist

- [] I have commented my code, particularly in hard-to-understand areas, if any.
- [] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Update build-plugin-artifact workflow to execute on release branch push


## Test Plan
See successful workflow run:
https://github.com/facebook/facebook-for-woocommerce/actions/runs/15846147228