### PR TITLE
WooCommerce Changes to call Customer Events Endpoint for Order Fulfilled

### DIFF
--- a/facebook-commerce-iframe-whatsapp-utility-event.php
+++ b/facebook-commerce-iframe-whatsapp-utility-event.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+use WooCommerce\Facebook\Handlers\WhatsAppExtension;
+use WooCommerce\Facebook\RolloutSwitches;
+
+/**
+ * Event Processor for sending WhatsApp Utility Message when Order Management events are triggered
+ */
+class WC_Facebookcommerce_Iframe_Whatsapp_Utility_Event {
+
+	/** @var array Mapping of Order Status to Event name */
+	const ORDER_STATUS_TO_EVENT_MAPPING = array(
+		'completed' => 'ORDER_FULFILLED',
+	);
+
+	/** @var \WC_Facebookcommerce */
+	private $plugin;
+
+
+	public function __construct( WC_Facebookcommerce $plugin ) {
+		$rollout_switches = $plugin->get_rollout_switches();
+		$this->plugin     = $plugin;
+		if ( ! $this->is_whatsapp_utility_enabled() ) {
+			return;
+		}
+		add_action( 'woocommerce_order_status_changed', array( $this, 'process_wc_order_status_changed' ), 10, 3 );
+	}
+
+
+	/**
+	 * Determines if WhatsApp Utility Messages are enabled
+	 *
+	 * @return bool
+	 */
+	private function is_whatsapp_utility_enabled() {
+		$is_enabled       = false;
+		$rollout_switches = $this->plugin->get_rollout_switches();
+		if ( isset( $rollout_switches ) ) {
+			$is_enabled = $rollout_switches->is_switch_enabled(
+				RolloutSwitches::WHATSAPP_UTILITY_MESSAGING_BETA_EXPERIENCE_DOGFOODING
+			) ?? false;
+		}
+		return $is_enabled;
+	}
+
+	/**
+	 * Hook to process Order Processing, Order Completed and Order Refunded events for WhatsApp Utility Messages
+	 *
+	 * @param string $order_id Order id
+	 * @param string $old_status Old Order Status
+	 * @param string $new_status New Order Status
+	 *
+	 * @return void
+	 * @since 2.3.0
+	 */
+	public function process_wc_order_status_changed( $order_id, $old_status, $new_status ) {
+		$supported_statuses = array_keys( self::ORDER_STATUS_TO_EVENT_MAPPING );
+		if ( ! in_array( $new_status, $supported_statuses, true ) ) {
+			return;
+		}
+
+		wc_get_logger()->info(
+			sprintf(
+			/* translators: %s $order_id */
+				__( 'Processing Order id %1$s to send Whatsapp Utility messages', 'facebook-for-woocommerce' ),
+				$order_id,
+			)
+		);
+		$event              = self::ORDER_STATUS_TO_EVENT_MAPPING[ $new_status ];
+		$order              = wc_get_order( $order_id );
+		$order_details_link = $order->get_checkout_order_received_url();
+		// Get WhatsApp Phone number from entered Billing and Shipping phone number
+		$billing_phone_number  = $order->get_billing_phone();
+		$shipping_phone_number = $order->get_shipping_phone();
+		$phone_number          = $billing_phone_number ?? $shipping_phone_number;
+		// Get Country Code from Billing and Shipping Country to override Country Calling Code
+		$country_code = $should_use_billing_info ? $order->get_billing_country() : $order->get_shipping_country();
+		// Get Customer first name
+		$first_name = $order->get_billing_first_name();
+		// Get Total Refund Amount for Order Refunded event
+		$total_refund = 0;
+		foreach ( $order->get_refunds() as $refund ) {
+			$total_refund += $refund->get_amount();
+		}
+		$currency      = $order->get_currency();
+		$refund_amount = $total_refund * 1000;
+		if ( empty( $phone_number ) || empty( $event ) || empty( $first_name ) ) {
+			wc_get_logger()->info(
+				sprintf(
+				/* translators: %s $order_id */
+					__( 'Customer Events Post API call for Order id %1$s skipped due to missing Order info', 'facebook-for-woocommerce' ),
+					$order_id,
+				)
+			);
+			return;
+		}
+		WhatsAppExtension::process_whatsapp_utility_message_event( $this->plugin, $event, $order_id, $order_details_link, $phone_number, $first_name, $refund_amount, $currency, $country_code );
+	}
+}

--- a/facebook-commerce-whatsapp-utility-event.php
+++ b/facebook-commerce-whatsapp-utility-event.php
@@ -38,7 +38,7 @@ class WC_Facebookcommerce_Whatsapp_Utility_Event {
 	 * @return bool
 	 */
 	private function is_whatsapp_utility_enabled() {
-		return true;
+		return false;
 	}
 
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -254,6 +254,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/** @var WC_Facebookcommerce_Whatsapp_Utility_Event instance. */
 	private $wa_utility_event_processor;
 
+	/** @var WC_Facebookcommerce_Iframe_Whatsapp_Utility_Event instance. */
+	private $wa_iframe_utility_event_processor;
+
 	/**
 	 * Init and hook in the integration.
 	 *
@@ -410,6 +413,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		// Track programmatic changes that don't update post_modified
 		add_action( 'updated_post_meta', array( $this, 'update_product_last_change_time' ), 10, 4 );
+
+		// Init Whatsapp Iframe Utility Event Processor
+		$this->wa_iframe_utility_event_processor = $this->load_whatsapp_iframe_utility_event_processor();
 	}
 
 	/**
@@ -2100,7 +2106,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 */
 	private function should_update_product_change_time( $product_id, $meta_key ) {
 		$product_id = absint( $product_id );
-		$meta_key = sanitize_key( $meta_key );
+		$meta_key   = sanitize_key( $meta_key );
 
 		// Check if this is a WooCommerce product
 		$product = wc_get_product( $product_id );
@@ -2184,7 +2190,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 * @since 3.5.8
 	 */
 	private function is_last_change_time_update_rate_limited( $product_id ) {
-		$cache_key = "last_change_time_{$product_id}";
+		$cache_key   = "last_change_time_{$product_id}";
 		$cached_time = wp_cache_get( $cache_key, 'facebook_for_woocommerce' );
 
 		// If no cached time, allow update
@@ -2194,7 +2200,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		// Rate limit to once every 60 seconds (1 minute)
 		$rate_limit_window = 60;
-		$current_time = time();
+		$current_time      = time();
 
 		// If the last update was within the rate limit window, prevent update
 		return ( $current_time - $cached_time ) < $rate_limit_window;
@@ -3295,6 +3301,21 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		if ( class_exists( 'WC_Facebookcommerce_Whatsapp_Utility_Event' ) ) {
 			if ( ! isset( $this->wa_utility_event_processor ) ) {
 				$this->wa_utility_event_processor = new WC_Facebookcommerce_Whatsapp_Utility_Event( $this );
+			}
+		}
+	}
+
+	/**
+	 * Init WhatsApp Utility Event Processor.
+	 *
+	 * @return void
+	 */
+	public function load_whatsapp_iframe_utility_event_processor() {
+		// Attempt to load Iframe WhatsApp Utility Event Processor
+		include_once 'facebook-commerce-iframe-whatsapp-utility-event.php';
+		if ( class_exists( 'WC_Facebookcommerce_Iframe_Whatsapp_Utility_Event' ) ) {
+			if ( ! isset( $this->wa_iframe_utility_event_processor ) ) {
+				$this->wa_iframe_utility_event_processor = new WC_Facebookcommerce_Iframe_Whatsapp_Utility_Event( $this->facebook_for_woocommerce );
 			}
 		}
 	}

--- a/includes/Handlers/WhatsAppExtension.php
+++ b/includes/Handlers/WhatsAppExtension.php
@@ -101,4 +101,96 @@ class WhatsAppExtension {
 		$response_object = json_decode( $data[0] );
 		return $response_object->iframe_management_uri;
 	}
+
+	/**
+	 * Trigger WhatsApp Message Sends for Processed Order
+	 *
+	 * @param object $plugin The plugin instance.
+	 * @param string $event Order Management event
+	 * @param string $order_id Order id
+	 * @param string $order_details_link Order Details Link
+	 * @param string $phone_number Customer phone number
+	 * @param string $first_name Customer first name
+	 * @param int    $refund_value Amount refunded to the Customer
+	 * @param string $currency Currency code
+	 * @param string $country_code Customer country code
+	 *
+	 * @return string
+	 * @since 3.5.0
+	 */
+	public static function process_whatsapp_utility_message_event(
+		$plugin,
+		$event,
+		$order_id,
+		$order_details_link,
+		$phone_number,
+		$first_name,
+		$refund_value,
+		$currency,
+		$country_code
+	) {
+		$whatsapp_connection = $plugin->get_whatsapp_connection_handler();
+		$is_connected        = $whatsapp_connection->is_connected();
+		if ( ! $is_connected ) {
+			wc_get_logger()->info(
+				sprintf(
+				/* translators: %s $order_id */
+					__( 'Customer Events Post API call for Order id %1$s Failed due to failed connection ', 'facebook-for-woocommerce' ),
+					$order_id,
+				)
+			);
+			return;
+		}
+		$wa_installation_id = $whatsapp_connection->get_wa_installation_id();
+		$base_url           = array( self::BASE_STEFI_ENDPOINT_URL, 'whatsapp/business', $wa_installation_id, 'customer_events' );
+		$base_url           = esc_url( implode( '/', $base_url ) );
+		$bisu_token         = $whatsapp_connection->get_access_token();
+		$options            = array(
+			'headers' => array(
+				'Authorization' => 'Bearer ' . $bisu_token,
+			),
+			'body'    => array(
+				'customer' => array(
+					'id'           => $phone_number,
+					'type'         => 'GUEST',
+					'first_name'   => $first_name,
+					'country_code' => $country_code,
+					'language'     => get_user_locale(),
+				),
+				'event'    => array(
+					'id'              => "#{$order_id}",
+					'type'            => $event,
+					'order_fulfilled' => array(
+						'tracking_url' => $order_details_link,
+					),
+				),
+			),
+			'timeout' => 3000, // 5 minutes
+		);
+
+		$response        = wp_remote_post( $base_url, $options );
+		$status_code     = wp_remote_retrieve_response_code( $response );
+		$data            = explode( "\n", wp_remote_retrieve_body( $response ) );
+		$response_object = json_decode( $data[0] );
+		if ( is_wp_error( $response ) || 200 !== $status_code ) {
+			$error_message = $response_object->error->error_user_title ?? $response_object->error->message ?? 'Something went wrong. Please try again later!';
+			wc_get_logger()->info(
+				sprintf(
+				/* translators: %s $order_id %s $error_message */
+					__( 'Customer Events Post API call for Order id %1$s Failed %2$s ', 'facebook-for-woocommerce' ),
+					$order_id,
+					$error_message,
+				)
+			);
+		} else {
+			wc_get_logger()->info(
+				sprintf(
+				/* translators: %s $order_id */
+					__( 'Customer Events Post API call for Order id %1$s Succeeded.', 'facebook-for-woocommerce' ),
+					$order_id
+				)
+			);
+		}
+		return;
+	}
 }


### PR DESCRIPTION
## Description

Changes to call the Customer Events API at Meta to send Order Fulfilled Utility WhatsApp Messages for the Iframe Integration

### Type of change
- Add (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.

## Changelog entry

Add call to Meta Event Processor when order status is completed

## Test Plan
Steps to reproduce:
1. Add Business id to dogfooding gk
2. Place order on WooCommerce site
3. Update order status to Completed
4. Validate Whatsapp Utility Message for Order Shipped is sent to phone number

https://github.com/user-attachments/assets/aba87162-a680-4911-96cc-200dd393985c


