### PR TITLE
rollout switch transient flag unit test

### DIFF
--- a/tests/Unit/RolloutSwitchesTest.php
+++ b/tests/Unit/RolloutSwitchesTest.php
@@ -262,27 +262,27 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 
 		$plugin_mock->method('get_connection_handler')->willReturn($mock_connection_handler);
 		$plugin_mock->method('get_api')->willReturn($mock_api);
-		$plugin_mock->method('get_version')->willReturnOnConsecutiveCalls('1.0.0', '2.0.0');
+		$plugin_mock->method('get_version')->willReturnOnConsecutiveCalls('1.x.x', '2.x.x');
 
 		$rollout_switches = new RolloutSwitches($plugin_mock);
 
 		// Clean up any existing transients
-		delete_transient('_wc_facebook_for_woocommerce_rollout_switch_flag_1.0.0');
-		delete_transient('_wc_facebook_for_woocommerce_rollout_switch_flag_2.0.0');
+		delete_transient('_wc_facebook_for_woocommerce_rollout_switch_flag_1.x.x');
+		delete_transient('_wc_facebook_for_woocommerce_rollout_switch_flag_2.x.x');
 
-		// First execution with version 1.0.0 - should execute and set transient
+		// First execution with version 1.x.x - should execute and set transient
 		$rollout_switches->init();
 
-		// Version upgrade to 2.0.0 - should bypass old transient and execute again
+		// Version upgrade to 2.x.x - should bypass old transient and execute again
 		$rollout_switches->init();
 
 		// Verify both version-specific transients were created
-		$this->assertEquals('yes', get_transient('_wc_facebook_for_woocommerce_rollout_switch_flag_1.0.0'));
-		$this->assertEquals('yes', get_transient('_wc_facebook_for_woocommerce_rollout_switch_flag_2.0.0'));
+		$this->assertEquals('yes', get_transient('_wc_facebook_for_woocommerce_rollout_switch_flag_1.x.x'));
+		$this->assertEquals('yes', get_transient('_wc_facebook_for_woocommerce_rollout_switch_flag_2.x.x'));
 
 		// Clean up
-		delete_transient('_wc_facebook_for_woocommerce_rollout_switch_flag_1.0.0');
-		delete_transient('_wc_facebook_for_woocommerce_rollout_switch_flag_2.0.0');
+		delete_transient('_wc_facebook_for_woocommerce_rollout_switch_flag_1.x.x');
+		delete_transient('_wc_facebook_for_woocommerce_rollout_switch_flag_2.x.x');
 	}
 
 	public function test_plugin_when_failing() {


### PR DESCRIPTION
## Description

Rollout Switch Test case to ensure version change leads to a complete check of all switches & doesn't return early
I have mocked getVersion with 1.x.x and 2.x.x

if 2.x.x gets created - it assets that execution continued on & didn't return early

### Type of change

- Unit Test

## Checklist

- [yes] I have commented my code, particularly in hard-to-understand areas, if any.
- [yes] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [yes] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [yes] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [yes] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [yes] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [no] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).



## Test Plan
It's a unit test - non breaking change
