### PR TITLE
Remove tax attribute mapping option

### DIFF
--- a/includes/ProductAttributeMapper.php
+++ b/includes/ProductAttributeMapper.php
@@ -46,7 +46,6 @@ class ProductAttributeMapper {
 	private static $extended_facebook_fields = array(
 		'sale_price' => array( 'sale_price', 'discount_price', 'offer_price' ),
 		'inventory'  => array( 'inventory', 'stock', 'quantity' ),
-		'tax'        => array( 'tax', 'tax_info' ),
 	);
 
 	/** @var array Maps WooCommerce attribute naming variations to standardized Meta field names */


### PR DESCRIPTION
## Description

Remove tax from WooCommerce mapper list of attributes.

## Checklist

- [X] I have commented my code, particularly in hard-to-understand areas, if any.
- [X] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [X] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [X] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [X] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [X] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [X] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Meta "Tax" attribute mapping field removed.

## Test Plan

<details>
<summary>Test suite - 1 unrelated failure</summary>
<br>

```
➜  facebook-for-woocommerce git:(T229653012) ✗ npm run test:php


> facebook-for-woocommerce@3.5.4 test:php
> composer test-unit

Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
Installing WooCommerce...
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
PHPUnit 9.6.19 by Sebastian Bergmann and contributors.

.............................................................   61 / 1400 (  4%)
.............................................................  122 / 1400 (  8%)
.............................................................  183 / 1400 ( 13%)
.............................................................  244 / 1400 ( 17%)
.............................................................  305 / 1400 ( 21%)
.............................................................  366 / 1400 ( 26%)
.............................................................  427 / 1400 ( 30%)
.............................................................  488 / 1400 ( 34%)
.............................................................  549 / 1400 ( 39%)
.............................................................  610 / 1400 ( 43%)
.............................................................  671 / 1400 ( 47%)
.............................................................  732 / 1400 ( 52%)
.....................................F.......................  793 / 1400 ( 56%)
.............................................................  854 / 1400 ( 61%)
.............................................................  915 / 1400 ( 65%)
.............................................................  976 / 1400 ( 69%)
............................................................. 1037 / 1400 ( 74%)
............................................................. 1098 / 1400 ( 78%)
...W......................................................... 1159 / 1400 ( 82%)
............................................................. 1220 / 1400 ( 87%)
............................................................. 1281 / 1400 ( 91%)
............................................................. 1342 / 1400 ( 95%)
..........................................................    1400 / 1400 (100%)

Time: 00:28.721, Memory: 387.00 MB

There was 1 warning:

1) Warning
No tests found in class "OfferManagementAPITestBase".

phpvfscomposer:///Users/jcgds/Local Sites/jcgds-woo/app/public/wp-content/plugins/facebook-for-woocommerce/vendor/phpunit/phpunit/phpunit:106

--

There was 1 failure:

1) WooCommerce\Facebook\Tests\Unit\Events\NormalizerTest::test_special_characters_handling
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'montréal'
+'montr�al'

/Users/jcgds/Local Sites/jcgds-woo/app/public/wp-content/plugins/facebook-for-woocommerce/tests/Unit/Events/NormalizerTest.php:408
phpvfscomposer:///Users/jcgds/Local Sites/jcgds-woo/app/public/wp-content/plugins/facebook-for-woocommerce/vendor/phpunit/phpunit/phpunit:106

FAILURES!
Tests: 1400, Assertions: 140837, Failures: 1, Warnings: 1.
Script ./vendor/bin/phpunit --testsuite=unit handling the test-unit event returned with error code 1
```

</details>



* Confirmed that product sync remains functional when a pre-existing mapping to the removed "Tax" attribute is present.
* Verified the behavior of the `Attribute Mapping` tab in when there's a pre-existing mapping to the now-removed "Tax" attribute.

https://github.com/user-attachments/assets/7edb81f7-eeed-47a7-968a-741351ad9103

## Screenshots

| Before | After |
| --- | --- |
| <img width="1436" alt="Screenshot 2025-07-03 at 11 46 32" src="https://github.com/user-attachments/assets/92a26588-cd80-4496-8f97-a9a26bd1c90b" />  | <img width="1436" alt="Screenshot 2025-07-03 at 11 46 12" src="https://github.com/user-attachments/assets/5f3d3b4d-46f4-4c54-87a6-39a405c9598d" /> | 

