### PR TITLE
feat: add variable to track sync latency

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -2204,6 +2204,9 @@ class WC_Facebook_Product {
 			$product_data['external_update_time'] = $date_modified->getTimestamp();
 		}
 
+		// Add product preparation timestamp
+		$product_data['product_prepare_time'] = time();
+
 		// Only use checkout URLs if they exist.
 		$checkout_url = $this->build_checkout_url( $product_url );
 		if ( $checkout_url ) {

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -421,7 +421,7 @@ class WC_Facebook_Product_Feed {
 		'additional_image_link,sale_price_effective_date,sale_price,condition,' .
 		'visibility,gender,color,size,pattern,google_product_category,default_product,' .
 		'variant,gtin,quantity_to_sell_on_facebook,rich_text_description,internal_label,external_update_time,' .
-		'external_variant_id, is_woo_all_products_sync' . PHP_EOL;
+		'product_prepare_time,external_variant_id, is_woo_all_products_sync' . PHP_EOL;
 	}
 
 
@@ -581,6 +581,7 @@ class WC_Facebook_Product_Feed {
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'rich_text_description' ) ) . ',' .
 		static::format_internal_labels_for_feed( static::get_value_from_product_data( $product_data, 'internal_label' ) ) . ',' .
 		static::get_value_from_product_data( $product_data, 'external_update_time' ) . ',' .
+		static::get_value_from_product_data( $product_data, 'product_prepare_time' ) . ',' .
 		static::get_value_from_product_data( $product_data, 'external_variant_id' ) . ',' .
 		static::format_string_for_feed( $is_woo_all_products_sync ) . PHP_EOL;
 	}

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -1086,23 +1086,23 @@ class fbproductTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSa
 	}
 
 	/**
-	 * Test prepare_product_time is populated
+	 * Test product_prepare_time is populated
 	 * @return void
 	 */
-	public function test_prepare_product_time_set() {
+	public function test_product_prepare_time_set() {
 		$woo_product = WC_Helper_Product::create_simple_product();
 
 		$before_time = time();
 		$fb_product = new \WC_Facebook_Product( $woo_product );
-		$data = $fb_product->prepare_product();
+		$data = $fb_product->product_prepare();
 		$after_time = time();
 
-		$this->assertArrayHasKey('prepare_product_time', $data);
-		$this->assertIsNumeric($data['prepare_product_time']);
+		$this->assertArrayHasKey('product_prepare_time', $data);
+		$this->assertIsNumeric($data['product_prepare_time']);
 
-		// Verify the timestamp is within the expected range (between before and after the prepare_product call)
-		$this->assertGreaterThanOrEqual($before_time, $data['prepare_product_time']);
-		$this->assertLessThanOrEqual($after_time, $data['prepare_product_time']);
+		// Verify the timestamp is within the expected range (between before and after the product_prepare call)
+		$this->assertGreaterThanOrEqual($before_time, $data['product_prepare_time']);
+		$this->assertLessThanOrEqual($after_time, $data['product_prepare_time']);
 	}
 
 	/**

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -1094,7 +1094,7 @@ class fbproductTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSa
 
 		$before_time = time();
 		$fb_product = new \WC_Facebook_Product( $woo_product );
-		$data = $fb_product->product_prepare();
+		$data = $fb_product->prepare_product();
 		$after_time = time();
 
 		$this->assertArrayHasKey('product_prepare_time', $data);

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -1086,6 +1086,26 @@ class fbproductTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSa
 	}
 
 	/**
+	 * Test prepare_product_time is populated
+	 * @return void
+	 */
+	public function test_prepare_product_time_set() {
+		$woo_product = WC_Helper_Product::create_simple_product();
+
+		$before_time = time();
+		$fb_product = new \WC_Facebook_Product( $woo_product );
+		$data = $fb_product->prepare_product();
+		$after_time = time();
+
+		$this->assertArrayHasKey('prepare_product_time', $data);
+		$this->assertIsNumeric($data['prepare_product_time']);
+
+		// Verify the timestamp is within the expected range (between before and after the prepare_product call)
+		$this->assertGreaterThanOrEqual($before_time, $data['prepare_product_time']);
+		$this->assertLessThanOrEqual($after_time, $data['prepare_product_time']);
+	}
+
+	/**
 	 * Test fallback to main description when it's less than 1000 characters.
 	 */
 	public function test_get_fb_short_description_fallback_to_short_main_description() {


### PR DESCRIPTION
## Description

I am adding a new field to add the current time during product preparation.  `product_prepare_time` marks the current unix timestamp of when the product is being prepared for sync to fb catalog. 
All sync changes go through prepare_product() function, this change will allow to track the time between preparation to when the product exists in FB/Meta catalog

### Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

✅ I have commented my code, particularly in hard-to-understand areas, if any.
✅ I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes. ([Tests Action Success Run](https://github.com/rithikb24/facebook-for-woocommerce/actions/runs/16179559300))
✅  I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.

## Changelog entry

One liner entry to be surfaced in changelog.txt


## Test Plan
### Automated testing
[Tests Action Success Run](https://github.com/rithikb24/facebook-for-woocommerce/actions/runs/16179559300))

### Manual testing
In WooCommerce UI I added one product and checked that Batch API request contains the new field and the timestamp value is correct.
Also, triggered a csv upload and verified the field in the Batch API request
