### PR TITLE
Fix/prevent woocommerce attribute summaries in facebook short descriptions

### DIFF
--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -1571,4 +1571,257 @@ class fbproductTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSa
 		$this->assertIsArray($batch_data['color'], 'Color should be an array for items batch');
 		$this->assertEquals(['red', 'blue', 'green'], $batch_data['color'], 'Color array for items batch should contain individual values');
 	}
+
+	/**
+	 * Test is_woocommerce_attribute_summary method with various inputs
+	 */
+	public function test_is_woocommerce_attribute_summary() {
+		$fb_product = new \WC_Facebook_Product($this->product);
+
+		// Test cases that should be detected as attribute summaries
+		$attribute_summaries = [
+			'1: kids',
+			'Size: Large',
+			'Color: Red',
+			'Size: Large, Color: Red',
+			'pa_color: Blue',
+			'age_group: adults',
+			'1: kids, 2: summer',
+			'Brand: Nike, Size: XL, Color: Black',
+			'material: cotton',
+			'gender: female',
+			'123: test',
+			'pa_size: medium',
+		];
+
+		foreach ($attribute_summaries as $summary) {
+			$this->assertTrue(
+				$fb_product->is_woocommerce_attribute_summary($summary),
+				"'{$summary}' should be detected as an attribute summary"
+			);
+		}
+
+		// Test cases that should NOT be detected as attribute summaries
+		$real_descriptions = [
+			'This is a genuine product description.',
+			'A high-quality item with excellent features.',
+			'Features include comfort and style.',
+			'Made with premium materials',
+			'Perfect for kids and adults alike',
+			'Available in multiple sizes',
+			'',
+			'Short description without colons',
+			'This product has: great features', // Contains colon but not in attribute format
+			'Description with, commas but no colons',
+			'Multi-line description
+			with line breaks',
+			'Very long description that exceeds typical attribute length and contains various punctuation marks!',
+		];
+
+		foreach ($real_descriptions as $description) {
+			$this->assertFalse(
+				$fb_product->is_woocommerce_attribute_summary($description),
+				"'{$description}' should NOT be detected as an attribute summary"
+			);
+		}
+	}
+
+	/**
+	 * Test is_woocommerce_attribute_summary with edge cases
+	 */
+	public function test_is_woocommerce_attribute_summary_edge_cases() {
+		$fb_product = new \WC_Facebook_Product($this->product);
+
+		// Test empty and null values
+		$this->assertFalse($fb_product->is_woocommerce_attribute_summary(''));
+		$this->assertFalse($fb_product->is_woocommerce_attribute_summary(null));
+
+		// Test whitespace handling
+		$this->assertTrue($fb_product->is_woocommerce_attribute_summary('  Size: Large  '));
+		$this->assertTrue($fb_product->is_woocommerce_attribute_summary("\tColor: Red\n"));
+
+		// Test complex attribute patterns
+		$this->assertTrue($fb_product->is_woocommerce_attribute_summary('Size: Large, Material: Cotton, Color: Blue'));
+		$this->assertTrue($fb_product->is_woocommerce_attribute_summary('pa_brand: Nike, pa_size: XL'));
+
+		// Test borderline cases that should be detected
+		$this->assertTrue($fb_product->is_woocommerce_attribute_summary('A: B'));
+		$this->assertTrue($fb_product->is_woocommerce_attribute_summary('1: 2'));
+
+		// Test cases that look like attributes but aren't
+		$this->assertFalse($fb_product->is_woocommerce_attribute_summary('Time: 3:30 PM'));
+		$this->assertFalse($fb_product->is_woocommerce_attribute_summary('Ratio: 1:2:3'));
+		$this->assertFalse($fb_product->is_woocommerce_attribute_summary('URL: https://example.com'));
+	}
+
+	/**
+	 * Test is_woocommerce_attribute_summary with numeric attribute names
+	 */
+	public function test_is_woocommerce_attribute_summary_numeric_attributes() {
+		$fb_product = new \WC_Facebook_Product($this->product);
+
+		// These should be detected as numeric attribute summaries
+		$numeric_attributes = [
+			'1: kids',
+			'2: adults',
+			'123: test',
+			'1: value, 2: another',
+			'999: long_value_name',
+		];
+
+		foreach ($numeric_attributes as $attr) {
+			$this->assertTrue(
+				$fb_product->is_woocommerce_attribute_summary($attr),
+				"'{$attr}' should be detected as a numeric attribute summary"
+			);
+		}
+	}
+
+	/**
+	 * Test is_woocommerce_attribute_summary with WooCommerce prefix patterns
+	 */
+	public function test_is_woocommerce_attribute_summary_pa_prefix() {
+		$fb_product = new \WC_Facebook_Product($this->product);
+
+		// These should be detected as WooCommerce attribute patterns
+		$pa_attributes = [
+			'pa_color: red',
+			'pa_size: large',
+			'pa_material: cotton',
+			'pa_brand: nike',
+			'pa_123: value',
+		];
+
+		foreach ($pa_attributes as $attr) {
+			$this->assertTrue(
+				$fb_product->is_woocommerce_attribute_summary($attr),
+				"'{$attr}' should be detected as a pa_ attribute summary"
+			);
+		}
+	}
+
+	/**
+	 * Test is_woocommerce_attribute_summary with common Facebook attribute names
+	 */
+	public function test_is_woocommerce_attribute_summary_common_names() {
+		$fb_product = new \WC_Facebook_Product($this->product);
+
+		// These should be detected as common Facebook attribute patterns
+		$common_attributes = [
+			'size: large',
+			'color: blue',
+			'brand: nike',
+			'material: cotton',
+			'style: modern',
+			'type: shirt',
+			'gender: unisex',
+			'age_group: adult',
+			'SIZE: LARGE', // Test case insensitivity
+			'Color: Red', // Test mixed case
+		];
+
+		foreach ($common_attributes as $attr) {
+			$this->assertTrue(
+				$fb_product->is_woocommerce_attribute_summary($attr),
+				"'{$attr}' should be detected as a common attribute summary"
+			);
+		}
+	}
+
+	/**
+	 * Test is_woocommerce_attribute_summary with multiple attributes
+	 */
+	public function test_is_woocommerce_attribute_summary_multiple_attributes() {
+		$fb_product = new \WC_Facebook_Product($this->product);
+
+		// These should be detected as multi-attribute summaries
+		$multi_attributes = [
+			'Size: Large, Color: Blue',
+			'Brand: Nike, Size: XL, Color: Black',
+			'1: kids, 2: summer, 3: outdoor',
+			'pa_color: red, pa_size: medium',
+			'material: cotton, color: blue, size: large',
+			'type: shirt, gender: male, age_group: adult',
+		];
+
+		foreach ($multi_attributes as $attr) {
+			$this->assertTrue(
+				$fb_product->is_woocommerce_attribute_summary($attr),
+				"'{$attr}' should be detected as a multi-attribute summary"
+			);
+		}
+	}
+
+	/**
+	 * Test is_woocommerce_attribute_summary integration with get_fb_short_description
+	 */
+	public function test_is_woocommerce_attribute_summary_integration() {
+		// Create a variation product to test the integration
+		$variable_product = WC_Helper_Product::create_variation_product();
+		$variation = wc_get_product($variable_product->get_children()[0]);
+
+		// Create a mock post object with attribute summary in post_excerpt
+		$post_data = (object) [
+			'post_excerpt' => '1: kids, Color: Red',
+			'post_content' => 'Real product description',
+			'post_title' => 'Test Product'
+		];
+
+		// Mock the get_post_data method to return our test data
+		$fb_product = new class($variation) extends \WC_Facebook_Product {
+			private $mock_post_data;
+
+			public function set_mock_post_data($data) {
+				$this->mock_post_data = $data;
+			}
+
+			public function get_post_data() {
+				return $this->mock_post_data;
+			}
+		};
+
+		$fb_product->set_mock_post_data($post_data);
+
+		// Test that attribute summary is detected and skipped
+		$short_description = $fb_product->get_fb_short_description();
+		
+		// Should not return the attribute summary
+		$this->assertNotEquals('1: kids, Color: Red', $short_description);
+		
+		// Should return empty string since no valid short description found
+		$this->assertEquals('', $short_description);
+
+		// Test with a real description that shouldn't be detected as attribute summary
+		$post_data->post_excerpt = 'This is a real product description with features.';
+		$fb_product->set_mock_post_data($post_data);
+		
+		$short_description = $fb_product->get_fb_short_description();
+		$this->assertEquals('This is a real product description with features.', $short_description);
+	}
+
+	/**
+	 * Test is_woocommerce_attribute_summary with malformed patterns
+	 */
+	public function test_is_woocommerce_attribute_summary_malformed_patterns() {
+		$fb_product = new \WC_Facebook_Product($this->product);
+
+		// These should NOT be detected as attribute summaries
+		$malformed_patterns = [
+			': value', // Missing attribute name
+			'attribute :', // Missing value
+			'attribute: ', // Empty value
+			': ', // Both missing
+			'no colon here',
+			'multiple:colons:here',
+			'Space Before: Colon',
+			'attribute:value:extra', // Too many parts
+		];
+
+		foreach ($malformed_patterns as $pattern) {
+			$this->assertFalse(
+				$fb_product->is_woocommerce_attribute_summary($pattern),
+				"'{$pattern}' should NOT be detected as an attribute summary"
+			);
+		}
+	}
 }


### PR DESCRIPTION
## Description

This PR fixes a systematic issue where WooCommerce-generated attribute summaries (like "1: kids", "Size: Large, Color: Red") were appearing as Facebook short descriptions for variation products.

**Root Cause:** WooCommerce core automatically writes variation attribute summaries to the `post_excerpt` field, but the Facebook plugin assumes this field contains user-entered short descriptions. This architectural conflict caused attribute data to contaminate Facebook shorproduct descriptions.

**Solution:** Added `is_woocommerce_attribute_summary()` method to detect and filter out WooCommerce-generated attribute summaries from short descriptions, ensuring only genuine user-entered content is used for Facebook sync.

**Key Changes:**
- Added precise regex patterns to identify WooCommerce attribute summary formats
- Implemented smart exclusion logic for common sentence patterns
- Added comprehensive test coverage (8 test methods, 72 assertions)
- Enhanced `get_fb_short_description()` to skip auto-generated summaries

### Type of change

Please delete options that are not relevant

- [x] Fix (non-breaking change which fixes an issue)
- [ ] Add (non-breaking change which adds functionality)
- [ ] Tweak (non-breaking change which fixes code modularity, linting or phpcs issues)
- [ ] Break (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Changelog entry

Fix: Prevent WooCommerce attribute summaries from appearing as Facebook short descriptions for variation products

## Test Plan

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration.

**Automated Tests:**
- Added 8 comprehensive test methods covering all edge cases
- All tests pass: `./vendor/bin/phpunit tests/Unit/fbproductTest.php --filter test_is_woocommerce_attribute_summary`

**Manual Testing:**
1. Create a variable product with attributes like "1" (mapped to age_group)
2. Create variations with values like "kids", "adults"  
3. Verify WooCommerce writes "1: kids" to post_excerpt automatically
4. Confirm Facebook plugin now filters this out and returns empty short description
5. Test with legitimate short descriptions to ensure they still work

**Test Cases Covered:**
- Numeric attributes: `"1: kids"`, `"123: test"`
- WooCommerce prefixes: `"pa_color: red"`
- Common attributes: `"Size: Large, Color: Red"`
- Legitimate descriptions: `"This is a genuine product description"`
- Edge cases: empty values, whitespace, complex patterns

### Before

Variation products showed attribute summaries like "1: kids" as Facebook short descriptions, causing confusion and poor product presentation.

### After

Facebook short descriptions are now clean - only genuine user-entered descriptions are used, with WooCommerce attribute summaries properly filtered out.

