### PR TITLE
[WooCommerce] Fix selected category values bug after a new category is created

### DIFF
--- a/assets/js/admin/product-categories.js
+++ b/assets/js/admin/product-categories.js
@@ -37,4 +37,25 @@ jQuery( document ).ready( ( $ ) => {
 				$form.data( 'allow-submit', true ).find( ':submit' ).trigger( 'click' );
 			} );
 	} );
+
+	// Add new category button handler to clear Google Product Category selections when clicked
+  $('#submit').on('click', function(e) {
+    // Only proceed if this is the "Add new category" button
+    if ($(this).val() === 'Add new category') {
+      // Check if the Google Product Category Fields handler exists
+      if (typeof window.wc_facebook_google_product_category_fields !== 'undefined') {
+
+        // Clear selections
+        $('#' + window.wc_facebook_google_product_category_fields.input_id).val('');
+        $('#wc-facebook-google-product-category-fields').empty();
+        $('.wc-facebook-enhanced-catalog-attribute-row').remove();
+
+        // Recreate initial empty selectors
+        window.wc_facebook_google_product_category_fields.addInitialSelects('');
+
+        // Set the last dropdown's margin bottom
+        $('.wc-facebook-google-product-category-field').last().attr('style', 'margin-bottom: 24px');
+      }
+    }
+  });
 } );


### PR DESCRIPTION
## Description

Fixed an issue on the Google Product categories page. When adding a new category, after tapping the confirmation button at the bottom of the page, the selected categories would remain selected. We want to clear selections after  anew category is created.

### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Clear google product categories selection form once a new category is created, so user can start fresh to create a new one.


## Test Plan

Verified the form is getting successfully cleared after creating a new category

## Screenshots
### Before

https://github.com/user-attachments/assets/bc6bc359-335e-4a1b-b471-678690e09088



### After

https://github.com/user-attachments/assets/66b86671-559a-4d38-ab66-236bcd29ba44


