### PR TITLE
feat: making product update sync to fb async

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -839,17 +839,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 * @internal
 	 */
 	public function schedule_product_sync( int $wp_id ) {
-		$product = wc_get_product( $wp_id );
-		if ( ! $product ) {
-			return;
-		}
-
 		// Store sync data in transient for async processing
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		$sync_data = [
 			'product_id' => $wp_id,
 			'post_data' => $_POST,
-			'products_to_delete' => $this->get_removed_from_sync_products_to_delete(),
 		];
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 


### PR DESCRIPTION
## Description

Setup a function schedule_product_save - that takes saves product data and schedules sync to commerce manager async instead of as part of product update call

### Type of change

Please delete options that are not relevant
- Add (non-breaking change which adds functionality)

## Checklist

- [] I have commented my code, particularly in hard-to-understand areas, if any.
- [] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

One liner entry to be surfaced in changelog.txt


## Test Plan

- Updated a product - it updates faster & syncs to commerce manager.

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before

### After
