### PR TITLE
Fix sale price higher than fb price

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -961,6 +961,12 @@ class WC_Facebook_Product {
 		$sale_start                = '';
 		$sale_end                  = '';
 
+		// discard sale price if it's not lower than product price
+		$product_price = $this->get_fb_price();
+		if ( ! ( is_numeric( $sale_price ) && (int) round( (float) $sale_price * 100 ) < (int) $product_price ) ) {
+			$sale_price = '';
+		}
+
 		// check if sale exist
 		if ( is_numeric( $sale_price ) && $sale_price > 0 ) {
 			$sale_start                = $this->woo_product->get_date_on_sale_from();

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -127,8 +127,20 @@ class fbproductTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSa
 				11.5,
 				null,
 				null,
+				15,
 				1150,
 				'11.5 USD',
+				'',
+				'',
+				'',
+			],
+			[
+				11.5,
+				null,
+				null,
+				10.5, // regular price lower than sale price
+				0,
+				'',
 				'',
 				'',
 				'',
@@ -137,6 +149,7 @@ class fbproductTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSa
 				0,
 				null,
 				null,
+				15,
 				0,
 				'0 USD',
 				'',
@@ -147,6 +160,7 @@ class fbproductTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSa
 				null,
 				null,
 				null,
+				15,
 				0,
 				'',
 				'',
@@ -157,6 +171,7 @@ class fbproductTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSa
 				null,
 				'2024-08-08',
 				'2024-08-18',
+				15,
 				0,
 				'',
 				'',
@@ -167,6 +182,7 @@ class fbproductTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSa
 				11,
 				'2024-08-08',
 				null,
+				15,
 				1100,
 				'11 USD',
 				'2024-08-08T00:00:00+00:00/2038-01-17T23:59+00:00',
@@ -177,6 +193,7 @@ class fbproductTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSa
 				11,
 				null,
 				'2024-08-08',
+15,
 				1100,
 				'11 USD',
 				'1970-01-29T00:00+00:00/2024-08-08T00:00:00+00:00',
@@ -187,11 +204,23 @@ class fbproductTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSa
 				11,
 				'2024-08-08',
 				'2024-08-09',
+				15,
 				1100,
 				'11 USD',
 				'2024-08-08T00:00:00+00:00/2024-08-09T00:00:00+00:00',
 				'2024-08-08T00:00:00+00:00',
 				'2024-08-09T00:00:00+00:00',
+			],
+			[
+				11,
+				'2024-08-08',
+				'2024-08-09',
+				10.5, // regular price lower than sale price
+				0,
+				'',
+				'',
+				'',
+				'',
 			],
 		];
 	}
@@ -203,9 +232,10 @@ class fbproductTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSa
 	 * @return void
 	 */
 	public function test_sale_price_and_effective_date(
-		$salePrice,
+		$sale_price,
 		$sale_price_start_date,
 		$sale_price_end_date,
+		$regular_price, 
 		$expected_sale_price,
 		$expected_sale_price_for_batch,
 		$expected_sale_price_effective_date,
@@ -214,7 +244,8 @@ class fbproductTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSa
 	) {
 		$product          = WC_Helper_Product::create_simple_product();
 		$facebook_product = new \WC_Facebook_Product( $product );
-		$facebook_product->set_sale_price( $salePrice );
+		$facebook_product->set_sale_price( $sale_price );
+		$facebook_product->set_price($regular_price);
 		$facebook_product->set_date_on_sale_from( $sale_price_start_date );
 		$facebook_product->set_date_on_sale_to( $sale_price_end_date );
 


### PR DESCRIPTION
## Description

Users could configure a fb price that's lower than the sale price. This results in invalid pricing shown on Commerce Manager, with a sale price higher than the regular price. 

This PR discards the sale price if it's higher than the regular price.

### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes. (There's an existing error on master branch)
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)). (This is not needed)


## Changelog entry

Discard sale price if it's higher than regular price


## Test Plan

`./vendor/bin/phpunit --filter fbproductTest` passed.

Manual test 1:
- set regular_price > sale_price > fb_price (invalid scenario)
- Commerce Manager shows fb_price only, which is the intended fix  (test recording for meta employees: https://fburl.com/px/8ja4lncb)

Manual test 2:
-  set regular_price > fb_price > sale_price (valid scenario)
-  Commerce Manager shows both fb_price and sale_price correctly, same as before (test recording for meta employees: https://fburl.com/px/t65u0sdg)

## Screenshots

### Before
<img width="942" height="303" alt="image" src="https://github.com/user-attachments/assets/86eaeb0a-a605-4e14-8450-7983c7d6a7b1" />

### After
<img width="1178" height="421" alt="image" src="https://github.com/user-attachments/assets/5fdcb2bd-7c31-41ee-8093-1435e407f01b" />
