### PR TITLE
Fix release workflow tag target

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -4,12 +4,11 @@ on:
   push:
     branches:
       - 'release/*/publish'
-      - 'tzahgr/fix_release_tag'
 
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
-    # environment: Deployment
+    environment: Deployment
     steps:
       - uses: actions/checkout@v4
 
@@ -17,42 +16,42 @@ jobs:
         id: package-version
         uses: martinbeentjes/npm-get-version-action@v1.3.1
 
-      # - name: Validate Git tag
-      #   run: |
-      #     if [ $(git tag -l "v${{ steps.package-version.outputs.current-version}}") ]; then
-      #       echo "Git tag exist" 1>&2
-      #       exit 1
-      #     fi
+      - name: Validate Git tag
+        run: |
+          if [ $(git tag -l "v${{ steps.package-version.outputs.current-version}}") ]; then
+            echo "Git tag exist" 1>&2
+            exit 1
+          fi
 
-      # - name: Setup PHP
-      #   uses: shivammathur/setup-php@v2
-      #   with:
-      #     php-version: '7.4'
-      #     tools: composer
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer
       
-      # - name: Setup Node.js
-      #   uses: actions/setup-node@v3
-      #   with:
-      #     node-version-file: 'package.json'
-      #     cache-dependency-path: './package-lock.json'
-      #     cache: 'npm'
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
+          cache-dependency-path: './package-lock.json'
+          cache: 'npm'
       
-      # - name: Install dependencies
-      #   run: |
-      #     composer install
-      #     npm ci || npm install
+      - name: Install dependencies
+        run: |
+          composer install
+          npm ci || npm install
           
-      # - name: Build plugin
-      #   run: |
-      #     npm run build
-      #     if [ -f "facebook-for-woocommerce.zip" ]; then
-      #       echo "build_success=true" >> $GITHUB_OUTPUT
-      #       echo "filesize=$(du -h facebook-for-woocommerce.zip | cut -f1)" >> $GITHUB_OUTPUT
-      #     else
-      #       echo "build_success=false" >> $GITHUB_OUTPUT
-      #       echo "Build error" 1>&2
-      #       exit 1
-      #     fi
+      - name: Build plugin
+        run: |
+          npm run build
+          if [ -f "facebook-for-woocommerce.zip" ]; then
+            echo "build_success=true" >> $GITHUB_OUTPUT
+            echo "filesize=$(du -h facebook-for-woocommerce.zip | cut -f1)" >> $GITHUB_OUTPUT
+          else
+            echo "build_success=false" >> $GITHUB_OUTPUT
+            echo "Build error" 1>&2
+            exit 1
+          fi
 
       - name: Extract Release Notes
         id: extract_release_notes
@@ -74,45 +73,45 @@ jobs:
           done < "$readme_file"
           echo "EOF" >> $GITHUB_ENV
 
-      # - name: Store built plugin
-      #   uses: actions/upload-artifact@master
-      #   with:
-      #     name: facebook-for-woocommerce
-      #     path: facebook-for-woocommerce.zip
+      - name: Store built plugin
+        uses: actions/upload-artifact@master
+        with:
+          name: facebook-for-woocommerce
+          path: facebook-for-woocommerce.zip
 
-      # - name: Install SVN
-      #   run: sudo apt-get install subversion -y
+      - name: Install SVN
+        run: sudo apt-get install subversion -y
 
-      # - name: Checkout SVN Repository
-      #   run: svn co https://plugins.svn.wordpress.org/facebook-for-woocommerce/ woocommerce_svn --quiet --non-interactive
+      - name: Checkout SVN Repository
+        run: svn co https://plugins.svn.wordpress.org/facebook-for-woocommerce/ woocommerce_svn --quiet --non-interactive
 
-      # - name: Validate SVN tag
-      #   run: |
-      #     if [ -d "woocommerce_svn/tags/${{ steps.package-version.outputs.current-version}}" ]; then
-      #       echo "SVN tag directory exist" 1>&2
-      #       exit 1
-      #     fi
+      - name: Validate SVN tag
+        run: |
+          if [ -d "woocommerce_svn/tags/${{ steps.package-version.outputs.current-version}}" ]; then
+            echo "SVN tag directory exist" 1>&2
+            exit 1
+          fi
 
-      # - name: Commit to SVN
-      #   env:
-      #     SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-      #     SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-      #   run: |
-      #     cd woocommerce_svn
-      #     rm -rf trunk
-      #     cp ../facebook-for-woocommerce.zip ./
-      #     echo "Unzipping the atrifact"
-      #     unzip facebook-for-woocommerce.zip
-      #     mv facebook-for-woocommerce trunk
-      #     rm facebook-for-woocommerce.zip
-      #     svn add --force .
-      #     svn st | grep ^! | awk '{print $2}' | xargs -r svn rm
-      #     svn status
-      #     echo "Tagging version ${{ steps.package-version.outputs.current-version}}"
-      #     svn cp trunk "tags/${{ steps.package-version.outputs.current-version}}"
-      #     echo "Status:"
-      #     svn status
-      #     svn commit -m "Deploy new version ${{ steps.package-version.outputs.current-version}}" --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --no-auth-cache --non-interactive
+      - name: Commit to SVN
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        run: |
+          cd woocommerce_svn
+          rm -rf trunk
+          cp ../facebook-for-woocommerce.zip ./
+          echo "Unzipping the atrifact"
+          unzip facebook-for-woocommerce.zip
+          mv facebook-for-woocommerce trunk
+          rm facebook-for-woocommerce.zip
+          svn add --force .
+          svn st | grep ^! | awk '{print $2}' | xargs -r svn rm
+          svn status
+          echo "Tagging version ${{ steps.package-version.outputs.current-version}}"
+          svn cp trunk "tags/${{ steps.package-version.outputs.current-version}}"
+          echo "Status:"
+          svn status
+          svn commit -m "Deploy new version ${{ steps.package-version.outputs.current-version}}" --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --no-auth-cache --non-interactive
 
       - name: Create a new release on GitHub
         uses: actions/github-script@v7
@@ -130,38 +129,38 @@ jobs:
             const release = await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: 'rel_tag_test1',
+              tag_name: `v${version}`,
               target_commitish: commitSha,
               name: `Release ${version}`,
               body: releaseNotes,
               draft: true,
             });
-# const maxRetries = 5;
-# const fileName = 'facebook-for-woocommerce.zip'
-# const filePath = path.join(process.env.GITHUB_WORKSPACE, fileName);
-# const source = fs.readFileSync(filePath);
-# for (let retry = 0; retry < maxRetries; retry++) {
-#   try {
-#     await github.rest.repos.uploadReleaseAsset({
-#       owner: context.repo.owner, 
-#       repo: context.repo.repo, 
-#       release_id: release.data.id,
-#       name: fileName, 
-#       headers: {'Content-Type': 'application/x-xz'}, 
-#       data: source
-#     });
-#     break;
-#   } catch (error) {
-#       console.log(`Failed to upload (status ${error.status}, retry: ${retry})`);
-#       if (error.status != 500) {
-#           throw error;
-#       }
-#   }
-# }
-# await github.rest.repos.updateRelease({
-#   owner: context.repo.owner, 
-#   repo: context.repo.repo, 
-#   release_id: release.data.id,
-#   draft: false,
-#   prerelease: true,
-# });
+            const maxRetries = 5;
+            const fileName = 'facebook-for-woocommerce.zip'
+            const filePath = path.join(process.env.GITHUB_WORKSPACE, fileName);
+            const source = fs.readFileSync(filePath);
+            for (let retry = 0; retry < maxRetries; retry++) {
+              try {
+                await github.rest.repos.uploadReleaseAsset({
+                  owner: context.repo.owner, 
+                  repo: context.repo.repo, 
+                  release_id: release.data.id,
+                  name: fileName, 
+                  headers: {'Content-Type': 'application/x-xz'}, 
+                  data: source
+                });
+                break;
+              } catch (error) {
+                  console.log(`Failed to upload (status ${error.status}, retry: ${retry})`);
+                  if (error.status != 500) {
+                      throw error;
+                  }
+              }
+            }
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner, 
+              repo: context.repo.repo, 
+              release_id: release.data.id,
+              draft: false,
+              prerelease: true,
+            });

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -4,11 +4,12 @@ on:
   push:
     branches:
       - 'release/*/publish'
+      - 'tzahgr/fix_release_tag'
 
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
-    environment: Deployment
+    # environment: Deployment
     steps:
       - uses: actions/checkout@v4
 
@@ -16,42 +17,42 @@ jobs:
         id: package-version
         uses: martinbeentjes/npm-get-version-action@v1.3.1
 
-      - name: Validate Git tag
-        run: |
-          if [ $(git tag -l "v${{ steps.package-version.outputs.current-version}}") ]; then
-            echo "Git tag exist" 1>&2
-            exit 1
-          fi
+      # - name: Validate Git tag
+      #   run: |
+      #     if [ $(git tag -l "v${{ steps.package-version.outputs.current-version}}") ]; then
+      #       echo "Git tag exist" 1>&2
+      #       exit 1
+      #     fi
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          tools: composer
+      # - name: Setup PHP
+      #   uses: shivammathur/setup-php@v2
+      #   with:
+      #     php-version: '7.4'
+      #     tools: composer
       
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: 'package.json'
-          cache-dependency-path: './package-lock.json'
-          cache: 'npm'
+      # - name: Setup Node.js
+      #   uses: actions/setup-node@v3
+      #   with:
+      #     node-version-file: 'package.json'
+      #     cache-dependency-path: './package-lock.json'
+      #     cache: 'npm'
       
-      - name: Install dependencies
-        run: |
-          composer install
-          npm ci || npm install
+      # - name: Install dependencies
+      #   run: |
+      #     composer install
+      #     npm ci || npm install
           
-      - name: Build plugin
-        run: |
-          npm run build
-          if [ -f "facebook-for-woocommerce.zip" ]; then
-            echo "build_success=true" >> $GITHUB_OUTPUT
-            echo "filesize=$(du -h facebook-for-woocommerce.zip | cut -f1)" >> $GITHUB_OUTPUT
-          else
-            echo "build_success=false" >> $GITHUB_OUTPUT
-            echo "Build error" 1>&2
-            exit 1
-          fi
+      # - name: Build plugin
+      #   run: |
+      #     npm run build
+      #     if [ -f "facebook-for-woocommerce.zip" ]; then
+      #       echo "build_success=true" >> $GITHUB_OUTPUT
+      #       echo "filesize=$(du -h facebook-for-woocommerce.zip | cut -f1)" >> $GITHUB_OUTPUT
+      #     else
+      #       echo "build_success=false" >> $GITHUB_OUTPUT
+      #       echo "Build error" 1>&2
+      #       exit 1
+      #     fi
 
       - name: Extract Release Notes
         id: extract_release_notes
@@ -73,92 +74,94 @@ jobs:
           done < "$readme_file"
           echo "EOF" >> $GITHUB_ENV
 
-      - name: Store built plugin
-        uses: actions/upload-artifact@master
-        with:
-          name: facebook-for-woocommerce
-          path: facebook-for-woocommerce.zip
+      # - name: Store built plugin
+      #   uses: actions/upload-artifact@master
+      #   with:
+      #     name: facebook-for-woocommerce
+      #     path: facebook-for-woocommerce.zip
 
-      - name: Install SVN
-        run: sudo apt-get install subversion -y
+      # - name: Install SVN
+      #   run: sudo apt-get install subversion -y
 
-      - name: Checkout SVN Repository
-        run: svn co https://plugins.svn.wordpress.org/facebook-for-woocommerce/ woocommerce_svn --quiet --non-interactive
+      # - name: Checkout SVN Repository
+      #   run: svn co https://plugins.svn.wordpress.org/facebook-for-woocommerce/ woocommerce_svn --quiet --non-interactive
 
-      - name: Validate SVN tag
-        run: |
-          if [ -d "woocommerce_svn/tags/${{ steps.package-version.outputs.current-version}}" ]; then
-            echo "SVN tag directory exist" 1>&2
-            exit 1
-          fi
+      # - name: Validate SVN tag
+      #   run: |
+      #     if [ -d "woocommerce_svn/tags/${{ steps.package-version.outputs.current-version}}" ]; then
+      #       echo "SVN tag directory exist" 1>&2
+      #       exit 1
+      #     fi
 
-      - name: Commit to SVN
-        env:
-          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-        run: |
-          cd woocommerce_svn
-          rm -rf trunk
-          cp ../facebook-for-woocommerce.zip ./
-          echo "Unzipping the atrifact"
-          unzip facebook-for-woocommerce.zip
-          mv facebook-for-woocommerce trunk
-          rm facebook-for-woocommerce.zip
-          svn add --force .
-          svn st | grep ^! | awk '{print $2}' | xargs -r svn rm
-          svn status
-          echo "Tagging version ${{ steps.package-version.outputs.current-version}}"
-          svn cp trunk "tags/${{ steps.package-version.outputs.current-version}}"
-          echo "Status:"
-          svn status
-          svn commit -m "Deploy new version ${{ steps.package-version.outputs.current-version}}" --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --no-auth-cache --non-interactive
+      # - name: Commit to SVN
+      #   env:
+      #     SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+      #     SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+      #   run: |
+      #     cd woocommerce_svn
+      #     rm -rf trunk
+      #     cp ../facebook-for-woocommerce.zip ./
+      #     echo "Unzipping the atrifact"
+      #     unzip facebook-for-woocommerce.zip
+      #     mv facebook-for-woocommerce trunk
+      #     rm facebook-for-woocommerce.zip
+      #     svn add --force .
+      #     svn st | grep ^! | awk '{print $2}' | xargs -r svn rm
+      #     svn status
+      #     echo "Tagging version ${{ steps.package-version.outputs.current-version}}"
+      #     svn cp trunk "tags/${{ steps.package-version.outputs.current-version}}"
+      #     echo "Status:"
+      #     svn status
+      #     svn commit -m "Deploy new version ${{ steps.package-version.outputs.current-version}}" --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --no-auth-cache --non-interactive
 
       - name: Create a new release on GitHub
         uses: actions/github-script@v7
         env:
           VERSION: ${{ steps.package-version.outputs.current-version}}
+          COMMIT_SHA: ${{ github.sha }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const path = require('path');
             const version = process.env.VERSION;
+            const commitSha = process.env.COMMIT_SHA;
             const releaseNotes = process.env.RELEASE_NOTES;
             const release = await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: `v${version}`,
-              target_commitish: 'release/current',
+              tag_name: 'rel_tag_test1',
+              target_commitish: commitSha,
               name: `Release ${version}`,
               body: releaseNotes,
               draft: true,
             });
-            const maxRetries = 5;
-            const fileName = 'facebook-for-woocommerce.zip'
-            const filePath = path.join(process.env.GITHUB_WORKSPACE, fileName);
-            const source = fs.readFileSync(filePath);
-            for (let retry = 0; retry < maxRetries; retry++) {
-              try {
-                await github.rest.repos.uploadReleaseAsset({
-                  owner: context.repo.owner, 
-                  repo: context.repo.repo, 
-                  release_id: release.data.id,
-                  name: fileName, 
-                  headers: {'Content-Type': 'application/x-xz'}, 
-                  data: source
-                });
-                break;
-              } catch (error) {
-                  console.log(`Failed to upload (status ${error.status}, retry: ${retry})`);
-                  if (error.status != 500) {
-                      throw error;
-                  }
-              }
-            }
-            await github.rest.repos.updateRelease({
-              owner: context.repo.owner, 
-              repo: context.repo.repo, 
-              release_id: release.data.id,
-              draft: false,
-              prerelease: true,
-            });
+# const maxRetries = 5;
+# const fileName = 'facebook-for-woocommerce.zip'
+# const filePath = path.join(process.env.GITHUB_WORKSPACE, fileName);
+# const source = fs.readFileSync(filePath);
+# for (let retry = 0; retry < maxRetries; retry++) {
+#   try {
+#     await github.rest.repos.uploadReleaseAsset({
+#       owner: context.repo.owner, 
+#       repo: context.repo.repo, 
+#       release_id: release.data.id,
+#       name: fileName, 
+#       headers: {'Content-Type': 'application/x-xz'}, 
+#       data: source
+#     });
+#     break;
+#   } catch (error) {
+#       console.log(`Failed to upload (status ${error.status}, retry: ${retry})`);
+#       if (error.status != 500) {
+#           throw error;
+#       }
+#   }
+# }
+# await github.rest.repos.updateRelease({
+#   owner: context.repo.owner, 
+#   repo: context.repo.repo, 
+#   release_id: release.data.id,
+#   draft: false,
+#   prerelease: true,
+# });


### PR DESCRIPTION
## Description

Fix release plugin workflow tag target from 'release/current' to current commit sha

### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)


## Changelog entry

Fix - Release workflow tag target


## Test Plan

Workflow run:
https://github.com/facebook/facebook-for-woocommerce/actions/runs/15911482022