### PR TITLE
fix: category name

### DIFF
--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -222,7 +222,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 			$content_category = array_values(
 				array_map(
 					function ( $item ) {
-						return $item->name;
+						return html_entity_decode( $item->name, ENT_QUOTES | ENT_HTML401, 'UTF-8' );
 					},
 					$category_path
 				)


### PR DESCRIPTION
## Description

https://wordpress.org/support/topic/synced-collections-show-amp-in-product-name/

Correctly, showing characters like "&"

### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fixes Characters like & showing correctly in commerce manager


## Test Plan

Before, 
"product_type":"abcd &amp; ab"

After, 
"product_type":"abcd & ab"
