### PR TITLE
[WIFI][EZ] Fix Iframe Management Url Stefi API Call

### DIFF
--- a/includes/Handlers/WhatsAppExtension.php
+++ b/includes/Handlers/WhatsAppExtension.php
@@ -96,7 +96,7 @@ class WhatsAppExtension {
 			'body'    => array(),
 			'timeout' => 3000, // 5 minutes
 		);
-		$response        = wp_remote_get( $base_url, $options );
+		$response        = wp_remote_get( $url, $options );
 		$data            = explode( "\n", wp_remote_retrieve_body( $response ) );
 		$response_object = json_decode( $data[0] );
 		return $response_object->iframe_management_uri;


### PR DESCRIPTION
## Description
The query params were not added to url hence locale wasn't being set in iframe_management url. Fixing this.

### Type of change

Please delete options that are not relevant
- Fix (non-breaking change which fixes an issue)


## Changelog entry
Fix Iframe Management Url Stefi API Call


## Test Plan
### Before - Locale not set in management uri
> https://www.76872.od.commercepartnerhub.com/whatsapp_utility_integration/onboarding/?app_id=753591807210902&wa_installation_id=24132996163048732&external_business_id=sharuna-local-store-68c9a664ab340&access_token={token}
### After - Locale set in management uri
>https://www.76872.od.commercepartnerhub.com/whatsapp_utility_integration/onboarding/?app_id=753591807210902&locale=en&wa_installation_id=24132996163048732&external_business_id=sharuna-local-store-68c9a664ab340&access_token={token}