### PR TITLE
Fix: Facebook product videos and attributes not saving

### DIFF
--- a/assets/js/admin/products-admin.js
+++ b/assets/js/admin/products-admin.js
@@ -624,6 +624,16 @@ jQuery( document ).ready( function( $ ) {
 		// toggle Sell on Instagram checkbox on page load
 		toggleFacebookSellOnInstagramSetting( isProductReadyForCommerce(), facebookSettingsPanel );
 
+		// Enable disabled fields before form submission so their values are saved
+		$( 'form#post' ).on( 'submit', function() {
+			// Re-enable all fields that were disabled by toggleFacebookSettings
+			// so their values are included in the form submission
+			$( '#facebook_options .enable-if-sync-enabled' ).prop( 'disabled', false );
+			$( '#facebook_options select' ).prop( 'disabled', false );
+			$( '.woocommerce_variations .enable-if-sync-enabled' ).prop( 'disabled', false );
+			$( '.woocommerce_variations select' ).prop( 'disabled', false );
+		} );
+
 		// fb product video support
 		const $openMediaButton = $('#open_media_library');
 		const $selectedVideoThumbnailsContainer = $('#fb_product_video_selected_thumbnails');

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1053,6 +1053,14 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 */
 	private function save_variable_product_settings( $product ) {
 		$woo_product = new WC_Facebook_Product( $product->get_id() );
+		
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		if ( isset( $_POST[ WC_Facebook_Product::FB_PRODUCT_VIDEO ] ) ) {
+			$attachment_ids = sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PRODUCT_VIDEO ] ) );
+			$woo_product->set_product_video_urls( $attachment_ids );
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+		
 		$this->save_facebook_product_attributes( $woo_product );
 	}
 


### PR DESCRIPTION
## Description

This PR fixes issue #3631 where Facebook product videos and product attributes were not being saved when updating products.

**Root Causes:**
1. The `save_variable_product_settings()` method in `facebook-commerce.php` was missing the video URL saving logic that existed for simple products in `save_product_settings()`.
2. Form fields with the `enable-if-sync-enabled` class were being disabled by JavaScript when certain conditions weren't met. Since disabled HTML form fields are not submitted with form data, all attribute values (MPN, Brand, Condition, Size, Color, Age Group, Gender, Material, Pattern) were lost on product update.

**Solution:**
- Added video URL saving logic to `save_variable_product_settings()` to match simple product behavior
- Added a form submit handler that re-enables all disabled fields immediately before submission, ensuring their values are included in the POST data

**Dependencies:** None

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki](https://fburl.com/wiki/2cgfduwc).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki](https://fburl.com/wiki/nhx73tgs).

## Changelog entry

Fixed Facebook product videos and attributes (MPN, Brand, Condition, Size, Color, Age Group, Gender, Material, Pattern) not being saved when updating products.

## Test Plan

### Test Case 1: Variable Product with Videos
1. Navigate to Products > Add New or edit an existing variable product
2. Go to the "Facebook" tab
3. Click "Choose" button under "Facebook Product Video"
4. Select a video from the media library and click "Save"
5. Click "Update" button to save the product
6. Reload the product edit page
7. **Expected:** Video thumbnail is displayed under "Facebook Product Video"
8. **Actual:** ✅ Video persists and displays correctly

### Test Case 2: Simple Product with All Attributes
1. Edit a simple product
2. Navigate to the "Facebook" tab
3. Fill in all Facebook attributes:
   - MPN: "TEST12345"
   - Brand: "Test Brand"
   - Condition: Select "New"
   - Size: "Medium"
   - Color: "Blue"
   - Age Group: Select "Adults"
   - Gender: Select "Male"
   - Material: "Cotton"
   - Pattern: "Solid"
4. Set Facebook Sync to any mode (including "Do not sync")
5. Click "Update"
6. Reload the product edit page
7. **Expected:** All attributes persist regardless of sync mode
8. **Actual:** ✅ All fields retain their values

### Test Case 3: Existing Videos Not Lost
1. Create a product with existing videos (or use a product from an earlier plugin version with videos)
2. Add a new video using "Choose" button
3. Click "Update"
4. Reload the product edit page
5. **Expected:** Both old and new videos are present
6. **Actual:** ✅ All videos preserved

### Test Configuration
- WordPress: 6.8.2
- WooCommerce: 10.2.1
- PHP: 8.3
- Plugin Version: 3.5.8
- Product Types Tested: Simple, Variable

## Screenshots

### Before
**Issue:** After adding a video and clicking Update, the video field appears empty on page reload. Attributes like Brand, MPN, etc. were also lost.

<img width="1666" height="467" alt="image" src="https://github.com/user-attachments/assets/7d360051-276f-40f0-b74a-015268018c1b" />


### After
**Fixed:** Videos and all attributes persist correctly after clicking Update.


<img width="1089" height="193" alt="Screenshot 2025-10-03 at 21 36 52" src="https://github.com/user-attachments/assets/824a0074-eb12-4ab0-a40f-a2bcdd03cd7b" />

---

**Related Support Forum Threads:**
- https://wordpress.org/support/topic/videos-not-synced-saved-in-setting/
- https://wordpress.org/support/topic/issue-with-product-videos-not-being-saved-in-facebook-tab/