### PR TITLE
Updating promotions feed upload utils tests to fix failure

### DIFF
--- a/tests/Unit/Feed/FeedUploadUtilsTest.php
+++ b/tests/Unit/Feed/FeedUploadUtilsTest.php
@@ -171,7 +171,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 		$coupon_id = self::factory()->post->create([
 			'post_type'   => 'shop_coupon',
 			'post_status' => 'publish',
-			'post_title'  => 'COUPON-CODE-1',
+			'post_title'  => 'coupon-code-1',
 		]);
 		// Set coupon meta so that it is valid and a percentage discount.
 		update_post_meta( $coupon_id, 'discount_type', 'percent' );
@@ -201,7 +201,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 		// Build the expected coupon shape according to how FeedUploadUtils outputs the data.
 		$expected_coupon = [
 			'offer_id'                              => $coupon_id,              // coupon ID as an integer
-			'title'                                 => 'COUPON-CODE-1',         // uppercase coupon post title
+			'title'                                 => 'coupon-code-1',         // lowercase coupon post title
 			'value_type'                            => 'PERCENTAGE',
 			'percent_off'                           => '15',                    // as a string
 			'fixed_amount_off'                      => '',                      // empty string output
@@ -211,7 +211,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 			'target_selection'                      => 'SPECIFIC_PRODUCTS',
 			'start_date_time'                       => $coupon_data['start_date_time'], // use the output from the coupon post date/time
 			'end_date_time'                         => '',
-			'coupon_codes'                          => ['COUPON-CODE-1'],
+			'coupon_codes'                          => ['coupon-code-1'],
 			'public_coupon_code'                    => '',
 			'target_filter'                         => '{"or":[{"retailer_id":{"eq":"product-sku-1_'.$product1->get_id().'"}}]}',
 			'target_product_retailer_ids'           => '',
@@ -241,7 +241,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 		$coupon_id = self::factory()->post->create([
 			'post_type'   => 'shop_coupon',
 			'post_status' => 'publish',
-			'post_title'  => 'COUPON-CODE-1',
+			'post_title'  => 'coupon-code-1',
 		]);
 		// Set coupon meta with free_shipping => yes
 		update_post_meta( $coupon_id, 'discount_type', 'fixed_cart' );
@@ -269,7 +269,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 		// Build the expected coupon shape according to how FeedUploadUtils outputs the data.
 		$expected_coupon = [
 			'offer_id'                              => $coupon_id,              // coupon ID as an integer
-			'title'                                 => 'COUPON-CODE-1',         // uppercase coupon post title
+			'title'                                 => 'coupon-code-1',         // lowercase coupon post title
 			'value_type'                            => 'PERCENTAGE',
 			'fixed_amount_off'                      => '0',                      // empty string output
 			'percent_off'                           => '100',                    // as a string
@@ -279,7 +279,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 			'target_selection'                      => 'ALL_CATALOG_PRODUCTS',
 			'start_date_time'                       => $coupon_data['start_date_time'], // use the output from the coupon post date/time
 			'end_date_time'                         => '',
-			'coupon_codes'                          => ['COUPON-CODE-1'],
+			'coupon_codes'                          => ['coupon-code-1'],
 			'public_coupon_code'                    => '',
 			'target_filter'                         => '',
 			'target_product_retailer_ids'           => '',
@@ -334,7 +334,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 		$coupon_id = self::factory()->post->create([
 			'post_type'   => 'shop_coupon',
 			'post_status' => 'publish',
-			'post_title'  => 'COUPON-INCL-EXCL',
+			'post_title'  => 'coupon-incl-excl',
 		]);
 		// Set coupon meta so that it is valid with a percentage discount.
 		update_post_meta( $coupon_id, 'discount_type', 'percent' );
@@ -361,7 +361,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 		// Build the expected coupon shape.
 		$expected_coupon = [
 			'offer_id'                              => $coupon_id,                          // coupon ID as an integer
-			'title'                                 => 'COUPON-INCL-EXCL',                  // uppercase coupon post title
+			'title'                                 => 'coupon-incl-excl',                  // lowercase coupon post title
 			'value_type'                            => 'PERCENTAGE',
 			'percent_off'                           => '20',                                // as a string
 			'fixed_amount_off'                      => '',                                  // empty string output
@@ -371,7 +371,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 			'target_selection'                      => 'SPECIFIC_PRODUCTS',
 			'start_date_time'                       => $coupon_data['start_date_time'],     // use the generated start date/time
 			'end_date_time'                         => '',
-			'coupon_codes'                          => ['COUPON-INCL-EXCL'],                // coupon_codes as an array containing the title
+			'coupon_codes'                          => ['coupon-incl-excl'],                // coupon_codes as an array containing the title
 			'public_coupon_code'                    => '',
 			'target_filter'                         => '{"and":[{"or":[{"retailer_id":{"eq":"product-sku-1_'.$product1->get_id().'"}},{"retailer_id":{"eq":"product-sku-2_'.$product2->get_id().'"}}]},{"and":[{"retailer_id":{"neq":"product-sku-3_'.$product3->get_id().'"}}]}]}',
 			'target_product_retailer_ids'           => '',
@@ -438,7 +438,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 		$coupon_id = self::factory()->post->create([
 			'post_type'   => 'shop_coupon',
 			'post_status' => 'publish',
-			'post_title'  => 'COUPON-CAT-ONLY',
+			'post_title'  => 'coupon-cat-only',
 		]);
 		// Set coupon meta for a percentage discount.
 		update_post_meta( $coupon_id, 'discount_type', 'percent' );
@@ -471,7 +471,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 		// Build the expected coupon shape.
 		$expected_coupon = [
 			'offer_id'                              => $coupon_id,                          // coupon ID as an integer
-			'title'                                 => 'COUPON-CAT-ONLY',                   // uppercase coupon post title
+			'title'                                 => 'coupon-cat-only',                   // uppercase coupon post title
 			'value_type'                            => 'PERCENTAGE',
 			'percent_off'                           => '15',                                // as a string
 			'fixed_amount_off'                      => '',                                  // empty string output
@@ -481,7 +481,7 @@ class FeedUploadUtilsTest extends FeedDataTestBase {
 			'target_selection'                      => 'SPECIFIC_PRODUCTS',
 			'start_date_time'                       => $coupon_data['start_date_time'],     // generated start date/time
 			'end_date_time'                         => '',
-			'coupon_codes'                          => ['COUPON-CAT-ONLY'],                 // coupon_codes as an array containing the code
+			'coupon_codes'                          => ['coupon-cat-only'],                 // coupon_codes as an array containing the code
 			'public_coupon_code'                    => '',
 			'target_filter'                         => $expected_target_filter,
 			'target_product_retailer_ids'           => '',


### PR DESCRIPTION
## Description

This PR fixes some promotions related tests failing in FeedUploadUtilsTest

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fixing failing tests in FeedUploadUtilsTest


## Test Plan

- Ran all tests in FeedUploadUtilsTest locally and verified they passed
<img width="645" height="381" alt="Screenshot 2025-07-14 at 3 39 29 PM" src="https://github.com/user-attachments/assets/6f3051ee-5818-4427-9ece-809d6513eae4" />