### PR TITLE
Fix: Disable dropdown fields when 'Do not sync' is selected

### DIFF
--- a/assets/js/admin/products-admin.js
+++ b/assets/js/admin/products-admin.js
@@ -87,6 +87,9 @@ jQuery( document ).ready( function( $ ) {
 		function toggleFacebookSettings( enabled, $container ) {
 
 			$container.find( '.enable-if-sync-enabled' ).prop( 'disabled', ! enabled );
+			
+			// Also disable all select elements that don't have the enable-if-sync-enabled class
+			$container.find( 'select' ).not( '.enable-if-sync-enabled' ).prop( 'disabled', ! enabled );
 		}
 
 


### PR DESCRIPTION
## Description

This PR fixes a UI consistency issue in the Facebook for WooCommerce plugin where certain dropdown fields remained interactive when the "Do not sync" option was selected. Previously, when users selected "Do not sync" from the Facebook Sync dropdown, text input fields were properly disabled, but the Condition, Age Group, and Gender dropdown fields remained clickable and functional, creating an inconsistent user experience.

The fix modifies the `toggleFacebookSettings()` JavaScript function to ensure all form elements in the Facebook settings panel are consistently disabled when sync is turned off. This provides better visual feedback to users and prevents them from attempting to configure settings that won't be used.

**Related Issue:** Dropdown fields (Condition, Age Group, Gender) remain clickable when "Do not sync" is selected

**Root Cause:** The dropdown fields were missing the `enable-if-sync-enabled` CSS class that the JavaScript function uses to identify which elements to disable.

**Solution:** Enhanced the `toggleFacebookSettings()` function to target all `select` elements in the Facebook settings panel that don't already have the `enable-if-sync-enabled` class, ensuring comprehensive form state management.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [ ] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Changelog entry

Fix dropdown fields remaining clickable when "Do not sync" is selected

## Test Plan

**Steps to reproduce the original issue:**
1. Navigate to WooCommerce > Products and edit any product
2. Scroll to the Facebook tab in the product data section  
3. Set "Facebook Sync" to "Do not sync"
4. Observe that text input fields are disabled (grayed out)
5. Notice that dropdown fields (Condition, Age Group, Gender) remain clickable and interactive

**Steps to verify the fix:**
1. Follow steps 1-3 above
2. Verify that ALL form elements, including dropdown fields, are now disabled and non-interactive
3. Change "Facebook Sync" to any sync option (e.g., "Sync and show in catalog")
4. Verify that all form elements become enabled and interactive again
5. Test with both simple and variable products to ensure consistent behavior

**Test Configuration:**
- WordPress version: Latest
- WooCommerce version: Latest compatible version
- Browser tested: Chrome, Firefox, Safari
- Device: Desktop

## Screenshots

### Before
The Condition, Age Group, and Gender dropdowns remain clickable and show their normal styling even when "Do not sync" is selected, while text inputs are properly disabled.

### After  
All form elements, including dropdown fields, are consistently disabled with proper visual styling (grayed out) when "Do not sync" is selected, providing a cohesive user experience.