### PR TITLE
Fix product set banner reappearance after dismissal 

### DIFF
--- a/assets/js/admin/plugin-rendering.js
+++ b/assets/js/admin/plugin-rendering.js
@@ -167,5 +167,21 @@ jQuery( document ).ready( function( $ ) {
             // No fail condition
         });
     });
+
+	// Product set banner dismissed callback 
+    $('.fb-product-set-banner').on('click', '.notice-dismiss', function(event) {
+		event.preventDefault();
+        $.post( facebook_for_woocommerce_plugin_update.ajax_url, {
+            action: 'wc_facebook_product_set_banner_closed',
+            nonce:  facebook_for_woocommerce_plugin_update.product_set_banner_closed_nonce,
+        }, function (response){
+            data = typeof response === "string" ? JSON.parse(response) : response;
+            if(data.success){
+                // No success condition
+            }   
+        }).fail(function(xhr) {
+            // No fail conditon
+        });
+    });
 });
 

--- a/includes/Admin/Enhanced_Settings.php
+++ b/includes/Admin/Enhanced_Settings.php
@@ -367,10 +367,10 @@ class Enhanced_Settings {
 
 	public function display_fb_product_sets_removed_banner() {
 		$dismissed = get_transient( 'fb_product_set_banner_dismissed' );
-		if ($dismissed) {
+		if ( $dismissed ) {
 			return; // Banner dismissed, do not show
 		}
-		
+
 		$screen = get_current_screen();
 		if ( ! $screen || ( 'marketing_page_wc-facebook' !== $screen->id && 'woocommerce_page_wc-facebook' !== $screen->id ) ) {
 			return;

--- a/includes/Admin/Enhanced_Settings.php
+++ b/includes/Admin/Enhanced_Settings.php
@@ -366,6 +366,11 @@ class Enhanced_Settings {
 	}
 
 	public function display_fb_product_sets_removed_banner() {
+		$dismissed = get_transient( 'fb_product_set_banner_dismissed' );
+		if ($dismissed) {
+			return; // Banner dismissed, do not show
+		}
+		
 		$screen = get_current_screen();
 		if ( ! $screen || ( 'marketing_page_wc-facebook' !== $screen->id && 'woocommerce_page_wc-facebook' !== $screen->id ) ) {
 			return;
@@ -373,7 +378,7 @@ class Enhanced_Settings {
 
 		$fb_catalog_id = facebook_for_woocommerce()->get_integration()->get_product_catalog_id();
 		?>
-			<div class="notice notice-info is-dismissible">
+			<div class="notice notice-info is-dismissible fb-product-set-banner">
 				<p><strong>The Product Sets tab has been removed</strong></p>
 				<p>The Product Sets tab is no longer available in the plugin. All product sets you created previously remain intact and accessible. Your WooCommerce categories will continue to sync automatically as product sets to your Meta catalog. To update synced sets, please <a href="edit-tags.php?taxonomy=product_cat&post_type=product" target="_blank" rel="noopener noreferrer">edit your categories in WooCommerce</a>. To view and manage your synced product sets, visit <a href="https://business.facebook.com/commerce/catalogs/<?php echo esc_attr( $fb_catalog_id ); ?>/sets" target="_blank" rel="noopener noreferrer">Commerce Manager</a>.</p>
 			</div>

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -344,6 +344,11 @@ class Settings {
 	}
 
 	public function display_fb_product_sets_removed_banner() {
+		$dismissed = get_transient( 'fb_product_set_banner_dismissed' );
+		if ($dismissed) {
+			return; // Banner dismissed, do not show
+		}
+		
 		$screen = get_current_screen();
 		if ( ! $screen || ( 'marketing_page_wc-facebook' !== $screen->id && 'woocommerce_page_wc-facebook' !== $screen->id ) ) {
 			return;
@@ -351,7 +356,7 @@ class Settings {
 
 		$fb_catalog_id = facebook_for_woocommerce()->get_integration()->get_product_catalog_id();
 		?>
-			<div class="notice notice-info is-dismissible">
+			<div class="notice notice-info is-dismissible fb-product-set-banner">
 				<p><strong>The Product Sets tab has been removed</strong></p>
 				<p>The Product Sets tab is no longer available in the plugin. All product sets you created previously remain intact and accessible. Your WooCommerce categories will continue to sync automatically as product sets to your Meta catalog. To update synced sets, please <a href="edit-tags.php?taxonomy=product_cat&post_type=product" target="_blank" rel="noopener noreferrer">edit your categories in WooCommerce</a>. To view and manage your synced product sets, visit <a href="https://business.facebook.com/commerce/catalogs/<?php echo esc_attr( $fb_catalog_id ); ?>/sets" target="_blank" rel="noopener noreferrer">Commerce Manager</a>.</p>
 			</div>

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -345,10 +345,10 @@ class Settings {
 
 	public function display_fb_product_sets_removed_banner() {
 		$dismissed = get_transient( 'fb_product_set_banner_dismissed' );
-		if ($dismissed) {
+		if ( $dismissed ) {
 			return; // Banner dismissed, do not show
 		}
-		
+
 		$screen = get_current_screen();
 		if ( ! $screen || ( 'marketing_page_wc-facebook' !== $screen->id && 'woocommerce_page_wc-facebook' !== $screen->id ) ) {
 			return;

--- a/includes/Handlers/PluginRender.php
+++ b/includes/Handlers/PluginRender.php
@@ -208,6 +208,11 @@ class PluginRender {
 		wp_send_json_success( 'Opted out successfully' );
 	}
 
+	public static function sync_all_clicked() {
+		update_option( self::MASTER_SYNC_OPT_OUT_TIME, '' );
+		wp_send_json_success( 'Synced all in successfully' );
+	}
+
 	public static function product_set_banner_closed() {
 		check_ajax_referer( self::ACTION_PRODUCT_SET_BANNER_CLOSED, 'nonce' );
 		set_transient( 'fb_product_set_banner_dismissed', true );

--- a/includes/Handlers/PluginRender.php
+++ b/includes/Handlers/PluginRender.php
@@ -41,6 +41,9 @@ class PluginRender {
 	/** @var string  action */
 	const ACTION_CLOSE_BANNER = 'wc_banner_close_action';
 
+	/** @var string  product set banner closed action */
+	const ACTION_PRODUCT_SET_BANNER_CLOSED = 'wc_facebook_product_set_banner_closed';
+
 	public function __construct( \WC_Facebookcommerce $plugin ) {
 		$this->plugin = $plugin;
 		$this->should_show_banners();
@@ -70,6 +73,7 @@ class PluginRender {
 				'opt_out_of_sync'                 => wp_create_nonce( self::ACTION_OPT_OUT_OF_SYNC ),
 				'banner_close'                    => wp_create_nonce( self::ACTION_CLOSE_BANNER ),
 				'sync_back_in'                    => wp_create_nonce( self::ACTION_SYNC_BACK_IN ),
+				'product_set_banner_closed_nonce' => wp_create_nonce( self::ACTION_PRODUCT_SET_BANNER_CLOSED ),
 				'sync_in_progress'                => Sync::is_sync_in_progress(),
 				'opt_out_confirmation_message'    => self::get_opt_out_modal_message(),
 				'opt_out_confirmation_buttons'    => self::get_opt_out_modal_buttons(),
@@ -89,6 +93,7 @@ class PluginRender {
 		add_action( 'wp_ajax_nopriv_wc_banner_post_update_close_action', [ __CLASS__,'reset_plugin_updated_successfully_banner' ] );
 		add_action( 'wp_ajax_wc_banner_post_update__master_sync_off_close_action', [ __CLASS__,  'reset_plugin_updated_successfully_but_master_sync_off_banner' ] );
 		add_action( 'wp_ajax_nopriv_wc_banner_post_update__master_sync_off_close_action', [ __CLASS__,'reset_plugin_updated_successfully_but_master_sync_off_banner' ] );
+		add_action( 'wp_ajax_wc_facebook_product_set_banner_closed', [ __CLASS__,  'product_set_banner_closed' ] );
 	}
 
 	public function should_show_banners() {
@@ -203,9 +208,9 @@ class PluginRender {
 		wp_send_json_success( 'Opted out successfully' );
 	}
 
-	public static function sync_all_clicked() {
-		update_option( self::MASTER_SYNC_OPT_OUT_TIME, '' );
-		wp_send_json_success( 'Synced all in successfully' );
+	public static function product_set_banner_closed() {
+		check_ajax_referer( self::ACTION_PRODUCT_SET_BANNER_CLOSED, 'nonce' );
+		set_transient( 'fb_product_set_banner_dismissed', true );
 	}
 
 	/**


### PR DESCRIPTION
## Description

The banner was introduced in #3534. 
This change fixes following bug:

**Repro steps:**
* User navigates to Marketing -> Facebook tab
* User clicks on 'X' in 'The Product Sets tab has been removed' banner
* User refreshes the page
    
**Actual Result:**          
Banner is displayed again despite user closing it.
    
**Expected Result:**            
The banner should not reappear after user has clicked 'X' OR if it should not be dismissible, the 'X' button should not be there.

 

### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)


## Changelog entry

Fixed product set banner reappearance after dismissal 


## Test Plan

Test scenario as per bug description above.

## Screenshots

### Before

https://github.com/user-attachments/assets/557e5304-a707-4ec0-bd19-d2dd46413621



### After

https://github.com/user-attachments/assets/847fd134-7166-4f95-87bd-6d8a9fb262ac

