### PR TITLE
Adding visibility hidden check for out of stock products

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1810,14 +1810,14 @@ class WC_Facebook_Product {
 				}
 			}
 		}
-		
+
 		/**
 		 * Additional check to ensure product is marked hidden in case of out of stock
 		 */
-		 $product_id = $this->get_id();
-		 $current_product = wc_get_product( $product_id );
+		$product_id      = $this->get_id();
+		$current_product = wc_get_product( $product_id );
 
-		if($current_product && !$current_product->is_in_stock() ){
+		if ( $current_product && ! $current_product->is_in_stock() ) {
 			$product_data['visibility'] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
 		}
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1810,6 +1810,16 @@ class WC_Facebook_Product {
 				}
 			}
 		}
+		
+		/**
+		 * Additional check to ensure product is marked hidden in case of out of stock
+		 */
+		 $product_id = $this->get_id();
+		 $current_product = wc_get_product( $product_id );
+
+		if($current_product && !$current_product->is_in_stock() ){
+			$product_data['visibility'] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
+		}
 
 		// Set any attributes not already set by direct mappings
 		if ( ! isset( $product_data['brand'] ) ) {


### PR DESCRIPTION
## Description

The out of stock products are showing up in ads as they are currently getting synced and marked active.

### Type of change

Fix: The change is made to mark the out of stock products as hidden, so that they go into archived state and does not pose as a candidate for ads creation.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry
Fix product synced and active when it is marked out of stock. Changed the status to hidden


## Test Plan

1. Create a product.
2. Mark the product out of stock in the product edit page.
3. Update the product.
4. Check in commerce manager.

Observation: The product should be synced but marked archived

## Screenshots
N/A
