### PR TITLE
Fix exclude_sale_price Value Type in Discount Syncing

### DIFF
--- a/includes/Feed/FeedUploadUtils.php
+++ b/includes/Feed/FeedUploadUtils.php
@@ -255,7 +255,7 @@ class FeedUploadUtils {
 						'prerequisite_product_retailer_ids' => '', // Concept does not exist in Woo
 						'prerequisite_product_group_retailer_ids' => '', // Concept does not exist in Woo
 						'prerequisite_product_set_retailer_ids' => '', // Concept does not exist in Woo
-						'exclude_sale_priced_products'    => $coupon->get_exclude_sale_items(),
+						'exclude_sale_priced_products'    => $coupon->get_exclude_sale_items() ? 'YES' : 'NO',
 						'usage_count'                     => $coupon->get_usage_count(),
 					);
 

--- a/tests/Unit/Feed/FeedUploadUtilsTest.php
+++ b/tests/Unit/Feed/FeedUploadUtilsTest.php
@@ -183,6 +183,8 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 		update_post_meta( $coupon_id, 'email_restrictions', array() );
 		update_post_meta( $coupon_id, 'product_ids', array( $product1->get_id() ) );
 		update_post_meta( $coupon_id, 'usage_count', 2 );
+		// Stored as 'yes'/'no' in post data. See update_post_meta in WC_Coupon_Data_Store_CPT
+		update_post_meta( $coupon_id, 'exclude_sale_items', wc_bool_to_string( true ) );
 
 		$query_args = [
 			'post_type'      => 'shop_coupon',
@@ -225,7 +227,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 			'prerequisite_product_retailer_ids'     => '',
 			'prerequisite_product_group_retailer_ids' => '',
 			'prerequisite_product_set_retailer_ids'   => '',
-			'exclude_sale_priced_products'          => false,
+			'exclude_sale_priced_products'          => 'YES',
 			'target_shipping_option_types'          => '',
 			'usage_count' => 2,
 		];
@@ -249,6 +251,8 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 		update_post_meta( $coupon_id, 'limit_usage_to_x_items', '' );
 		update_post_meta( $coupon_id, 'maximum_amount', '' );
 		update_post_meta( $coupon_id, 'email_restrictions', array() );
+		update_post_meta( $coupon_id, 'exclude_sale_items', wc_bool_to_string( false ) );
+
 
 		$query_args = [
 			'post_type'      => 'shop_coupon',
@@ -291,7 +295,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 			'prerequisite_product_retailer_ids'     => '',
 			'prerequisite_product_group_retailer_ids' => '',
 			'prerequisite_product_set_retailer_ids'   => '',
-			'exclude_sale_priced_products'          => false,
+			'exclude_sale_priced_products'          => 'NO',
 			'target_shipping_option_types'          => ['STANDARD'],
 			'usage_count' => 0,
 		];
@@ -383,7 +387,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 			'prerequisite_product_retailer_ids'     => '',
 			'prerequisite_product_group_retailer_ids' => '',
 			'prerequisite_product_set_retailer_ids'   => '',
-			'exclude_sale_priced_products'          => false,
+			'exclude_sale_priced_products'          => 'NO',
 			'target_shipping_option_types'          => '',
 			'usage_count' => 0,
 		];
@@ -493,7 +497,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 			'prerequisite_product_retailer_ids'     => '',
 			'prerequisite_product_group_retailer_ids' => '',
 			'prerequisite_product_set_retailer_ids'   => '',
-			'exclude_sale_priced_products'          => false,
+			'exclude_sale_priced_products'          => 'NO',
 			'target_shipping_option_types'          => '',
 			'usage_count' => 0,
 		];


### PR DESCRIPTION
## Description

When syncing promotions data, we currently read the exclude_ale_items field as a bool and pass that into the promotions feed as a bool value. This gets converted to an integer in the feed file for the column/field exclude_sale_priced_products. 

The exclude_sale_priced_products column is actually defined to take in a 'YES' or 'NO' value representing the setting. This fixes the generation of the feed to set YES or NO. 

### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry
Fix exclude_sale_price Value Type in Discount Syncing 


## Test Plan
Ran fixed integration test
Tested syncing of discounts from WooC to Meta
