### PR TITLE
Show Facebook Product Video field for variable products

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1078,6 +1078,13 @@ class Admin {
 				);
 				?>
 			</div>
+
+			<?php
+			if ( $product && $product->is_type( 'variable' ) ) {
+				// Render video field only for variable products
+				$this->render_facebook_product_video_field( $video_urls );
+			}
+			?>
 			
 			
 			<div class='options_group hide_if_variable'>


### PR DESCRIPTION
## Description

This change addresses a regression introduced in [PR #3491](https://github.com/facebook/facebook-for-woocommerce/pull/3491), where the Facebook Product Video field was mistakenly placed inside a .hide_if_variable container, causing it to be hidden on variable products.

This update ensures the video field is conditionally rendered for variable products. It also resolves [Issue #3540](https://github.com/facebook/facebook-for-woocommerce/issues/3540), where users reported the video field missing from variable product edit pages.

### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have commented my code, particularly in hard-to-understand areas, if any.
- [X] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [X] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [X] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [X] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [X] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [X] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fix: Restored Facebook Product Video field visibility on variable products (regression from PR #3491)

## Test Plan

Tests Performed
Steps to Reproduce the Original Issue:

1. Go to Products → Edit a variable product.
2. Scroll down to the Facebook settings section.
3. Observe that the Facebook Product Video field is missing due to .hide_if_variable class hiding the container.

Steps to Verify the Fix:
Apply the changes from this PR.

1. Go to Products → Edit a variable product.
2. Confirm that the Facebook Product Video field is now visible.
3. Confirm the field still appears for simple or other product types.
4. Test media selection via the button to ensure it still opens the WordPress media library and saves the video URL correctly.

## Screenshots
### Before
<img width="1920" height="824" alt="Screenshot 2025-08-05 at 15 53 51" src="https://github.com/user-attachments/assets/bddd241f-cf58-40fd-a32d-9a8b8c103a63" />

### After
<img width="1920" height="825" alt="Screenshot 2025-08-05 at 15 53 25" src="https://github.com/user-attachments/assets/737e13f9-b26a-42e6-82b3-2f6dcc53c8af" />
