### PR TITLE
Rolling back out of stock change

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1811,16 +1811,6 @@ class WC_Facebook_Product {
 			}
 		}
 
-		/**
-		 * Additional check to ensure product is marked hidden in case of out of stock
-		 */
-		$product_id      = $this->get_id();
-		$current_product = wc_get_product( $product_id );
-
-		if ( $current_product && ! $current_product->is_in_stock() ) {
-			$product_data['visibility'] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
-		}
-
 		// Set any attributes not already set by direct mappings
 		if ( ! isset( $product_data['brand'] ) ) {
 			$product_data['brand'] = Helper::str_truncate( $this->get_fb_brand( $is_api_call ), 100 );


### PR DESCRIPTION
## Description

Yesterday we added the functionality to mark out of stock products to archive.

### Type of change

Revert: The code logic to mark out of stock archive

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Reverting the change for marking out of stock products to hidden/archived

## Test Plan

N/A

## Screenshots
N/A
