### PR TITLE
Fix bug in plugin version upgrade/downgrade logic in Lifecycle

### DIFF
--- a/includes/Framework/Lifecycle.php
+++ b/includes/Framework/Lifecycle.php
@@ -95,9 +95,9 @@ class Lifecycle {
 				 */
 				do_action( 'wc_' . $this->get_plugin()->get_id() . '_updated', $installed_version );
 			}
-			// new version number
-			$this->set_installed_version( $plugin_version );
 		}
+		// new version number
+		$this->set_installed_version( $plugin_version );
 	}
 
 


### PR DESCRIPTION
## Description

While dogfooding PR #3534, I cam across a bug in Lifecycle plugin version update logic:

1. Install plugin version, let's say 3.5.5
2. Install plugin version higher (uprade), let's say 3.5.6
3. Install  plugin version lower (downgrade), let's say 3.5.5
4. Install any other version of the plugin and see that plugin still thinks it's on v 3.5.6 rather than 3.5.5

The bug was that we failed to update plugin version on downgrades which leads to bugs like not running functions that supposed to be run when we start installing newer version of the plugin after this. 

### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)


## Changelog entry

Fix bug in plugin version upgrade/downgrade logic in Lifecycle


## Test Plan

This was tested as part on a feature that required this fix PR #3534.
