### PR TITLE
Validate PR has single changelog label

### DIFF
--- a/.github/workflows/validate-pr-labels.yml
+++ b/.github/workflows/validate-pr-labels.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-label:
-    name: Validate PR has single changelog label
+    name: Validate single changelog label
     runs-on: ubuntu-latest
     steps:
       - name: Validate label
@@ -29,5 +29,5 @@ jobs:
             if (matching.length !== 1) {
               core.setFailed(`PR must have exactly one changelog label, ${matching.length} detected.`);
             } else {
-              console.log(`✅ Single changelog label: ${matching[0]}`);
+              console.log(`✅ Single changelog label: "${matching[0]}"`);
             }

--- a/.github/workflows/validate-pr-labels.yml
+++ b/.github/workflows/validate-pr-labels.yml
@@ -1,0 +1,33 @@
+name: Validate PR Labels
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize, reopened, edited]
+
+jobs:
+  check-label:
+    name: Validate PR has single changelog label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const allowedLabels = ['feature', 'bug', 'chore'];
+            const changelogLabelPrefix = 'changelog:';
+            const prNumber = context.payload.pull_request.number;
+
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+
+            const prLabels = labels.map(label => label.name);
+            const matching = prLabels.filter(label => label.startsWith(changelogLabelPrefix));
+
+            if (matching.length !== 1) {
+              core.setFailed(`PR must have exactly one changelog label, ${matching.length} detected.`);
+            } else {
+              console.log(`✅ Single changelog label: ${matching[0]}`);
+            }


### PR DESCRIPTION
## Description

PR Workflow to validate it has exactly one changelog label.

### Type of change

Please delete options that are not relevant

- Add (non-breaking change which adds functionality)

## Checklist

- [] I have commented my code, particularly in hard-to-understand areas, if any.
- [] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Validate PR has single changelog label

## Test Plan
0 changelog labels:
https://github.com/facebook/facebook-for-woocommerce/actions/runs/15922124699/job/44911088592

1 changelog label:
https://github.com/facebook/facebook-for-woocommerce/actions/runs/15922165683/job/44911225204

Multiple changelog labels:
https://github.com/facebook/facebook-for-woocommerce/actions/runs/15922181771/job/44911277975?pr=3470
