### PR TITLE
Update facebook-commerce-admin-notice.php

### DIFF
--- a/facebook-commerce-admin-notice.php
+++ b/facebook-commerce-admin-notice.php
@@ -28,23 +28,29 @@ class WC_Facebookcommerce_Admin_Notice {
 	}
 
 	public function enqueue_notice_script() {
-		wp_enqueue_script(
-			'whatsapp-admin-notice',
-			plugins_url( 'assets/js/admin/whatsapp-admin-notice.js', __FILE__ ),
-			array( 'jquery' ),
-			'1.0',
-			true
-		);
-		wp_localize_script(
-			'whatsapp-admin-notice',
-			'WCFBAdminNotice',
-			array(
-				'ajax_url'  => admin_url( 'admin-ajax.php' ),
-				'nonce'     => wp_create_nonce( self::NOTICE_ID ),
-				'notice_id' => self::NOTICE_ID,
-			)
-		);
-	}
+    // Define a unique handle for the script. Use a prefix to avoid conflicts.
+    $handle = 'wcfb-whatsapp-admin-notice';
+
+    // Enqueue the script with a unique handle, dependencies, and version.
+    wp_enqueue_script(
+        $handle,
+        plugins_url( 'assets/js/admin/whatsapp-admin-notice.js', __FILE__ ),
+        [ 'jquery' ], // Use modern short-array syntax.
+        '1.0.0',      // A more standard versioning format.
+        true
+    );
+
+    // Immediately localize the script using the same handle.
+    wp_localize_script(
+        $handle,
+        'WCFBAdminNotice',
+        [
+            'ajax_url'  => admin_url( 'admin-ajax.php' ),
+            'nonce'     => wp_create_nonce( self::NOTICE_ID ),
+            'notice_id' => self::NOTICE_ID,
+        ]
+    );
+}
 
 	/**
 	 * Handles the AJAX request to dismiss the notice.


### PR DESCRIPTION
To optimize this WordPress function, you should consolidate the calls to wp_enqueue_script and wp_localize_script, and follow a few key best practices. The goal is to make the code more readable, robust, and maintainable.

## Description

Please include a summary of the changes and the related issue. 
Please also include relevant motivation and context. 
List any dependencies that are required for this change.

### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)
- Add (non-breaking change which adds functionality)
- Tweak (non-breaking change which fixes code modularity, linting or phpcs issues)
- Break (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [] I have commented my code, particularly in hard-to-understand areas, if any.
- [] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

One liner entry to be surfaced in changelog.txt


## Test Plan

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration.

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before

### After
