### PR TITLE
Fix/automate stable version prep release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -171,10 +171,8 @@ jobs:
         run: |
           echo "Getting the current stable version"
           CURRENT_STABLE=$(curl 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request%5Bslug%5D=facebook-for-woocommerce' | jq -r '.version')
-          CURRENT_STABLE="9.9.99"
           echo "Current stable version: ${CURRENT_STABLE}"
           sed -i -E "s/^(Stable tag:)[[:space:]]*[0-9.]+/\1 $CURRENT_STABLE/" "readme.txt"
-          git diff
 
       - name: Update readme.txt
         uses: actions/github-script@v7
@@ -214,8 +212,8 @@ jobs:
           git commit -m "Updating version to $NEW_VERSION"
           git push origin HEAD
 
-  # build-and-upload:
-  #   needs: prepare-release
-  #   uses: ./.github/workflows/shared-build-plugin-artifact.yml
-  #   with:
-  #     ref: ${{ format('refs/heads/release/{0}', github.event.inputs.version) }}
+  build-and-upload:
+    needs: prepare-release
+    uses: ./.github/workflows/shared-build-plugin-artifact.yml
+    with:
+      ref: ${{ format('refs/heads/release/{0}', github.event.inputs.version) }}


### PR DESCRIPTION
## Description

Automating step 2.c of Preparing Release Branch workflow: https://fburl.com/wiki/52dra7no

### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Dev - Improving the Prep New Release Github Workflow, automating 2.c

## Test Plan

Go to the Github repo, select Actions, and then select Prepare New Release. 
Click on the "Run workflow" button, select this branch: fix/automate_stable_version_prep_release, and give it an arbitrary version name ( Avoid using real values that will be used for a release like 3.5.X/3.6/4/... )
Run the workflow. After it's completed, go to your release branch 'release/<version name you chose>' 
Check readme.txt, in the 'Stable tag' section it should have the same value as it is here in Version section: https://wordpress.org/plugins/facebook-for-woocommerce/