### PR TITLE
add helper functions for tracking product meta change times & rate limit them (#3571)

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -2036,6 +2036,43 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	}
 
 	/**
+	 * Checks if the last change time update is rate limited for a product.
+	 *
+	 * @param int $product_id Product ID.
+	 * @return bool True if rate limited, false otherwise.
+	 * @since 3.5.8
+	 */
+	private function is_last_change_time_update_rate_limited( $product_id ) {
+		$cache_key = "last_change_time_{$product_id}";
+		$cached_time = wp_cache_get( $cache_key, 'facebook_for_woocommerce' );
+
+		// If no cached time, allow update
+		if ( false === $cached_time ) {
+			return false;
+		}
+
+		// Rate limit to once every 60 seconds (1 minute)
+		$rate_limit_window = 60;
+		$current_time = time();
+
+		// If the last update was within the rate limit window, prevent update
+		return ( $current_time - $cached_time ) < $rate_limit_window;
+	}
+
+	/**
+	 * Sets the last change time in cache for rate limiting.
+	 *
+	 * @param int $product_id Product ID.
+	 * @param int $timestamp Timestamp to cache.
+	 * @since 3.5.8
+	 */
+	private function set_last_change_time_cache( $product_id, $timestamp ) {
+		$cache_key = "last_change_time_{$product_id}";
+		// Cache for 2 minutes (120 seconds) to ensure it persists longer than the rate limit window
+		wp_cache_set( $cache_key, $timestamp, 'facebook_for_woocommerce', 120 );
+	}
+
+	/**
 	 * Loop through array of WPIDs to remove metadata.
 	 *
 	 * @param array $products


### PR DESCRIPTION
Summary:

## Changes to Facebook for WooCommerce Plugin
### Summary

This diff introduces helper functions for tracking product meta change times and rate limiting updates. 

Specifically, it adds a new function `is_last_change_time_update_rate_limited` to the `facebook-commerce.php` file. This function checks if the last change time update is rate limited for a given product ID.

### Key Features

*   Checks for rate limiting based on a cached time for each product ID
*   Uses the WordPress cache to store the last change time for each product
*   Returns a boolean value indicating whether the update is rate limited or not

### Version History

*   Since 3.5.7

### Example Use Case

```php
$product_id = 123;
$is_rate_limited = $facebook-commerce->is_last_change_time_update_rate_limited($product_id);

if (!$is_rate_limited) {
    // Proceed with updating the product meta change time
} else {
    // Update is rate limited, skip or reschedule the update
}
```

Differential Revision: D81231381


