### PR TITLE
[EZ] Error Message for Customer Events API call

### DIFF
--- a/facebook-commerce-iframe-whatsapp-utility-event.php
+++ b/facebook-commerce-iframe-whatsapp-utility-event.php
@@ -19,8 +19,8 @@ class WC_Facebookcommerce_Iframe_Whatsapp_Utility_Event {
 	/** @var array Mapping of Order Status to Event name */
 	const ORDER_STATUS_TO_EVENT_MAPPING = array(
 		'processing' => 'ORDER_PLACED',
-		'completed' => 'ORDER_FULFILLED',
-		'refunded'  => 'ORDER_REFUNDED',
+		'completed'  => 'ORDER_FULFILLED',
+		'refunded'   => 'ORDER_REFUNDED',
 	);
 
 	/** @var \WC_Facebookcommerce */

--- a/includes/Handlers/WhatsAppExtension.php
+++ b/includes/Handlers/WhatsAppExtension.php
@@ -206,7 +206,7 @@ class WhatsAppExtension {
 		$data            = explode( "\n", wp_remote_retrieve_body( $response ) );
 		$response_object = json_decode( $data[0] );
 		if ( is_wp_error( $response ) || 200 !== $status_code ) {
-			$error_message = $response_object->error->error_user_title ?? $response_object->error->message ?? 'Something went wrong. Please try again later!';
+			$error_message = $response_object->detail ?? $response_object->title ?? 'Something went wrong. Please try again later!';
 			wc_get_logger()->info(
 				sprintf(
 				/* translators: %s $order_id %s $error_message */


### PR DESCRIPTION
## Description
Fix error message in Customer Event Logging

### Type of change
- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.


## Changelog entry

Fix error message in Customer Event Error Logs

## Test Plan

1. Place an Order on WooCommerce Site
2. Trigger error state artificially by passing empty phone number in api call
3. Validate error log has details on phone number

## Screenshots
<img width="1742" height="895" alt="Screenshot 2025-09-23 at 12 06 47 PM" src="https://github.com/user-attachments/assets/de01d1c8-9feb-441d-80d2-fbcf59e16d8e" />

