### PR TITLE
Fixes add new attribute mapping row selection

### DIFF
--- a/includes/Admin/Settings_Screens/Product_Attributes.php
+++ b/includes/Admin/Settings_Screens/Product_Attributes.php
@@ -419,11 +419,6 @@ class Product_Attributes extends Abstract_Settings_Screen {
 						updateDisabledAttributes();
 					}, 200);
 					
-					// Focus the first select field in the new row
-					setTimeout(function() {
-						$newRow.find('.wc-attribute-search').select2('open');
-					}, 100);
-					
 					// Scroll to the newly added row
 					$('html, body').animate({
 						scrollTop: $newRow.offset().top - 100


### PR DESCRIPTION
## Description
In the attribute mapping tab, once the user clicks on the add new mapping button the attribute selection field would briefly become selected and then revert to unselected state.
This was caused by a delayed selection command that is unnecessary. 
Removing the selection fixed the issue


### Type of change

Please delete options that are not relevant
- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fix the add new attribute mapping row

## Test Plan
- Performed the changes
- Tested it locally to verify the issue was fixed

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before
https://fb.workplace.com/groups/937343410765935/permalink/1456088172224787/

### After
https://pxl.cl/7Dh3J