### PR TITLE
Updated the ajax calls to check if the caller is a legit user

### DIFF
--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -135,13 +135,13 @@ class AJAX {
 	 * @since 2.0.0
 	 */
 	public function sync_products() {
+		\WC_Facebookcommerce_Utils::is_legit_ajax_call( Product_Sync::ACTION_SYNC_PRODUCTS );
+		
 		// Allow opt-out of full batch-API sync, for example if store has a large number of products.
 		if ( ! facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
 			wp_send_json_error( __( 'Full product sync disabled by filter.', 'facebook-for-woocommerce' ) );
 			return;
 		}
-
-		check_admin_referer( Product_Sync::ACTION_SYNC_PRODUCTS, 'nonce' );
 
 		try {
 			facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_all_products();
@@ -159,8 +159,7 @@ class AJAX {
 	 * @since 3.5.0
 	 */
 	public function sync_coupons() {
-		check_admin_referer( Shops::ACTION_SYNC_COUPONS, 'nonce' );
-
+		\WC_Facebookcommerce_Utils::is_legit_ajax_call( Shops::ACTION_SYNC_COUPONS );
 		try {
 			facebook_for_woocommerce()->feed_manager->get_feed_instance( 'promotions' )->regenerate_feed();
 			wp_send_json_success();
@@ -177,7 +176,7 @@ class AJAX {
 	 * @since 3.5.0
 	 */
 	public function sync_shipping_profiles() {
-		check_admin_referer( Shops::ACTION_SYNC_SHIPPING_PROFILES, 'nonce' );
+		\WC_Facebookcommerce_Utils::is_legit_ajax_call( Shops::ACTION_SYNC_SHIPPING_PROFILES );
 
 		try {
 			facebook_for_woocommerce()->feed_manager->get_feed_instance( 'shipping_profiles' )->regenerate_feed();
@@ -195,7 +194,7 @@ class AJAX {
 	 * @since 3.5.0
 	 */
 	public function sync_navigation_menu() {
-		check_admin_referer( Shops::ACTION_SYNC_NAVIGATION_MENU, 'nonce' );
+		\WC_Facebookcommerce_Utils::is_legit_ajax_call( Shops::ACTION_SYNC_NAVIGATION_MENU );
 
 		try {
 			facebook_for_woocommerce()->feed_manager->get_feed_instance( 'navigation_menu' )->regenerate_feed();
@@ -214,7 +213,7 @@ class AJAX {
 	 * @since 2.0.0
 	 */
 	public function get_sync_status() {
-		check_admin_referer( Product_Sync::ACTION_GET_SYNC_STATUS, 'nonce' );
+		\WC_Facebookcommerce_Utils::is_legit_ajax_call( Product_Sync::ACTION_GET_SYNC_STATUS );
 
 		$remaining_products = 0;
 

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -136,7 +136,7 @@ class AJAX {
 	 */
 	public function sync_products() {
 		\WC_Facebookcommerce_Utils::is_legit_ajax_call( Product_Sync::ACTION_SYNC_PRODUCTS );
-		
+
 		// Allow opt-out of full batch-API sync, for example if store has a large number of products.
 		if ( ! facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
 			wp_send_json_error( __( 'Full product sync disabled by filter.', 'facebook-for-woocommerce' ) );

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -135,8 +135,9 @@ class AJAX {
 	 * @since 2.0.0
 	 */
 	public function sync_products() {
-		\WC_Facebookcommerce_Utils::is_legit_ajax_call( Product_Sync::ACTION_SYNC_PRODUCTS );
-
+		if ( ! \WC_Facebookcommerce_Utils::is_legit_ajax_call( Shops::ACTION_SYNC_PRODUCTS ) ) {
+			wp_send_json_error( 'Permission denied' );
+		}
 		// Allow opt-out of full batch-API sync, for example if store has a large number of products.
 		if ( ! facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
 			wp_send_json_error( __( 'Full product sync disabled by filter.', 'facebook-for-woocommerce' ) );
@@ -159,7 +160,9 @@ class AJAX {
 	 * @since 3.5.0
 	 */
 	public function sync_coupons() {
-		\WC_Facebookcommerce_Utils::is_legit_ajax_call( Shops::ACTION_SYNC_COUPONS );
+		if ( ! \WC_Facebookcommerce_Utils::is_legit_ajax_call( Shops::ACTION_SYNC_COUPONS ) ) {
+			wp_send_json_error( 'Permission denied' );
+		}
 		try {
 			facebook_for_woocommerce()->feed_manager->get_feed_instance( 'promotions' )->regenerate_feed();
 			wp_send_json_success();
@@ -176,8 +179,9 @@ class AJAX {
 	 * @since 3.5.0
 	 */
 	public function sync_shipping_profiles() {
-		\WC_Facebookcommerce_Utils::is_legit_ajax_call( Shops::ACTION_SYNC_SHIPPING_PROFILES );
-
+		if ( ! \WC_Facebookcommerce_Utils::is_legit_ajax_call( Shops::ACTION_SYNC_SHIPPING_PROFILES ) ) {
+			wp_send_json_error( 'Permission denied' );
+		}
 		try {
 			facebook_for_woocommerce()->feed_manager->get_feed_instance( 'shipping_profiles' )->regenerate_feed();
 			wp_send_json_success();
@@ -194,7 +198,9 @@ class AJAX {
 	 * @since 3.5.0
 	 */
 	public function sync_navigation_menu() {
-		\WC_Facebookcommerce_Utils::is_legit_ajax_call( Shops::ACTION_SYNC_NAVIGATION_MENU );
+		if ( ! \WC_Facebookcommerce_Utils::is_legit_ajax_call( Shops::ACTION_SYNC_NAVIGATION_MENU ) ) {
+			wp_send_json_error( 'Permission denied' );
+		}
 
 		try {
 			facebook_for_woocommerce()->feed_manager->get_feed_instance( 'navigation_menu' )->regenerate_feed();
@@ -213,7 +219,9 @@ class AJAX {
 	 * @since 2.0.0
 	 */
 	public function get_sync_status() {
-		\WC_Facebookcommerce_Utils::is_legit_ajax_call( Product_Sync::ACTION_GET_SYNC_STATUS );
+		if ( ! \WC_Facebookcommerce_Utils::is_legit_ajax_call( Product_Sync::ACTION_GET_SYNC_STATUS ) ) {
+			wp_send_json_error( 'Permission denied' );
+		}
 
 		$remaining_products = 0;
 

--- a/includes/Handlers/PluginRender.php
+++ b/includes/Handlers/PluginRender.php
@@ -204,7 +204,7 @@ class PluginRender {
 
 	public static function opt_out_of_sync_clicked() {
 		\WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_OPT_OUT_OF_SYNC );
-		
+
 		$latest_date = gmdate( 'Y-m-d H:i:s' );
 		update_option( self::MASTER_SYNC_OPT_OUT_TIME, $latest_date );
 		wp_send_json_success( 'Opted out successfully' );
@@ -212,14 +212,14 @@ class PluginRender {
 
 	public static function sync_all_clicked() {
 		\WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_SYNC_BACK_IN );
-		
+
 		update_option( self::MASTER_SYNC_OPT_OUT_TIME, '' );
 		wp_send_json_success( 'Synced all in successfully' );
 	}
 
 	public static function product_set_banner_closed() {
 		\WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_PRODUCT_SET_BANNER_CLOSED );
-		
+
 		set_transient( 'fb_product_set_banner_dismissed', true );
 	}
 
@@ -229,7 +229,7 @@ class PluginRender {
 	 */
 	public static function reset_upcoming_version_banners() {
 		\WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_CLOSE_BANNER );
-		
+
 		set_transient( 'upcoming_woo_all_products_banner_hide', true, 7 * DAY_IN_SECONDS );
 	}
 

--- a/includes/Handlers/PluginRender.php
+++ b/includes/Handlers/PluginRender.php
@@ -203,21 +203,23 @@ class PluginRender {
 	}
 
 	public static function opt_out_of_sync_clicked() {
-		check_admin_referer( self::ACTION_OPT_OUT_OF_SYNC, 'nonce' );
+		\WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_OPT_OUT_OF_SYNC );
+		
 		$latest_date = gmdate( 'Y-m-d H:i:s' );
 		update_option( self::MASTER_SYNC_OPT_OUT_TIME, $latest_date );
 		wp_send_json_success( 'Opted out successfully' );
 	}
 
 	public static function sync_all_clicked() {
-		check_admin_referer( self::ACTION_SYNC_BACK_IN, 'nonce' );
+		\WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_SYNC_BACK_IN );
+		
 		update_option( self::MASTER_SYNC_OPT_OUT_TIME, '' );
 		wp_send_json_success( 'Synced all in successfully' );
 	}
 
 	public static function product_set_banner_closed() {
-		check_admin_referer( self::ACTION_PRODUCT_SET_BANNER_CLOSED, 'nonce' );
-		check_ajax_referer( self::ACTION_PRODUCT_SET_BANNER_CLOSED, 'nonce' );
+		\WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_PRODUCT_SET_BANNER_CLOSED );
+		
 		set_transient( 'fb_product_set_banner_dismissed', true );
 	}
 
@@ -226,7 +228,8 @@ class PluginRender {
 	 * after a week
 	 */
 	public static function reset_upcoming_version_banners() {
-		check_admin_referer( self::ACTION_CLOSE_BANNER, 'nonce' );
+		\WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_CLOSE_BANNER );
+		
 		set_transient( 'upcoming_woo_all_products_banner_hide', true, 7 * DAY_IN_SECONDS );
 	}
 
@@ -236,7 +239,8 @@ class PluginRender {
 	 * NOTE: We are doing this because anyway we will remove this in cleanup post : 3.5.3
 	 */
 	public static function reset_plugin_updated_successfully_banner() {
-		check_admin_referer( self::ACTION_CLOSE_BANNER, 'nonce' );
+		\WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_CLOSE_BANNER );
+
 		set_transient( 'plugin_updated_banner_hide', true, 12 * MONTH_IN_SECONDS );
 	}
 
@@ -245,7 +249,8 @@ class PluginRender {
 	 * But this will keep showing every week fortnight if user not synced in
 	 */
 	public static function reset_plugin_updated_successfully_but_master_sync_off_banner() {
-		check_admin_referer( self::ACTION_CLOSE_BANNER, 'nonce' );
+		\WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_CLOSE_BANNER );
+
 		set_transient( 'plugin_updated_with_master_sync_off_banner_hide', true, 2 * WEEK_IN_SECONDS );
 	}
 

--- a/includes/Handlers/PluginRender.php
+++ b/includes/Handlers/PluginRender.php
@@ -203,7 +203,9 @@ class PluginRender {
 	}
 
 	public static function opt_out_of_sync_clicked() {
-		\WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_OPT_OUT_OF_SYNC );
+		if ( ! \WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_OPT_OUT_OF_SYNC ) ) {
+			wp_send_json_error( 'Permission denied' );
+		}
 
 		$latest_date = gmdate( 'Y-m-d H:i:s' );
 		update_option( self::MASTER_SYNC_OPT_OUT_TIME, $latest_date );
@@ -211,14 +213,18 @@ class PluginRender {
 	}
 
 	public static function sync_all_clicked() {
-		\WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_SYNC_BACK_IN );
+		if ( ! \WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_SYNC_BACK_IN ) ) {
+			wp_send_json_error( 'Permission denied' );
+		}
 
 		update_option( self::MASTER_SYNC_OPT_OUT_TIME, '' );
 		wp_send_json_success( 'Synced all in successfully' );
 	}
 
 	public static function product_set_banner_closed() {
-		\WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_PRODUCT_SET_BANNER_CLOSED );
+		if ( ! \WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_PRODUCT_SET_BANNER_CLOSED ) ) {
+			wp_send_json_error( 'Permission denied' );
+		}
 
 		set_transient( 'fb_product_set_banner_dismissed', true );
 	}
@@ -228,7 +234,9 @@ class PluginRender {
 	 * after a week
 	 */
 	public static function reset_upcoming_version_banners() {
-		\WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_CLOSE_BANNER );
+		if ( ! \WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_CLOSE_BANNER ) ) {
+			wp_send_json_error( 'Permission denied' );
+		}
 
 		set_transient( 'upcoming_woo_all_products_banner_hide', true, 7 * DAY_IN_SECONDS );
 	}
@@ -239,7 +247,9 @@ class PluginRender {
 	 * NOTE: We are doing this because anyway we will remove this in cleanup post : 3.5.3
 	 */
 	public static function reset_plugin_updated_successfully_banner() {
-		\WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_CLOSE_BANNER );
+		if ( ! \WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_CLOSE_BANNER ) ) {
+			wp_send_json_error( 'Permission denied' );
+		}
 
 		set_transient( 'plugin_updated_banner_hide', true, 12 * MONTH_IN_SECONDS );
 	}
@@ -249,7 +259,9 @@ class PluginRender {
 	 * But this will keep showing every week fortnight if user not synced in
 	 */
 	public static function reset_plugin_updated_successfully_but_master_sync_off_banner() {
-		\WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_CLOSE_BANNER );
+		if ( ! \WC_Facebookcommerce_Utils::is_legit_ajax_call( self::ACTION_CLOSE_BANNER ) ) {
+			wp_send_json_error( 'Permission denied' );
+		}
 
 		set_transient( 'plugin_updated_with_master_sync_off_banner_hide', true, 2 * WEEK_IN_SECONDS );
 	}

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -446,6 +446,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		/**
 		 * Checks if the ajax caller is admin.
 		 *
+		 * @param string $action
+		 * @param string $nonce
 		 * @return bool
 		 */
 		public static function is_legit_ajax_call( $action, $nonce = 'nonce' ) {

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -451,7 +451,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		 * @return bool
 		 */
 		public static function is_legit_ajax_call( $action, $nonce = 'nonce' ) {
-			return self::is_admin_user() && check_ajax_referrer( $action, $nonce );
+			return self::is_admin_user() && check_ajax_referer( $action, $nonce );
 		}
 
 		/**

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -444,7 +444,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		}
 
 		/**
-		 * Checks if the ajax caller is admin.
+		 * Checks if the ajax caller is admin and the call is stemming from an active admin session.
 		 *
 		 * @param string $action
 		 * @param string $nonce

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -455,8 +455,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 				wp_send_json_error( 'Permission denied' );
 				return false;
 			}
-    		check_ajax_referer( $action, $nonce );
-    		return true;
+			check_ajax_referer( $action, $nonce );
+			return true;
 		}
 
 		/**

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -451,12 +451,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		 * @return bool
 		 */
 		public static function is_legit_ajax_call( $action, $nonce = 'nonce' ) {
-			if ( ! self::is_admin_user() ) {
-				wp_send_json_error( 'Permission denied' );
-				return false;
-			}
-			check_ajax_referer( $action, $nonce );
-			return true;
+			return self::is_admin_user() && check_ajax_referer( $action, $nonce );
 		}
 
 		/**

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -451,7 +451,12 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		 * @return bool
 		 */
 		public static function is_legit_ajax_call( $action, $nonce = 'nonce' ) {
-			return self::is_admin_user() && check_ajax_referer( $action, $nonce );
+			if ( ! self::is_admin_user() ) {
+				wp_send_json_error( 'Permission denied' );
+				return false;
+			}
+    		check_ajax_referer( $action, $nonce );
+    		return true;
 		}
 
 		/**

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -444,6 +444,15 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		}
 
 		/**
+		 * Checks if the ajax caller is admin.
+		 *
+		 * @return bool
+		 */
+		public static function is_legit_ajax_call( $action, $nonce = 'nonce' ) {
+			return self::is_admin_user() && check_ajax_referrer( $action, $nonce );
+		}
+
+		/**
 		 * Returns whether AJAX permissions are valid.
 		 *
 		 * @param string $action_text


### PR DESCRIPTION
## Description

Added extra checks to ensure the plugin ajax calls are only made by the admin user.

### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fix - Updated the ajax calls to ensure caller is legit

## Test Plan

2 things need to be tested:
- The affected actions ( product sync, coupons sync, shipping profile sync, closing banners ) can be called by an admin user
- The relevant ajax calls cannot be called by a non-admin user: 
-- wp_ajax_wc_facebook_opt_out_of_sync
-- wp_ajax_wc_banner_close_action
-- wp_ajax_wc_facebook_sync_all_products
-- wp_ajax_wc_banner_post_update_close_action
-- wp_ajax_wc_banner_post_update__master_sync_off_close_action
-- wp_ajax_wc_facebook_product_set_banner_closed