### PR TITLE
Feat/stock update fix

### DIFF
--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -185,7 +185,8 @@ class Sync {
 				$this->create_or_update_products( array( $product->get_id() ) );
 			}
 		} catch ( Exception $e ) {
-			// catch any sync errors
+			// Silently handle any sync errors - Facebook sync should not break stock updates.
+			unset( $e ); // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 		}
 	}
 

--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -157,7 +157,7 @@ class Sync {
 	/**
 	 * Adds the products with stock changes to the requests array to be updated.
 	 *
-	 * @since 2.1.0
+	 * @since 3.5.8
 	 *
 	 * @param \WC_Product $product product object
 	 */
@@ -173,15 +173,18 @@ class Sync {
 			return;
 		}
 
-		// handle variable products - sync children only, not the parent
-		if ( $product->is_type( 'variable' ) ) {
-			$variation_ids = $product->get_children();
-			if ( ! empty( $variation_ids ) ) {
-				$this->create_or_update_products( $variation_ids );
+		try {
+			// handle variable products - sync children only, not the parent
+			if ( $product->is_type( 'variable' ) ) {
+				$variation_ids = $product->get_children();
+				if ( ! empty( $variation_ids ) ) {
+					$this->create_or_update_products( $variation_ids );
+				}
+			} else {
+				// add the product to the list of products to be updated
+				$this->create_or_update_products( array( $product->get_id() ) );
 			}
-		} else {
-			// add the product to the list of products to be updated
-			$this->create_or_update_products( array( $product->get_id() ) );
+		} catch ( Exception $e ) {
 		}
 	}
 

--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -168,8 +168,16 @@ class Sync {
 			return;
 		}
 
-		// add the product to the list of products to be updated
-		$this->create_or_update_products( array( $product->get_id() ) );
+		// handle variable products - sync children only, not the parent
+		if ( $product->is_type( 'variable' ) ) {
+			$variation_ids = $product->get_children();
+			if ( ! empty( $variation_ids ) ) {
+				$this->create_or_update_products( $variation_ids );
+			}
+		} else {
+			// add the product to the list of products to be updated
+			$this->create_or_update_products( array( $product->get_id() ) );
+		}
 	}
 
 

--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -185,6 +185,7 @@ class Sync {
 				$this->create_or_update_products( array( $product->get_id() ) );
 			}
 		} catch ( Exception $e ) {
+			// catch any sync errors
 		}
 	}
 


### PR DESCRIPTION
## Description

Bug on stock update - 
Item now has +1 variant count and a new variant has been created. If QTY was changed for the new variant  all sizes example - 'S|M|L|XL' are listed as the variants value
### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)


## Checklist

- [yes] I have commented my code, particularly in hard-to-understand areas, if any.
- [yes] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [yes] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [yes] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fixes variant product sync for stock updates to commerce manager


## Test Plan

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration.

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before

### After
