### PR TITLE
DO change: Add route & feed column

### DIFF
--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -412,3 +412,4 @@ class WC_Facebook_Loader {
 
 // fire it up!
 WC_Facebook_Loader::instance();
+require_once __DIR__ . '/includes/fbcollection.php';

--- a/includes/fbcollection.php
+++ b/includes/fbcollection.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Facebook Commerce Recommendation Override for /fbcollection/
+ * New URL Example: /fbcollection/?clicked_product_id=SKU123_123&shown_product_ids=SKU456_456,SKU789_789
+ */
+
+namespace Facebook\WooCommerce;
+
+defined( 'ABSPATH' ) || exit;
+
+class Commerce_Page_Override {
+
+    const REWRITE_VERSION = '1.0.0';  // Bump this ONLY when rewrite rules change.
+
+    public function __construct() {
+        add_action( 'init', [ $this, 'register_rewrite_rule' ] );
+        add_filter( 'query_vars', [ $this, 'add_query_vars' ] );
+        add_action( 'woocommerce_product_query', [ $this, 'modify_product_query' ] );
+        add_action( 'plugins_loaded', [ $this, 'check_and_trigger_flush' ] );
+        add_action( 'init', [ $this, 'flush_rewrite_if_needed' ] );
+    }
+
+    /**
+     * Register /fbcollection/ as a virtual WooCommerce archive page.
+     */
+    public function register_rewrite_rule() {
+        add_rewrite_rule( '^fbcollection/?$', 'index.php?post_type=product&custom_fbcollection_page=1', 'top' );
+    }
+
+    /**
+     * Add custom query variable.
+     */
+    public function add_query_vars( $vars ) {
+        $vars[] = 'custom_fbcollection_page';
+        return $vars;
+    }
+
+    /**
+     * Modify WooCommerce product query to inject custom product IDs.
+     */
+    public function modify_product_query( $query ) {
+        if ( intval( get_query_var( 'custom_fbcollection_page' ) ) !== 1 ) {
+            return;
+        }
+
+        // Debug logger to verify query filtering triggers
+        error_log('FBCollection Query Triggered: ' . print_r($_GET, true));
+
+        // Helper to extract product_id from retailer_id format
+        $extract_product_id = function( $retailer_id ) {
+            if ( false !== strpos( $retailer_id, '_' ) ) {
+                $parts = explode( '_', $retailer_id );
+                return absint( end( $parts ) );
+            }
+            return absint( $retailer_id );
+        };
+
+        // Parse clicked_product_id
+        $clicked_product_id_raw = isset( $_GET['clicked_product_id'] ) ? $_GET['clicked_product_id'] : '';
+        $clicked_product_id = $extract_product_id( $clicked_product_id_raw );
+
+        // Parse shown_product_ids
+        $shown_product_ids_raw = isset( $_GET['shown_product_ids'] ) ? explode( ',', $_GET['shown_product_ids'] ) : [];
+        $shown_product_ids = array_map( $extract_product_id, $shown_product_ids_raw );
+        $shown_product_ids = array_filter( $shown_product_ids ); // Remove empty/invalid
+        $shown_product_ids = array_slice( $shown_product_ids, 0, 30 ); // Limit to 30
+
+        $final_product_ids = [];
+
+        if ( $clicked_product_id && get_post_type( $clicked_product_id ) === 'product' ) {
+            $final_product_ids[] = $clicked_product_id;
+        }
+
+        $valid_shown_ids = array_filter( $shown_product_ids, function( $id ) use ( $clicked_product_id ) {
+            if ( $id === $clicked_product_id ) {
+                return false;
+            }
+            $product = wc_get_product( $id );
+            return $product && $product->is_visible();
+        });
+
+        $final_product_ids = array_merge( $final_product_ids, $valid_shown_ids );
+
+        if ( ! empty( $final_product_ids ) ) {
+            $query->set( 'post__in', $final_product_ids );
+            $query->set( 'orderby', 'post__in' );
+            $query->set( 'posts_per_page', count( $final_product_ids ) );
+        } else {
+            $query->set( 'orderby', 'popularity' );
+            $query->set( 'posts_per_page', 8 );
+        }
+    }
+
+    /**
+     * Versioned Rewrite Rules Flush on Upgrade.
+     */
+    public function check_and_trigger_flush() {
+        $stored_version = get_option( 'fbwcommerce_rewrites_flushed' );
+        if ( $stored_version !== self::REWRITE_VERSION ) {
+            update_option( 'fbwcommerce_flush_needed', true );
+            update_option( 'fbwcommerce_rewrites_flushed', self::REWRITE_VERSION );
+        }
+    }
+
+    public function flush_rewrite_if_needed() {
+        // This function checks if a flush is required (flagged by check_and_trigger_flush)
+        // If the flag is set, it flushes rewrite rules and deletes the flag to avoid repeat flushes.
+        if ( get_option( 'fbwcommerce_flush_needed' ) ) {
+            flush_rewrite_rules();
+            delete_option( 'fbwcommerce_flush_needed' );
+        }
+    }
+}
+
+// Initialize the override logic.
+new Commerce_Page_Override();

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1787,7 +1787,9 @@ class WC_Facebook_Product {
 		$product_data['age_group'] = $this->get_fb_age_group();
 		$product_data['gender']    = $this->get_fb_gender();
 		$product_data['material']  = Helper::str_truncate( $this->get_fb_material(), 100 );
-
+		// Generate and add collection URI
+		$collection_uri 				= site_url( '/fbcollection/' );
+		$product_data['custom_label_4'] = $collection_uri;
 		if ( $this->get_type() === 'variation' ) {
 			$parent_id      = $this->woo_product->get_parent_id();
 			$parent_product = wc_get_product( $parent_id );

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -420,7 +420,7 @@ class WC_Facebook_Product_Feed {
 		'brand,price,availability,item_group_id,checkout_url,' .
 		'additional_image_link,sale_price_effective_date,sale_price,condition,' .
 		'visibility,gender,color,size,pattern,google_product_category,default_product,' .
-		'variant,gtin,quantity_to_sell_on_facebook,rich_text_description,internal_label,external_update_time,' .
+		'variant,gtin,quantity_to_sell_on_facebook,custom_label_4,rich_text_description,internal_label,external_update_time,' .
 		'external_variant_id, is_woo_all_products_sync' . PHP_EOL;
 	}
 
@@ -578,6 +578,7 @@ class WC_Facebook_Product_Feed {
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'variant' ) ) . ',' .
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'gtin' ) ) . ',' .
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'quantity_to_sell_on_facebook' ) ) . ',' .
+		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'custom_label_4' ) ) . ',' . // <-- Added here
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'rich_text_description' ) ) . ',' .
 		static::format_internal_labels_for_feed( static::get_value_from_product_data( $product_data, 'internal_label' ) ) . ',' .
 		static::get_value_from_product_data( $product_data, 'external_update_time' ) . ',' .


### PR DESCRIPTION
## Description

A new rewrite rule for the path '/fbcollection' is setup to intercept the query parameters clicked_product_id and shown_product_ids for displaying the linked products.

### Type of change

- Add (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

A new rewrite rule for '/fbcollection' ie., a new page 
Query parameters being processed: clicked_product_id, shown_product_ids 

## Test Plan
1. Basic URL Access
URL: /fbcollection/
Expected: Shows 8 popular products (default fallback).
<img width="469" height="327" alt="image" src="https://github.com/user-attachments/assets/83ef2d80-1eb0-467b-80e0-7d629992c533" />

2. With only clicked_product_id
URL: /fbcollection/?clicked_product_id={Product SKU}_{Product Id}
Expected: Shows the product with ID 'Product Id' if valid and visible.
<img width="468" height="358" alt="image" src="https://github.com/user-attachments/assets/108faa5a-091c-486c-b5a7-5c18cdd4ce47" />


3. With shown_product_ids
URL: /fbcollection/?clicked_product_id={Product SKU1}_{Product Id1}&shown_product_ids={Product SKU2}_{Product Id2},{Product SKU3}_{Product Id3}
Expected: Shows product 1,2,3 if valid and visible. Repeating IDs are cut to just one.
<img width="475" height="338" alt="image" src="https://github.com/user-attachments/assets/6d186604-77a9-477a-837f-c0d1cced1a92" />

4. Invalid or Missing Parameters
URL: /fbcollection/?clicked_product_id=xdyr123_999999&shown_product_ids=asdf_abc_123,def_1231241
Expected: Falls back to 8 popular products due to invalid IDs.
<img width="471" height="370" alt="image" src="https://github.com/user-attachments/assets/764549c8-ea27-4aec-8eff-ab805fc857c6" />



