### PR TITLE
Fix filter not fully visible in Product Media Frame

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -121,6 +121,10 @@
     text-decoration: none;
 }
 
+.fb-product-video-media-frame .media-toolbar-secondary select.attachment-filters {
+	width: 350px;
+}
+
 #woocommerce-product-data #wc-facebook-google-product-category-fields {
 	width: 50%;
 }

--- a/assets/js/admin/products-admin.js
+++ b/assets/js/admin/products-admin.js
@@ -663,6 +663,7 @@ jQuery( document ).ready( function( $ ) {
 
 			// Pre-select previously selected attachments
 			productGalleryFrame.on('open', function () {
+				productGalleryFrame.$el.addClass('fb-product-video-media-frame');
 				const selection = productGalleryFrame.state().get('selection');
 				attachmentIds.forEach(function (id) {
 					const attachment = wp.media.attachment(id);


### PR DESCRIPTION
## Description

Fix filter not fully visible in Product Media Frame

### Type of change
- Tweak (non-breaking change which fixes code modularity, linting or phpcs issues)

## Checklist

- [] I have commented my code, particularly in hard-to-understand areas, if any.
- [] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fix filter not fully visible in Product Media Frame


## Test Plan

1. Run all tests : `npm run test:php`
<img width="541" alt="image" src="https://github.com/user-attachments/assets/8456d111-9f7b-4e6a-9575-bf7ac5ff3b09" />

2. Lint: `./vendor/bin/phpcs`
3. Run test `./vendor/bin/phpunit --filter test_prepare_product_videos`
4. **E2E Tests**
   - Single Product Update
       * Go to individual product. Upload a video using FB product video form field.
       * Click Publish->Update
       * Outcome : Video Synced to facebook
       
   - Batch API Update
      * Disconnect from facebook
      * Connect back and create a new catalog
      * Products are synced with batch API flow
      * Outcomes : New catalog created on facebook, with Videos synced at product level.


## Screenshots
| **Before** | **After**|
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/6f9bc795-6c95-45b2-b016-a1c90492840d) | <img width="1267" alt="image" src="https://github.com/user-attachments/assets/99ffcd90-4ae5-4698-b650-beae87d5090d" /> |


