### PR TITLE
Update checkout page to prevent lazy loading plugin interference

### DIFF
--- a/includes/Checkout.php
+++ b/includes/Checkout.php
@@ -211,9 +211,28 @@ class Checkout {
 						box-sizing: border-box;
 					}
 				</style>
+				<script>
+					// Prevent lazy loading plugins from interfering with the checkout iframe
+					document.addEventListener("DOMContentLoaded", function() {
+						var iframe = document.querySelector("iframe");
+						if (iframe) {
+							// Ensure the iframe loads immediately
+							iframe.setAttribute("data-no-lazy", "1");
+							iframe.setAttribute("data-skip-lazy", "1");
+							iframe.setAttribute("loading", "eager");
+							iframe.removeAttribute("data-src");
+							iframe.removeAttribute("class");
+							
+							// Force reload if src was changed to placeholder
+							if (iframe.src.includes("data:image/svg+xml")) {
+								iframe.src = "' . esc_url( $checkout_url ) . '";
+							}
+						}
+					});
+				</script>
 			</head>
 			<body>
-				<iframe src="' . esc_url( $checkout_url ) . '"></iframe>
+				<iframe src="' . esc_url( $checkout_url ) . '" data-no-lazy="1" data-skip-lazy="1" loading="eager"></iframe>
 			</body>
 			</html>';
 


### PR DESCRIPTION
## Description

We encountered a seller whose /fb-checkout/ page was completely blank.
Upon further investigation, the Facebook checkout seems to be working correctly - it's outputting the proper iframe HTML. However, a lazy loading plugin (likely WP Rocket, Smush, or another WordPress optimization plugin) is intercepting the iframe and converting it to lazy load format

The page source looks like
`<iframe data-src="https://<url>.com/checkout/" src="data:image/svg+xml;" class="lazyload" data-load-mode="1"></iframe>
`

### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)

## Checklist

- [] I have commented my code, particularly in hard-to-understand areas, if any.
- [] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fix blank fb-checkout page caused by a lazy-load plugin intercepting the iframe


## Test Plan

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration.

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before

### After
