### PR TITLE
Add Rollout Switches for Gating Multiple Variants

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -13,6 +13,7 @@ namespace WooCommerce\Facebook;
 use WooCommerce\Facebook\Admin\Enhanced_Catalog_Attribute_Fields;
 use WooCommerce\Facebook\Framework\Helper;
 use WooCommerce\Facebook\ProductAttributeMapper;
+use WooCommerce\Facebook\RolloutSwitches;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 
 defined( 'ABSPATH' ) || exit;
@@ -952,6 +953,11 @@ class Admin {
 	 * @param int   $variation_id The variation ID.
 	 */
 	private function render_facebook_product_images_field( $attachment_ids, $index, $variation_id ) {
+		// Check if multiple images feature is enabled via rollout switch
+		if ( ! facebook_for_woocommerce()->get_rollout_switches()->is_switch_enabled( RolloutSwitches::SWITCH_MULTIPLE_IMAGES_ENABLED ) ) {
+			return;
+		}
+
 		// attachment_ids is already an array of attachment IDs
 
 		// Output the form field for Facebook Product Images with a description tip
@@ -960,7 +966,7 @@ class Admin {
 			<!-- <label for="fb_product_images_<?php echo esc_attr( $index ); ?>"><?php esc_html_e( 'Facebook Product Images', 'facebook-for-woocommerce' ); ?></label> -->
 			<button type="button" class="button fb-open-images-library" data-variation-index="<?php echo esc_attr( $index ); ?>" data-variation-id="<?php echo esc_attr( $variation_id ); ?>"><?php esc_html_e( 'Choose Multiple Images', 'facebook-for-woocommerce' ); ?></button>
 			<span class="woocommerce-help-tip" data-tip="<?php esc_attr_e( 'Choose multiple product images that should be synced to the Facebook catalog and displayed for this variation.', 'facebook-for-woocommerce' ); ?>" tabindex="0"></span>
-			
+
 			<div id="fb_product_images_selected_thumbnails_<?php echo esc_attr( $index ); ?>" class="fb-product-images-thumbnails">
 			<?php
 			if ( ! empty( $attachment_ids ) && is_array( $attachment_ids ) ) {
@@ -1067,8 +1073,8 @@ class Admin {
 				$this->render_facebook_product_video_field( $video_urls );
 			}
 			?>
-			
-			
+
+
 			<div class='options_group hide_if_variable'>
 				<?php
 				echo '<div class="wp-editor-wrap">';
@@ -1147,7 +1153,7 @@ class Admin {
 				);
 				?>
 			</div>
-			
+
 			<div class='wc_facebook_commerce_fields'>
 				<p class="text-heading">
 					<span><?php echo esc_html( \WooCommerce\Facebook\Admin\Product_Categories::get_catalog_explanation_text() ); ?></span>
@@ -1447,12 +1453,12 @@ class Admin {
 			jQuery(document).ready(function($) {
 				// Remove any existing click handlers first
 				$('.facebook-metabox h3, .facebook-metabox .handlediv').off('click');
-				
+
 				// Add new click handler
 				$('.facebook-metabox h3, .facebook-metabox .handlediv').on('click', function(e) {
 					e.preventDefault(); // Prevent any default behavior
 					e.stopPropagation(); // Stop event bubbling
-					
+
 					var $metabox = $(this).closest('.facebook-metabox');
 					$metabox.toggleClass('closed');
 					$metabox.find('.wc-metabox-content').slideToggle();
@@ -1705,7 +1711,7 @@ class Admin {
 		?>
 		<script type="text/javascript">
 			jQuery(document).ready(function($) {
-				
+
 				// State object to track badge display status
 				var syncedBadgeState = {
 					material: false,
@@ -1724,30 +1730,30 @@ class Admin {
 
 				// Track which fields are currently synced
 				var syncedFields = {};
-				
+
 				// Helper function to clean up any previous sync UI elements
 				function cleanupSyncedField(fieldId) {
 					var $field = $(fieldId);
-					
+
 					// First find all multi-value displays and sync indicators in the parent wrapper
 					var $parent = $field.parent();
 					$parent.find('.multi-value-display').remove();
 					$parent.find('.sync-indicator').remove();
-					
+
 					// Also remove any elements directly after the field
 					$field.next('.multi-value-display').remove();
 					$field.next('.sync-indicator').remove();
-					
+
 					// Double check for elements with specific classes anywhere in the row
 					var $row = $parent.closest('.form-field, .form-row');
 					if ($row.length) {
 						$row.find('.multi-value-display').remove();
 						$row.find('.sync-indicator').remove();
 					}
-					
+
 					// Show the original field if it was hidden
 					$field.show();
-					
+
 					// Reset the field state
 					$field.prop('disabled', false).removeClass('synced-attribute');
 				}
@@ -1755,15 +1761,15 @@ class Admin {
 				// Function to completely reset a field to its default state
 				function resetFieldToDefault(fieldId) {
 					var $field = $(fieldId);
-					
+
 					// Skip if field doesn't exist
 					if (!$field.length) {
 						return;
 					}
-					
+
 					// Clean up UI elements
 					cleanupSyncedField(fieldId);
-					
+
 					// Reset select fields to first option (usually "Select")
 					if ($field.is('select')) {
 						// Check if the select has options
@@ -1771,7 +1777,7 @@ class Admin {
 							$field.val('').trigger('change');
 							$field.find('option:first').prop('selected', true);
 						}
-						
+
 						// Reset select2 if it's initialized
 						if ($field.hasClass('wc-enhanced-select') || $field.hasClass('select2-hidden-accessible')) {
 							try {
@@ -1824,7 +1830,7 @@ class Admin {
 							$siblings.not(':first').remove();
 						}
 					});
-					
+
 					$.ajax({
 						url: ajaxurl,
 						type: 'POST',
@@ -1851,20 +1857,20 @@ class Admin {
 								Object.keys(fields).forEach(function(key) {
 									var fieldId = '#' + fields[key];
 									var $field = $(fieldId);
-									
+
 									// Skip if field doesn't exist
 									if (!$field.length) {
 										return;
 									}
-									
+
 									// First thoroughly clean up any previous sync UI elements
 									cleanupSyncedField(fieldId);
-									
+
 									if (response.data && response.data[key]) {
 										// Field has a synced value
 										var syncedValue = response.data[key];
 										var isMultipleValues = syncedValue.includes(' | ');
-										
+
 										// For fields with multiple values or dropdown fields that need special handling
 										if (isMultipleValues || (key === 'age_group' || key === 'gender' || key === 'condition')) {
 											// First check if this is a standard dropdown or a multi-value field
@@ -1874,7 +1880,7 @@ class Admin {
 													// For dropdown fields with multiple values (used in variations)
 													// Disable the original dropdown
 													$field.prop('disabled', true).addClass('synced-attribute').hide();
-													
+
 													// Create a styled disabled field to show multiple values
 													var fieldWidth = $field.outerWidth();
 													var $multiDisplay = $('<input type="text" class="multi-value-display wc-enhanced-select" disabled>')
@@ -1897,7 +1903,7 @@ class Admin {
 															'cursor': 'not-allowed'
 														})
 														.insertAfter($field);
-													
+
 													// Always add the sync badge after the multi-value display
 													// Only if it doesn't already exist
 													if ($multiDisplay.next('.wc-attributes-icon').length === 0) {
@@ -1916,9 +1922,9 @@ class Admin {
 												$field.find('option').each(function() {
 													var optionValue = $(this).val();
 													var optionText = $(this).text();
-													
+
 													// Check both option value and option text (case-insensitive)
-													if (optionValue === syncedValue || 
+													if (optionValue === syncedValue ||
 														optionText.toLowerCase() === syncedValue.toLowerCase() ||
 														optionValue.toLowerCase() === syncedValue.toLowerCase()) {
 														hasMatchingOption = true;
@@ -1926,7 +1932,7 @@ class Admin {
 														return false; // break loop
 													}
 												});
-												
+
 												if (hasMatchingOption) {
 													$field.val(matchingOptionValue) // Use the correct option value
 														.prop('disabled', true)
@@ -1936,7 +1942,7 @@ class Admin {
 															'background-color': '#f0f0f1',
 															'color': 'rgba(44, 51, 56, .5)'
 														});
-													
+
 													// Add the sync badge if it doesn't exist
 													if ($field.next('.wc-attributes-icon').length === 0) {
 														$field.after('<span class="sync-indicator wc-attributes-icon" data-tip="Synced from the Attributes tab." style="margin-left: 4px;"><span class="sync-tooltip">Synced from the Attributes tab.</span></span>');
@@ -1944,12 +1950,12 @@ class Admin {
 												} else if (isMultipleValues) {
 													// This is a multi-value field but not a dropdown
 													$field.prop('disabled', true).addClass('synced-attribute').hide();
-													
+
 													// Create a styled disabled field to show multiple values
 													var $multiDisplay = $('<input type="text" class="multi-value-display" disabled>')
 														.val(syncedValue)
 														.insertAfter($field);
-													
+
 													// Add the sync badge
 													$multiDisplay.after('<span class="wc-attributes-icon" data-tip="Synced from product attributes"></span>');
 												}
@@ -1964,7 +1970,7 @@ class Admin {
 														'color': 'rgba(44, 51, 56, .5)'
 													})
 													.show();
-													
+
 												// Add the sync badge if it doesn't exist
 												if ($field.next('.wc-attributes-icon').length === 0) {
 													$field.after('<span class="sync-indicator wc-attributes-icon" data-tip="Synced from the Attributes tab." style="margin-left: 4px;"><span class="sync-tooltip">Synced from the Attributes tab.</span></span>');
@@ -1980,7 +1986,7 @@ class Admin {
 														'color': 'rgba(44, 51, 56, .5)'
 													})
 													.show();
-													
+
 												// Add the sync badge if it doesn't exist
 												if ($field.next('.wc-attributes-icon').length === 0) {
 													$field.after('<span class="sync-indicator wc-attributes-icon" data-tip="Synced from the Attributes tab." style="margin-left: 4px;"><span class="sync-tooltip">Synced from the Attributes tab.</span></span>');
@@ -1992,18 +1998,18 @@ class Admin {
 												.prop('disabled', true)
 												.addClass('synced-attribute')
 												.css({
-													'cursor': 'not-allowed', 
+													'cursor': 'not-allowed',
 													'background-color': '#f0f0f1',
 													'color': 'rgba(44, 51, 56, .5)'
 												})
 												.show();
-											
+
 											// Add the sync badge if it doesn't exist
 											if ($field.next('.wc-attributes-icon').length === 0) {
 												$field.after('<span class="sync-indicator wc-attributes-icon" data-tip="Synced from the Attributes tab." style="margin-left: 4px;"><span class="sync-tooltip">Synced from the Attributes tab.</span></span>');
 											}
 										}
-										
+
 										// Mark this field as synced
 										syncedFields[key] = true;
 										syncedBadgeState[key] = true;
@@ -2012,14 +2018,14 @@ class Admin {
 										if (syncedFields[key]) {
 											// Reset synced state
 											syncedFields[key] = false;
-											
+
 											// Completely reset the field value
 											resetFieldToDefault(fieldId);
 										} else if (manualValues[key] && !$field.val()) {
 											// Restore manual value if field is empty
 											$field.val(manualValues[key]);
 										}
-										
+
 										// Reset the badge state
 										syncedBadgeState[key] = false;
 									}
@@ -2042,7 +2048,7 @@ class Admin {
 						'gender': '<?php echo esc_js( \WC_Facebook_Product::FB_GENDER ); ?>',
 						'condition': '<?php echo esc_js( \WC_Facebook_Product::FB_PRODUCT_CONDITION ); ?>'
 					};
-					
+
 					Object.keys(fields).forEach(function(key) {
 						var fieldId = '#' + fields[key];
 						resetFieldToDefault(fieldId);
@@ -2080,7 +2086,7 @@ class Admin {
 					// Store information about which row was removed
 					var $removedRow = $(this).closest('tr');
 					var attributeName = $removedRow.find('td.attribute_name').text().trim().toLowerCase();
-					
+
 					// Wait a brief moment for WooCommerce to remove the attribute
 					setTimeout(function() {
 						// Clean up any extra UI elements that might be leftover
@@ -2088,22 +2094,22 @@ class Admin {
 							// For each multi-value display, check if there's a corresponding select field
 							var $this = $(this);
 							var $select = $this.prev('select');
-							
+
 							// If no select exists or the select has no options, remove the multi-value display
 							if ($select.length === 0 || $select.find('option').length <= 1) {
 								$this.next('.sync-indicator').remove();
 								$this.remove();
 							}
 						});
-						
+
 						// Only trigger if we're on the Facebook tab
 						if ($('.fb_commerce_tab').hasClass('active')) {
 							// First reset all fields to ensure dropdowns are cleared
 							resetAllFields();
-							
+
 							// Then perform a complete cleanup of all UI elements
 							$('.woocommerce_options_panel').find('.multi-value-display, .sync-indicator').remove();
-							
+
 							// Re-check all select fields for emptiness
 							$('.woocommerce_options_panel select').each(function() {
 								if ($(this).find('option').length <= 1) {
@@ -2113,7 +2119,7 @@ class Admin {
 									$(this).show().prop('disabled', false).removeClass('synced-attribute');
 								}
 							});
-							
+
 							// Then sync to update based on remaining attributes
 							syncFacebookAttributes();
 						}
@@ -2125,46 +2131,46 @@ class Admin {
 					// Store reference to the button and attributes panel
 					var $button = $(this);
 					var $attributesPanel = $('#product_attributes');
-					
+
 					// Wait a brief moment for WooCommerce to save the attributes
 					setTimeout(function() {
 						// Perform cleanup of any stray elements across the entire form
 						$('.woocommerce_options_panel').find('.multi-value-display, .sync-indicator').each(function() {
 							var $element = $(this);
 							var $prevSelect = $element.prev('select');
-							
+
 							// If this is a multi-value display without a valid select, remove it
-							if ($element.hasClass('multi-value-display') && 
+							if ($element.hasClass('multi-value-display') &&
 								(!$prevSelect.length || $prevSelect.find('option').length <= 1 || !$prevSelect.is(':visible'))) {
 								$element.next('.sync-indicator').remove();
 								$element.remove();
 							}
-							
+
 							// If this is a sync indicator without a valid field before it, remove it
-							if ($element.hasClass('sync-indicator') && 
-								(!$element.prev().length || 
+							if ($element.hasClass('sync-indicator') &&
+								(!$element.prev().length ||
 								($element.prev().is('select') && $element.prev().find('option').length <= 1))) {
 								$element.remove();
 							}
 						});
-						
+
 						// Re-check all select fields
 						$('.woocommerce_options_panel select').each(function() {
 							var $select = $(this);
-							
+
 							// Check for empty or nearly empty selects
 							if ($select.find('option').length <= 1) {
 								// Clean up any associated UI elements
 								$select.next('.multi-value-display').next('.sync-indicator').remove();
 								$select.next('.multi-value-display').remove();
 								$select.next('.sync-indicator').remove();
-								
+
 								// Reset the select
 								$select.val('').prop('selected', true)
 									.show().prop('disabled', false).removeClass('synced-attribute');
 							}
 						});
-						
+
 						// Only trigger if we're on the Facebook tab
 						if ($('.fb_commerce_tab').hasClass('active')) {
 							syncFacebookAttributes();
@@ -2176,17 +2182,17 @@ class Admin {
 				function cleanupAllUIElements() {
 					// Remove all multi-value displays and sync indicators
 					$('.woocommerce_options_panel').find('.multi-value-display, .sync-indicator').remove();
-					
+
 					// Reset all select fields
 					$('.woocommerce_options_panel select').each(function() {
 						var $select = $(this);
 						$select.show().prop('disabled', false).removeClass('synced-attribute');
-						
+
 						// If the select has no options ensure it's properly reset
 						if ($select.find('option').length < 1) {
 							$select.val('').prop('selected', true);
 						}
-						
+
 						// Reset select2 if applicable
 						if ($select.hasClass('wc-enhanced-select') || $select.hasClass('select2-hidden-accessible')) {
 							try {
@@ -2196,7 +2202,7 @@ class Admin {
 							}
 						}
 					});
-					
+
 					// Reset all text inputs styling
 					$('.woocommerce_options_panel input[type="text"]').each(function() {
 						var $input = $(this);
@@ -2211,7 +2217,7 @@ class Admin {
 				// Original tab click handler
 				$('.product_data_tabs li').on('click', function() {
 					var tabClass = $(this).attr('class');
-					
+
 					// If we're clicking on a tab that isn't the Facebook tab,
 					// clean up all UI elements first
 					if (!tabClass || !tabClass.includes('fb_commerce_tab')) {
@@ -2238,7 +2244,7 @@ class Admin {
 					if (key === 'age_group') fieldId = '#' + '<?php echo esc_js( \WC_Facebook_Product::FB_AGE_GROUP ); ?>';
 					if (key === 'gender') fieldId = '#' + '<?php echo esc_js( \WC_Facebook_Product::FB_GENDER ); ?>';
 					if (key === 'condition') fieldId = '#' + '<?php echo esc_js( \WC_Facebook_Product::FB_PRODUCT_CONDITION ); ?>';
-					
+
 					var $field = $(fieldId);
 					var value = $field.val();
 					if (value && !$field.hasClass('synced-attribute')) {

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -954,7 +954,8 @@ class Admin {
 	 */
 	private function render_facebook_product_images_field( $attachment_ids, $index, $variation_id ) {
 		// Check if multiple images feature is enabled via rollout switch
-		if ( ! facebook_for_woocommerce()->get_rollout_switches()->is_switch_enabled( RolloutSwitches::SWITCH_MULTIPLE_IMAGES_ENABLED ) ) {
+		$plugin = isset( $GLOBALS['wc_facebook_commerce'] ) ? $GLOBALS['wc_facebook_commerce'] : facebook_for_woocommerce();
+		if ( ! $plugin || ! $plugin->get_rollout_switches()->is_switch_enabled( RolloutSwitches::SWITCH_MULTIPLE_IMAGES_ENABLED ) ) {
 			return;
 		}
 

--- a/includes/RolloutSwitches.php
+++ b/includes/RolloutSwitches.php
@@ -29,6 +29,7 @@ class RolloutSwitches {
 	public const SWITCH_PRODUCT_SETS_SYNC_ENABLED     = 'product_sets_sync_enabled';
 	public const SWITCH_WOO_ALL_PRODUCTS_SYNC_ENABLED = 'woo_all_products_sync_enabled';
 	public const SWITCH_OFFER_MANAGEMENT_ENABLED      = 'offer_management_enabled';
+	public const SWITCH_MULTIPLE_IMAGES_ENABLED       = 'woo_variant_multiple_images_enabled';
 	private const SETTINGS_KEY                        = 'wc_facebook_for_woocommerce_rollout_switches';
 
 	private const ACTIVE_SWITCHES = array(
@@ -37,6 +38,7 @@ class RolloutSwitches {
 		self::SWITCH_PRODUCT_SETS_SYNC_ENABLED,
 		self::SWITCH_WOO_ALL_PRODUCTS_SYNC_ENABLED,
 		self::SWITCH_OFFER_MANAGEMENT_ENABLED,
+		self::SWITCH_MULTIPLE_IMAGES_ENABLED,
 	);
 
 	public function __construct( \WC_Facebookcommerce $plugin ) {

--- a/tests/Unit/AdminTest.php
+++ b/tests/Unit/AdminTest.php
@@ -301,6 +301,27 @@ class AdminTest extends \WP_UnitTestCase {
      * Test render_facebook_product_images_field with empty attachment IDs
      */
     public function test_render_facebook_product_images_field_empty() {
+        // Mock the rollout switches to enable multiple images feature
+        $plugin = $this->getMockBuilder(\WC_Facebookcommerce::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $rollout_switches = $this->getMockBuilder(\WooCommerce\Facebook\RolloutSwitches::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $rollout_switches->expects($this->once())
+            ->method('is_switch_enabled')
+            ->with(\WooCommerce\Facebook\RolloutSwitches::SWITCH_MULTIPLE_IMAGES_ENABLED)
+            ->willReturn(true);
+
+        $plugin->expects($this->once())
+            ->method('get_rollout_switches')
+            ->willReturn($rollout_switches);
+
+        // Mock the global function
+        $GLOBALS['wc_facebook_commerce'] = $plugin;
+
         $attachment_ids = [];
         $index = 1;
         $variation_id = 888;
@@ -321,6 +342,9 @@ class AdminTest extends \WP_UnitTestCase {
         $this->assertStringContainsString('data-variation-id="888"', $output);
         $this->assertStringContainsString('variable_fb_product_images1', $output);
         $this->assertStringContainsString('value=""', $output);
+
+        // Clean up
+        unset($GLOBALS['wc_facebook_commerce']);
     }
 
     /**

--- a/tests/Unit/RolloutSwitchesTest.php
+++ b/tests/Unit/RolloutSwitchesTest.php
@@ -129,7 +129,7 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 	public function test_multiple_images_switch_constant_exists() {
 		// Test that the new multiple images switch constant exists
 		$this->assertTrue(defined('WooCommerce\Facebook\RolloutSwitches::SWITCH_MULTIPLE_IMAGES_ENABLED'));
-		$this->assertEquals('multiple_images_enabled', RolloutSwitches::SWITCH_MULTIPLE_IMAGES_ENABLED);
+		$this->assertEquals('woo_variant_multiple_images_enabled', RolloutSwitches::SWITCH_MULTIPLE_IMAGES_ENABLED);
 	}
 
 	public function test_multiple_images_switch_in_active_switches() {


### PR DESCRIPTION
## Description

Added rollout switch functionality to control the multiple images feature for product variations in Facebook for WooCommerce. This change implements a new rollout switch `SWITCH_MULTIPLE_IMAGES_ENABLED` that allows Meta to control the visibility and availability of the multiple images feature that was previously added in D79719919.

**Motivation**: The multiple images functionality for product variations needs to be rolled out in a controlled manner to ensure stability and allow for gradual deployment across merchants.

**Changes made**:
- Added `SWITCH_MULTIPLE_IMAGES_ENABLED` constant to `RolloutSwitches.php`
- Modified `render_facebook_product_images_field()` method in `Admin.php` to check rollout switch before rendering UI
- Added comprehensive test coverage for both rollout switch functionality and UI behavior

**Dependencies**: None - this builds on existing rollout switch infrastructure.

### Type of change

- Add (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Changelog entry

Add rollout switch for multiple images feature in product variations

## Test Plan

**Unit Tests**:
1. Run `RolloutSwitchesTest.php` to verify:
   - New switch constant exists and has correct value
   - Switch is included in active switches list
   - Switch behavior when enabled/disabled
2. Run `AdminTest.php` to verify:
   - Multiple images UI renders when rollout switch is enabled
   - No UI output when rollout switch is disabled

**Manual Testing**:
1. **When rollout switch is ENABLED**:
   - Navigate to WooCommerce > Products > Edit a variable product
   - Go to a product variation
   - Verify "Choose Multiple Images" button appears when "Use multiple images" is selected
   - Verify multiple images functionality works as expected

2. **When rollout switch is DISABLED**:
   - Same navigation as above
   - Verify "Choose Multiple Images" option is not visible
   - Verify no multiple images UI elements are rendered

**Test Configuration**:
- WordPress with WooCommerce installed
- Facebook for WooCommerce plugin active
- Variable products with variations created
- Mock rollout switch responses for testing

## Screenshots

### Before
Multiple images feature was always visible regardless of rollout switch configuration.

### After  
Multiple images feature is now controlled by the `SWITCH_MULTIPLE_IMAGES_ENABLED` rollout switch and only appears when the switch is enabled via Meta's rollout system.
