### PR TITLE
Remediate privacy vulnerability due to lack of nonce check

### DIFF
--- a/includes/Handlers/PluginRender.php
+++ b/includes/Handlers/PluginRender.php
@@ -209,6 +209,7 @@ class PluginRender {
 	}
 
 	public static function sync_all_clicked() {
+		check_admin_referer( self::ACTION_SYNC_BACK_IN, 'nonce' );
 		update_option( self::MASTER_SYNC_OPT_OUT_TIME, '' );
 		wp_send_json_success( 'Synced all in successfully' );
 	}

--- a/includes/Handlers/PluginRender.php
+++ b/includes/Handlers/PluginRender.php
@@ -216,6 +216,7 @@ class PluginRender {
 	}
 
 	public static function product_set_banner_closed() {
+		check_admin_referer( self::ACTION_PRODUCT_SET_BANNER_CLOSED, 'nonce' );
 		check_ajax_referer( self::ACTION_PRODUCT_SET_BANNER_CLOSED, 'nonce' );
 		set_transient( 'fb_product_set_banner_dismissed', true );
 	}
@@ -225,6 +226,7 @@ class PluginRender {
 	 * after a week
 	 */
 	public static function reset_upcoming_version_banners() {
+		check_admin_referer( self::ACTION_CLOSE_BANNER, 'nonce' );
 		set_transient( 'upcoming_woo_all_products_banner_hide', true, 7 * DAY_IN_SECONDS );
 	}
 
@@ -234,6 +236,7 @@ class PluginRender {
 	 * NOTE: We are doing this because anyway we will remove this in cleanup post : 3.5.3
 	 */
 	public static function reset_plugin_updated_successfully_banner() {
+		check_admin_referer( self::ACTION_CLOSE_BANNER, 'nonce' );
 		set_transient( 'plugin_updated_banner_hide', true, 12 * MONTH_IN_SECONDS );
 	}
 
@@ -242,6 +245,7 @@ class PluginRender {
 	 * But this will keep showing every week fortnight if user not synced in
 	 */
 	public static function reset_plugin_updated_successfully_but_master_sync_off_banner() {
+		check_admin_referer( self::ACTION_CLOSE_BANNER, 'nonce' );
 		set_transient( 'plugin_updated_with_master_sync_off_banner_hide', true, 2 * WEEK_IN_SECONDS );
 	}
 

--- a/includes/Handlers/PluginRender.php
+++ b/includes/Handlers/PluginRender.php
@@ -203,6 +203,7 @@ class PluginRender {
 	}
 
 	public static function opt_out_of_sync_clicked() {
+		check_admin_referer( self::ACTION_OPT_OUT_OF_SYNC, 'nonce' );
 		$latest_date = gmdate( 'Y-m-d H:i:s' );
 		update_option( self::MASTER_SYNC_OPT_OUT_TIME, $latest_date );
 		wp_send_json_success( 'Opted out successfully' );


### PR DESCRIPTION
## Description

A privacy vulnerability has been identified where ajax call can be exploited without any authentication. This is due to the lack of nonce check.

In this PR we add the missing nonce check to the identified ajax calls.

### Type of change
- Fix (non-breaking change which fixes an issue)

## Checklist

- [] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Add check_admin_referer to ajax calls.

## Test Plan

Using the script exploiting ajax calls: ([link](https://patchstack-database.s3.us-east-2.amazonaws.com/files/cee826db-a2eb-48e7-8245-adaa7bbf47cf/f5733814-bb1c-4f69-919c-e626d5004102.txt?X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIATLPOZUEKEA5CDFOJ%2F20250918%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20250918T153413Z&X-Amz-SignedHeaders=host&X-Amz-Expires=604800&X-Amz-Signature=4abb2f7956aa9efd77f5730f9989ab460be104439be8b9b281bc34acc554daea) to script)

- Before: received success response
- After: received expired response

See screenshots below.

## Screenshots

### Before
<img width="773" height="307" alt="image" src="https://github.com/user-attachments/assets/88d122d4-f627-4b4d-98a3-742cecc367d6" />


### After
<img width="722" height="314" alt="image" src="https://github.com/user-attachments/assets/010986f1-18b1-493d-b6d8-c3a7cbb76eeb" />

