### PR TITLE
Added a check for the # of posts found with a query

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -518,7 +518,11 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				$product_ids  = array();
 				$contents     = array();
 				$total_value  = 0.00;
-
+				
+				if ( $wp_query->found_posts == 0) {
+					return null;
+				}
+				
 				foreach ( $wp_query->posts as $post ) {
 
 					$product = wc_get_product( $post );


### PR DESCRIPTION
## Description

Added a check for the # of posts found in the result of the search query, before proceeding to create a search event. 
This is to fix issues like [this](https://wordpress.org/support/topic/missing-content_id-warnings-on-empty-woocommerce-search-result-pages/#utm_medium=referral&utm_source=facebook.com&utm_content=social)

### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fix - Prevent Missing content_id warnings on empty WooCommerce search result pages


## Test Plan

Manually tested
