### PR TITLE
[WIFI]Return Error Banner if Iframe Management Url Fetching Fails

### DIFF
--- a/includes/Admin/WhatsApp_Integration_Settings.php
+++ b/includes/Admin/WhatsApp_Integration_Settings.php
@@ -186,7 +186,7 @@ class WhatsApp_Integration_Settings {
 		}
 
 		if ( empty( $iframe_url ) ) {
-			return;
+			return $this->error_banner();
 		}
 		?>
 		<div class="facebook-whatsapp-iframe-container">
@@ -195,6 +195,51 @@ class WhatsApp_Integration_Settings {
 				src="<?php echo esc_url( $iframe_url ); ?>"
 				></iframe>
 		</div>
+		<?php
+	}
+
+	private function error_banner() {
+		?>
+		<div class="facebook-whatsapp-iframe-error-container">
+			<div class="notice notice-error" style="margin: 0; padding-bottom: 20px;">
+				<h3><?php esc_html_e( 'WhatsApp Utility Connection Error', 'facebook-for-woocommerce' ); ?></h3>
+				<p><?php esc_html_e( 'There was an error loading the WhatsApp Utility Message Integration. Please try reloading the page or resetting your settings.', 'facebook-for-woocommerce' ); ?></p>
+				<div style="margin-top: 15px;">
+					<button
+						type="button"
+						class="button button-primary"
+						onclick="window.location.reload();"
+						style="margin-right: 10px;"
+					>
+						<?php esc_html_e( 'Reload Page', 'facebook-for-woocommerce' ); ?>
+					</button>
+					<button
+						type="button"
+						class="button button-secondary"
+						onclick="if(confirm('<?php echo esc_js( __( 'Are you sure you want to reset WhatsApp settings? This action cannot be undone and you will have to re-onboard.', 'facebook-for-woocommerce' ) ); ?>')) { resetWhatsAppSettings(); }"
+					>
+						<?php esc_html_e( 'Reset Settings', 'facebook-for-woocommerce' ); ?>
+					</button>
+				</div>
+			</div>
+		</div>
+		<script type="text/javascript">
+			function resetWhatsAppSettings() {
+				// Use the same API client that's available on the page
+				if (typeof whatsAppAPI !== 'undefined') {
+					whatsAppAPI.uninstallWhatsAppSettings()
+						.then(function(response) {
+							if (response.success) {
+								window.location.reload();
+							}
+						})
+						.catch(function(error) {
+							console.error('Error during settings reset:', error);
+							alert('<?php echo esc_js( __( 'Error resetting settings. Please try again or contact support.', 'facebook-for-woocommerce' ) ); ?>');
+						});
+				}
+			}
+		</script>
 		<?php
 	}
 

--- a/includes/Handlers/WhatsAppExtension.php
+++ b/includes/Handlers/WhatsAppExtension.php
@@ -110,7 +110,7 @@ class WhatsAppExtension {
 		$data            = explode( "\n", wp_remote_retrieve_body( $response ) );
 		$response_object = json_decode( $data[0] );
 		if ( is_wp_error( $response ) || 200 !== $status_code ) {
-			$error_message = $response_object->error->error_user_title ?? $response_object->error->message ?? 'Something went wrong. Please try again later!';
+			$error_message = $response_object->detail ?? $response_object->title ?? 'Something went wrong. Please try again later!';
 			wc_get_logger()->info(
 				sprintf(
 				/* translators: %s $wa_installation_id %s $error_message */


### PR DESCRIPTION
## Description
Return Error Banner if Iframe Management Url Fetching Fails. Error banner has two buttons:
1. Reload to Refetch the iframe Url
2. Reset - If there is an issue with fetching the iframe management url then we should allow reset the connection

### Type of change
- Add (non-breaking change which adds functionality)



## Changelog entry
Return Error Banner if Iframe Management Url Fetching Fails


## Test Plan
Before
<img width="1723" height="957" alt="Screenshot 2025-09-19 at 11 10 04 AM" src="https://github.com/user-attachments/assets/fa3ae1f1-ab4e-4428-8afd-a1a4c43682b4" />

After 
https://github.com/user-attachments/assets/2cebc08f-f7a0-4d47-9ec2-2a61b0f01475


