### PR TITLE
Adding back set-stable-tag workflow

### DIFF
--- a/.github/workflows/set-stable-tag.yml
+++ b/.github/workflows/set-stable-tag.yml
@@ -1,0 +1,160 @@
+name: Set Stable Tag
+
+on: workflow_dispatch
+
+jobs:
+  final-qa-checks:
+    uses: ./.github/workflows/final-qa-checks.yml
+
+  set-stable-tag:
+    runs-on: ubuntu-latest
+    needs: final-qa-checks
+    environment: Deployment
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fail if not on a release publish branch
+        run: |
+          echo "Current ref: ${{ github.ref }}"
+          BRANCH="${{ github.ref }}"
+          if [[ ! $BRANCH == refs/heads/release/*/publish ]]; then
+            echo "❌ This workflow can only be run on release/*/publish branches."
+            exit 1
+          fi
+
+      - name: Get NPM Version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@v1.3.1
+
+      - name: Validate Git tag
+        run: |
+          git fetch --tags
+          if [ ! $(git tag -l "v${{ steps.package-version.outputs.current-version}}") ]; then
+            echo "❌ Git tag does not exist" 1>&2
+            exit 1
+          fi
+
+      - name: Install SVN
+        run: sudo apt-get install subversion -y
+
+      - name: Checkout SVN Repository
+        run: svn co https://plugins.svn.wordpress.org/facebook-for-woocommerce/ woocommerce_svn --quiet --non-interactive
+
+      - name: Validate SVN tag
+        run: |
+          if [ ! -d "woocommerce_svn/tags/${{ steps.package-version.outputs.current-version}}" ]; then
+            echo "❌ SVN tag directory does not exist" 1>&2
+            exit 1
+          fi
+
+      - name: Update readme.txt
+        env:
+          NEW_VERSION: ${{ steps.package-version.outputs.current-version}}
+        run: |
+          cd woocommerce_svn
+          sed -i -E "s/^(Stable tag:)[[:space:]]*[0-9.]+/\1 $NEW_VERSION/" "trunk/readme.txt"
+
+      - name: Commit to SVN
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        run: |
+          cd woocommerce_svn
+          cat trunk/readme.txt
+          svn status
+          svn diff
+          svn commit -m "Update stable tag for version ${{ steps.package-version.outputs.current-version}}" --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --no-auth-cache --non-interactive
+
+  set-last-release-as-latest:
+    runs-on: ubuntu-latest
+    environment: Deployment
+    needs: set-stable-tag
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: get npm version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@v1.3.1
+
+      - name: get release id from last successful release workflow
+        id: get-release-id
+        run: |
+          version="${{ steps.package-version.outputs.current-version }}"
+          expected_branch="release/p${version}/publish"
+
+          echo "Looking for successful release workflow run from branch: $expected_branch"
+
+
+          # Get the most recent successful workflow run for release-plugin.yml
+          workflow_runs=$(curl -s \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/release-plugin.yml/runs?branch=${expected_branch}&status=completed&per_page=1")
+
+          echo "$workflow_runs"
+          run_conclusion=$(echo "$workflow_runs" | jq -r '.workflow_runs[0].conclusion // empty')
+
+          if [ "$run_conclusion" != "success" ]; then
+            echo "❌ Last release workflow run was not successful (conclusion: $run_conclusion)"
+            echo "Cannot proceed with setting release as latest"
+            exit 1
+          fi
+
+          # Get the most recent successful run ID
+          run_id=$(echo "$workflow_runs" | jq -r '.workflow_runs[0].id // empty')
+
+          if [ -z "$run_id" ] || [ "$run_id" = "null" ] || [ "$run_id" = "" ]; then
+            echo "❌ No successful release workflow runs found"
+            exit 1
+          fi
+
+          echo "✅ Found successful workflow run ID: $run_id"
+          echo "run_id=$run_id" >> $GITHUB_OUTPUT
+
+      - name: Download release ID artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: release-id
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.get-release-id.outputs.run_id }}
+
+      - name: Read release ID from artifact
+        id: read-release-id
+        run: |
+          if [ ! -f "release-id.txt" ]; then
+            echo "❌ release-id.txt file not found"
+            exit 1
+          fi
+
+          release_id=$(cat release-id.txt)
+
+          if [ -z "$release_id" ]; then
+            echo "❌ Release ID is empty"
+            exit 1
+          fi
+
+          echo "✅ Found release ID: $release_id"
+          echo "release_id=$release_id" >> $GITHUB_OUTPUT
+
+
+      - name: Set release as latest
+        if: steps.read-release-id.outputs.release_id != ''
+        run: |
+          version="${{ steps.package-version.outputs.current-version }}"
+          release_id="${{ steps.read-release-id.outputs.release_id }}"
+
+          # Update release to make it latest
+          echo "Setting release v${version} as latest..."
+          update_response=$(curl -s -X PATCH \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -d '{"prerelease": false, "make_latest": true}' \
+            "https://api.github.com/repos/${{ github.repository }}/releases/${release_id}")
+
+          if echo "$update_response" | grep -q '"Error"'; then
+            echo "❌ Failed to update release v${version} as latest"
+            exit 1
+          fi
+
+          echo "✅ Release v${version} set as latest"


### PR DESCRIPTION
## Description

Adding back the set-stable-tag workflow that will help automate the last part of the release.

### Type of change

- Add (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Added-back the set-stable-tag workflow that helps automate the release

