### PR TITLE
Fix unit tests failing silently

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -44,27 +44,41 @@ jobs:
       - name: Run PHP unit tests with coverage
         id: phpunit
         run: |
-          # Run tests silently and generate coverage XML only
-          ./vendor/bin/phpunit --coverage-clover=coverage.xml > /dev/null 2>&1
+          echo "🧪 Running PHP unit tests with coverage..."
 
-          # Extract coverage summary from XML
-          COVERAGE=$(php -r "
-            if (file_exists('coverage.xml')) {
-              \$xml = simplexml_load_file('coverage.xml');
-              \$metrics = \$xml->project->metrics;
-              \$covered = (int)\$metrics['coveredstatements'];
-              \$total = (int)\$metrics['statements'];
-              \$percentage = \$total > 0 ? round((\$covered / \$total) * 100, 2) : 0;
-              echo \$percentage;
-            } else {
-              echo '0';
-            }
-          ")
+          # Run tests once with both verbose output and coverage generation
+          if ./vendor/bin/phpunit --verbose --coverage-clover=coverage.xml; then
+            echo "✅ All tests passed!"
+            TEST_STATUS="passed"
 
-          echo "coverage_summary=$COVERAGE" >> $GITHUB_OUTPUT
-          echo "📊 Coverage: $COVERAGE%"
+            # Extract coverage summary from XML
+            COVERAGE=$(php -r "
+              if (file_exists('coverage.xml')) {
+                \$xml = simplexml_load_file('coverage.xml');
+                \$metrics = \$xml->project->metrics;
+                \$covered = (int)\$metrics['coveredstatements'];
+                \$total = (int)\$metrics['statements'];
+                \$percentage = \$total > 0 ? round((\$covered / \$total) * 100, 2) : 0;
+                echo \$percentage;
+              } else {
+                echo '0';
+              }
+            ")
+
+            echo "coverage_summary=$COVERAGE" >> $GITHUB_OUTPUT
+            echo "📊 Coverage: $COVERAGE%"
+          else
+            echo "❌ Some tests failed!"
+            TEST_STATUS="failed"
+            # Clean up any partial coverage file
+            rm -f coverage.xml
+            exit 1
+          fi
+
+          echo "test_status=$TEST_STATUS" >> $GITHUB_OUTPUT
 
       - name: Upload coverage reports
+        if: steps.phpunit.outputs.test_status == 'passed'
         uses: actions/upload-artifact@v4
         with:
           name: php-coverage-report PHP - ${{ matrix.php }}, WP - ${{ matrix.wp-version }} , WC - ${{ matrix.wc-version }}
@@ -72,6 +86,7 @@ jobs:
           retention-days: 30
 
       - name: Check coverage threshold
+        if: steps.phpunit.outputs.test_status == 'passed'
         continue-on-error: true
         run: |
           COVERAGE="${{ steps.phpunit.outputs.coverage_summary }}"

--- a/tests/Unit/LocaleTest.php
+++ b/tests/Unit/LocaleTest.php
@@ -264,16 +264,3 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 			);
 		}
 	}
-
-	/**
-	 * TEMPORARY TEST: This test is intentionally failing to verify workflow error handling.
-	 * This should be removed after testing the workflow.
-	 */
-	public function test_intentional_failure_for_workflow_testing() {
-		// This test will always fail to verify that:
-		// 1. The workflow shows which specific tests failed
-		// 2. The workflow stops execution when tests fail
-		// 3. Coverage is not calculated when tests fail
-		$this->assertTrue( false, 'This test intentionally fails to test workflow error handling' );
-	}
-}

--- a/tests/Unit/LocaleTest.php
+++ b/tests/Unit/LocaleTest.php
@@ -25,7 +25,7 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 	 */
 	public function test_get_supported_locales_returns_array() {
 		$locales = Locale::get_supported_locales();
-		
+
 		$this->assertIsArray( $locales );
 		$this->assertNotEmpty( $locales );
 	}
@@ -35,11 +35,11 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 	 */
 	public function test_get_supported_locales_format() {
 		$locales = Locale::get_supported_locales();
-		
+
 		foreach ( $locales as $locale => $name ) {
 			// Locale should be in xx_XX format
 			$this->assertMatchesRegularExpression( '/^[a-z]{2}_[A-Z]{2}$/', $locale );
-			
+
 			// Name should be a non-empty string
 			$this->assertIsString( $name );
 			$this->assertNotEmpty( $name );
@@ -52,12 +52,12 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 	public function test_get_supported_locales_is_sorted() {
 		$locales = Locale::get_supported_locales();
 		$values = array_values( $locales );
-		
+
 		// Create a copy and sort it
 		$sorted_values = $values;
 		natcasesort( $sorted_values );
 		$sorted_values = array_values( $sorted_values ); // Re-index
-		
+
 		// Compare with original
 		$this->assertEquals( $sorted_values, $values );
 	}
@@ -71,16 +71,16 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 		$this->assertFalse( Locale::is_supported_locale( 'EN_US' ) );
 		$this->assertFalse( Locale::is_supported_locale( 'en-US' ) );
 		$this->assertFalse( Locale::is_supported_locale( 'english' ) );
-		
+
 		// Non-existent locales
 		$this->assertFalse( Locale::is_supported_locale( 'xx_XX' ) );
 		$this->assertFalse( Locale::is_supported_locale( 'en_UK' ) ); // Should be en_GB
 		$this->assertFalse( Locale::is_supported_locale( 'fr_US' ) );
-		
+
 		// Empty and null
 		$this->assertFalse( Locale::is_supported_locale( '' ) );
 		$this->assertFalse( Locale::is_supported_locale( ' ' ) );
-		
+
 		// Case sensitivity tests
 		$this->assertFalse( Locale::is_supported_locale( 'en_us' ) );
 		$this->assertFalse( Locale::is_supported_locale( 'EN_US' ) );
@@ -96,9 +96,9 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 		$property = $reflection->getProperty( 'supported_locales' );
 		$property->setAccessible( true );
 		$hardcoded_locales = $property->getValue();
-		
+
 		foreach ( $hardcoded_locales as $locale ) {
-			$this->assertTrue( 
+			$this->assertTrue(
 				Locale::is_supported_locale( $locale ),
 				"Locale {$locale} should be supported"
 			);
@@ -114,13 +114,13 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 			$locales['test_XX'] = 'Test Language';
 			return $locales;
 		} );
-		
+
 		$locales = Locale::get_supported_locales();
-		
+
 		// Check that our test locale was added
 		$this->assertArrayHasKey( 'test_XX', $locales );
 		$this->assertEquals( 'Test Language', $locales['test_XX'] );
-		
+
 		// Clean up
 		remove_all_filters( 'wc_facebook_messenger_supported_locales' );
 	}
@@ -137,18 +137,18 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 			$locales['dup_US'] = $locales['en_US'];
 			return $locales;
 		} );
-		
+
 		$locales = Locale::get_supported_locales();
-		
+
 		// The filter should have added our new locale
 		$this->assertArrayHasKey( 'new_XX', $locales );
 		$this->assertEquals( 'New Language', $locales['new_XX'] );
-		
+
 		// Both keys should exist even with duplicate values
 		// array_unique preserves keys, so duplicate values are allowed
 		$this->assertArrayHasKey( 'en_US', $locales );
 		$this->assertArrayHasKey( 'dup_US', $locales );
-		
+
 		// Clean up
 		remove_all_filters( 'wc_facebook_messenger_supported_locales' );
 	}
@@ -161,7 +161,7 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 		// which is complex in PHPUnit. Instead, we'll test that the method
 		// works regardless of the Locale extension availability
 		$locales = Locale::get_supported_locales();
-		
+
 		// Should always have en_US at minimum
 		$this->assertArrayHasKey( 'en_US', $locales );
 		$this->assertNotEmpty( $locales['en_US'] );
@@ -172,7 +172,7 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 	 */
 	public function test_specific_locale_formats() {
 		$locales = Locale::get_supported_locales();
-		
+
 		// Test some specific locale codes that might be edge cases
 		$edge_cases = array(
 			'zh_CN' => 'Chinese (China)',
@@ -183,7 +183,7 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 			'es_ES' => 'Spanish (Spain)',
 			'es_LA' => 'Spanish (Latin America)',
 		);
-		
+
 		foreach ( $edge_cases as $locale => $expected_pattern ) {
 			if ( isset( $locales[ $locale ] ) ) {
 				$this->assertArrayHasKey( $locale, $locales );
@@ -197,14 +197,14 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 	 */
 	public function test_locale_names_capitalization() {
 		$locales = Locale::get_supported_locales();
-		
+
 		// Check that en_US specifically has proper capitalization
 		if ( isset( $locales['en_US'] ) ) {
 			$name = $locales['en_US'];
 			// Should start with capital letter
 			$this->assertMatchesRegularExpression( '/^[A-Z]/', $name );
 		}
-		
+
 		// Check a few more if they exist
 		foreach ( array( 'fr_FR', 'de_DE', 'es_ES' ) as $locale ) {
 			if ( isset( $locales[ $locale ] ) ) {
@@ -221,17 +221,17 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 	public function test_is_supported_locale_edge_cases() {
 		// Numeric input
 		$this->assertFalse( Locale::is_supported_locale( '123' ) );
-		
+
 		// Special characters
 		$this->assertFalse( Locale::is_supported_locale( 'en_US!' ) );
 		$this->assertFalse( Locale::is_supported_locale( '@#$%' ) );
-		
+
 		// Very long string
 		$this->assertFalse( Locale::is_supported_locale( str_repeat( 'a', 100 ) ) );
-		
+
 		// Locale with extra parts
 		$this->assertFalse( Locale::is_supported_locale( 'en_US_extra' ) );
-		
+
 		// Partial matches
 		$this->assertFalse( Locale::is_supported_locale( 'en_' ) );
 		$this->assertFalse( Locale::is_supported_locale( '_US' ) );
@@ -242,10 +242,10 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 	 */
 	public function test_supported_locales_count() {
 		$locales = Locale::get_supported_locales();
-		
+
 		// Should have a reasonable number of locales (at least 50)
 		$this->assertGreaterThan( 50, count( $locales ) );
-		
+
 		// But not too many (less than 200)
 		$this->assertLessThan( 200, count( $locales ) );
 	}
@@ -255,13 +255,25 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 	 */
 	public function test_consistency_between_methods() {
 		$locales = Locale::get_supported_locales();
-		
+
 		// Every locale returned by get_supported_locales should return true for is_supported_locale
 		foreach ( array_keys( $locales ) as $locale ) {
-			$this->assertTrue( 
+			$this->assertTrue(
 				Locale::is_supported_locale( $locale ),
 				"Locale {$locale} from get_supported_locales() should return true for is_supported_locale()"
 			);
 		}
 	}
-} 
+
+	/**
+	 * TEMPORARY TEST: This test is intentionally failing to verify workflow error handling.
+	 * This should be removed after testing the workflow.
+	 */
+	public function test_intentional_failure_for_workflow_testing() {
+		// This test will always fail to verify that:
+		// 1. The workflow shows which specific tests failed
+		// 2. The workflow stops execution when tests fail
+		// 3. Coverage is not calculated when tests fail
+		$this->assertTrue( false, 'This test intentionally fails to test workflow error handling' );
+	}
+}

--- a/tests/Unit/LocaleTest.php
+++ b/tests/Unit/LocaleTest.php
@@ -264,3 +264,4 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 			);
 		}
 	}
+}


### PR DESCRIPTION
## Description

Unit tests were being failed silently and it was hard to debug what tests actually failed and why. 
Fixed it to run with verbose output.

### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)

## Checklist

- [✅] I have commented my code, particularly in hard-to-understand areas, if any.
- [✅] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [✅] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [✅] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [✅] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

unit tests made to run with verbose output and not fail silently 

## Test Plan

Positive test (latest state) - 
https://github.com/immadhavv/facebook-for-woocommerce/actions/runs/17430183597

Negative test (with test made to fail) - 
https://github.com/immadhavv/facebook-for-woocommerce/actions/runs/17430031445

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before

### After
