### PR TITLE
Add surface catalog id display with link to commerce manager in produ…

### DIFF
--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -164,10 +164,10 @@ class Product_Sync extends Abstract_Settings_Screen {
 	}
 
 	/**
-	* Renders the custom title.
+	 * Renders the custom title.
 	 *
 	 * @internal
-	 * 
+	 *
 	 * @since 2.0.0
 	 *
 	 * @param array $field field data
@@ -357,13 +357,13 @@ class Product_Sync extends Abstract_Settings_Screen {
 	 */
 	public function render_catalog_display( $field ) {
 		$integration = facebook_for_woocommerce()->get_integration();
-		$catalog_id = $integration->get_product_catalog_id();
-		
+		$catalog_id  = $integration->get_product_catalog_id();
+
 		// Only display if catalog ID exists
 		if ( empty( $catalog_id ) ) {
 			return;
 		}
-		
+
 		$catalog_item = array(
 			'label' => __( 'Catalog', 'facebook-for-woocommerce' ),
 			'value' => $catalog_id,
@@ -389,7 +389,7 @@ class Product_Sync extends Abstract_Settings_Screen {
 					'woocommerce_log_level'          => \WC_Log_Levels::ERROR,
 				)
 			);
-			
+
 			// Use store name
 			$store_name = get_bloginfo( 'name' );
 			if ( ! empty( $store_name ) ) {

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -351,7 +351,7 @@ class Product_Sync extends Abstract_Settings_Screen {
 	 *
 	 * @internal
 	 *
-	 * @since 2.1.0
+	 * @since 3.5.4
 	 *
 	 * @param array $field field data
 	 */

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -376,6 +376,14 @@ class Product_Sync extends Abstract_Settings_Screen {
 			$name     = $response->name ?? '';
 			if ( $name ) {
 				$catalog_item['value'] = $name;
+			} else {
+				// API succeeded but returned empty name - use store name fallback
+				$store_name = get_bloginfo( 'name' );
+				if ( ! empty( $store_name ) ) {
+					$catalog_item['value'] = sprintf( '%s Catalog', $store_name );
+				} else {
+					$catalog_item['value'] = __( 'Facebook Catalog', 'facebook-for-woocommerce' );
+				}
 			}
 		} catch ( ApiException $exception ) {
 			// Log the exception with additional information
@@ -389,8 +397,8 @@ class Product_Sync extends Abstract_Settings_Screen {
 					'woocommerce_log_level'          => \WC_Log_Levels::ERROR,
 				)
 			);
-
-			// Use store name
+			
+			// Use store name as fallback
 			$store_name = get_bloginfo( 'name' );
 			if ( ! empty( $store_name ) ) {
 				$catalog_item['value'] = sprintf( '%s Catalog', $store_name );

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -164,8 +164,10 @@ class Product_Sync extends Abstract_Settings_Screen {
 	}
 
 	/**
-	 * Renders the title for the product sync screen.
+	* Renders the custom title.
 	 *
+	 * @internal
+	 * 
 	 * @since 2.0.0
 	 *
 	 * @param array $field field data

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -357,12 +357,12 @@ class Product_Sync extends Abstract_Settings_Screen {
 	 */
 	public function render_catalog_display( $field ) {
 		$catalog_item = $this->get_catalog_item_data();
-		
+
 		// Only display if catalog ID exists
 		if ( empty( $catalog_item ) ) {
 			return;
 		}
-		
+
 		$this->render_catalog_row( $catalog_item );
 	}
 
@@ -373,13 +373,13 @@ class Product_Sync extends Abstract_Settings_Screen {
 	 */
 	private function get_catalog_item_data() {
 		$integration = facebook_for_woocommerce()->get_integration();
-		$catalog_id = $integration->get_product_catalog_id();
-		
+		$catalog_id  = $integration->get_product_catalog_id();
+
 		// Return null if no catalog ID exists
 		if ( empty( $catalog_id ) ) {
 			return null;
 		}
-		
+
 		// Build catalog item similar to Connection screen
 		$catalog_item = array(
 			'label' => __( 'Catalog', 'facebook-for-woocommerce' ),
@@ -409,7 +409,7 @@ class Product_Sync extends Abstract_Settings_Screen {
 					'woocommerce_log_level'          => \WC_Log_Levels::ERROR,
 				)
 			);
-			
+
 			// Use store name as fallback
 			$catalog_item['value'] = $this->get_catalog_fallback_name();
 		}


### PR DESCRIPTION
## Description

This PR adds a catalog ID display with a clickable link to Facebook Commerce Manager on the Product Sync tab. The feature was previously available in a deprecated page and has been restored to improve user experience.

The implementation:
- Displays the catalog information at the bottom of the Product Sync page, under the "Default Google product category" section
- Attempts to fetch the catalog name from Facebook's API for better user experience
- Falls back to using the store name + "Catalog" if the API call fails
- Provides a direct link to Facebook Commerce Manager for easy access
- Includes proper error logging with structured logging format
- Only displays when a catalog ID is available

### Type of change

Please delete options that are not relevant.

- **New feature (non-breaking change which adds functionality)**

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Changelog entry

Add catalog ID display with link to Facebook Commerce Manager in Product Sync tab

## Test Plan

### Manual Testing Steps:
1. Navigate to WooCommerce > Facebook > Product sync tab
2. Scroll to the bottom of the page
3. Verify that the "Catalog" row appears under the "Default Google product category" section
4. Verify that the catalog name (e.g., "Site 4.0 Catalog") is displayed instead of the numeric ID
5. Click the catalog link to verify it opens Facebook Commerce Manager in a new tab
6. Test API failure scenario by temporarily disconnecting from Facebook and verify fallback behavior shows store name + "Catalog"

### Test Configuration:
- WordPress version: Latest
- WooCommerce version: Latest
- Facebook for WooCommerce plugin: Current development version
- PHP version: 8.1+
- Connected Facebook account with valid catalog

## Screenshots


### Before
<img width="991" height="806" alt="Screenshot 2025-07-16 at 15 43 34" src="https://github.com/user-attachments/assets/188fded0-48f5-4313-a2ec-46d6ef2621b5" />



### After
<img width="951" height="598" alt="Screenshot 2025-07-16 at 16 28 37" src="https://github.com/user-attachments/assets/dc4d6da7-e7b4-4a7f-a420-3f71418e6b12" />

- Clickable link that opens Facebook Commerce Manager in a new tab
- Seamless integration with existing form styling