### PR TITLE
[WIFI][1/n] Add Scaffolding WhatsApp Page under Marketing for WAUM Beta Experience

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -64,6 +64,9 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	/** @var WooCommerce\Facebook\Admin\Enhanced_Settings */
 	private $admin_enhanced_settings;
 
+	/** @var WooCommerce\Facebook\Admin\WhatsApp_Integration_Settings */
+	private $wa_admin_settings;
+
 	/** @var WooCommerce\Facebook\AJAX Ajax handler instance */
 	private $ajax;
 
@@ -251,6 +254,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 				} else {
 					$this->admin_settings = new WooCommerce\Facebook\Admin\Settings( $this );
 				}
+				$this->wa_admin_settings     = new WooCommerce\Facebook\Admin\WhatsApp_Integration_Settings( $this );
 				$this->plugin_render_handler = new \WooCommerce\Facebook\Handlers\PluginRender( $this );
 			}
 		}

--- a/includes/Admin/WhatsApp_Integration_Settings.php
+++ b/includes/Admin/WhatsApp_Integration_Settings.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace WooCommerce\Facebook\Admin;
+
+use WooCommerce\Facebook\RolloutSwitches;
+use WooCommerce\Facebook\Framework\Logger;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Admin WhatsApp Integration Settings handler.
+ *
+ * @since 3.5.0
+ */
+class WhatsApp_Integration_Settings {
+
+	/** @var string */
+	const PAGE_ID = 'wc-whatsapp';
+
+
+	/** @var \WC_Facebookcommerce */
+	private $plugin;
+
+
+	/**
+	 * WhatsApp Integration Settings constructor.
+	 *
+	 * @since 3.5.0
+	 *
+	 * @param \WC_Facebookcommerce $plugin is the plugin instance of WC_Facebookcommerce
+	 */
+	public function __construct( \WC_Facebookcommerce $plugin ) {
+		$this->plugin = $plugin;
+
+		add_action( 'admin_menu', array( $this, 'add_menu_item' ) );
+	}
+
+
+	/**
+	 * Adds the WhatsApp menu item.
+	 *
+	 * @since 3.5.0
+	 */
+	public function add_menu_item() {
+		$rollout_switches                           = $this->plugin->get_rollout_switches();
+		$is_connected                               = $this->plugin->get_connection_handler()->is_connected();
+		$is_whatsapp_utility_messaging_beta_enabled = $rollout_switches->is_switch_enabled( RolloutSwitches::WHATSAPP_UTILITY_MESSAGING_BETA_EXPERIENCE_DOGFOODING ); // TODO: update to prod GK during launch
+
+		if ( ! $is_connected || ! $is_whatsapp_utility_messaging_beta_enabled ) {
+			return;
+		}
+
+		$root_menu_item = $this->root_menu_item();
+
+		add_submenu_page(
+			$root_menu_item,
+			__( 'WhatsApp for WooCommerce', 'facebook-for-woocommerce' ),
+			__( 'WhatsApp', 'facebook-for-woocommerce' ),
+			'manage_woocommerce',
+			self::PAGE_ID,
+			[ $this, 'render' ],
+			5
+		);
+	}
+
+	/**
+	 * Checks if marketing feature is enabled in woocommerce.
+	 *
+	 * @since 3.5.0
+	 *
+	 * @return bool
+	 */
+	public function is_marketing_enabled() {
+		if ( class_exists( WooAdminFeatures::class ) ) {
+			return WooAdminFeatures::is_enabled( 'marketing' );
+		}
+
+		return is_callable( '\Automattic\WooCommerce\Admin\Loader::is_feature_enabled' )
+				&& \Automattic\WooCommerce\Admin\Loader::is_feature_enabled( 'marketing' );
+	}
+
+	/**
+	 * Gets the root menu item.
+	 *
+	 * @since 3.5.0
+	 *
+	 * @return string
+	 */
+	public function root_menu_item() {
+		if ( $this->is_marketing_enabled() ) {
+			return 'woocommerce-marketing';
+		}
+
+		return 'woocommerce';
+	}
+
+	/**
+	 * Renders the whatsapp utility settings page.
+	 *
+	 * @since 3.5.0
+	 */
+	public function render() {
+		?>
+				<div style="display: flex; justify-content: center; max-width: 1200px; margin: 0 auto;">
+					<h1><?php echo esc_html( 'Whatsapp Utility Screen' ); ?></h1>
+				</div>
+		<?php
+	}
+}

--- a/includes/RolloutSwitches.php
+++ b/includes/RolloutSwitches.php
@@ -24,13 +24,14 @@ class RolloutSwitches {
 	/** @var \WC_Facebookcommerce commerce handler */
 	private \WC_Facebookcommerce $plugin;
 
-	public const SWITCH_ROLLOUT_FEATURES              = 'rollout_enabled';
-	public const WHATSAPP_UTILITY_MESSAGING           = 'whatsapp_utility_messages_enabled';
-	public const SWITCH_PRODUCT_SETS_SYNC_ENABLED     = 'product_sets_sync_enabled';
-	public const SWITCH_WOO_ALL_PRODUCTS_SYNC_ENABLED = 'woo_all_products_sync_enabled';
-	public const SWITCH_OFFER_MANAGEMENT_ENABLED      = 'offer_management_enabled';
-	public const SWITCH_MULTIPLE_IMAGES_ENABLED       = 'woo_variant_multiple_images_enabled';
-	private const SETTINGS_KEY                        = 'wc_facebook_for_woocommerce_rollout_switches';
+	public const SWITCH_ROLLOUT_FEATURES                               = 'rollout_enabled';
+	public const WHATSAPP_UTILITY_MESSAGING                            = 'whatsapp_utility_messages_enabled';
+	public const WHATSAPP_UTILITY_MESSAGING_BETA_EXPERIENCE_DOGFOODING = 'woocommerce_utility_beta_iframe_integration_dogfooding'; // TODO: update to Prod GK during closed Beta launch
+	public const SWITCH_PRODUCT_SETS_SYNC_ENABLED                      = 'product_sets_sync_enabled';
+	public const SWITCH_WOO_ALL_PRODUCTS_SYNC_ENABLED                  = 'woo_all_products_sync_enabled';
+	public const SWITCH_OFFER_MANAGEMENT_ENABLED                       = 'offer_management_enabled';
+	public const SWITCH_MULTIPLE_IMAGES_ENABLED                        = 'woo_variant_multiple_images_enabled';
+	private const SETTINGS_KEY = 'wc_facebook_for_woocommerce_rollout_switches';
 
 	private const ACTIVE_SWITCHES = array(
 		self::SWITCH_ROLLOUT_FEATURES,
@@ -38,6 +39,7 @@ class RolloutSwitches {
 		self::SWITCH_WOO_ALL_PRODUCTS_SYNC_ENABLED,
 		self::SWITCH_OFFER_MANAGEMENT_ENABLED,
 		self::SWITCH_MULTIPLE_IMAGES_ENABLED,
+		self::WHATSAPP_UTILITY_MESSAGING_BETA_EXPERIENCE_DOGFOODING,
 	);
 
 	public function __construct( \WC_Facebookcommerce $plugin ) {


### PR DESCRIPTION
## Description
We are building the WhatsApp Utility Integration Beta Experience in a seperate tab under "marketing". We add a new submenu "WhatsApp" under the Marketing Root menu and add a scaffolding page in this diff.

### Type of change
- Add (non-breaking change which adds functionality)

## Checklist
- [yes] I have commented my code, particularly in hard-to-understand areas, if any.
- [yes] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [yes] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [yes] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [yes] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [yes] I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [not yet] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry
Add scaffolding whatsapp submenu and page for waum beta integration 


## Test Plan
UI Testing and Debug log checks

## Screenshots
### Passing GK
<img width="1728" height="954" alt="Screenshot 2025-08-20 at 11 10 23 AM" src="https://github.com/user-attachments/assets/e63e5b0a-db0d-4e26-ac77-86476611a05c" />

### Failing GK
<img width="1728" height="956" alt="Screenshot 2025-08-20 at 11 45 00 AM" src="https://github.com/user-attachments/assets/62fdc2cd-ecb5-43b0-aa35-20fd2cd2689b" />