### PR TITLE
issue-3558-deprecated-warning

### DIFF
--- a/includes/Handlers/WhatsAppUtilityConnection.php
+++ b/includes/Handlers/WhatsAppUtilityConnection.php
@@ -386,7 +386,7 @@ class WhatsAppUtilityConnection {
 				'messaging_product' => 'whatsapp',
 				'to'                => $phone_number,
 				'event_config_id'   => $event_config_id,
-				'external_event_id' => "${order_id}",
+				'external_event_id' => "{$order_id}",
 				'country_code'      => $country_code,
 				'template'          => array(
 					'language'   => array(


### PR DESCRIPTION
## Description

This fixes a warning that appears as deprecated from PHP 8.2..
Fixes #3558

### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)

## Checklist

- [] I have commented my code, particularly in hard-to-understand areas, if any.
- [] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

One liner entry to be surfaced in changelog.txt


## Test Plan

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration.

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before

### After
