### PR TITLE
Prepare Release Workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -41,10 +41,6 @@ changelog:
         - "changelog: doc"
         - "type: documentation"
 
-    - title: Merged
-      labels:
-        - "Merged"
-
     - title: Other Changes
       labels:
         - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -41,6 +41,10 @@ changelog:
         - "changelog: doc"
         - "type: documentation"
 
+    - title: Merged
+      labels:
+        - "Merged"
+
     - title: Other Changes
       labels:
         - "*"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,20 +1,14 @@
 name: "Prepare New Release"
-# run-name: Prepare New Release `${{ github.event.inputs.type }}/${{ github.event.inputs.version }}` from by @${{ github.actor }}
+run-name: Prepare New Release release/${{ github.event.inputs.version }}` from by @${{ github.actor }}
 
-# **What it does**: Does release preparation: creates the release branch and the PR with a checklist.
-# **Why we have it**: To support devs automating a few manual steps and to leave a nice reference for consumers.
 
 on:
-  # workflow_dispatch:
-  #   inputs:
-  #     ## In the future we could infer that version from the changelog, or bump it via major|minor|patch.
-  #     version:
-  #       description: "Version number to be released"
-  #       required: true
-  push:
-    branches:
-      - 'tzahgr/prepare_release'
-
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version number to be released"
+        required: true
+  
 permissions:
   contents: write
 
@@ -31,7 +25,9 @@ jobs:
 
       - name: Set Version
         id: set_version
-        run: echo "new_version=99.99.99" >> "$GITHUB_OUTPUT"
+        env:
+          NEW_VERSION: ${{ github.event.inputs.version }}
+        run: echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Check if branch exists
         uses: actions/github-script@v7

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -40,8 +40,36 @@ jobs:
       - name: Get commits since latest release
         id: get_commits
         run: |
-          git fetch --tags
+          git fetch origin tag ${{ steps.get_release.outputs.latest_tag }}
           COMMITS=$(git rev-list ${{ steps.get_release.outputs.latest_tag }}..HEAD)
           echo "commits<<EOF" >> $GITHUB_OUTPUT
           echo "$COMMITS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Build changelog from PRs
+        id: changelog
+        uses: actions/github-script@v7
+        env:
+          COMMITS: ${{ steps.get_commits.outputs.commits }}
+        with:
+          script: |
+            const commits = process.env.COMMITS.trim().split('\n');
+            const changelog = [];
+
+            for (const sha of commits) {
+              const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: sha,
+              });
+
+              if (prs.data.length > 0) {
+                const pr = prs.data[0];
+                const labels = pr.labels.map(l => l.name).join(', ');
+                changelog.push(`- ${pr.title} [${labels}]`);
+              } 
+            }
+
+            const output = changelog.join('\n');
+            core.setOutput('changelog', output);
+            console.log("Changelog:\n" + output);

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -33,8 +33,15 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
             });
-
             const tag = latestRelease.data.tag_name;
-            core.setOutput("tag", tag);
+            core.setOutput("latest_tag", tag);
             console.log("Latest release tag:", tag);
 
+      - name: Get commits since latest release
+              id: get_commits
+              run: |
+                git fetch --tags
+                COMMITS=$(git rev-list ${{ steps.get_release.outputs.latest_tag }}..HEAD)
+                echo "commits<<EOF" >> $GITHUB_OUTPUT
+                echo "$COMMITS" >> $GITHUB_OUTPUT
+                echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -41,9 +41,8 @@ jobs:
         id: get_commits
         run: |
           git fetch origin tag ${{ steps.get_release.outputs.latest_tag }}
-          COMMITS=$(git rev-list ${{ steps.get_release.outputs.latest_tag }}..HEAD)
           echo "commits<<EOF" >> $GITHUB_OUTPUT
-          echo "$COMMITS" >> $GITHUB_OUTPUT
+          git rev-list ${{ steps.get_release.outputs.latest_tag }}..HEAD >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Build changelog from PRs

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -51,5 +51,5 @@ jobs:
 
             core.summary
               .addHeading("Output")
-              .addRaw(response.data)
+              .addRaw(JSON.stringify(response.data))
               .write();

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Set Version
         id: set_version
-        run: echo "new_version=3.5.3" >> "$GITHUB_OUTPUT"
+        run: echo "new_version=9.9.9" >> "$GITHUB_OUTPUT"
 
       - name: Check if branch exists
         uses: actions/github-script@v7

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -146,7 +146,15 @@ jobs:
         env:
           NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
         run: |
-          sed -i -E "s/^  \"version\":[[:space:]]*\"[^\"]*\"[[:space:]]*,/  \"version\": \"${NEW_VERSION}\",/" "package.json"
+          sed -i -E "s/^  \"version\":[[:space:]]*\"[^\"]*\"[[:space:]]*,/  \"version\": \"$NEW_VERSION\",/" "package.json"
+          git diff
+
+      - name: Update facebook-for-woocommerce.php
+        env:
+          NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
+        run: |
+          sed -i -E "s/^ \* Version:.*/ \* Version: $NEW_VERSION/" "facebook-for-woocommerce.php"
+          sed -i -E "s/^([[:space:]]*const PLUGIN_VERSION = ')[^']*(';.*)/\1$NEW_VERSION\2/" "facebook-for-woocommerce.php"
           git diff
 
       - name: Commit changes

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -167,7 +167,7 @@ jobs:
             const filePath = 'changelog.txt';
             let content = fs.readFileSync(filePath).toString().split('\n');
             const newLines = process.env.CHANGELOG_TEXT.split(/\r?\n/);
-            content.splice(1, 0, ...newLines);
+            content.splice(2, 0, ...newLines);
             fs.writeFileSync(filePath, content.join('\n'));
 
       - name: Commit changes

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -183,9 +183,15 @@ jobs:
             if (markerIndex === -1) {
               throw new Error('Marker not found in file');
             }
+
+            function shouldRemove(line) {
+              const trimmed = line.trim();
+              return trimmed === '' || trimmed.startsWith('=') || trimmed.startsWith('*');
+            }
+
             let i = markerIndex + 1;
             // Remove all lines starting with "*" after the marker
-            while (i < content.length && content[i].startsWith('*')) {
+            while (i < content.length && shouldRemove(content[i])) {
               content.splice(i, 1); // Don't increment i since we're removing current line
             }
             const newLines = process.env.CHANGELOG_TEXT.split(/\r?\n/);

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -157,10 +157,25 @@ jobs:
           sed -i -E "s/^([[:space:]]*const PLUGIN_VERSION = ')[^']*(';.*)/\1$NEW_VERSION\2/" "facebook-for-woocommerce.php"
           git diff
 
+      - name: Update changelog.txt
+        uses: actions/github-script@v7
+        env:
+          CHANGELOG_TEXT: ${{ steps.changelog.outputs.changelog }}
+        with:
+          script: |
+            const fs = require('fs');
+            const changelogText = process.env.CHANGELOG_TEXT;
+            const filePath = 'changelog.txt';
+            let content = fs.readFileSync(filePath).split('\n');;
+            const newLines = insertText.split(/\r?\n/);
+            content.splice(1, 0, ...newLines);
+            fs.writeFileSync(filePath, content.join('\n'));
+
       - name: Commit changes
         env:
           NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
         run: |
+          git diff
           git status
           git add .
           git commit -m "Updating version to $NEW_VERSION"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,7 +23,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
+        with:
+            fetch-depth: 0
+            
       - name: Get latest release tag
         id: get_release
         uses: actions/github-script@v7

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -165,7 +165,7 @@ jobs:
           script: |
             const fs = require('fs');
             const filePath = 'changelog.txt';
-            let content = fs.readFileSync(filePath).split('\n');;
+            let content = fs.readFileSync(filePath).toString().split('\n');
             const newLines = process.env.CHANGELOG_TEXT.split(/\r?\n/);
             content.splice(1, 0, ...newLines);
             fs.writeFileSync(filePath, content.join('\n'));

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -76,7 +76,7 @@ jobs:
                 })).data;
                 console.log(sha, pr);
                 const labels = pr.labels.map(l => l.name).join(', ');
-                changelog.push(`- ${pr.title} [${labels}]`);
+                changelog.push(`- [${labels}] ${pr.title} by ${pr.user.login} in #${prNumber}`);
               }
             }
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -146,7 +146,7 @@ jobs:
         env:
           NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
         run: |
-          sed -i -E 's/^  "version":[[:space:]]*"[^\"]*"[[:space:]]*,/  "version": "$NEW_VERSION",/' 'package.json'
+          sed -i -E 's/^  "version":[[:space:]]*"[^\"]*"[[:space:]]*,/  "version": "${NEW_VERSION}",/' 'package.json'
           git diff
 
       - name: Commit changes
@@ -156,5 +156,5 @@ jobs:
           git status
           git add .
           git commit -m "Updating version to $NEW_VERSION"
-          git log
+          git log -n 5
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -24,32 +24,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Changelog
+      - name: Get latest release tag
+        id: get_release
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const fs = require('fs');
-            const path = require('path');
-            const version = process.env.VERSION;
-            const releaseNotes = process.env.RELEASE_NOTES;
-            const release = await github.rest.repos.createRelease({
+            const latestRelease = await github.rest.repos.getLatestRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: `v${version}`,
-              target_commitish: 'release/current',
-              name: `Release ${version}`,
-              body: releaseNotes,
-              draft: true,
             });
-            const response = await github.rest.repos.generateReleaseNotes( {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: 'v3.5.4',
-              previous_tag_name: 'v3.5.3',
-            } );
 
-            core.summary
-              .addHeading("Output")
-              .addRaw(JSON.stringify(response.data))
-              .write();
+            const tag = latestRelease.data.tag_name;
+            core.setOutput("tag", tag);
+            console.log("Latest release tag:", tag);
+

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -15,6 +15,8 @@ on:
     branches:
       - 'tzahgr/prepare_release'
 
+permissions:
+  contents: write
 
 jobs:
   prepare-release:
@@ -24,6 +26,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
+            token: ${{ secrets.GITHUB_TOKEN }}
             fetch-depth: 0
 
       - name: Set Version
@@ -127,3 +130,31 @@ jobs:
             const output = `= ${newVersion} - ${date.toISOString().slice(0, 10)} =\n${changelog.join('\n')}\n`;
             core.setOutput('changelog', output);
             console.log(output);
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create new branch locally
+        env:
+          NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
+        run: |
+          git checkout -b "release/$NEW_VERSION"
+
+      - name: Update package.json
+        env:
+          NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
+        run: |
+          sed -i -E 's/^  "version":[[:space:]]*"[^\"]*"[[:space:]]*,/  "version": "$NEW_VERSION",/' 'package.json'
+          git diff
+
+      - name: Commit changes
+        env:
+          NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
+        run: |
+          git status
+          git add .
+          git commit -m "Updating version to $NEW_VERSION"
+          git log
+

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -74,7 +74,7 @@ jobs:
                   pull_number: prNumber,
                 })).data;
                 const labelPrefix = "changelog: ";
-                const changeLogLabels = pr.labels.map(l => l.name).filter((l) => l.startsWith(labelPrefix)).map(l => l.replace(labelPrefix, "");
+                const changeLogLabels = pr.labels.map(l => l.name).filter((l) => l.startsWith(labelPrefix)).map(l => l.replace(labelPrefix, ""));
                 const itemPrefix = changeLogLabels.length > 0 ? `${changeLogLabels[0].charAt(0).toUpperCase()}${changeLogLabels[0].slice(1)} - ` : "";
                 changelog.push(`* ${itemPrefix}${pr.title} by @${pr.user.login} in #${prNumber}`);
               }

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -164,10 +164,9 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const changelogText = process.env.CHANGELOG_TEXT;
             const filePath = 'changelog.txt';
             let content = fs.readFileSync(filePath).split('\n');;
-            const newLines = insertText.split(/\r?\n/);
+            const newLines = process.env.CHANGELOG_TEXT.split(/\r?\n/);
             content.splice(1, 0, ...newLines);
             fs.writeFileSync(filePath, content.join('\n'));
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Set Version
         id: set_version
-        run: echo "new_version=9.9.9" >> "$GITHUB_OUTPUT"
+        run: echo "new_version=99.99.99" >> "$GITHUB_OUTPUT"
 
       - name: Check if branch exists
         uses: actions/github-script@v7
@@ -168,6 +168,28 @@ jobs:
             let content = fs.readFileSync(filePath).toString().split('\n');
             const newLines = process.env.CHANGELOG_TEXT.split(/\r?\n/);
             content.splice(2, 0, ...newLines);
+            fs.writeFileSync(filePath, content.join('\n'));
+
+      - name: Update readme.txt
+        uses: actions/github-script@v7
+        env:
+          CHANGELOG_TEXT: ${{ steps.changelog.outputs.changelog }}
+        with:
+          script: |
+            const fs = require('fs');
+            const filePath = 'readme.txt';
+            let content = fs.readFileSync(filePath).toString().split('\n');
+            const markerIndex = content.findIndex(line => line.trim().toLowerCase() === '== changelog ==');
+            if (markerIndex === -1) {
+              throw new Error('Marker not found in file');
+            }
+            let i = markerIndex + 1;
+            // Remove all lines starting with "*" after the marker
+            while (i < content.length && content[i].startsWith('*')) {
+              content.splice(i, 1); // Don't increment i since we're removing current line
+            }
+            const newLines = process.env.CHANGELOG_TEXT.split(/\r?\n/);
+            content.splice(i, 0, ...newLines);
             fs.writeFileSync(filePath, content.join('\n'));
 
       - name: Commit changes

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -73,8 +73,10 @@ jobs:
                   repo: context.repo.repo,
                   pull_number: prNumber,
                 })).data;
-                const labels = pr.labels.map(l => l.name).join(', ');
-                changelog.push(`- [${labels}] ${pr.title} by ${pr.user.login} in #${prNumber}`);
+                const labelPrefix = "changelog: ";
+                const changeLogLabels = pr.labels.map(l => l.name).filter((l) => l.startsWith(labelPrefix)).map(l => l.replace(labelPrefix, "");
+                const itemPrefix = changeLogLabels.length > 0 ? `${changeLogLabels[0].charAt(0).toUpperCase()}${changeLogLabels[0].slice(1)} - ` : "";
+                changelog.push(`* ${itemPrefix}${pr.title} by @${pr.user.login} in #${prNumber}`);
               }
             }
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -66,19 +66,30 @@ jobs:
 
               const msg = commit.data.commit.message;
               const prMatch = msg.match(/\(#(\d+)\)/);
-              if (prMatch) {
-                const prNumber = parseInt(prMatch[1], 10);
-                pr = (await github.rest.pulls.get({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: prNumber,
-                })).data;
-                const labelPrefix = "changelog: ";
-                const changeLogLabels = pr.labels.map(l => l.name).filter((l) => l.startsWith(labelPrefix)).map(l => l.replace(labelPrefix, ""));
-                const itemPrefix = changeLogLabels.length > 0 ? `${changeLogLabels[0].charAt(0).toUpperCase()}${changeLogLabels[0].slice(1)} - ` : "";
-                changelog.push(`* ${itemPrefix}${pr.title} by @${pr.user.login} in #${prNumber}`);
+              if (!prMatch) {
+                continue;
               }
+
+              const prNumber = parseInt(prMatch[1], 10);
+              pr = (await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              })).data;
+              const labelPrefix = "changelog:";
+              const changeLogLabels = pr.labels.map(l => l.name).filter((l) => l.startsWith(labelPrefix)).map(l => l.replace(labelPrefix, "").trim());
+              if (changeLogLabels.length === 0){
+                continue;
+              }
+
+              const changeLogLabel = changeLogLabels[0];
+              if (changeLogLabel.toLowerCase() === 'none'){
+                continue;
+              }
+
+              changelog.push(`* ${changeLogLabel.charAt(0).toUpperCase()}${changeLogLabel.slice(1)} - ${pr.title} by @${pr.user.login} in #${prNumber}`);              
             }
+            
             const version = "X.X.X";
             const date = new Date();
             const output = `= ${version} - ${date.toISOString().slice(0, 10)} =\n${changelog.join('\n')}\n`;

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -38,10 +38,10 @@ jobs:
             console.log("Latest release tag:", tag);
 
       - name: Get commits since latest release
-              id: get_commits
-              run: |
-                git fetch --tags
-                COMMITS=$(git rev-list ${{ steps.get_release.outputs.latest_tag }}..HEAD)
-                echo "commits<<EOF" >> $GITHUB_OUTPUT
-                echo "$COMMITS" >> $GITHUB_OUTPUT
-                echo "EOF" >> $GITHUB_OUTPUT
+        id: get_commits
+        run: |
+          git fetch --tags
+          COMMITS=$(git rev-list ${{ steps.get_release.outputs.latest_tag }}..HEAD)
+          echo "commits<<EOF" >> $GITHUB_OUTPUT
+          echo "$COMMITS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -26,6 +26,37 @@ jobs:
         with:
             fetch-depth: 0
 
+      - name: Set Version
+        id: set_version
+        run: echo "new_version=3.5.3" >> "$GITHUB_OUTPUT"
+
+      - name: Check if branch exists
+        uses: actions/github-script@v7
+        env:
+          NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
+        with:
+          script: |
+            const newVersion = process.env.NEW_VERSION.trim();            
+            const branch = `release/${newVersion}`;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            try {
+              await github.rest.repos.getBranch({
+                owner,
+                repo,
+                branch,
+              });
+
+              core.setFailed(`Branch "${branch}" already exists.`);
+            } catch (error) {
+              if (error.status === 404) {
+                console.log(`✅ Branch "${branch}" does not exist.`);
+              } else {
+                throw error;
+              }
+            }
+
       - name: Get latest release tag
         id: get_release
         uses: actions/github-script@v7
@@ -52,8 +83,10 @@ jobs:
         uses: actions/github-script@v7
         env:
           COMMITS: ${{ steps.get_commits.outputs.commits }}
+          NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
         with:
           script: |
+            const newVersion = process.env.NEW_VERSION.trim();
             const commits = process.env.COMMITS.trim().split('\n');
             const changelog = [];
 
@@ -89,9 +122,8 @@ jobs:
 
               changelog.push(`* ${changeLogLabel.charAt(0).toUpperCase()}${changeLogLabel.slice(1)} - ${pr.title} by @${pr.user.login} in #${prNumber}`);              
             }
-            
-            const version = "X.X.X";
+
             const date = new Date();
-            const output = `= ${version} - ${date.toISOString().slice(0, 10)} =\n${changelog.join('\n')}\n`;
+            const output = `= ${newVersion} - ${date.toISOString().slice(0, 10)} =\n${changelog.join('\n')}\n`;
             core.setOutput('changelog', output);
             console.log(output);

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -59,17 +59,25 @@ jobs:
             const changelog = [];
 
             for (const sha of commits) {
-              const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              const commit = await github.rest.repos.getCommit({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                commit_sha: sha,
+                ref: sha,
               });
-              console.log(sha, prs);
-              if (prs.data.length > 0) {
-                const pr = prs.data[0];
+
+              const msg = commit.data.commit.message;
+              const prMatch = msg.match(/\(#(\d+)\)/);
+              if (prMatch) {
+                const prNumber = parseInt(prMatch[1], 10);
+                pr = (await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                })).data;
+                console.log(sha, pr);
                 const labels = pr.labels.map(l => l.name).join(', ');
                 changelog.push(`- ${pr.title} [${labels}]`);
-              } 
+              }
             }
 
             const output = changelog.join('\n');

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,51 +1,55 @@
 name: "Prepare New Release"
-run-name: Prepare New Release `${{ github.event.inputs.type }}/${{ github.event.inputs.version }}` from by @${{ github.actor }}
+# run-name: Prepare New Release `${{ github.event.inputs.type }}/${{ github.event.inputs.version }}` from by @${{ github.actor }}
 
 # **What it does**: Does release preparation: creates the release branch and the PR with a checklist.
 # **Why we have it**: To support devs automating a few manual steps and to leave a nice reference for consumers.
 
 on:
-  workflow_dispatch:
-    inputs:
-      ## In the future we could infer that version from the changelog, or bump it via major|minor|patch.
-      version:
-        description: "Version number to be released"
-        required: true
-      type:
-        description: "Type of the release (release|hotfix)"
-        required: true
-        default: "release"
-      wp-version:
-        description: "WordPress tested up to"
-      wc-version:
-        description: "WooCommerce tested up to"
+  # workflow_dispatch:
+  #   inputs:
+  #     ## In the future we could infer that version from the changelog, or bump it via major|minor|patch.
+  #     version:
+  #       description: "Version number to be released"
+  #       required: true
+  push:
+    branches:
+      - 'tzahgr/prepare_release'
+
 
 jobs:
-  PrepareRelease:
+  prepare-release:
     name: Prepare Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Create branch & PR
-        uses: woocommerce/grow/prepare-extension-release@actions-v1
+      - name: Changelog
+        uses: actions/github-script@v7
         with:
-          version: ${{ github.event.inputs.version }}
-          type: ${{ github.event.inputs.type }}
-          wp-version: ${{ github.event.inputs.wp-version }}
-          wc-version: ${{ github.event.inputs.wc-version }}
-          main-branch: "main"
-          post-steps: |
-            ### After deploy
-            1. [ ] Confirm the release deployed correctly to [WPORG](https://wordpress.org/plugins/facebook-for-woocommerce/).
-               - [ ] Ensure you can download and install the latest release from WPORG and WCCOM.
-               - [ ] We've had an issue where the release tag (e.g. 2.6.1) wasn't present in the svn `tags/` folder.
-               - [ ] Troubleshooting processes when the release version doesn't exist in the svn `tags/` folder:
-                    1. [ ] Check the version by `Stable tag` in [https://plugins.svn.wordpress.org/facebook-for-woocommerce/trunk/readme.txt](https://plugins.svn.wordpress.org/facebook-for-woocommerce/trunk/readme.txt) to see if the new release is committed to `trunk`
-                    1. [ ] If the above version is the same as the one just released, then you can make up the missed version tag by `svn cp https://plugins.svn.wordpress.org/facebook-for-woocommerce/trunk https://plugins.svn.wordpress.org/facebook-for-woocommerce/tags/X.X.X -m "Tagging version X.X.X"`. Please note that the `X.X.X` is used as a placeholder but should be replaced with the *actual* release version (e.g., `1.5.0`).
-                    1. [ ] Wait for a while, and the zip file should be able to download from: [https://downloads.wordpress.org/plugin/facebook-for-woocommerce.x.x.x.zip](https://downloads.wordpress.org/plugin/facebook-for-woocommerce.x.x.x.zip)
-            1. [ ] Close the release milestone.
-            1. [ ] Publish any documentation updates relating to the release:
-               - [ ] [User documentation](https://woocommerce.com/document/facebook-for-woocommerce)
-               - [ ] [Any changes to privacy/tracking](https://woocommerce.com/usage-tracking/)
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const version = process.env.VERSION;
+            const releaseNotes = process.env.RELEASE_NOTES;
+            const release = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: `v${version}`,
+              target_commitish: 'release/current',
+              name: `Release ${version}`,
+              body: releaseNotes,
+              draft: true,
+            });
+            const response = await github.rest.repos.generateReleaseNotes( {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: 'v3.5.4',
+              previous_tag_name: 'v3.5.3',
+            } );
+
+            core.summary
+              .addHeading("Output")
+              .addRaw(response.data)
+              .write();

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -54,7 +54,6 @@ jobs:
           COMMITS: ${{ steps.get_commits.outputs.commits }}
         with:
           script: |
-            console.log("Commits:\n" + process.env.COMMITS);
             const commits = process.env.COMMITS.trim().split('\n');
             const changelog = [];
 
@@ -74,7 +73,6 @@ jobs:
                   repo: context.repo.repo,
                   pull_number: prNumber,
                 })).data;
-                console.log(sha, pr);
                 const labels = pr.labels.map(l => l.name).join(', ');
                 changelog.push(`- [${labels}] ${pr.title} by ${pr.user.login} in #${prNumber}`);
               }

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v3
         with:
             fetch-depth: 0
-            
+
       - name: Get latest release tag
         id: get_release
         uses: actions/github-script@v7
@@ -64,7 +64,7 @@ jobs:
                 repo: context.repo.repo,
                 commit_sha: sha,
               });
-
+              console.log(sha, prs);
               if (prs.data.length > 0) {
                 const pr = prs.data[0];
                 const labels = pr.labels.map(l => l.name).join(', ');

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -203,4 +203,3 @@ jobs:
           git add .
           git commit -m "Updating version to $NEW_VERSION"
           git push origin HEAD
-

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -195,16 +195,16 @@ jobs:
               content.splice(i, 1); // Don't increment i since we're removing current line
             }
             const newLines = process.env.CHANGELOG_TEXT.split(/\r?\n/);
+            newLines.unshift("");
             content.splice(i, 0, ...newLines);
             fs.writeFileSync(filePath, content.join('\n'));
 
-      - name: Commit changes
+      - name: Commit and Push
         env:
           NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
         run: |
           git diff
-          git status
           git add .
           git commit -m "Updating version to $NEW_VERSION"
-          git log -n 5
+          git push origin HEAD
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -146,7 +146,7 @@ jobs:
         env:
           NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
         run: |
-          sed -i -E 's/^  "version":[[:space:]]*"[^\"]*"[[:space:]]*,/  "version": "${NEW_VERSION}",/' 'package.json'
+          sed -i -E "s/^  \"version\":[[:space:]]*\"[^\"]*\"[[:space:]]*,/  \"version\": \"${NEW_VERSION}\",/" "package.json"
           git diff
 
       - name: Commit changes

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -53,6 +53,7 @@ jobs:
           COMMITS: ${{ steps.get_commits.outputs.commits }}
         with:
           script: |
+            console.log("Commits:\n" + process.env.COMMITS);
             const commits = process.env.COMMITS.trim().split('\n');
             const changelog = [];
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -81,6 +81,6 @@ jobs:
             }
             const version = "X.X.X";
             const date = new Date();
-            const output = `= ${version} - ${date.toISOString().slice(10)} =\n${changelog.join('\n')}\n`;
+            const output = `= ${version} - ${date.toISOString().slice(0, 10)} =\n${changelog.join('\n')}\n`;
             core.setOutput('changelog', output);
             console.log(output);

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -79,7 +79,8 @@ jobs:
                 changelog.push(`* ${itemPrefix}${pr.title} by @${pr.user.login} in #${prNumber}`);
               }
             }
-
-            const output = changelog.join('\n');
+            const version = "X.X.X";
+            const date = new Date();
+            const output = `= ${version} - ${date.toISOString().slice(10)} =\n${changelog.join('\n')}\n`;
             core.setOutput('changelog', output);
-            console.log("Changelog:\n" + output);
+            console.log(output);


### PR DESCRIPTION
## Description

This workflow is triggered manually and takes the version number as input parameter.

The workflow will:
1. Validate if a release branch with the same version already exist.
2. Get the latest release from GitHub releases.
3. Generate changelog based on PRs such that every PR between the previous and current release will have a line item. PRs need to have a single "changelog:" label. PR with no "changelog:" label will not be included in the changelog. PR with the "changelog: none" label will not be included in the changelog.
4. Create new release branch locally
5. Update package.json
6. Update facebook-for-woocommerce.php
7. Update changelog.txt
8. Update readme.txt
9. Commits and Push


### Type of change

Please delete options that are not relevant

- Add (non-breaking change which adds functionality)

## Checklist

- [] I have commented my code, particularly in hard-to-understand areas, if any.
- [] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Prepare Release Workflow

## Test Plan

Workflow run:
https://github.com/facebook/facebook-for-woocommerce/actions/runs/15928482896