### PR TITLE
Woo Changes to support Order Refunded

### DIFF
--- a/facebook-commerce-iframe-whatsapp-utility-event.php
+++ b/facebook-commerce-iframe-whatsapp-utility-event.php
@@ -19,6 +19,7 @@ class WC_Facebookcommerce_Iframe_Whatsapp_Utility_Event {
 	/** @var array Mapping of Order Status to Event name */
 	const ORDER_STATUS_TO_EVENT_MAPPING = array(
 		'completed' => 'ORDER_FULFILLED',
+		'refunded'  => 'ORDER_REFUNDED',
 	);
 
 	/** @var \WC_Facebookcommerce */

--- a/includes/Handlers/WhatsAppExtension.php
+++ b/includes/Handlers/WhatsAppExtension.php
@@ -145,6 +145,13 @@ class WhatsAppExtension {
 		$base_url           = array( self::BASE_STEFI_ENDPOINT_URL, 'whatsapp/business', $wa_installation_id, 'customer_events' );
 		$base_url           = esc_url( implode( '/', $base_url ) );
 		$bisu_token         = $whatsapp_connection->get_access_token();
+		$event_lowercase    = strtolower( $event );
+		$event_object       = self::get_object_for_event(
+			$event,
+			$order_details_link,
+			$refund_value,
+			$currency
+		);
 		$options            = array(
 			'headers' => array(
 				'Authorization' => 'Bearer ' . $bisu_token,
@@ -158,11 +165,9 @@ class WhatsAppExtension {
 					'language'     => get_user_locale(),
 				),
 				'event'    => array(
-					'id'              => "#{$order_id}",
-					'type'            => $event,
-					'order_fulfilled' => array(
-						'tracking_url' => $order_details_link,
-					),
+					'id'             => "#{$order_id}",
+					'type'           => $event,
+					$event_lowercase => $event_object,
 				),
 			),
 			'timeout' => 3000, // 5 minutes
@@ -192,5 +197,27 @@ class WhatsAppExtension {
 			);
 		}
 		return;
+	}
+
+	/**
+	 * Gets event data tied to Order Management Event
+	 *
+	 * @param string $event Order Management event
+	 * @param string $order_details_link Order details link
+	 * @param string $refund_value Amount refunded to the Customer
+	 * @param string $currency Currency code
+	 */
+	public static function get_object_for_event( $event, $order_details_link, $refund_value, $currency ) {
+		switch ( $event ) {
+			case 'ORDER_FULFILLED':
+				return array(
+					'tracking_url' => $order_details_link,
+				);
+			case 'ORDER_REFUNDED':
+				return array(
+					'amount_1000' => $refund_value,
+					'currency'    => $currency,
+				);
+		}
 	}
 }


### PR DESCRIPTION
## Description

Changes to call the Customer Events API at Meta to send Order Refunded Utility WhatsApp Messages for the Iframe Integration

### Type of change
- Add (non-breaking change which adds functionality)


## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.


## Changelog entry

Add call to Meta Event Processor when order status is refunded

## Test Plan

Steps to reproduce:
1. Add Business id to dogfooding gk
2. Place order on WooCommerce site
3. Update order status to Completed
4. Validate Whatsapp Utility Message for Order Shipped is sent to phone number
5. Update order status to Redunded
6. Validate Whatsapp Utility Message for Order Refunded is sent to phone number


https://github.com/user-attachments/assets/283be9cc-655a-4217-8cbe-714d905f911c


