### PR TITLE
Run e2e tests on marketplace release of the plugin

### DIFF
--- a/.github/workflows/product-creation-tests.yml
+++ b/.github/workflows/product-creation-tests.yml
@@ -1,6 +1,13 @@
 name: Product Creation E2E Tests
 
 on:
+  # make this workflow reusable and take in marketplace version as input
+  workflow_call:
+    inputs:
+        marketplace-version:
+          description: 'Plugin version to test'
+          required: false
+          type: string
   pull_request:
     branches: [ main, master, develop ]
 
@@ -123,17 +130,25 @@ jobs:
       - name: Install Facebook for WooCommerce plugin
         run: |
           cd /tmp/wordpress
-          # Copy plugin files from the checked out repository root
-          cp -r ${{ github.workspace }} wp-content/plugins/facebook-for-woocommerce/
 
-          # Install Composer dependencies for the plugin
-          cd wp-content/plugins/facebook-for-woocommerce
-          if [ -f composer.json ]; then
-            composer install --no-dev --optimize-autoloader
+          # Use marketplace version if version is passed
+          if [[ -n ${{ inputs.marketplace-version }} ]]; then
+            echo "Installing Facebook for WooCommerce from wordpress.org marketplace"
+            wp plugin install facebook-for-woocommerce --allow-root --version=${{ inputs.marketplace-version }}
+          else
+            echo "Installing Facebook for WooCommerce from local workspace"
+            # Copy plugin files from the checked out repository root
+            cp -r ${{ github.workspace }} wp-content/plugins/facebook-for-woocommerce/
+
+            # Install Composer dependencies for the plugin
+            cd wp-content/plugins/facebook-for-woocommerce
+            if [ -f composer.json ]; then
+              composer install --no-dev --optimize-autoloader
+            fi
+            cd /tmp/wordpress
           fi
 
           # Activate the plugin
-          cd /tmp/wordpress
           wp plugin activate facebook-for-woocommerce --allow-root
 
       - name: Verify WordPress setup

--- a/.github/workflows/set-stable-tag.yml
+++ b/.github/workflows/set-stable-tag.yml
@@ -1,11 +1,14 @@
 name: Set Stable Tag
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
 
 jobs:
-  set-stable-tag:
+  set-stable-tag-prechecks:
     runs-on: ubuntu-latest
     environment: Deployment
+    outputs:
+      current-version: ${{ steps.package-version.outputs.current-version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -30,6 +33,19 @@ jobs:
             exit 1
           fi
 
+  #reusing existing workflow to run e2e tests, but on the marketplace version
+  e2e-tests-on-marketplace-version:
+    needs: set-stable-tag-prechecks
+    uses: ./.github/workflows/product-creation-tests.yml
+    with:
+      marketplace-version: ${{ needs.set-stable-tag-prechecks.outputs.current-version }}
+
+
+  set-stable-tag:
+    runs-on: ubuntu-latest
+    environment: Deployment
+    needs: [set-stable-tag-prechecks, e2e-tests-on-marketplace-version]
+    steps:
       - name: Install SVN
         run: sudo apt-get install subversion -y
 
@@ -38,18 +54,18 @@ jobs:
 
       - name: Validate SVN tag
         run: |
-          if [ ! -d "woocommerce_svn/tags/${{ steps.package-version.outputs.current-version}}" ]; then
+          if [ ! -d "woocommerce_svn/tags/${{ needs.set-stable-tag-prechecks.outputs.current-version }}" ]; then
             echo "❌ SVN tag directory does not exist" 1>&2
             exit 1
           fi
 
       - name: Update readme.txt
         env:
-          NEW_VERSION: ${{ steps.package-version.outputs.current-version}}
+          NEW_VERSION: ${{ needs.set-stable-tag-prechecks.outputs.current-version }}
         run: |
           cd woocommerce_svn
           sed -i -E "s/^(Stable tag:)[[:space:]]*[0-9.]+/\1 $NEW_VERSION/" "trunk/readme.txt"
-      
+
       - name: Commit to SVN
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
@@ -59,4 +75,4 @@ jobs:
           cat trunk/readme.txt
           svn status
           svn diff
-          svn commit -m "Update stable tag for version ${{ steps.package-version.outputs.current-version}}" --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --no-auth-cache --non-interactive
+          svn commit -m "Update stable tag for version ${{ needs.set-stable-tag-prechecks.outputs.current-version }}" --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --no-auth-cache --non-interactive


### PR DESCRIPTION
Added e2e tests on marketplace release of the plugin , in the set stable tag workflow

## Description

Updated an existing workflow - product-creation-tests.yml to become reusable , and take marketplace-version as input. If this input is passed, it pulls the marketplace version of the plugin to run the e2e tests against. Else, uses the local workspace.

Added a new job in set-stable-tag workflow , to run existing e2e tests on the marketplace version , using this reusable workflow.

### Type of change

- Add (non-breaking change which adds functionality)

## Checklist

- [✅] I have commented my code, particularly in hard-to-understand areas, if any.
- [✅] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [✅] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [✅] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [✅] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [✅] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Added e2e tests on marketplace release of the plugin 

## Test Plan

Since this change is part of the workflow that updates the stable tag on wordpress, I commented out those parts that actually updates the stable tag , and with the remaining steps of the workflow , triggered it manually in this run - https://github.com/immadhavv/facebook-for-woocommerce/actions/runs/16621028865 
It pulls in the marketplace version correctly and runs the e2e tests against it. 

The warning seen was from the existing workflow as you can see in any old example like this - https://github.com/facebook/facebook-for-woocommerce/actions/runs/16527319140/job/46743863604?pr=3531

## Screenshots

Not applicable.

### Before

### After
