### PR TITLE
Adding better queries for Filters & removing variant dependencies

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1810,14 +1810,14 @@ class WC_Facebook_Product {
 				}
 			}
 		}
-		
+
 		/**
 		 * Additional check to ensure product is marked hidden in case of out of stock
 		 */
-		 $product_id = $this->get_id();
-		 $current_product = wc_get_product( $product_id );
+		$product_id      = $this->get_id();
+		$current_product = wc_get_product( $product_id );
 
-		if($current_product && !$current_product->is_in_stock() ){
+		if ( $current_product && ! $current_product->is_in_stock() ) {
 			$product_data['visibility'] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
 		}
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1810,6 +1810,16 @@ class WC_Facebook_Product {
 				}
 			}
 		}
+		
+		/**
+		 * Additional check to ensure product is marked hidden in case of out of stock
+		 */
+		 $product_id = $this->get_id();
+		 $current_product = wc_get_product( $product_id );
+
+		if($current_product && !$current_product->is_in_stock() ){
+			$product_data['visibility'] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
+		}
 
 		// Set any attributes not already set by direct mappings
 		if ( ! isset( $product_data['brand'] ) ) {


### PR DESCRIPTION
## Description
Adding better filters for products page. This will help to filter better across multiple pages.
Here are the changes.
1. Previously the filters used to do additional heavy lifting by checking all the variants and then deciding the logic. That is changed as we have new **product level sync** which will no longer require variant level stuff to be computed to decide the sync status. This **saves computation** and **DB fetches** for non required products.
2. There was this flag used before: ``` $query_vars['post__in'] ``` that will **override any such previous filtration** things and will only show the newly added product ids, this was tampering with the pagination and **was a long standing issue**. This will now help to filter out all the products that are originally part of the query.


### Type of change

Fix: Filters fix for products page

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fix: Adding fixes to filters with better logic and clean code.


## Test Plan

1. Go to products page
2. Now try to filter by 'Filter by sync to meta catalog' 
3. You should see the change.

## Screenshots
### Before
<img width="1530" alt="Screenshot 2025-07-06 at 5 38 14 pm" src="https://github.com/user-attachments/assets/b1b78ff9-6329-4b55-8a48-7f193ed45d0d" />

### After
![image](https://github.com/user-attachments/assets/fd8eb421-6c45-4c65-b67a-485a24f228ab)
