### PR TITLE
fix: 'Facebook Product Video' field placement

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1201,6 +1201,9 @@ class Admin {
 					)
 				);
 
+				// Render the Facebook Product Video field at Product level
+				$this->render_facebook_product_video_field( $video_urls );
+
 				woocommerce_wp_text_input(
 					array(
 						'id'          => \WC_Facebook_Product::FB_PRODUCT_PRICE,
@@ -1249,9 +1252,6 @@ class Admin {
 			</script>
 
 			<?php
-				// Render the Facebook Product Video field at Product level
-				$this->render_facebook_product_video_field( $video_urls );
-
 				woocommerce_wp_text_input(
 					array(
 						'id'          => \WC_Facebook_Product::FB_MPN,


### PR DESCRIPTION
## Description

Move the placement of 'Facebook Product Video' UI field before the `Facebook Price` UI field.

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.

## Test Plan
Tested on local site after making the change.

## Screenshots
### Before
https://github.com/user-attachments/assets/755b36ac-0822-49b8-8ac0-0c2b4f710357

### After
https://github.com/user-attachments/assets/8943fad7-6c9a-49c5-b629-8b76c7780fb6


