### PR TITLE
Prevent cleanupAllUIElements from resetting selects with one option to maintain Composite Products compatibility

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -2105,8 +2105,8 @@ class Admin {
 						var $select = $(this);
 						$select.show().prop('disabled', false).removeClass('synced-attribute');
 						
-						// If the select has no options or just one, ensure it's properly reset
-						if ($select.find('option').length <= 1) {
+						// If the select has no options ensure it's properly reset
+						if ($select.find('option').length < 1) {
 							$select.val('').prop('selected', true);
 						}
 						


### PR DESCRIPTION
## Description
Prevent cleanupAllUIElements() from clearing valid single-option <select> elements to ensure compatibility with Composite Products and similar extensions.
Addresses the bug reported in [#3325](https://github.com/facebook/facebook-for-woocommerce/issues/3325), where Composite Product component options are removed due to aggressive UI cleanup logic that resets <select> fields with only one option.
### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have commented my code, particularly in hard-to-understand areas, if any.
- [X] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [X] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [X] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [X] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [X] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fix - Prevent clearing valid single-option dropdowns in product edit screen to maintain compatibility with Composite Products #3325.

## Test Plan

Ensure the following plugins are installed and active:

- WooCommerce
- Composite Products
- Facebook for WooCommerce

1. Create a simple product:
2. Create a Composite Product:
3. Add a new component
4. Under “Component Options,” select only one product (the simple product you created in step 2)
5. Set the component as non-optional
6. Choose the simple product as the Default Option
7. Save or update the product
8. Observe behavior with Facebook for WooCommerce active:
9. Refresh the product edit page - the selected default option is gone
10. Test again with Facebook for WooCommerce deactivated
11. Refresh the same Composite Product - the component dropdown and selected product are preserved as expected


## Screenshots
### Before
<img width="1512" height="790" alt="Screenshot 2025-07-16 at 15 32 04" src="https://github.com/user-attachments/assets/f0229942-3ce9-42fd-a87a-ece14fd903d4" />

### After
<img width="1512" height="795" alt="Screenshot 2025-07-16 at 15 32 40" src="https://github.com/user-attachments/assets/8a0e6674-1072-47ae-a30e-03adb7863a3f" />
