### PR TITLE
Add functionality to clear unmapped attribute banner in Product Attributes settings

### DIFF
--- a/includes/Admin/Settings_Screens/Product_Attributes.php
+++ b/includes/Admin/Settings_Screens/Product_Attributes.php
@@ -1138,22 +1138,22 @@ class Product_Attributes extends Abstract_Settings_Screen {
 	private function clear_unmapped_attribute_banner( $new_mappings ) {
 		// Get the current banner data
 		$banner_data = get_transient( 'fb_new_unmapped_attribute_banner' );
-		
+
 		// If there's no banner showing, nothing to do
 		if ( ! $banner_data || ! isset( $banner_data['attribute_name'] ) ) {
 			return;
 		}
-		
+
 		$banner_attribute = $banner_data['attribute_name'];
-		
+
 		// Check if the banner's attribute is now mapped
 		if ( ! class_exists( 'WooCommerce\Facebook\ProductAttributeMapper' ) ) {
 			return;
 		}
-		
+
 		// Use the same logic as the banner system to check if the attribute is now mapped
 		$mapped_field = ProductAttributeMapper::check_attribute_mapping( 'pa_' . $banner_attribute );
-		
+
 		// If the attribute is now mapped, clear the banner
 		if ( false !== $mapped_field ) {
 			delete_transient( 'fb_new_unmapped_attribute_banner' );

--- a/includes/Admin/Settings_Screens/Product_Attributes.php
+++ b/includes/Admin/Settings_Screens/Product_Attributes.php
@@ -951,6 +951,9 @@ class Product_Attributes extends Abstract_Settings_Screen {
 		// Update last sync time
 		update_option( 'wc_facebook_last_attribute_sync', current_time( 'mysql' ) );
 
+		// Check if we need to clear the unmapped attribute banner
+		$this->clear_unmapped_attribute_banner( $new_mappings );
+
 		// Add success notice
 		$message = empty( $new_mappings )
 			? __( 'All attribute mappings have been removed.', 'facebook-for-woocommerce' )
@@ -1123,5 +1126,38 @@ class Product_Attributes extends Abstract_Settings_Screen {
 		}
 
 		return $removed_count;
+	}
+
+	/**
+	 * Checks if we need to clear the unmapped attribute banner.
+	 *
+	 * @since 3.5.4
+	 *
+	 * @param array $new_mappings The new attribute mappings.
+	 */
+	private function clear_unmapped_attribute_banner( $new_mappings ) {
+		// Get the current banner data
+		$banner_data = get_transient( 'fb_new_unmapped_attribute_banner' );
+		
+		// If there's no banner showing, nothing to do
+		if ( ! $banner_data || ! isset( $banner_data['attribute_name'] ) ) {
+			return;
+		}
+		
+		$banner_attribute = $banner_data['attribute_name'];
+		
+		// Check if the banner's attribute is now mapped
+		if ( ! class_exists( 'WooCommerce\Facebook\ProductAttributeMapper' ) ) {
+			return;
+		}
+		
+		// Use the same logic as the banner system to check if the attribute is now mapped
+		$mapped_field = ProductAttributeMapper::check_attribute_mapping( 'pa_' . $banner_attribute );
+		
+		// If the attribute is now mapped, clear the banner
+		if ( false !== $mapped_field ) {
+			delete_transient( 'fb_new_unmapped_attribute_banner' );
+			delete_transient( 'fb_show_banner_now' );
+		}
 	}
 }

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -19,6 +19,7 @@ use WooCommerce\Facebook\ProductAttributeMapper;
 
 defined( 'ABSPATH' ) || exit;
 
+
 /**
  * Custom FB Product proxy class
  */

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -19,7 +19,6 @@ use WooCommerce\Facebook\ProductAttributeMapper;
 
 defined( 'ABSPATH' ) || exit;
 
-
 /**
  * Custom FB Product proxy class
  */

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -2807,13 +2807,13 @@ class WC_Facebook_Product {
 				'facebook_attributes'       => $facebook_attributes,
 				'facebook_attribute_values' => array(
 					'age_group' => array(
-						'adult'     => __( 'Adult', 'facebook-for-woocommerce' ),
-						'all ages'  => __( 'All Ages', 'facebook-for-woocommerce' ),
-						'kids'      => __( 'Kids', 'facebook-for-woocommerce' ),
-						'teen'      => __( 'Teen', 'facebook-for-woocommerce' ),
-						'infant'    => __( 'Infant', 'facebook-for-woocommerce' ),
-						'newborn'   => __( 'Newborn', 'facebook-for-woocommerce' ),
-						'toddler'   => __( 'Toddler', 'facebook-for-woocommerce' ),
+						'adult'    => __( 'Adult', 'facebook-for-woocommerce' ),
+						'all ages' => __( 'All Ages', 'facebook-for-woocommerce' ),
+						'kids'     => __( 'Kids', 'facebook-for-woocommerce' ),
+						'teen'     => __( 'Teen', 'facebook-for-woocommerce' ),
+						'infant'   => __( 'Infant', 'facebook-for-woocommerce' ),
+						'newborn'  => __( 'Newborn', 'facebook-for-woocommerce' ),
+						'toddler'  => __( 'Toddler', 'facebook-for-woocommerce' ),
 					),
 					'gender'    => array(
 						'female' => __( 'Female', 'facebook-for-woocommerce' ),
@@ -2848,13 +2848,13 @@ class WC_Facebook_Product {
 			),
 			'facebook_attribute_values' => array(
 				'age_group' => array(
-					'adult'     => __( 'Adult', 'facebook-for-woocommerce' ),
-					'all ages'  => __( 'All Ages', 'facebook-for-woocommerce' ),
-					'kids'      => __( 'Kids', 'facebook-for-woocommerce' ),
-					'teen'      => __( 'Teen', 'facebook-for-woocommerce' ),
-					'infant'    => __( 'Infant', 'facebook-for-woocommerce' ),
-					'newborn'   => __( 'Newborn', 'facebook-for-woocommerce' ),
-					'toddler'   => __( 'Toddler', 'facebook-for-woocommerce' ),
+					'adult'    => __( 'Adult', 'facebook-for-woocommerce' ),
+					'all ages' => __( 'All Ages', 'facebook-for-woocommerce' ),
+					'kids'     => __( 'Kids', 'facebook-for-woocommerce' ),
+					'teen'     => __( 'Teen', 'facebook-for-woocommerce' ),
+					'infant'   => __( 'Infant', 'facebook-for-woocommerce' ),
+					'newborn'  => __( 'Newborn', 'facebook-for-woocommerce' ),
+					'toddler'  => __( 'Toddler', 'facebook-for-woocommerce' ),
 				),
 				'gender'    => array(
 					'female' => __( 'Female', 'facebook-for-woocommerce' ),


### PR DESCRIPTION
## Description

Fixed a bug where the "attribute doesn't directly map to a Meta catalog field" banner would persist even after users mapped the attribute through the Facebook for WooCommerce attribute mapping interface.

**Problem**: When users created a new WooCommerce attribute, a banner would appear prompting them to map it to a Meta catalog field. However, after mapping the attribute via the UI, the banner would continue to show until manually dismissed or expired (30 minutes), creating user confusion about whether the mapping was successful.

**Root Cause**: The banner system used transients to store and display unmapped attribute notifications, but there was no mechanism to clear these transients when attribute mappings were updated.

**Solution**: Added automatic banner clearing functionality that triggers when attribute mappings are saved. The system now checks if any currently displayed banner is for an attribute that has been mapped and automatically clears the banner transients.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Changelog entry

Fixed unmapped attribute banner persisting after attribute mapping is saved

## Test Plan

**Test Scenario**: Verify banner automatically disappears after attribute mapping

1. **Setup**: 
   - WordPress site with WooCommerce and Facebook for WooCommerce plugin active
   - Admin user with manage_woocommerce capability

2. **Steps to Reproduce**:
   - Go to WooCommerce → Products → Attributes
   - Create a new attribute with a custom name (e.g., "Test-Material")
   - Observe the banner appears: "Your new Test-Material attribute doesn't directly map to a Meta catalog field"
   - Go to Facebook for WooCommerce → Attribute Mapping
   - Map the "Test-Material" attribute to "Material"
   - Click "Save Changes"
   - Return to any admin page where the banner would display

3. **Expected Results**:
   - **Before Fix**: Banner continues to show despite successful mapping
   - **After Fix**: Banner automatically disappears after saving the mapping

4. **Additional Test Cases**:
   - Test with multiple attributes mapped simultaneously
   - Test banner dismissal still works manually
   - Test banner reappears for genuinely unmapped new attributes
   - Test edge case where banner exists but no ProductAttributeMapper class

