### PR TITLE
Improving website prformance by reducing frequency of heavy queries

### DIFF
--- a/includes/Jobs/CleanupSkyvergeFrameworkJobOptions.php
+++ b/includes/Jobs/CleanupSkyvergeFrameworkJobOptions.php
@@ -38,6 +38,13 @@ class CleanupSkyvergeFrameworkJobOptions {
 	 * @see Products\Sync\Background
 	 */
 	public function clean_up_old_completed_options() {
+
+		$flag_name = '_wc_facebook_for_woocommerce_cleanup_sky_verge';
+		if ( 'yes' === get_transient( $flag_name ) ) {
+			return;
+		}
+		set_transient( $flag_name, 'yes', DAY_IN_SECONDS );
+
 		global $wpdb;
 
 		/**


### PR DESCRIPTION
## Description

Issue:
Advertiser highlighted that they have a number of customers using the Facebook for WooCommerce plugin across their WooCommerce sites. Over the past couple of months, we’ve observed that high-volume stores are experiencing significant performance degradation due to a specific query generated by the plugin:

SELECT COUNT(*)
FROM wp_options
WHERE option_name LIKE 'wc_facebook_background_product_sync_job_%'
AND (option_value LIKE '%\"status\":\"queued\"%'
OR option_value LIKE '%\"status\":\"processing\"%');

Because this query relies heavily on wildcards, index usage is minimal, resulting in full table scans. On sites where the wp_options table contains a large number of rows, these scans are causing slow queries and noticeable site performance issues.

Fix:
I've added a quick fix to ensure this query doesn't get executed more than once a day.

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Improving website performance by reducing frequency of heavy queries