### PR TITLE
Fix - PHP 8.2 string interpolation warning

### DIFF
--- a/includes/Handlers/WhatsAppUtilityConnection.php
+++ b/includes/Handlers/WhatsAppUtilityConnection.php
@@ -386,7 +386,7 @@ class WhatsAppUtilityConnection {
 				'messaging_product' => 'whatsapp',
 				'to'                => $phone_number,
 				'event_config_id'   => $event_config_id,
-				'external_event_id' => "${order_id}",
+				'external_event_id' => "{$order_id}",
 				'country_code'      => $country_code,
 				'template'          => array(
 					'language'   => array(


### PR DESCRIPTION
## Description

This PR fixes a PHP 8.2 deprecation notice caused by the use of deprecated string interpolation syntax (`"${var}"`).

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fix: Replace deprecated string interpolation syntax for PHP 8.2 compatibility

## Test Plan

### Steps to Reproduce (Before Fix)
1. On `main`, enable `WP_DEBUG_LOG` in `wp-config.php`.
2. Place a test order.
3. Check `wp-content/debug.log`.
4. Observe the following deprecation notice:
`PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in app/public/wp-content/plugins/facebook-for-woocommerce/includes/Handlers/WhatsAppUtilityConnection.php on line 389`

### Steps to Verify (After Fix)
1. Switch to this branch.
2. Repeat the steps above (place a test order).
3. Check `wp-content/debug.log`.
4. Confirm that **no deprecation notice** appears.

## Screenshots

### Before

### After
