### PR TITLE
feat: making product update sync to fb async

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -832,13 +832,13 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/**
 	 * Stores sync data in a transient for async processing.
 	 *
-	 * @param int   $product_id The product ID
+	 * @param int   $wp_id The product ID
 	 * @param array $sync_data  The sync data to store
 	 * @return string The transient key used for storage
 	 * @since 3.5.10
 	 */
-	private function store_sync_transient( int $product_id, array $sync_data ): string {
-		$sync_key = 'fb_sync_data_' . $product_id . '_' . time();
+	private function get_store_sync_transient( int $wp_id, array $sync_data ): string {
+		$sync_key = 'fb_sync_data_' . $wp_id . '_' . time();
 		set_transient( $sync_key, $sync_data, 300 );
 		return $sync_key;
 	}
@@ -910,7 +910,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		];
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
-		$sync_key = $this->store_sync_transient( $wp_id, $sync_data );
+		$sync_key = $this->get_store_sync_transient( $wp_id, $sync_data );
 
 		// Schedule WordPress cron event
 		$scheduled = wp_schedule_single_event(

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -309,6 +309,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			update_option( self::SETTING_ENABLE_META_DIAGNOSIS, 'yes' );
 		}
 
+		// Register the WordPress cron hook for async processing
+		add_action( 'wc_facebook_async_sync', [ $this, 'on_product_save' ] );
+
 		if ( is_admin() ) {
 
 			$this->init_pixel();
@@ -348,7 +351,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			if ( $this->is_configured() && $this->get_product_catalog_id() ) {
 
 				// On_product_save() must run with priority larger than 20 to make sure WooCommerce has a chance to save the submitted product information.
-				add_action( 'woocommerce_process_product_meta', [ $this, 'on_product_save' ], 40 );
+				add_action( 'woocommerce_process_product_meta', [ $this, 'schedule_product_sync' ], 40 );
 
 				add_action(
 					'woocommerce_product_quick_edit_save',
@@ -825,16 +828,63 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		return array_map( 'absint', explode( ',', $posted_products ) );
 	}
 
+
+	/**
+	 * Schedule product sync for async processing using WordPress cron.
+	 *
+	 * @param int $wp_id post ID
+	 *
+	 * @since 3.5.9
+	 *
+	 * @internal
+	 */
+	public function schedule_product_sync( int $wp_id ) {
+		// Store sync data in transient for async processing
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		$sync_data = [
+			'product_id' => $wp_id,
+			'post_data' => $_POST,
+		];
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		$sync_key = 'fb_sync_data_' . $wp_id . '_' . time();
+		set_transient( $sync_key, $sync_data, 300 );
+
+		// Schedule WordPress cron event
+		$scheduled = wp_schedule_single_event(
+			time() + 1,
+			'wc_facebook_async_sync',
+			[ $sync_key ]
+		);
+
+		// Fallback to synchronous processing if scheduling fails
+		if ( false === $scheduled ) {
+			delete_transient( $sync_key );
+			$this->on_product_save( $wp_id );
+		}
+	}
+
 	/**
 	 * Checks the product type and calls the corresponding on publish method.
 	 *
-	 * @param int $wp_id post ID
+	 * @param int|string $wp_id post ID or transient key for async calls
 	 *
 	 * @since 1.10.0
 	 *
 	 * @internal
 	 */
-	public function on_product_save( int $wp_id ) {
+	public function on_product_save( $wp_id ) {
+		// Handle async calls with transient key
+		if ( is_string( $wp_id ) && strpos( $wp_id, 'fb_sync_data_' ) === 0 ) {
+			// Called from WordPress cron with transient key
+			$sync_data = get_transient( $wp_id );
+			if ( ! $sync_data ) {
+				return; // Data expired or doesn't exist
+			}
+			delete_transient( $wp_id );
+			$wp_id = $sync_data['product_id'];
+			$_POST = $sync_data['post_data']; // Restore $_POST data
+		}
 		$product = wc_get_product( $wp_id );
 		if ( ! $product ) {
 			return;

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -935,7 +935,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 *
 	 * @internal
 	 */
-	public function on_product_save( $wp_id ) {
+	public function on_product_save( int $wp_id ) {
 		$product = wc_get_product( $wp_id );
 		if ( ! $product ) {
 			return;

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -871,7 +871,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		return [
 			'product_id' => $product_id,
-			'success' => true
+			'success' => true,
 		];
 	}
 


### PR DESCRIPTION
## Description

Adding schedule_product_sync that creates a transient job to sync product to commerce manager, and making it async to product update call on admin page & in turn much faster

Helper Function Summaries
-------------------------

**`store_sync_transient(int $product_id, array $sync_data): string`**  
Creates a unique transient key and stores sync data with 300-second expiration for async processing.

**`process_sync_transient(string $transient_key): ?array`**  
Validates transient key format, retrieves and deletes sync data, and restores $_POST context for processing.

**`handle_async_product_save(string $transient_key): void`**  
Processes WordPress cron async calls by handling transient data and calling the main product save method with clean product ID.

### Type of change

Please delete options that are not relevant

- Add (non-breaking change which adds functionality)

## Checklist

- [yes] I have commented my code, particularly in hard-to-understand areas, if any.
- [yes] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [yes] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [yes] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [yes] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [yes] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [yes] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Making product update changes sync to commerce manager async

## Test Plan
Updated a product and verified sync to commerce manager

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before

### After
