### PR TITLE
add WooCommerce product validation utility (#3572)

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -2036,6 +2036,22 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	}
 
 	/**
+	 * Checks if a post is a WooCommerce product.
+	 *
+	 * @param int $product_id Post ID to check.
+	 * @return bool True if the post is a WooCommerce product.
+	 * @since 3.5.7
+	 */
+	private function is_woocommerce_product( $product_id ) {
+		if ( ! is_numeric( $product_id ) || $product_id <= 0 ) {
+			return false;
+		}
+
+		$post_type = get_post_type( $product_id );
+		return in_array( $post_type, [ 'product', 'product_variation' ], true );
+	}
+
+	/**
 	 * Checks if the last change time update is rate limited for a product.
 	 *
 	 * @param int $product_id Product ID.


### PR DESCRIPTION
Summary:

# Diff Summary: Add WooCommerce Product Validation Utility

## Overview

This diff introduces a new utility function to validate WooCommerce products, enhancing the plugin's functionality and ensuring seamless integration with the WooCommerce platform.

## Changes

The diff modifies the `facebook-commerce.php` file by adding a new private method `is_woocommerce_product`. This method takes a product ID as input and returns a boolean indicating whether the post is a valid WooCommerce product.

### Key Highlights

*   The `is_woocommerce_product` function checks if a post is a WooCommerce product.
*   It verifies that the product ID is numeric and greater than 0.
*   The function uses `get_post_type` to determine the post type and checks if it is a WooCommerce product.

### Code Snippet

```php
private function is_woocommerce_product( $product_id ) {
    if ( ! is_numeric( $product_id ) || $product_id <= 0 ) {
        return false;
    }

    $post_type = get_post_type( $product_id );
    return in_array( $post_type, 
```

### Impact

This update enhances the plugin's functionality by providing a robust method for validating WooCommerce products, ensuring accurate and reliable results. By incorporating this utility function, developers can streamline their workflows and improve the overall quality of their code.

Differential Revision: D81231382


