### PR TITLE
Automated secondary QA test to compare artifact from prepare-release and marketplace version

### DIFF
--- a/.github/workflows/final-qa-checks.yml
+++ b/.github/workflows/final-qa-checks.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Compare the two artifacts
         id: compare
         run: |
-          diff -r downloaded-plugin/facebook-for-woocommerce marketplace-version/facebook-for-woocommerce > diff_output.txt || DIFF_EXIT=$?
+          diff -r downloaded-plugin/facebook-for-woocommerce marketplace-version > diff_output.txt || DIFF_EXIT=$?
 
           # Check if there are differences
           if [ -s diff_output.txt ]; then

--- a/.github/workflows/final-qa-checks.yml
+++ b/.github/workflows/final-qa-checks.yml
@@ -39,23 +39,24 @@ jobs:
           # First check if the API returns any results
           response=$(gh api repos/${{ github.repository }}/actions/workflows/prepare-release.yml/runs -q '.')
 
-          # Check if we got a 404 error
-          if echo "$response" | grep -q '"status":"404"'; then
+          # Check if we got a 404 error or empty response
+          if echo "$response" | grep -q '"status":"404"' || [ -z "$response" ]; then
             echo "❌ No workflow runs found for prepare-release"
             exit 1
           fi
 
-          # Now filter for successful runs
+          # Now get latest run and check if it was successful
           # Skipping branch filtering because we may end up releasing from a branch other than main
-          run_id=$(echo "$response" | jq -r ".workflow_runs[] | select(.conclusion == \"success\" ) | .id" | head -n1)
+          latest_run=$(echo "$response" | jq '.workflow_runs[0]')
+          conclusion=$(echo "$latest_run" | jq -r '.conclusion')
 
-          if [ -z "$run_id" ]; then
-            echo "❌ No successful run found for prepare-release from main branch"
-            exit 1
+          if [ "$conclusion" == "success" ]; then
+            run_id=$(echo "$latest_run" | jq -r '.id')
+            echo "✅ Latest run was successful: $run_id"
+          else
+            echo "❌ Latest run was not successful: $conclusion"
+            run_id=""
           fi
-
-          echo "✅ Found run ID: $run_id"
-          echo "run_id=$run_id" >> $GITHUB_OUTPUT
 
       - name: Get artifact ID for facebook-for-woocommerce
         id: compare-artifacts
@@ -87,23 +88,17 @@ jobs:
 
 
       # Download marketplace version
-      - name: Install SVN
-        run: sudo apt-get install subversion -y
-
-      - name: Checkout SVN Repository
-        run: svn co https://plugins.svn.wordpress.org/facebook-for-woocommerce/ svn_repo --quiet --non-interactive
-
-      - name: Extract SVN trunk
+      - name: Download marketplace version
         run: |
-          mkdir -p marketplace-version
-          cp -r svn_repo/trunk/* marketplace-version/
-          echo "Downloaded SVN trunk to marketplace-version directory"
+         curl -L https://downloads.wordpress.org/plugin/facebook-for-woocommerce.zip -o marketplace.zip
+         unzip marketplace.zip -d marketplace-version
+         echo "Downloaded marketplace version of plugin to marketplace-version directory"
 
       # Compare the two artifacts
       - name: Compare the two artifacts
         id: compare
         run: |
-          diff -r downloaded-plugin/facebook-for-woocommerce marketplace-version > diff_output.txt || DIFF_EXIT=$?
+          diff -r downloaded-plugin/facebook-for-woocommerce marketplace-version/facebook-for-woocommerce > diff_output.txt || DIFF_EXIT=$?
 
           # Check if there are differences
           if [ -s diff_output.txt ]; then

--- a/.github/workflows/final-qa-checks.yml
+++ b/.github/workflows/final-qa-checks.yml
@@ -1,0 +1,136 @@
+name: Final QA Checks
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  compare-artifacts:
+    runs-on: ubuntu-latest
+    environment: Deployment
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get NPM Version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@v1.3.1
+
+      - name: Install Github CLI
+        run: |
+          # Install GitHub CLI
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt update
+          sudo apt install gh
+
+           # Authenticate with GitHub CLI
+          gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Get latest successful prepare-release run ID
+        id: get_run
+        run: |
+          version="${{ steps.package-version.outputs.current-version }}"
+          expected_branch="main"
+
+          # First check if the API returns any results
+          response=$(gh api repos/${{ github.repository }}/actions/workflows/prepare-release.yml/runs -q '.')
+
+          # Check if we got a 404 error
+          if echo "$response" | grep -q '"status":"404"'; then
+            echo "❌ No workflow runs found for prepare-release"
+            exit 1
+          fi
+
+          # Now filter for successful runs with the expected branch
+          run_id=$(echo "$response" | jq -r ".workflow_runs[] | select(.conclusion == \"success\" and .head_branch == \"$expected_branch\") | .id" | head -n1)
+
+          if [ -z "$run_id" ]; then
+            echo "❌ No successful run found for prepare-release from main branch"
+            exit 1
+          fi
+
+          echo "✅ Found run ID: $run_id"
+          echo "run_id=$run_id" >> $GITHUB_OUTPUT
+
+      - name: Get artifact ID for facebook-for-woocommerce
+        id: compare-artifacts
+        run: |
+          artifact_id=$(gh api \
+            repos/${{ github.repository }}/actions/runs/${{ steps.get_run.outputs.run_id }}/artifacts \
+            --jq '.artifacts[] | select(.name == "facebook-for-woocommerce") | .id')
+
+          if [ -z "$artifact_id" ]; then
+            echo "❌ Artifact not found"
+            exit 1
+          fi
+
+          echo "✅ Artifact ID: $artifact_id"
+          echo "artifact_id=$artifact_id" >> $GITHUB_OUTPUT
+
+      - name: Download ZIP using curl
+        run: |
+          curl -L \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -o plugin-release.zip \
+            https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${{ steps.compare-artifacts.outputs.artifact_id }}/zip
+
+      - name: Unzip
+        run: |
+          unzip plugin-release.zip -d extracted-plugin
+          unzip extracted-plugin/facebook-for-woocommerce.zip -d downloaded-plugin
+
+
+      # Download marketplace version
+      - name: Install SVN
+        run: sudo apt-get install subversion -y
+
+      - name: Checkout SVN Repository
+        run: svn co https://plugins.svn.wordpress.org/facebook-for-woocommerce/ svn_repo --quiet --non-interactive
+
+      - name: Extract SVN trunk
+        run: |
+          mkdir -p marketplace-version
+          cp -r svn_repo/trunk/* marketplace-version/
+          echo "Downloaded SVN trunk to marketplace-version directory"
+
+      # Compare the two artifacts
+      - name: Compare the two artifacts
+        id: compare
+        run: |
+          diff -r downloaded-plugin/facebook-for-woocommerce marketplace-version > diff_output.txt || DIFF_EXIT=$?
+
+          # Check if there are differences
+          if [ -s diff_output.txt ]; then
+            echo "match=false" >> $GITHUB_OUTPUT
+          else
+            echo "✅ No differences found between built plugin and marketplace version."
+            echo "match=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload diff output
+        if: steps.compare.outputs.match == 'false'
+        uses: actions/upload-artifact@master
+        continue-on-error: true
+        with:
+          name: plugin-diff-output
+          path: diff_output.txt
+          retention-days: 5
+
+      - name: Fail if differences found
+        if: steps.compare.outputs.match == 'false'
+        run: |
+          echo "❌ Differences found between plugin from prepare-release and marketplace version! See diff_output.txt artifact for details."
+          exit 1
+
+  #reusing existing workflow to run e2e tests, but on the marketplace version
+  e2e-tests-on-marketplace-version:
+    uses: ./.github/workflows/product-creation-tests.yml
+    needs: compare-artifacts
+    with:
+      use-marketplace-version: true

--- a/.github/workflows/final-qa-checks.yml
+++ b/.github/workflows/final-qa-checks.yml
@@ -36,27 +36,28 @@ jobs:
         run: |
           version="${{ steps.package-version.outputs.current-version }}"
 
-          # First check if the API returns any results
-          response=$(gh api repos/${{ github.repository }}/actions/workflows/prepare-release.yml/runs -q '.')
+          # Get the latest workflow run (only 1 result)
+          latest_run=$(gh api repos/${{ github.repository }}/actions/workflows/prepare-release.yml/runs \
+            --field per_page=1 \
+            --jq '.workflow_runs[0]')
 
-          # Check if we got a 404 error or empty response
-          if echo "$response" | grep -q '"status":"404"' || [ -z "$response" ]; then
+          # Check if the API returned anything
+          if [ -z "$latest_run" ]; then
             echo "❌ No workflow runs found for prepare-release"
             exit 1
           fi
 
-          # Now get latest run and check if it was successful
-          # Skipping branch filtering because we may end up releasing from a branch other than main
-          latest_run=$(echo "$response" | jq '.workflow_runs[0]')
+          # Check if the latest run was successful
           conclusion=$(echo "$latest_run" | jq -r '.conclusion')
-
           if [ "$conclusion" == "success" ]; then
             run_id=$(echo "$latest_run" | jq -r '.id')
             echo "✅ Latest run was successful: $run_id"
+            echo "run_id=$run_id" >> $GITHUB_OUTPUT
           else
             echo "❌ Latest run was not successful: $conclusion"
-            run_id=""
+            exit 1
           fi
+
 
       - name: Get artifact ID for facebook-for-woocommerce
         id: compare-artifacts

--- a/.github/workflows/final-qa-checks.yml
+++ b/.github/workflows/final-qa-checks.yml
@@ -95,6 +95,20 @@ jobs:
          unzip marketplace.zip -d marketplace-version
          echo "Downloaded marketplace version of plugin to marketplace-version directory"
 
+      - name: Check version of marketplace version pulled
+        run: |
+          stable_tag=$(grep -E '^Stable tag:' marketplace-version/facebook-for-woocommerce/readme.txt | awk -F': ' '{print $2}' | xargs)
+          echo "Stable tag from marketplace version is $stable_tag"
+
+          release_version="${{ steps.package-version.outputs.current-version }}"
+
+          if [[ "$stable_tag" != "$release_version" ]]; then
+            echo "❌ Version mismatch! Marketplace version is $stable_tag, but release version is $release_version"
+            exit 1
+          else
+            echo "✅ Version matches."
+          fi
+
       # Compare the two artifacts
       - name: Compare the two artifacts
         id: compare

--- a/.github/workflows/final-qa-checks.yml
+++ b/.github/workflows/final-qa-checks.yml
@@ -89,26 +89,18 @@ jobs:
 
 
       # Download marketplace version
-      - name: Download marketplace version
+      - name: Install SVN
+        run: sudo apt-get install subversion -y
+
+      - name: Checkout SVN Repository
+        run: svn co https://plugins.svn.wordpress.org/facebook-for-woocommerce/ svn_repo --quiet --non-interactive
+
+      - name: Extract SVN trunk
         run: |
-         curl -L https://downloads.wordpress.org/plugin/facebook-for-woocommerce.zip -o marketplace.zip
-         unzip marketplace.zip -d marketplace-version
-         echo "Downloaded marketplace version of plugin to marketplace-version directory"
+          mkdir -p marketplace-version
+          cp -r svn_repo/trunk/* marketplace-version/
+          echo "Downloaded SVN trunk to marketplace-version directory"
 
-      - name: Check version of marketplace version pulled
-        run: |
-          stable_tag=$(grep -m1 -E '^Stable tag:' marketplace-version/facebook-for-woocommerce/readme.txt | awk -F': ' '{print $2}' | tr -d '\n\r' | xargs)
-          echo "Stable tag from marketplace version is '$stable_tag'"
-
-          release_version="${{ steps.package-version.outputs.current-version }}"
-          echo "Release version is '$release_version'"
-
-          if [[ "$stable_tag" != "$release_version" ]]; then
-            echo "❌ Version mismatch! Marketplace version is $stable_tag, but release version is $release_version"
-            exit 1
-          else
-            echo "✅ Version matches."
-          fi
 
       # Compare the two artifacts
       - name: Compare the two artifacts

--- a/.github/workflows/final-qa-checks.yml
+++ b/.github/workflows/final-qa-checks.yml
@@ -35,7 +35,6 @@ jobs:
         id: get_run
         run: |
           version="${{ steps.package-version.outputs.current-version }}"
-          expected_branch="main"
 
           # First check if the API returns any results
           response=$(gh api repos/${{ github.repository }}/actions/workflows/prepare-release.yml/runs -q '.')
@@ -46,8 +45,9 @@ jobs:
             exit 1
           fi
 
-          # Now filter for successful runs with the expected branch
-          run_id=$(echo "$response" | jq -r ".workflow_runs[] | select(.conclusion == \"success\" and .head_branch == \"$expected_branch\") | .id" | head -n1)
+          # Now filter for successful runs
+          # Skipping branch filtering because we may end up releasing from a branch other than main
+          run_id=$(echo "$response" | jq -r ".workflow_runs[] | select(.conclusion == \"success\" ) | .id" | head -n1)
 
           if [ -z "$run_id" ]; then
             echo "❌ No successful run found for prepare-release from main branch"

--- a/.github/workflows/final-qa-checks.yml
+++ b/.github/workflows/final-qa-checks.yml
@@ -36,28 +36,28 @@ jobs:
         run: |
           version="${{ steps.package-version.outputs.current-version }}"
 
-          # Get the latest workflow run (only 1 result)
-          latest_run=$(gh api repos/${{ github.repository }}/actions/workflows/prepare-release.yml/runs \
-            --field per_page=1 \
-            --jq '.workflow_runs[0]')
+          # First check if the API returns any results
+          response=$(gh api repos/${{ github.repository }}/actions/workflows/prepare-release.yml/runs -q '.')
 
-          # Check if the API returned anything
-          if [ -z "$latest_run" ]; then
+          # Check if we got a 404 error or empty response
+          if echo "$response" | grep -q '"status":"404"' || [ -z "$response" ]; then
             echo "❌ No workflow runs found for prepare-release"
             exit 1
           fi
 
-          # Check if the latest run was successful
+          # Now get latest run and check if it was successful
+          # Skipping branch filtering because we may end up releasing from a branch other than main
+          latest_run=$(echo "$response" | jq '.workflow_runs[0]')
           conclusion=$(echo "$latest_run" | jq -r '.conclusion')
+
           if [ "$conclusion" == "success" ]; then
             run_id=$(echo "$latest_run" | jq -r '.id')
             echo "✅ Latest run was successful: $run_id"
             echo "run_id=$run_id" >> $GITHUB_OUTPUT
+
           else
             echo "❌ Latest run was not successful: $conclusion"
-            exit 1
           fi
-
 
       - name: Get artifact ID for facebook-for-woocommerce
         id: compare-artifacts

--- a/.github/workflows/final-qa-checks.yml
+++ b/.github/workflows/final-qa-checks.yml
@@ -97,10 +97,11 @@ jobs:
 
       - name: Check version of marketplace version pulled
         run: |
-          stable_tag=$(grep -E '^Stable tag:' marketplace-version/facebook-for-woocommerce/readme.txt | awk -F': ' '{print $2}' | xargs)
-          echo "Stable tag from marketplace version is $stable_tag"
+          stable_tag=$(grep -m1 -E '^Stable tag:' marketplace-version/facebook-for-woocommerce/readme.txt | awk -F': ' '{print $2}' | tr -d '\n\r' | xargs)
+          echo "Stable tag from marketplace version is '$stable_tag'"
 
           release_version="${{ steps.package-version.outputs.current-version }}"
+          echo "Release version is '$release_version'"
 
           if [[ "$stable_tag" != "$release_version" ]]; then
             echo "❌ Version mismatch! Marketplace version is $stable_tag, but release version is $release_version"

--- a/.github/workflows/set-stable-tag.yml
+++ b/.github/workflows/set-stable-tag.yml
@@ -3,14 +3,12 @@ name: Set Stable Tag
 on: workflow_dispatch
 
 jobs:
-  #reusing existing workflow to run e2e tests, but on the marketplace version
-  e2e-tests-on-marketplace-version:
-    uses: ./.github/workflows/product-creation-tests.yml
-    with:
-      use-marketplace-version: true
+  final-qa-checks:
+    uses: ./.github/workflows/final-qa-checks.yml
 
   set-stable-tag:
     runs-on: ubuntu-latest
+    needs: final-qa-checks
     environment: Deployment
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description
Add a new workflow (final-qa-checks) to compare artifact from prepare-release and marketplace version and verify if they are the same.

The workflow:
- Runs on "Deployment" environment
- Validates if the last prepare-release workflow had a successful run
- Gets the latest artifact ID from prepare-release and downloads it.
- Downloads marketplace version through SVN trunk.
- Compares the above two artifacts and aborts if there is a difference and uploads the diff_report
- If no difference, it further runs the e2e tests on marketplace version.
- This workflow is added as a dependency to set-stable-tag workflow

### Type of change

- Add (non-breaking change which adds functionality)
- 
## Checklist

- [✅] I have commented my code, particularly in hard-to-understand areas, if any.
- [✅] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [✅] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [✅] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [✅] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Automated secondary QA test to compare artifact from prepare-release and marketplace version

## Test Plan
Triggered prepare release to prepare a build artifact successfully - https://github.com/immadhavv/facebook-for-woocommerce/actions/runs/16790677076 

Test run of final-qa-checks workflow to compare the above artifact and marketplace version to check if there are any differences - https://github.com/immadhavv/facebook-for-woocommerce/actions/runs/16827002313/job/47665696257

As expected, it detects the differences and uploads a report of the same.

Negative test case - 
Then triggered a prepare release which fails - https://github.com/immadhavv/facebook-for-woocommerce/actions/runs/16802889561 

Test run of final-qa-checks workflow fails as expected - as it finds that the last prepare release run was not a success - https://github.com/immadhavv/facebook-for-woocommerce/actions/runs/16802919229/job/47588264244

## Screenshots
### Before
NA
### After
NA