### PR TITLE
chore: add multiple images functionality tests with rollout switch in…

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1377,6 +1377,19 @@ class Admin {
 					)
 				);
 
+				// Build image source options
+				$image_source_options = array(
+					Products::PRODUCT_IMAGE_SOURCE_PRODUCT => __( 'Use variation image', 'facebook-for-woocommerce' ),
+					Products::PRODUCT_IMAGE_SOURCE_PARENT_PRODUCT => __( 'Use parent image', 'facebook-for-woocommerce' ),
+					Products::PRODUCT_IMAGE_SOURCE_CUSTOM  => __( 'Use custom image', 'facebook-for-woocommerce' ),
+				);
+
+				// Add multiple images option only if rollout switch is enabled
+				$plugin = isset( $GLOBALS['wc_facebook_commerce'] ) ? $GLOBALS['wc_facebook_commerce'] : facebook_for_woocommerce();
+				if ( $plugin && $plugin->get_rollout_switches()->is_switch_enabled( RolloutSwitches::SWITCH_MULTIPLE_IMAGES_ENABLED ) ) {
+					$image_source_options[ Products::PRODUCT_IMAGE_SOURCE_MULTIPLE ] = __( 'Use multiple images', 'facebook-for-woocommerce' );
+				}
+
 				woocommerce_wp_radio(
 					array(
 						'id'            => "variable_fb_product_image_source$index",
@@ -1384,12 +1397,7 @@ class Admin {
 						'label'         => __( 'Facebook Product Image', 'facebook-for-woocommerce' ),
 						'desc_tip'      => true,
 						'description'   => __( 'Choose the product image that should be synced to the Facebook catalog and displayed for this product.', 'facebook-for-woocommerce' ),
-						'options'       => array(
-							Products::PRODUCT_IMAGE_SOURCE_PRODUCT => __( 'Use variation image', 'facebook-for-woocommerce' ),
-							Products::PRODUCT_IMAGE_SOURCE_PARENT_PRODUCT => __( 'Use parent image', 'facebook-for-woocommerce' ),
-							Products::PRODUCT_IMAGE_SOURCE_CUSTOM  => __( 'Use custom image', 'facebook-for-woocommerce' ),
-							Products::PRODUCT_IMAGE_SOURCE_MULTIPLE => __( 'Use multiple images', 'facebook-for-woocommerce' ),
-						),
+						'options'       => $image_source_options,
 						'value'         => $image_source ? $image_source : Products::PRODUCT_IMAGE_SOURCE_PRODUCT,
 						'class'         => 'enable-if-sync-enabled js-fb-product-image-source',
 						'wrapper_class' => 'fb-product-image-source-field',

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -965,7 +965,7 @@ class Admin {
 		?>
 		<p class="form-field product-image-source-field show-if-product-image-source-<?php echo esc_attr( Products::PRODUCT_IMAGE_SOURCE_MULTIPLE ); ?>">
 			<!-- <label for="fb_product_images_<?php echo esc_attr( $index ); ?>"><?php esc_html_e( 'Facebook Product Images', 'facebook-for-woocommerce' ); ?></label> -->
-			<button type="button" class="button fb-open-images-library" data-variation-index="<?php echo esc_attr( $index ); ?>" data-variation-id="<?php echo esc_attr( $variation_id ); ?>"><?php esc_html_e( 'Choose Multiple Images', 'facebook-for-woocommerce' ); ?></button>
+			<button type="button" class="button fb-open-images-library" data-variation-index="<?php echo esc_attr( $index ); ?>" data-variation-id="<?php echo esc_attr( $variation_id ); ?>"><?php esc_html_e( 'Add Multiple Images', 'facebook-for-woocommerce' ); ?></button>
 			<span class="woocommerce-help-tip" data-tip="<?php esc_attr_e( 'Choose multiple product images that should be synced to the Facebook catalog and displayed for this variation.', 'facebook-for-woocommerce' ); ?>" tabindex="0"></span>
 
 			<div id="fb_product_images_selected_thumbnails_<?php echo esc_attr( $index ); ?>" class="fb-product-images-thumbnails">
@@ -1387,7 +1387,7 @@ class Admin {
 				// Add multiple images option only if rollout switch is enabled
 				$plugin = isset( $GLOBALS['wc_facebook_commerce'] ) ? $GLOBALS['wc_facebook_commerce'] : facebook_for_woocommerce();
 				if ( $plugin && $plugin->get_rollout_switches()->is_switch_enabled( RolloutSwitches::SWITCH_MULTIPLE_IMAGES_ENABLED ) ) {
-					$image_source_options[ Products::PRODUCT_IMAGE_SOURCE_MULTIPLE ] = __( 'Use multiple images', 'facebook-for-woocommerce' );
+					$image_source_options[ Products::PRODUCT_IMAGE_SOURCE_MULTIPLE ] = __( 'Add multiple images', 'facebook-for-woocommerce' );
 				}
 
 				woocommerce_wp_radio(

--- a/tests/Unit/AdminTest.php
+++ b/tests/Unit/AdminTest.php
@@ -238,7 +238,7 @@ class AdminTest extends \WP_UnitTestCase {
         $output = ob_get_clean();
 
         // Verify the HTML contains expected elements
-        $this->assertStringContainsString('Choose Multiple Images', $output);
+        $this->assertStringContainsString('Add Multiple Images', $output);
         $this->assertStringContainsString('data-variation-index="0"', $output);
         $this->assertStringContainsString('data-variation-id="999"', $output);
         $this->assertStringContainsString('fb-product-images-thumbnails', $output);
@@ -291,7 +291,7 @@ class AdminTest extends \WP_UnitTestCase {
 
         // Verify no output is generated when rollout switch is disabled
         $this->assertEmpty($output);
-        $this->assertStringNotContainsString('Choose Multiple Images', $output);
+        $this->assertStringNotContainsString('Add Multiple Images', $output);
         $this->assertStringNotContainsString('fb-product-images-thumbnails', $output);
 
         // Clean up
@@ -338,7 +338,7 @@ class AdminTest extends \WP_UnitTestCase {
         $output = ob_get_clean();
 
         // Verify the HTML contains expected elements for empty state
-        $this->assertStringContainsString('Choose Multiple Images', $output);
+        $this->assertStringContainsString('Add Multiple Images', $output);
         $this->assertStringContainsString('data-variation-index="1"', $output);
         $this->assertStringContainsString('data-variation-id="888"', $output);
         $this->assertStringContainsString('variable_fb_product_images1', $output);
@@ -722,11 +722,11 @@ class AdminTest extends \WP_UnitTestCase {
         $this->admin->add_product_variation_edit_fields(0, array(), $variation);
         $output_enabled = ob_get_clean();
 
-        // Verify that "Use multiple images" option is not present when switch is disabled
-        $this->assertStringNotContainsString('Use multiple images', $output_disabled);
+        // Verify that "Add multiple images" option is not present when switch is disabled
+        $this->assertStringNotContainsString('Add multiple images', $output_disabled);
 
-        // Verify that "Use multiple images" option is present when switch is enabled
-        $this->assertStringContainsString('Use multiple images', $output_enabled);
+        // Verify that "Add multiple images" option is present when switch is enabled
+        $this->assertStringContainsString('Add multiple images', $output_enabled);
 
         // Clean up
         unset($GLOBALS['wc_facebook_commerce']);

--- a/tests/js/multiple-images.test.js
+++ b/tests/js/multiple-images.test.js
@@ -278,7 +278,7 @@ describe('Multiple Images Functionality', function() {
             
             // Mock media frame creation parameters
             const mediaFrameOptions = {
-                title: 'Choose Multiple Images',
+                title: 'Add Multiple Images',
                 button: {
                     text: 'Select Images'
                 },
@@ -290,7 +290,7 @@ describe('Multiple Images Functionality', function() {
             
             expect(mediaFrameOptions.multiple).toBe(true);
             expect(mediaFrameOptions.library.type).toBe('image');
-            expect(mediaFrameOptions.title).toBe('Choose Multiple Images');
+            expect(mediaFrameOptions.title).toBe('Add Multiple Images');
         });
         
         it('should pre-select existing images in media library', function() {
@@ -367,7 +367,7 @@ describe('Multiple Images Functionality', function() {
 
     describe('Event Handling', function() {
         
-        it('should bind click event to "Choose Multiple Images" button', function() {
+        it('should bind click event to "Add Multiple Images" button', function() {
             const mockDocument = {
                 on: jest.fn()
             };


### PR DESCRIPTION
## Description

This PR adds gating for the use multiple images options and comprehensive test coverage for the multiple images functionality with rollout switch gating. The tests ensure that the multiple images feature is properly controlled by the rollout switch and validates all aspects of the functionality including field rendering, data persistence, and user interaction scenarios.

**Key changes:**
- Added test coverage for `render_facebook_product_images_field` method with rollout switch enabled/disabled states
- Added comprehensive tests for multiple images data validation, persistence, and edge cases
- Added tests to verify rollout switch properly controls multiple images option visibility
- Improved test maintainability by replacing magic number '123' with descriptive `TEST_MATERIAL_ATTRIBUTE_ID` constant
- Fixed anonymous class constant access issue in test setup

**Motivation:** 
The multiple images feature was missing proper test coverage, particularly around the rollout switch integration. This could lead to regressions or unexpected behavior when the feature is enabled/disabled via rollout switches.

### Type of change

- Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Changelog entry

Added comprehensive test coverage for multiple images functionality with rollout switch integration.

## Test Plan

**Unit Tests Added:**
1. `test_render_facebook_product_images_field()` - Tests field rendering when rollout switch is enabled
2. `test_render_facebook_product_images_field_rollout_switch_disabled()` - Tests no output when rollout switch is disabled
3. `test_render_facebook_product_images_field_empty()` - Tests field rendering with empty attachment IDs
4. `test_multiple_images_option_controlled_by_rollout_switch()` - Tests rollout switch controls option visibility
5. Additional tests for data validation, persistence, and edge cases

**Test Execution:**
```bash
# Run the specific test class
vendor/bin/phpunit tests/Unit/AdminTest.php

# Run all tests to ensure no regressions
vendor/bin/phpunit
```

**Manual Testing:**
1. Enable/disable the multiple images rollout switch
2. Verify multiple images option appears/disappears in product variation settings
3. Test image selection, removal, and persistence scenarios
4. Verify proper handling of malformed data (trailing commas, spaces, etc.)

## Screenshots

### Before
- Missing test coverage for multiple images rollout switch integration
- Magic number '123' used without context in tests
- Potential for regressions when rollout switch state changes

### After
- Comprehensive test suite covering all multiple images scenarios
- Descriptive constants improve test readability
- Rollout switch behavior properly validated
- Edge cases and data validation thoroughly tested