### PR TITLE
[WooCommerce] Fix selected category values bug after a new category i…

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -44,27 +44,41 @@ jobs:
       - name: Run PHP unit tests with coverage
         id: phpunit
         run: |
-          # Run tests silently and generate coverage XML only
-          ./vendor/bin/phpunit --coverage-clover=coverage.xml > /dev/null 2>&1
+          echo "🧪 Running PHP unit tests with coverage..."
 
-          # Extract coverage summary from XML
-          COVERAGE=$(php -r "
-            if (file_exists('coverage.xml')) {
-              \$xml = simplexml_load_file('coverage.xml');
-              \$metrics = \$xml->project->metrics;
-              \$covered = (int)\$metrics['coveredstatements'];
-              \$total = (int)\$metrics['statements'];
-              \$percentage = \$total > 0 ? round((\$covered / \$total) * 100, 2) : 0;
-              echo \$percentage;
-            } else {
-              echo '0';
-            }
-          ")
+          # Run tests once with both verbose output and coverage generation
+          if ./vendor/bin/phpunit --verbose --coverage-clover=coverage.xml; then
+            echo "✅ All tests passed!"
+            TEST_STATUS="passed"
 
-          echo "coverage_summary=$COVERAGE" >> $GITHUB_OUTPUT
-          echo "📊 Coverage: $COVERAGE%"
+            # Extract coverage summary from XML
+            COVERAGE=$(php -r "
+              if (file_exists('coverage.xml')) {
+                \$xml = simplexml_load_file('coverage.xml');
+                \$metrics = \$xml->project->metrics;
+                \$covered = (int)\$metrics['coveredstatements'];
+                \$total = (int)\$metrics['statements'];
+                \$percentage = \$total > 0 ? round((\$covered / \$total) * 100, 2) : 0;
+                echo \$percentage;
+              } else {
+                echo '0';
+              }
+            ")
+
+            echo "coverage_summary=$COVERAGE" >> $GITHUB_OUTPUT
+            echo "📊 Coverage: $COVERAGE%"
+          else
+            echo "❌ Some tests failed!"
+            TEST_STATUS="failed"
+            # Clean up any partial coverage file
+            rm -f coverage.xml
+            exit 1
+          fi
+
+          echo "test_status=$TEST_STATUS" >> $GITHUB_OUTPUT
 
       - name: Upload coverage reports
+        if: steps.phpunit.outputs.test_status == 'passed'
         uses: actions/upload-artifact@v4
         with:
           name: php-coverage-report PHP - ${{ matrix.php }}, WP - ${{ matrix.wp-version }} , WC - ${{ matrix.wc-version }}
@@ -72,6 +86,7 @@ jobs:
           retention-days: 30
 
       - name: Check coverage threshold
+        if: steps.phpunit.outputs.test_status == 'passed'
         continue-on-error: true
         run: |
           COVERAGE="${{ steps.phpunit.outputs.coverage_summary }}"

--- a/.github/workflows/set-stable-tag.yml
+++ b/.github/workflows/set-stable-tag.yml
@@ -1,0 +1,160 @@
+name: Set Stable Tag
+
+on: workflow_dispatch
+
+jobs:
+  final-qa-checks:
+    uses: ./.github/workflows/final-qa-checks.yml
+
+  set-stable-tag:
+    runs-on: ubuntu-latest
+    needs: final-qa-checks
+    environment: Deployment
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fail if not on a release publish branch
+        run: |
+          echo "Current ref: ${{ github.ref }}"
+          BRANCH="${{ github.ref }}"
+          if [[ ! $BRANCH == refs/heads/release/*/publish ]]; then
+            echo "❌ This workflow can only be run on release/*/publish branches."
+            exit 1
+          fi
+
+      - name: Get NPM Version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@v1.3.1
+
+      - name: Validate Git tag
+        run: |
+          git fetch --tags
+          if [ ! $(git tag -l "v${{ steps.package-version.outputs.current-version}}") ]; then
+            echo "❌ Git tag does not exist" 1>&2
+            exit 1
+          fi
+
+      - name: Install SVN
+        run: sudo apt-get install subversion -y
+
+      - name: Checkout SVN Repository
+        run: svn co https://plugins.svn.wordpress.org/facebook-for-woocommerce/ woocommerce_svn --quiet --non-interactive
+
+      - name: Validate SVN tag
+        run: |
+          if [ ! -d "woocommerce_svn/tags/${{ steps.package-version.outputs.current-version}}" ]; then
+            echo "❌ SVN tag directory does not exist" 1>&2
+            exit 1
+          fi
+
+      - name: Update readme.txt
+        env:
+          NEW_VERSION: ${{ steps.package-version.outputs.current-version}}
+        run: |
+          cd woocommerce_svn
+          sed -i -E "s/^(Stable tag:)[[:space:]]*[0-9.]+/\1 $NEW_VERSION/" "trunk/readme.txt"
+
+      - name: Commit to SVN
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        run: |
+          cd woocommerce_svn
+          cat trunk/readme.txt
+          svn status
+          svn diff
+          svn commit -m "Update stable tag for version ${{ steps.package-version.outputs.current-version}}" --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --no-auth-cache --non-interactive
+
+  set-last-release-as-latest:
+    runs-on: ubuntu-latest
+    environment: Deployment
+    needs: set-stable-tag
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: get npm version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@v1.3.1
+
+      - name: get release id from last successful release workflow
+        id: get-release-id
+        run: |
+          version="${{ steps.package-version.outputs.current-version }}"
+          expected_branch="release/p${version}/publish"
+
+          echo "Looking for successful release workflow run from branch: $expected_branch"
+
+
+          # Get the most recent successful workflow run for release-plugin.yml
+          workflow_runs=$(curl -s \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/release-plugin.yml/runs?branch=${expected_branch}&status=completed&per_page=1")
+
+          echo "$workflow_runs"
+          run_conclusion=$(echo "$workflow_runs" | jq -r '.workflow_runs[0].conclusion // empty')
+
+          if [ "$run_conclusion" != "success" ]; then
+            echo "❌ Last release workflow run was not successful (conclusion: $run_conclusion)"
+            echo "Cannot proceed with setting release as latest"
+            exit 1
+          fi
+
+          # Get the most recent successful run ID
+          run_id=$(echo "$workflow_runs" | jq -r '.workflow_runs[0].id // empty')
+
+          if [ -z "$run_id" ] || [ "$run_id" = "null" ] || [ "$run_id" = "" ]; then
+            echo "❌ No successful release workflow runs found"
+            exit 1
+          fi
+
+          echo "✅ Found successful workflow run ID: $run_id"
+          echo "run_id=$run_id" >> $GITHUB_OUTPUT
+
+      - name: Download release ID artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: release-id
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.get-release-id.outputs.run_id }}
+
+      - name: Read release ID from artifact
+        id: read-release-id
+        run: |
+          if [ ! -f "release-id.txt" ]; then
+            echo "❌ release-id.txt file not found"
+            exit 1
+          fi
+
+          release_id=$(cat release-id.txt)
+
+          if [ -z "$release_id" ]; then
+            echo "❌ Release ID is empty"
+            exit 1
+          fi
+
+          echo "✅ Found release ID: $release_id"
+          echo "release_id=$release_id" >> $GITHUB_OUTPUT
+
+
+      - name: Set release as latest
+        if: steps.read-release-id.outputs.release_id != ''
+        run: |
+          version="${{ steps.package-version.outputs.current-version }}"
+          release_id="${{ steps.read-release-id.outputs.release_id }}"
+
+          # Update release to make it latest
+          echo "Setting release v${version} as latest..."
+          update_response=$(curl -s -X PATCH \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -d '{"prerelease": false, "make_latest": true}' \
+            "https://api.github.com/repos/${{ github.repository }}/releases/${release_id}")
+
+          if echo "$update_response" | grep -q '"Error"'; then
+            echo "❌ Failed to update release v${version} as latest"
+            exit 1
+          fi
+
+          echo "✅ Release v${version} set as latest"

--- a/assets/css/admin/facebook-for-woocommerce-whatsapp-enhanced.css
+++ b/assets/css/admin/facebook-for-woocommerce-whatsapp-enhanced.css
@@ -1,19 +1,11 @@
  .facebook-whatsapp-iframe-container {
     display: flex;
-    align-items: center;
     justify-content: center;
-    min-height: 80vh;
-    min-width: 100vw;
-    background: #f9f9f9;
-}
+    margin: 0 auto;
+ }
 #facebook-whatsapp-iframe-enhanced {
-    width: 90vw;
-    height: 80vh;
-    max-width: 1200px;
-    max-height: 800px;
-    border: 1px solid #ddd;
-    border-radius: 8px;
-    background: #fff;
-    box-shadow: 0 4px 32px rgba(0,0,0,0.08);
-    display: block;
+    width: 100%;
+	min-height: calc(100vh - 200px);
+	background: transparent;
+	border: none;
 }

--- a/assets/js/admin/product-categories.js
+++ b/assets/js/admin/product-categories.js
@@ -53,7 +53,7 @@ jQuery( document ).ready( ( $ ) => {
         // Recreate initial empty selectors
         window.wc_facebook_google_product_category_fields.addInitialSelects('');
 
-        // // Set the last dropdown's margin bottom
+        // Set the last dropdown's margin bottom
         $('.wc-facebook-google-product-category-field').last().attr('style', 'margin-bottom: 24px');
       }
     }

--- a/assets/js/admin/product-categories.js
+++ b/assets/js/admin/product-categories.js
@@ -37,4 +37,25 @@ jQuery( document ).ready( ( $ ) => {
 				$form.data( 'allow-submit', true ).find( ':submit' ).trigger( 'click' );
 			} );
 	} );
+
+  // Add new category button handler to clear Google Product Category selections when clicked
+  $('#submit').on('click', function(e) {
+    // Only proceed if this is the "Add new category" button
+    if ($(this).val() === 'Add new category') {
+      // Check if the Google Product Category Fields handler exists
+      if (typeof window.wc_facebook_google_product_category_fields !== 'undefined') {
+
+        // Clear selections
+        $('#' + window.wc_facebook_google_product_category_fields.input_id).val('');
+        $('#wc-facebook-google-product-category-fields').empty();
+        $('.wc-facebook-enhanced-catalog-attribute-row').remove();
+
+        // Recreate initial empty selectors
+        window.wc_facebook_google_product_category_fields.addInitialSelects('');
+
+        // // Set the last dropdown's margin bottom
+        $('.wc-facebook-google-product-category-field').last().attr('style', 'margin-bottom: 24px');
+      }
+    }
+  });
 } );

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,20 @@
 *** Facebook for WooCommerce Changelog ***
 
+= 3.5.7 - 2025-09-02 =
+* Add - DO change: Add route & feed column by @unnivgit in #3580
+* Fix - removing set stable tag to unblock release for now by @immadhavv in #3584
+* Fix - Fixed syncing of excluded product categories and tags info by @vinkmeta in #3582
+* Add - feat: quick edit syncing by @rithikb24 in #3557
+* Add - [WIFI]30/n]Fetch the iframe management url through the Stefi API by @sharunaanandraj in #3569
+* Add - changelog: add referrer url by @chc421 in #3545
+* Fix - Fix sale price higher than fb price by @guansu-meta in #3567
+* Add - [WIFI][26/n]Add Listener and update Whatsapp Settings in DB after onboarding by @sharunaanandraj in #3568
+* Add - [WIFI][25/n]Add scaffolding Iframe Integration in the Whatsapp Tab by @sharunaanandraj in #3566
+* Add - [WIFI][1/n] Add Scaffolding WhatsApp Page under Marketing for WAUM Beta Experience by @sharunaanandraj in #3564
+* Dev - cleanup: remove dead code for product sets sync rollout switch by @devbodaghe in #3560
+* Add - Automatically set last release from release-plugin workflow as latest by @immadhavv in #3552
+* Add - Run unit tests with coverage and compare against threshold by @immadhavv in #3553
+
 = 3.5.6 - 2025-08-18 =
 * Fix - Improving website prformance by reducing frequency of heavy queries by @vinkmeta in #3556
 * Dev - chore: add multiple images functionality tests with rollout switch in… by @devbodaghe in #3554

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "woocommerce/action-scheduler-job-framework": "2.0.0",
     "composer/installers": "~1.0",
     "woocommerce/grow": "dev-compat-checker",
-    "firebase/php-jwt": "^6.10"
+    "firebase/php-jwt": "^6.10",
+    "facebook/capi-param-builder-php": "^1.0.1"
   },
   "require-dev": {
     "composer/installers": "^1.7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4e80c194ac3fde3776fb76150346aee6",
+    "content-hash": "b893d11fc146c4af223557f99ee67187",
     "packages": [
         {
             "name": "composer/installers",
@@ -158,6 +158,40 @@
             "time": "2021-09-13T08:19:44+00:00"
         },
         {
+            "name": "facebook/capi-param-builder-php",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/facebook/capi-param-builder.git",
+                "reference": "b9ddd734c11a44d99f0d71913255a70cbc43b35b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/facebook/capi-param-builder/zipball/b9ddd734c11a44d99f0d71913255a70cbc43b35b",
+                "reference": "b9ddd734c11a44d99f0d71913255a70cbc43b35b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FacebookAds\\": "php/capi-param-builder/src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "description": "Parameter builder SDK for Conversion API events",
+            "support": {
+                "issues": "https://github.com/facebook/capi-param-builder/issues",
+                "source": "https://github.com/facebook/capi-param-builder/tree/v1.0.1"
+            },
+            "time": "2025-08-04T23:12:03+00:00"
+        },
+        {
             "name": "firebase/php-jwt",
             "version": "v6.10.0",
             "source": {
@@ -267,12 +301,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/grow.git",
-                "reference": "92a72d51e81b2ec62eb74d3e950a1e55cac63469"
+                "reference": "3bc225916439d7b93d4f5ecb209c94fb47e76172"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/grow/zipball/92a72d51e81b2ec62eb74d3e950a1e55cac63469",
-                "reference": "92a72d51e81b2ec62eb74d3e950a1e55cac63469",
+                "url": "https://api.github.com/repos/woocommerce/grow/zipball/3bc225916439d7b93d4f5ecb209c94fb47e76172",
+                "reference": "3bc225916439d7b93d4f5ecb209c94fb47e76172",
                 "shasum": ""
             },
             "require-dev": {
@@ -292,34 +326,34 @@
                 "source": "https://github.com/woocommerce/grow/tree/compat-checker",
                 "issues": "https://github.com/woocommerce/grow/issues"
             },
-            "time": "2024-05-09T12:50:05+00:00"
+            "time": "2025-06-25T12:19:53+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.0.0",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da"
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
+                "composer-plugin-api": "^2.2",
                 "php": ">=5.4",
                 "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
-                "composer/composer": "*",
+                "composer/composer": "^2.2",
                 "ext-json": "*",
                 "ext-zip": "*",
-                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9.0",
                 "yoast/phpunit-polyfills": "^1.0"
             },
@@ -339,9 +373,9 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl",
-                    "role": "Developer / IT Manager"
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
                 },
                 {
                     "name": "Contributors",
@@ -349,7 +383,6 @@
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -370,9 +403,28 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
                 "source": "https://github.com/PHPCSStandards/composer-installer"
             },
-            "time": "2023-01-05T11:28:13+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-07-17T20:45:56+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -504,16 +556,16 @@
         },
         {
             "name": "gettext/gettext",
-            "version": "v4.8.11",
+            "version": "v4.8.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-gettext/Gettext.git",
-                "reference": "b632aaf5e4579d0b2ae8bc61785e238bff4c5156"
+                "reference": "11af89ee6c087db3cf09ce2111a150bca5c46e12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-gettext/Gettext/zipball/b632aaf5e4579d0b2ae8bc61785e238bff4c5156",
-                "reference": "b632aaf5e4579d0b2ae8bc61785e238bff4c5156",
+                "url": "https://api.github.com/repos/php-gettext/Gettext/zipball/11af89ee6c087db3cf09ce2111a150bca5c46e12",
+                "reference": "11af89ee6c087db3cf09ce2111a150bca5c46e12",
                 "shasum": ""
             },
             "require": {
@@ -565,7 +617,7 @@
             "support": {
                 "email": "oom@oscarotero.com",
                 "issues": "https://github.com/oscarotero/Gettext/issues",
-                "source": "https://github.com/php-gettext/Gettext/tree/v4.8.11"
+                "source": "https://github.com/php-gettext/Gettext/tree/v4.8.12"
             },
             "funding": [
                 {
@@ -581,20 +633,20 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2023-08-14T15:15:05+00:00"
+            "time": "2024-05-18T10:25:07+00:00"
         },
         {
             "name": "gettext/languages",
-            "version": "2.10.0",
+            "version": "2.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-gettext/Languages.git",
-                "reference": "4d61d67fe83a2ad85959fe6133d6d9ba7dddd1ab"
+                "reference": "0b0b0851c55168e1dfb14305735c64019732b5f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-gettext/Languages/zipball/4d61d67fe83a2ad85959fe6133d6d9ba7dddd1ab",
-                "reference": "4d61d67fe83a2ad85959fe6133d6d9ba7dddd1ab",
+                "url": "https://api.github.com/repos/php-gettext/Languages/zipball/0b0b0851c55168e1dfb14305735c64019732b5f1",
+                "reference": "0b0b0851c55168e1dfb14305735c64019732b5f1",
                 "shasum": ""
             },
             "require": {
@@ -604,7 +656,8 @@
                 "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5 || ^8.4"
             },
             "bin": [
-                "bin/export-plural-rules"
+                "bin/export-plural-rules",
+                "bin/import-cldr-data"
             ],
             "type": "library",
             "autoload": {
@@ -643,7 +696,7 @@
             ],
             "support": {
                 "issues": "https://github.com/php-gettext/Languages/issues",
-                "source": "https://github.com/php-gettext/Languages/tree/2.10.0"
+                "source": "https://github.com/php-gettext/Languages/tree/2.12.1"
             },
             "funding": [
                 {
@@ -655,20 +708,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-10-18T15:00:10+00:00"
+            "time": "2025-03-19T11:14:02+00:00"
         },
         {
             "name": "mck89/peast",
-            "version": "v1.16.2",
+            "version": "v1.17.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mck89/peast.git",
-                "reference": "2791b08ffcc1862fe18eef85675da3aa58c406fe"
+                "reference": "465810689c477fbba17f4f949b75e4d0bdab13ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mck89/peast/zipball/2791b08ffcc1862fe18eef85675da3aa58c406fe",
-                "reference": "2791b08ffcc1862fe18eef85675da3aa58c406fe",
+                "url": "https://api.github.com/repos/mck89/peast/zipball/465810689c477fbba17f4f949b75e4d0bdab13ea",
+                "reference": "465810689c477fbba17f4f949b75e4d0bdab13ea",
                 "shasum": ""
             },
             "require": {
@@ -681,7 +734,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.16.2-dev"
+                    "dev-master": "1.17.2-dev"
                 }
             },
             "autoload": {
@@ -702,72 +755,22 @@
             "description": "Peast is PHP library that generates AST for JavaScript code",
             "support": {
                 "issues": "https://github.com/mck89/peast/issues",
-                "source": "https://github.com/mck89/peast/tree/v1.16.2"
+                "source": "https://github.com/mck89/peast/tree/v1.17.2"
             },
-            "time": "2024-03-05T09:16:03+00:00"
-        },
-        {
-            "name": "mustache/mustache",
-            "version": "v2.14.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/bobthecow/mustache.php.git",
-                "reference": "e62b7c3849d22ec55f3ec425507bf7968193a6cb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/mustache.php/zipball/e62b7c3849d22ec55f3ec425507bf7968193a6cb",
-                "reference": "e62b7c3849d22ec55f3ec425507bf7968193a6cb",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2.4"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "~1.11",
-                "phpunit/phpunit": "~3.7|~4.0|~5.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Mustache": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Justin Hileman",
-                    "email": "justin@justinhileman.info",
-                    "homepage": "http://justinhileman.com"
-                }
-            ],
-            "description": "A Mustache implementation in PHP.",
-            "homepage": "https://github.com/bobthecow/mustache.php",
-            "keywords": [
-                "mustache",
-                "templating"
-            ],
-            "support": {
-                "issues": "https://github.com/bobthecow/mustache.php/issues",
-                "source": "https://github.com/bobthecow/mustache.php/tree/v2.14.2"
-            },
-            "time": "2022-08-23T13:07:01+00:00"
+            "time": "2025-07-01T09:30:45+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.1",
+            "version": "1.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
                 "shasum": ""
             },
             "require": {
@@ -775,11 +778,12 @@
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
             },
             "require-dev": {
                 "doctrine/collections": "^1.6.8",
                 "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
                 "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
@@ -805,7 +809,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
             },
             "funding": [
                 {
@@ -813,20 +817,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-08T13:26:56+00:00"
+            "time": "2025-08-01T08:46:24+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.0.2",
+            "version": "v5.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13"
+                "reference": "221b0d0fdf1369c71047ad1d18bb5880017bbc56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/139676794dc1e9231bf7bcd123cfc0c99182cb13",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/221b0d0fdf1369c71047ad1d18bb5880017bbc56",
+                "reference": "221b0d0fdf1369c71047ad1d18bb5880017bbc56",
                 "shasum": ""
             },
             "require": {
@@ -837,7 +841,7 @@
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -869,9 +873,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.0"
             },
-            "time": "2024-03-05T20:51:40+00:00"
+            "time": "2025-07-27T20:03:57+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1127,21 +1131,22 @@
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.5",
+            "version": "2.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "01c1ff2704a58e46f0cb1ca9d06aee07b3589082"
+                "reference": "5bfbbfbabb3df2b9a83e601de9153e4a7111962c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/01c1ff2704a58e46f0cb1ca9d06aee07b3589082",
-                "reference": "01c1ff2704a58e46f0cb1ca9d06aee07b3589082",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/5bfbbfbabb3df2b9a83e601de9153e4a7111962c",
+                "reference": "5bfbbfbabb3df2b9a83e601de9153e4a7111962c",
                 "shasum": ""
             },
             "require": {
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0",
+                "squizlabs/php_codesniffer": "^3.3"
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
@@ -1191,35 +1196,39 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-04-24T21:37:59+00:00"
+            "time": "2025-05-12T16:38:37+00:00"
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.2.1",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489"
+                "reference": "fa4b8d051e278072928e32d817456a7fdb57b6ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
-                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/fa4b8d051e278072928e32d817456a7fdb57b6ca",
+                "reference": "fa4b8d051e278072928e32d817456a7fdb57b6ca",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.0.9",
-                "squizlabs/php_codesniffer": "^3.8.0"
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.0 || ^4.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcsstandards/phpcsdevcs": "^1.1.6",
                 "phpcsstandards/phpcsdevtools": "^1.2.1",
-                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -1269,35 +1278,39 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2023-12-08T16:49:07+00:00"
+            "time": "2025-06-14T07:40:39+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.11",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "c457da9dabb60eb7106dd5e3c05132b1a6539c6a"
+                "reference": "f7eb16f2fa4237d5db9e8fed8050239bee17a9bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c457da9dabb60eb7106dd5e3c05132b1a6539c6a",
-                "reference": "c457da9dabb60eb7106dd5e3c05132b1a6539c6a",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/f7eb16f2fa4237d5db9e8fed8050239bee17a9bd",
+                "reference": "f7eb16f2fa4237d5db9e8fed8050239bee17a9bd",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.9.0 || 4.0.x-dev@dev"
+                "squizlabs/php_codesniffer": "^3.13.0 || ^4.0"
             },
             "require-dev": {
                 "ext-filter": "*",
                 "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcsstandards/phpcsdevcs": "^1.1.6",
-                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0"
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -1334,6 +1347,7 @@
                 "phpcodesniffer-standard",
                 "phpcs",
                 "phpcs3",
+                "phpcs4",
                 "standards",
                 "static analysis",
                 "tokens",
@@ -1357,41 +1371,45 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-04-24T11:47:18+00:00"
+            "time": "2025-08-10T01:04:45+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.31",
+            "version": "9.2.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965"
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/48c34b5d8d983006bd2adc2d0de92963b9155965",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.18 || ^5.0",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
                 "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
-                "theseer/tokenizer": "^1.2.0"
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.6"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -1400,7 +1418,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "9.2.x-dev"
                 }
             },
             "autoload": {
@@ -1429,7 +1447,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.31"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
             },
             "funding": [
                 {
@@ -1437,7 +1455,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:37:42+00:00"
+            "time": "2024-08-22T04:23:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1682,45 +1700,45 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.19",
+            "version": "9.6.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8"
+                "reference": "ea49afa29aeea25ea7bf9de9fdd7cab163cc0701"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a1a54a473501ef4cdeaae4e06891674114d79db8",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ea49afa29aeea25ea7bf9de9fdd7cab163cc0701",
+                "reference": "ea49afa29aeea25ea7bf9de9fdd7cab163cc0701",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
+                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.28",
-                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
                 "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.9",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.6",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
@@ -1765,7 +1783,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.19"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.24"
             },
             "funding": [
                 {
@@ -1777,11 +1795,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-05T04:35:58+00:00"
+            "time": "2025-08-10T08:32:42+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1952,16 +1978,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "4.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
                 "shasum": ""
             },
             "require": {
@@ -2014,15 +2040,27 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.9"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2025-08-10T06:51:50+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -2289,16 +2327,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.7",
+            "version": "5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
                 "shasum": ""
             },
             "require": {
@@ -2341,15 +2379,27 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T06:35:11+00:00"
+            "time": "2025-08-10T07:10:35+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -2522,16 +2572,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
                 "shasum": ""
             },
             "require": {
@@ -2573,15 +2623,27 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
+            "time": "2025-08-10T06:57:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -2748,23 +2810,23 @@
         },
         {
             "name": "sirbrillig/phpcs-changed",
-            "version": "v2.11.4",
+            "version": "v2.11.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-changed.git",
-                "reference": "acc946731ec65053e49cb0d3185c8ffe74895f93"
+                "reference": "1c6deb684d648b4d75c577bead4c6d43dc46e4ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-changed/zipball/acc946731ec65053e49cb0d3185c8ffe74895f93",
-                "reference": "acc946731ec65053e49cb0d3185c8ffe74895f93",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-changed/zipball/1c6deb684d648b4d75c577bead4c6d43dc46e4ab",
+                "reference": "1c6deb684d648b4d75c577bead4c6d43dc46e4ab",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1 || ^1.0.0",
                 "phpunit/phpunit": "^6.4 || ^9.5",
                 "sirbrillig/phpcs-variable-analysis": "^2.1.3",
                 "squizlabs/php_codesniffer": "^3.2.1",
@@ -2796,22 +2858,22 @@
             "description": "Run phpcs on files, but only report warnings/errors from lines which were changed.",
             "support": {
                 "issues": "https://github.com/sirbrillig/phpcs-changed/issues",
-                "source": "https://github.com/sirbrillig/phpcs-changed/tree/v2.11.4"
+                "source": "https://github.com/sirbrillig/phpcs-changed/tree/v2.11.8"
             },
-            "time": "2023-09-29T21:27:51+00:00"
+            "time": "2025-03-11T15:23:48+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.9.2",
+            "version": "3.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "aac1f6f347a5c5ac6bc98ad395007df00990f480"
+                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/aac1f6f347a5c5ac6bc98ad395007df00990f480",
-                "reference": "aac1f6f347a5c5ac6bc98ad395007df00990f480",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5b5e3821314f947dd040c70f7992a64eac89025c",
+                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c",
                 "shasum": ""
             },
             "require": {
@@ -2876,22 +2938,26 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-04-23T20:25:34+00:00"
+            "time": "2025-06-17T22:17:01+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.3",
+            "version": "v2.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "80d075412b557d41002320b96a096ca65aa2c98d"
+                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/80d075412b557d41002320b96a096ca65aa2c98d",
-                "reference": "80d075412b557d41002320b96a096ca65aa2c98d",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/605389f2a7e5625f273b53960dc46aeaf9c62918",
+                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918",
                 "shasum": ""
             },
             "require": {
@@ -2899,12 +2965,12 @@
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
                 "branch-alias": {
                     "dev-main": "2.5-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -2929,7 +2995,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.3"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.4"
             },
             "funding": [
                 {
@@ -2945,20 +3011,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-24T14:02:46+00:00"
+            "time": "2024-09-25T14:11:13+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v5.4.39",
+            "version": "v5.4.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "f6a96e4fcd468a25fede16ee665f50ced856bd0a"
+                "reference": "63741784cd7b9967975eec610b256eed3ede022b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/f6a96e4fcd468a25fede16ee665f50ced856bd0a",
-                "reference": "f6a96e4fcd468a25fede16ee665f50ced856bd0a",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/63741784cd7b9967975eec610b256eed3ede022b",
+                "reference": "63741784cd7b9967975eec610b256eed3ede022b",
                 "shasum": ""
             },
             "require": {
@@ -2992,7 +3058,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.39"
+                "source": "https://github.com/symfony/finder/tree/v5.4.45"
             },
             "funding": [
                 {
@@ -3008,30 +3074,30 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T08:26:06+00:00"
+            "time": "2024-09-28T13:32:08+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.29.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b"
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
-                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -3072,7 +3138,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -3088,7 +3154,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2025-01-02T08:10:11+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -3181,27 +3247,27 @@
         },
         {
             "name": "wp-cli/i18n-command",
-            "version": "2.6.1",
+            "version": "v2.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/i18n-command.git",
-                "reference": "7538d684d4f06b0e10c8a0166ce4e6d9e1687aa1"
+                "reference": "5e73d417398993625331a9f69f6c2ef60f234070"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/7538d684d4f06b0e10c8a0166ce4e6d9e1687aa1",
-                "reference": "7538d684d4f06b0e10c8a0166ce4e6d9e1687aa1",
+                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/5e73d417398993625331a9f69f6c2ef60f234070",
+                "reference": "5e73d417398993625331a9f69f6c2ef60f234070",
                 "shasum": ""
             },
             "require": {
                 "eftec/bladeone": "3.52",
                 "gettext/gettext": "^4.8",
                 "mck89/peast": "^1.13.11",
-                "wp-cli/wp-cli": "^2.5"
+                "wp-cli/wp-cli": "^2.12"
             },
             "require-dev": {
                 "wp-cli/scaffold-command": "^1.2 || ^2",
-                "wp-cli/wp-cli-tests": "^4"
+                "wp-cli/wp-cli-tests": "^4.3.9"
             },
             "suggest": {
                 "ext-json": "Used for reading and generating JSON translation files",
@@ -3209,9 +3275,6 @@
             },
             "type": "wp-cli-package",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "2.x-dev"
-                },
                 "bundled": true,
                 "commands": [
                     "i18n",
@@ -3220,7 +3283,10 @@
                     "i18n make-mo",
                     "i18n make-php",
                     "i18n update-po"
-                ]
+                ],
+                "branch-alias": {
+                    "dev-main": "2.x-dev"
+                }
             },
             "autoload": {
                 "files": [
@@ -3244,9 +3310,61 @@
             "homepage": "https://github.com/wp-cli/i18n-command",
             "support": {
                 "issues": "https://github.com/wp-cli/i18n-command/issues",
-                "source": "https://github.com/wp-cli/i18n-command/tree/2.6.1"
+                "source": "https://github.com/wp-cli/i18n-command/tree/v2.6.5"
             },
-            "time": "2024-02-28T11:27:34+00:00"
+            "time": "2025-04-25T21:49:29+00:00"
+        },
+        {
+            "name": "wp-cli/mustache",
+            "version": "v2.14.99",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-cli/mustache.php.git",
+                "reference": "ca23b97ac35fbe01c160549eb634396183d04a59"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-cli/mustache.php/zipball/ca23b97ac35fbe01c160549eb634396183d04a59",
+                "reference": "ca23b97ac35fbe01c160549eb634396183d04a59",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "replace": {
+                "mustache/mustache": "^2.14.2"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.19.3",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Mustache": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Justin Hileman",
+                    "email": "justin@justinhileman.info",
+                    "homepage": "http://justinhileman.com"
+                }
+            ],
+            "description": "A Mustache implementation in PHP.",
+            "homepage": "https://github.com/bobthecow/mustache.php",
+            "keywords": [
+                "mustache",
+                "templating"
+            ],
+            "support": {
+                "source": "https://github.com/wp-cli/mustache.php/tree/v2.14.99"
+            },
+            "time": "2025-05-06T16:15:37+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",
@@ -3301,20 +3419,20 @@
         },
         {
             "name": "wp-cli/php-cli-tools",
-            "version": "v0.11.22",
+            "version": "v0.12.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/php-cli-tools.git",
-                "reference": "a6bb94664ca36d0962f9c2ff25591c315a550c51"
+                "reference": "34b83b4f700df8a4ec3fd17bf7e7e7d8ca5f28da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/a6bb94664ca36d0962f9c2ff25591c315a550c51",
-                "reference": "a6bb94664ca36d0962f9c2ff25591c315a550c51",
+                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/34b83b4f700df8a4ec3fd17bf7e7e7d8ca5f28da",
+                "reference": "34b83b4f700df8a4ec3fd17bf7e7e7d8ca5f28da",
                 "shasum": ""
             },
             "require": {
-                "php": ">= 5.3.0"
+                "php": ">= 5.6.0"
             },
             "require-dev": {
                 "roave/security-advisories": "dev-latest",
@@ -3358,39 +3476,38 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-cli/php-cli-tools/issues",
-                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.22"
+                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.12.5"
             },
-            "time": "2023-12-03T19:25:05+00:00"
+            "time": "2025-03-26T16:13:46+00:00"
         },
         {
             "name": "wp-cli/wp-cli",
-            "version": "v2.10.0",
+            "version": "v2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "a339dca576df73c31af4b4d8054efc2dab9a0685"
+                "reference": "03d30d4138d12b4bffd8b507b82e56e129e0523f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/a339dca576df73c31af4b4d8054efc2dab9a0685",
-                "reference": "a339dca576df73c31af4b4d8054efc2dab9a0685",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/03d30d4138d12b4bffd8b507b82e56e129e0523f",
+                "reference": "03d30d4138d12b4bffd8b507b82e56e129e0523f",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
-                "mustache/mustache": "^2.14.1",
                 "php": "^5.6 || ^7.0 || ^8.0",
                 "symfony/finder": ">2.7",
+                "wp-cli/mustache": "^2.14.99",
                 "wp-cli/mustangostang-spyc": "^0.6.3",
-                "wp-cli/php-cli-tools": "~0.11.2"
+                "wp-cli/php-cli-tools": "~0.12.4"
             },
             "require-dev": {
-                "roave/security-advisories": "dev-latest",
                 "wp-cli/db-command": "^1.3 || ^2",
                 "wp-cli/entity-command": "^1.2 || ^2",
                 "wp-cli/extension-command": "^1.1 || ^2",
                 "wp-cli/package-command": "^1 || ^2",
-                "wp-cli/wp-cli-tests": "^4.0.1"
+                "wp-cli/wp-cli-tests": "^4.3.10"
             },
             "suggest": {
                 "ext-readline": "Include for a better --prompt implementation",
@@ -3403,7 +3520,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.10.x-dev"
+                    "dev-main": "2.12.x-dev"
                 }
             },
             "autoload": {
@@ -3430,20 +3547,20 @@
                 "issues": "https://github.com/wp-cli/wp-cli/issues",
                 "source": "https://github.com/wp-cli/wp-cli"
             },
-            "time": "2024-02-08T16:52:43+00:00"
+            "time": "2025-05-07T01:16:12+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.1.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "9333efcbff231f10dfd9c56bb7b65818b4733ca7"
+                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/9333efcbff231f10dfd9c56bb7b65818b4733ca7",
-                "reference": "9333efcbff231f10dfd9c56bb7b65818b4733ca7",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/d2421de7cec3274ae622c22c744de9a62c7925af",
+                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af",
                 "shasum": ""
             },
             "require": {
@@ -3452,13 +3569,13 @@
                 "ext-tokenizer": "*",
                 "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "phpcsstandards/phpcsextra": "^1.2.1",
-                "phpcsstandards/phpcsutils": "^1.0.10",
-                "squizlabs/php_codesniffer": "^3.9.0"
+                "phpcsstandards/phpcsextra": "^1.4.0",
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9.0",
                 "phpcsstandards/phpcsdevtools": "^1.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
@@ -3496,20 +3613,20 @@
                     "type": "custom"
                 }
             ],
-            "time": "2024-03-25T16:39:00+00:00"
+            "time": "2025-07-24T20:08:31+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "2.0.1",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "4a088f125c970d6d6ea52c927f96fe39b330d0f1"
+                "reference": "1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/4a088f125c970d6d6ea52c927f96fe39b330d0f1",
-                "reference": "4a088f125c970d6d6ea52c927f96fe39b330d0f1",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27",
+                "reference": "1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27",
                 "shasum": ""
             },
             "require": {
@@ -3519,12 +3636,12 @@
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
                 "php-parallel-lint/php-parallel-lint": "^1.4.0",
-                "yoast/yoastcs": "^3.1.0"
+                "yoast/yoastcs": "^3.2.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.x-dev"
+                    "dev-main": "4.x-dev"
                 }
             },
             "autoload": {
@@ -3559,7 +3676,7 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2024-04-05T16:36:44+00:00"
+            "time": "2025-08-10T05:13:49+00:00"
         }
     ],
     "aliases": [],

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -51,6 +51,13 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		/** @var bool whether the pixel should be enabled */
 		private $is_pixel_enabled;
 
+		/**
+		 * The Facebook CAPI Parameter Builder instance.
+		 *
+		 * @var \FacebookAds\ParamBuilder
+		 */
+		private $param_builder;
+
 
 		/**
 		 * Events tracker constructor.
@@ -101,10 +108,14 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 * @since 2.2.0
 		 */
 		private function add_hooks() {
+			add_action( 'init', array( $this, 'param_builder_set_cookies' ), 15 );
 
 			// inject Pixel
 			add_action( 'wp_head', array( $this, 'inject_base_pixel' ) );
 			add_action( 'wp_footer', array( $this, 'inject_base_pixel_noscript' ) );
+
+			// set up CAPI Param Builder libraries
+			add_action( 'wp_enqueue_scripts', array( $this, 'param_builder_client_setup' ) );
 
 			// ViewContent for individual products
 			add_action( 'woocommerce_after_single_product', array( $this, 'inject_view_content_event' ) );
@@ -149,7 +160,6 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			add_action( 'shutdown', array( $this, 'send_pending_events' ) );
 		}
 
-
 		/**
 		 * Prints the base JavaScript pixel code
 		 *
@@ -176,6 +186,62 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			}
 		}
 
+		/**
+		 * Sets the Parameter Builder cookies using the Facebook CAPI Parameter Builder.
+		 */
+		public function param_builder_set_cookies() {
+			$param_builder = facebook_for_woocommerce()->get_param_builder();
+			if ( ! $param_builder ) {
+				return;
+			}
+
+			try {
+				$cookie_to_set = $param_builder->getCookiesToSet();
+
+				if ( ! empty( $cookie_to_set ) ) {
+					foreach ( $cookie_to_set as $cookie ) {
+						setcookie(
+							$cookie->name,
+							$cookie->value,
+							array(
+								'expires' => time() + $cookie->max_age,
+								'path' => '/',
+								'domain' => $cookie->domain,
+								'secure' => is_ssl(),
+								'samesite' => 'Lax',
+							)
+						);
+					}
+				}
+			} catch ( \Exception $exception ) {
+				$this->log( 'Error setting CAPI Parameter Builder cookies: ' . $exception->getMessage() );
+			}
+		}
+
+		/**
+		 * Enqueues the Facebook CAPI Param Builder script.
+		 */
+		public function param_builder_client_setup() {
+			// Client js setup
+			if ( ! facebook_for_woocommerce()->get_connection_handler()->is_connected() ) {
+				return;
+			}
+
+			wp_enqueue_script(
+				'facebook-capi-param-builder',
+				'https://capi-automation.s3.us-east-2.amazonaws.com/public/client_js/capiParamBuilder/clientParamBuilder.bundle.js',
+				array(),
+				null,
+				true
+			);
+			// Add inline script that executes after the external script has loaded
+			wp_add_inline_script(
+				'facebook-capi-param-builder',
+				'if (typeof clientParamBuilder !== "undefined") {
+					clientParamBuilder.processAndCollectAllParams(window.location.href);
+				}'
+			);
+		}
 
 		/**
 		 * Triggers the PageView event

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -170,7 +170,6 @@ class WC_Facebookcommerce_Pixel {
 					// Insert placeholder for events injected when a product is added to the cart through AJAX.
 					document.body.insertAdjacentHTML( 'beforeend', '<div class=\"wc-facebook-pixel-event-placeholder\"></div>' );
 				}, false );
-
 			</script>
 			<!-- WooCommerce Facebook Integration End -->
 			<?php

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -2036,6 +2036,43 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	}
 
 	/**
+	 * Checks if the last change time update is rate limited for a product.
+	 *
+	 * @param int $product_id Product ID.
+	 * @return bool True if rate limited, false otherwise.
+	 * @since 3.5.8
+	 */
+	private function is_last_change_time_update_rate_limited( $product_id ) {
+		$cache_key = "last_change_time_{$product_id}";
+		$cached_time = wp_cache_get( $cache_key, 'facebook_for_woocommerce' );
+
+		// If no cached time, allow update
+		if ( false === $cached_time ) {
+			return false;
+		}
+
+		// Rate limit to once every 60 seconds (1 minute)
+		$rate_limit_window = 60;
+		$current_time = time();
+
+		// If the last update was within the rate limit window, prevent update
+		return ( $current_time - $cached_time ) < $rate_limit_window;
+	}
+
+	/**
+	 * Sets the last change time in cache for rate limiting.
+	 *
+	 * @param int $product_id Product ID.
+	 * @param int $timestamp Timestamp to cache.
+	 * @since 3.5.8
+	 */
+	private function set_last_change_time_cache( $product_id, $timestamp ) {
+		$cache_key = "last_change_time_{$product_id}";
+		// Cache for 2 minutes (120 seconds) to ensure it persists longer than the rate limit window
+		wp_cache_set( $cache_key, $timestamp, 'facebook_for_woocommerce', 120 );
+	}
+
+	/**
 	 * Loop through array of WPIDs to remove metadata.
 	 *
 	 * @param array $products

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -10,14 +10,14 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 3.5.6
+ * Version: 3.5.7
  * Requires at least: 5.6
  * Requires PHP: 7.4
  * Text Domain: facebook-for-woocommerce
  * Requires Plugins: woocommerce
  * Tested up to: 6.8.1
  * WC requires at least: 6.4
- * WC tested up to: 9.9.4
+ * WC tested up to: 10.1.2
  *
  * @package FacebookCommerce
  */
@@ -62,7 +62,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '3.5.6'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '3.5.7'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.4.0';

--- a/includes/Admin/WhatsApp_Integration_Settings.php
+++ b/includes/Admin/WhatsApp_Integration_Settings.php
@@ -115,8 +115,8 @@ class WhatsApp_Integration_Settings {
 			return WooAdminFeatures::is_enabled( 'marketing' );
 		}
 
-		return is_callable( '\Automattic\WooCommerce\Admin\Loader::is_feature_enabled' )
-				&& \Automattic\WooCommerce\Admin\Loader::is_feature_enabled( 'marketing' );
+		return is_callable( '\Automattic\WooCommerce\Admin\Features\Features::is_enabled' )
+				&& \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'marketing' );
 	}
 
 	/**
@@ -215,6 +215,18 @@ class WhatsApp_Integration_Settings {
 						.catch(function(error) {
 							console.error('Error during settings update:', error);
 						});
+				}
+
+				if (messageEvent === 'CommerceExtension::RESIZE') {
+					const iframe = document.getElementById('facebook-whatsapp-iframe-enhanced');
+					if ( iframe ) {
+						if ( message.height ) {
+							iframe.height = message.height;
+						}
+						if ( message.width ) {
+							iframe.width = message.width;
+						}
+					}
 				}
 			});
 		JAVASCRIPT;

--- a/includes/Events/Event.php
+++ b/includes/Events/Event.php
@@ -27,6 +27,13 @@ class Event {
 	 */
 	protected $data = array();
 
+	/**
+	 * The Facebook CAPI Parameter Builder instance.
+	 *
+	 * @var \FacebookAds\ParamBuilder
+	 */
+	private $param_builder = null;
+
 
 	/**
 	 * Gets version information for pixel events.
@@ -69,6 +76,7 @@ class Event {
 	 * @param array $data event data
 	 */
 	public function __construct( $data = array() ) {
+		$this->param_builder = facebook_for_woocommerce()->get_param_builder();
 		$this->prepare_data( $data );
 	}
 
@@ -131,6 +139,9 @@ class Event {
 			$this->data['user_data']['country'] = $country;
 			unset( $this->data['user_data']['cn'] );
 		}
+
+		$this->data['user_data']['fbc'] = $this->get_click_id();
+		$this->data['user_data']['fbp'] = $this->get_browser_id();
 		$this->data['user_data'] = Normalizer::normalize_array( $this->data['user_data'], false );
 		$this->data['user_data'] = $this->hash_pii_data( $this->data['user_data'] );
 	}
@@ -284,10 +295,13 @@ class Event {
 	 */
 	protected function get_browser_id() {
 		$fbp = ! empty( $_COOKIE['_fbp'] ) ? wc_clean( wp_unslash( $_COOKIE['_fbp'] ) ) : '';
-		if ( $fbp ) {
-			$_SESSION['_fbp'] = $fbp;
+		if ( ! $fbp && isset( $this->param_builder ) ) {
+			$fbp = $this->param_builder->getFBP();
 		} elseif ( isset( $_SESSION['_fbp'] ) ) {
 			$fbp = $_SESSION['_fbp']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		}
+		if ( $fbp ) {
+			$_SESSION['_fbp'] = $fbp;
 		}
 		return $fbp;
 	}

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -341,7 +341,8 @@ class ProductValidator {
 			/**
 			 * This check will run for background jobs like sync all and feeds
 			 */
-			$parent_sync = $this->product_parent->get_meta( Products::get_product_sync_meta_key() ) || null;
+			// Check if product_parent exists before calling get_meta() to prevent "Call to a member function get_meta() on null" error
+			$parent_sync = $this->product_parent ? $this->product_parent->get_meta( Products::get_product_sync_meta_key() ) : null;
 
 			if ( 'yes' === $parent_sync ) {
 				return;

--- a/includes/RolloutSwitches.php
+++ b/includes/RolloutSwitches.php
@@ -52,7 +52,9 @@ class RolloutSwitches {
 			return;
 		}
 
-		$flag_name = '_wc_facebook_for_woocommerce_rollout_switch_flag';
+		// Include plugin version in transient key to reset on version upgrades
+		$plugin_version = $this->plugin->get_version();
+		$flag_name = '_wc_facebook_for_woocommerce_rollout_switch_flag_' . $plugin_version;
 		if ( 'yes' === get_transient( $flag_name ) ) {
 			return;
 		}

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -2248,9 +2248,17 @@ class WC_Facebook_Product {
 			$product_data['gtin'] = $this->woo_product->get_global_unique_id();
 		}
 
-		if ( $this->woo_product->get_date_modified() ) {
-			$date_modified                        = $this->woo_product->get_date_modified();
-			$product_data['external_update_time'] = $date_modified->getTimestamp();
+		$date_modified = $this->woo_product->get_date_modified();
+		if ( $date_modified ) {
+			$external_update_time = (int) $date_modified->getTimestamp();
+			$last_change_time = (int) $this->woo_product->get_meta( '_last_change_time' );
+
+			// Use the newer timestamp if _last_change_time is valid, otherwise use external_update_time
+			if ( $last_change_time > 0 ) {
+				$product_data['external_update_time'] = max( $external_update_time, $last_change_time );
+			} else {
+				$product_data['external_update_time'] = $external_update_time;
+			}
 		}
 
 		// Only use checkout URLs if they exist.

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -222,7 +222,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 			$content_category = array_values(
 				array_map(
 					function ( $item ) {
-						return $item->name;
+						return html_entity_decode( $item->name, ENT_QUOTES | ENT_HTML401, 'UTF-8' );
 					},
 					$category_path
 				)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.5.6",
+  "version": "3.5.7",
   "author": "Facebook",
   "homepage": "https://woocommerce.com/products/facebook/",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -41,20 +41,19 @@ To suggest technical improvements, you can raise an issue on our [Github reposit
 
 == Changelog ==
 
-= 3.5.6 - 2025-08-18 =
-* Fix - Improving website prformance by reducing frequency of heavy queries by @vinkmeta in #3556
-* Dev - chore: add multiple images functionality tests with rollout switch in… by @devbodaghe in #3554
-* Update - Enable Offer Management APIs + Tweaks by @mradmeta in #3548
-* Add - Add Rollout Switches for Gating Multiple Variants by @devbodaghe in #3551
-* Add - Feature/multiple images for variants by @devbodaghe in #3543
-* Fix - Fix product set banner reappearance after dismissal  by @mshymon in #3547
-* Fix - Remove unnecessary logging for product attribute mapper attributes by @devbodaghe in #3546
-* Update - Deprecate FB Product Sets tab and migrate legacy product sets by @mshymon in #3534
-* Add - Automated secondary QA test to compare artifact from prepare-release and marketplace version by @immadhavv in #3544
-* Fix - Fix: Disable dropdown fields when 'Do not sync' is selected by @devbodaghe in #3541
-* Fix - Show Facebook Product Video field for variable products by @ukilla in #3542
-* Fix - Fix bug in plugin version upgrade/downgrade logic in Lifecycle by @mshymon in #3539
-* Add - Run e2e tests on marketplace release of the plugin by @immadhavv in #3535
-* Fix - Fix/prevent woocommerce attribute summaries in facebook short descriptions by @devbodaghe in #3531
+= 3.5.7 - 2025-09-02 =
+* Add - DO change: Add route & feed column by @unnivgit in #3580
+* Fix - removing set stable tag to unblock release for now by @immadhavv in #3584
+* Fix - Fixed syncing of excluded product categories and tags info by @vinkmeta in #3582
+* Add - feat: quick edit syncing by @rithikb24 in #3557
+* Add - [WIFI]30/n]Fetch the iframe management url through the Stefi API by @sharunaanandraj in #3569
+* Add - changelog: add referrer url by @chc421 in #3545
+* Fix - Fix sale price higher than fb price by @guansu-meta in #3567
+* Add - [WIFI][26/n]Add Listener and update Whatsapp Settings in DB after onboarding by @sharunaanandraj in #3568
+* Add - [WIFI][25/n]Add scaffolding Iframe Integration in the Whatsapp Tab by @sharunaanandraj in #3566
+* Add - [WIFI][1/n] Add Scaffolding WhatsApp Page under Marketing for WAUM Beta Experience by @sharunaanandraj in #3564
+* Dev - cleanup: remove dead code for product sets sync rollout switch by @devbodaghe in #3560
+* Add - Automatically set last release from release-plugin workflow as latest by @immadhavv in #3552
+* Add - Run unit tests with coverage and compare against threshold by @immadhavv in #3553
 
 [See changelog for all versions](https://raw.githubusercontent.com/facebook/facebook-for-woocommerce/refs/heads/main/changelog.txt).

--- a/tests/Unit/LocaleTest.php
+++ b/tests/Unit/LocaleTest.php
@@ -25,7 +25,7 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 	 */
 	public function test_get_supported_locales_returns_array() {
 		$locales = Locale::get_supported_locales();
-		
+
 		$this->assertIsArray( $locales );
 		$this->assertNotEmpty( $locales );
 	}
@@ -35,11 +35,11 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 	 */
 	public function test_get_supported_locales_format() {
 		$locales = Locale::get_supported_locales();
-		
+
 		foreach ( $locales as $locale => $name ) {
 			// Locale should be in xx_XX format
 			$this->assertMatchesRegularExpression( '/^[a-z]{2}_[A-Z]{2}$/', $locale );
-			
+
 			// Name should be a non-empty string
 			$this->assertIsString( $name );
 			$this->assertNotEmpty( $name );
@@ -52,12 +52,12 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 	public function test_get_supported_locales_is_sorted() {
 		$locales = Locale::get_supported_locales();
 		$values = array_values( $locales );
-		
+
 		// Create a copy and sort it
 		$sorted_values = $values;
 		natcasesort( $sorted_values );
 		$sorted_values = array_values( $sorted_values ); // Re-index
-		
+
 		// Compare with original
 		$this->assertEquals( $sorted_values, $values );
 	}
@@ -71,16 +71,16 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 		$this->assertFalse( Locale::is_supported_locale( 'EN_US' ) );
 		$this->assertFalse( Locale::is_supported_locale( 'en-US' ) );
 		$this->assertFalse( Locale::is_supported_locale( 'english' ) );
-		
+
 		// Non-existent locales
 		$this->assertFalse( Locale::is_supported_locale( 'xx_XX' ) );
 		$this->assertFalse( Locale::is_supported_locale( 'en_UK' ) ); // Should be en_GB
 		$this->assertFalse( Locale::is_supported_locale( 'fr_US' ) );
-		
+
 		// Empty and null
 		$this->assertFalse( Locale::is_supported_locale( '' ) );
 		$this->assertFalse( Locale::is_supported_locale( ' ' ) );
-		
+
 		// Case sensitivity tests
 		$this->assertFalse( Locale::is_supported_locale( 'en_us' ) );
 		$this->assertFalse( Locale::is_supported_locale( 'EN_US' ) );
@@ -96,9 +96,9 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 		$property = $reflection->getProperty( 'supported_locales' );
 		$property->setAccessible( true );
 		$hardcoded_locales = $property->getValue();
-		
+
 		foreach ( $hardcoded_locales as $locale ) {
-			$this->assertTrue( 
+			$this->assertTrue(
 				Locale::is_supported_locale( $locale ),
 				"Locale {$locale} should be supported"
 			);
@@ -114,13 +114,13 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 			$locales['test_XX'] = 'Test Language';
 			return $locales;
 		} );
-		
+
 		$locales = Locale::get_supported_locales();
-		
+
 		// Check that our test locale was added
 		$this->assertArrayHasKey( 'test_XX', $locales );
 		$this->assertEquals( 'Test Language', $locales['test_XX'] );
-		
+
 		// Clean up
 		remove_all_filters( 'wc_facebook_messenger_supported_locales' );
 	}
@@ -137,18 +137,18 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 			$locales['dup_US'] = $locales['en_US'];
 			return $locales;
 		} );
-		
+
 		$locales = Locale::get_supported_locales();
-		
+
 		// The filter should have added our new locale
 		$this->assertArrayHasKey( 'new_XX', $locales );
 		$this->assertEquals( 'New Language', $locales['new_XX'] );
-		
+
 		// Both keys should exist even with duplicate values
 		// array_unique preserves keys, so duplicate values are allowed
 		$this->assertArrayHasKey( 'en_US', $locales );
 		$this->assertArrayHasKey( 'dup_US', $locales );
-		
+
 		// Clean up
 		remove_all_filters( 'wc_facebook_messenger_supported_locales' );
 	}
@@ -161,7 +161,7 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 		// which is complex in PHPUnit. Instead, we'll test that the method
 		// works regardless of the Locale extension availability
 		$locales = Locale::get_supported_locales();
-		
+
 		// Should always have en_US at minimum
 		$this->assertArrayHasKey( 'en_US', $locales );
 		$this->assertNotEmpty( $locales['en_US'] );
@@ -172,7 +172,7 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 	 */
 	public function test_specific_locale_formats() {
 		$locales = Locale::get_supported_locales();
-		
+
 		// Test some specific locale codes that might be edge cases
 		$edge_cases = array(
 			'zh_CN' => 'Chinese (China)',
@@ -183,7 +183,7 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 			'es_ES' => 'Spanish (Spain)',
 			'es_LA' => 'Spanish (Latin America)',
 		);
-		
+
 		foreach ( $edge_cases as $locale => $expected_pattern ) {
 			if ( isset( $locales[ $locale ] ) ) {
 				$this->assertArrayHasKey( $locale, $locales );
@@ -197,14 +197,14 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 	 */
 	public function test_locale_names_capitalization() {
 		$locales = Locale::get_supported_locales();
-		
+
 		// Check that en_US specifically has proper capitalization
 		if ( isset( $locales['en_US'] ) ) {
 			$name = $locales['en_US'];
 			// Should start with capital letter
 			$this->assertMatchesRegularExpression( '/^[A-Z]/', $name );
 		}
-		
+
 		// Check a few more if they exist
 		foreach ( array( 'fr_FR', 'de_DE', 'es_ES' ) as $locale ) {
 			if ( isset( $locales[ $locale ] ) ) {
@@ -221,17 +221,17 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 	public function test_is_supported_locale_edge_cases() {
 		// Numeric input
 		$this->assertFalse( Locale::is_supported_locale( '123' ) );
-		
+
 		// Special characters
 		$this->assertFalse( Locale::is_supported_locale( 'en_US!' ) );
 		$this->assertFalse( Locale::is_supported_locale( '@#$%' ) );
-		
+
 		// Very long string
 		$this->assertFalse( Locale::is_supported_locale( str_repeat( 'a', 100 ) ) );
-		
+
 		// Locale with extra parts
 		$this->assertFalse( Locale::is_supported_locale( 'en_US_extra' ) );
-		
+
 		// Partial matches
 		$this->assertFalse( Locale::is_supported_locale( 'en_' ) );
 		$this->assertFalse( Locale::is_supported_locale( '_US' ) );
@@ -242,10 +242,10 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 	 */
 	public function test_supported_locales_count() {
 		$locales = Locale::get_supported_locales();
-		
+
 		// Should have a reasonable number of locales (at least 50)
 		$this->assertGreaterThan( 50, count( $locales ) );
-		
+
 		// But not too many (less than 200)
 		$this->assertLessThan( 200, count( $locales ) );
 	}
@@ -255,13 +255,13 @@ class LocaleTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 	 */
 	public function test_consistency_between_methods() {
 		$locales = Locale::get_supported_locales();
-		
+
 		// Every locale returned by get_supported_locales should return true for is_supported_locale
 		foreach ( array_keys( $locales ) as $locale ) {
-			$this->assertTrue( 
+			$this->assertTrue(
 				Locale::is_supported_locale( $locale ),
 				"Locale {$locale} from get_supported_locales() should return true for is_supported_locale()"
 			);
 		}
 	}
-} 
+}

--- a/tests/Unit/UpdateLastChangeTimeTest.php
+++ b/tests/Unit/UpdateLastChangeTimeTest.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+require_once __DIR__ . '/../../facebook-commerce.php';
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the updated last change time functionality
+ */
+class UpdateLastChangeTimeTest extends TestCase {
+
+    private $integration;
+    private $facebook_for_woocommerce;
+
+    public function setUp(): void {
+        parent::setUp();
+
+        // Create minimal mocks for the integration constructor
+        $this->facebook_for_woocommerce = $this->createMock(WC_Facebookcommerce::class);
+
+        // Mock rollout switches to prevent initialization issues
+        $rollout_switches = $this->createMock(WooCommerce\Facebook\RolloutSwitches::class);
+        $rollout_switches->method('is_switch_enabled')->willReturn(false);
+        $this->facebook_for_woocommerce->method('get_rollout_switches')->willReturn($rollout_switches);
+
+        // Create integration instance for testing the refactored methods
+        $this->integration = new WC_Facebookcommerce_Integration($this->facebook_for_woocommerce);
+    }
+
+    /**
+     * Test: Core last change time flow
+     * Tests main entry point, validation, and update mechanisms
+     */
+    public function test_core_last_change_time_flow() {
+        // Test main entry point with edge cases
+        $edge_cases = [
+            [0, 0, '', null],                           // Empty values
+            [1, 999999, 'normal_key', 'value'],        // Non-existent product
+            [1, 123, '_last_change_time', 'value'],    // Self-referential (should be excluded)
+        ];
+
+        foreach ($edge_cases as [$meta_id, $product_id, $meta_key, $meta_value]) {
+            try {
+                $this->integration->update_product_last_change_time($meta_id, $product_id, $meta_key, $meta_value);
+                $this->assertTrue(true, 'update_product_last_change_time handled edge case gracefully');
+            } catch (Exception $e) {
+                $this->assertTrue(true, 'update_product_last_change_time properly caught exception');
+            }
+        }
+
+        // Test validation methods using reflection for private method
+        $reflection = new \ReflectionClass($this->integration);
+        $validation_method = $reflection->getMethod('should_update_product_change_time');
+        $validation_method->setAccessible(true);
+
+        $this->assertFalse(
+            $validation_method->invoke($this->integration, 123, 'irrelevant_meta'),
+            'should_update_product_change_time rejects irrelevant meta keys'
+        );
+
+        $this->assertFalse(
+            $validation_method->invoke($this->integration, 123, '_last_change_time'),
+            'should_update_product_change_time rejects self-referential updates'
+        );
+
+        // Test core update mechanism
+        $reflection = new \ReflectionClass($this->integration);
+        $update_method = $reflection->getMethod('perform_product_last_change_time_update');
+        $update_method->setAccessible(true);
+
+        try {
+            $update_method->invoke($this->integration, 123);
+            $this->assertTrue(true, 'perform_product_last_change_time_update executes without errors');
+        } catch (Exception $e) {
+            $this->fail('perform_product_last_change_time_update should not throw exceptions: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Test: Meta key filtering logic
+     * Tests which meta keys should trigger sync updates
+     */
+    public function test_meta_key_filtering() {
+        $reflection = new \ReflectionClass($this->integration);
+        $method = $reflection->getMethod('is_product_attribute_sync_relevant');
+        $method->setAccessible(true);
+
+        // Should EXCLUDE these keys
+        $excluded_keys = [
+            '_last_change_time', '_fb_sync_last_time',  // Prevent infinite loops
+            '_wp_attached_file', '_edit_last',          // WordPress internals
+            'custom_field', 'other_plugin_meta'         // Unrelated meta
+        ];
+
+        foreach ($excluded_keys as $key) {
+            $this->assertFalse(
+                $method->invoke($this->integration, $key),
+                "Should exclude key: {$key}"
+            );
+        }
+
+        // Should INCLUDE these keys (trigger sync)
+        $sync_relevant_keys = [
+            '_regular_price', '_sale_price', '_stock', '_stock_status',     // WooCommerce core
+            'fb_brand', 'fb_color', 'fb_size', 'fb_product_condition',     // Facebook attributes
+            '_wc_facebook_sync_enabled'                                     // Facebook settings
+        ];
+
+        foreach ($sync_relevant_keys as $key) {
+            $this->assertTrue(
+                $method->invoke($this->integration, $key),
+                "Should include key: {$key}"
+            );
+        }
+    }
+
+    /**
+     * Test: Rate limiting functionality
+     * Tests that updates are properly rate-limited to prevent spam
+     */
+    public function test_rate_limiting() {
+        $reflection = new \ReflectionClass($this->integration);
+        $rate_limited_method = $reflection->getMethod('is_last_change_time_update_rate_limited');
+        $rate_limited_method->setAccessible(true);
+
+        $cache_method = $reflection->getMethod('set_last_change_time_cache');
+        $cache_method->setAccessible(true);
+
+        $product_id = 456;
+
+        // Initially not rate limited
+        $this->assertFalse(
+            $rate_limited_method->invoke($this->integration, $product_id),
+            'Should not be rate limited initially'
+        );
+
+        // Set cache with current time - should now be rate limited
+        $current_time = time();
+        $cache_method->invoke($this->integration, $product_id, $current_time);
+        $this->assertTrue(
+            $rate_limited_method->invoke($this->integration, $product_id),
+            'Should be rate limited after setting cache'
+        );
+
+        // Set cache with old time (beyond 60s window) - should not be rate limited
+        $old_time = $current_time - 120;
+        $cache_method->invoke($this->integration, $product_id, $old_time);
+        $this->assertFalse(
+            $rate_limited_method->invoke($this->integration, $product_id),
+            'Should not be rate limited after cache expires'
+        );
+
+        // Test cache setting doesn't throw exceptions
+        try {
+            $cache_method->invoke($this->integration, $product_id, time());
+            $this->assertTrue(true, 'set_last_change_time_cache executes without errors');
+        } catch (Exception $e) {
+            $this->fail('set_last_change_time_cache should not throw exceptions: ' . $e->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixed an issue on the Google Product categories page. When adding a new category, after tapping the confirmation button at the bottom of the page, the selected categories would remain selected. We want to clear selections after  anew category is created.

### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Clear google product categories selection form once a new category is created, so user can start fresh to create a new one.


## Test Plan

Verified the form is getting successfully cleared after creating a new category

## Screenshots
### Before

https://github.com/user-attachments/assets/bc6bc359-335e-4a1b-b471-678690e09088



### After

https://github.com/user-attachments/assets/66b86671-559a-4d38-ab66-236bcd29ba44


