### PR TITLE
[BUG] fix: Product description is a different font size from the rest of the fields on the fb product page 

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -166,6 +166,7 @@
     width: 150px;
     padding: 0;
     margin: 0 0 0 12px;
+	font-size: 12px;
 }
 
 /* Ensure the wp-editor-wrap takes full width */


### PR DESCRIPTION
## Description

Product description is a different font size from the rest of the fields on the fb product page, rest of the font is 12 facebook description size is 13

### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fix font size for product description

## Test Plan
- Performed the changes
- Tested it locally to verify the issue was fixed


## Screenshots


### Before
![image](https://github.com/user-attachments/assets/6aa74fc6-22b8-40b8-830f-dea10994b893)

### After
<img width="822" alt="Screenshot 2025-07-04 at 12 04 49" src="https://github.com/user-attachments/assets/3ddf8954-537e-4906-a326-77e5afa1609f" />
