### PR TITLE
Separate Purchase event tracking for Pixel and CAPI

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -910,7 +910,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				return;
 			}
 
-			// use a session flag to ensure this Purchase event is not tracked multiple times along multiple processes
+			// Use a session flag to ensure this Purchase event is not tracked multiple times along multiple processes.
 			$purchase_tracked_flag = '_wc_' . facebook_for_woocommerce()->get_id() . '_purchase_tracked_' . $order_id . '_' . ( $is_browser ? 'browser' : 'server' );
 
 			// Return if this Purchase event has already been tracked.


### PR DESCRIPTION
## Description

This changeset updates Purchase event tracking so we can fire the Pixel and CAPI events independently while retaining deduplication with the Event ID. Tracking is now separated by using meta data to determine if the Purchase event is tracked by browser or server side (`META_PURCHASE_TRACKED_BROWSER` and `META_PURCHASE_TRACKED_SERVER`). Because of possible race conditions with the meta data (conflicts with other plugins and payment gateways) after checking the meta data of the order a transient is also used for additional checks. The transient key is scoped by order ID and event source (browser or server), acting as a short-lived session flag that prevents the same Purchase event from being tracked multiple times across concurrent processes.

We also clean up unused metadata and transients related to tracking Purchase events.

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [n/a] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Changelog entry

Separate Purchase event tracking for Pixel and CAPI

## Test Plan

After installing the plugin, connect to MBE and go through the website to make a purchase: the expected outcome is to see 1 Pixel and 1 CAPI `Purchase` event per order made on the website.