### PR TITLE
removing external-time from feed job

### DIFF
--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -420,7 +420,7 @@ class WC_Facebook_Product_Feed {
 		'brand,price,availability,item_group_id,checkout_url,' .
 		'additional_image_link,sale_price_effective_date,sale_price,condition,' .
 		'visibility,gender,color,size,pattern,google_product_category,default_product,' .
-		'variant,gtin,quantity_to_sell_on_facebook,custom_label_4,rich_text_description,internal_label,external_update_time,' .
+		'variant,gtin,quantity_to_sell_on_facebook,custom_label_4,rich_text_description,internal_label,' .
 		'external_variant_id, is_woo_all_products_sync' . PHP_EOL;
 	}
 
@@ -581,7 +581,6 @@ class WC_Facebook_Product_Feed {
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'custom_label_4' ) ) . ',' .
 		static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'rich_text_description' ) ) . ',' .
 		static::format_internal_labels_for_feed( static::get_value_from_product_data( $product_data, 'internal_label' ) ) . ',' .
-		static::get_value_from_product_data( $product_data, 'external_update_time' ) . ',' .
 		static::get_value_from_product_data( $product_data, 'external_variant_id' ) . ',' .
 		static::format_string_for_feed( $is_woo_all_products_sync ) . PHP_EOL;
 	}


### PR DESCRIPTION
## Description

# Fixing Latency Metric Discrepancy in WooCommerce Feed Ingestion

**Background:**  
Latency metrics for WooCommerce product syncs via the facebook-for-woocommerce plugin show extreme values for some catalogs—sometimes measured in years—while others are reasonable.

**Root Cause:**  
The current logging mechanism records latency whenever the `external_update_time` field exists, regardless of whether it has changed. Since the daily feed job processes all products (not just updated ones), it repeatedly logs latency for old, unchanged products, inflating latency values.

**Proposed Change:**  
- Exclude latency samples from the daily feed job in logging..
- This will prevent artificially high latency values and allow for more accurate monitoring.


### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)

## Checklist

- [yes] I have commented my code, particularly in hard-to-understand areas, if any.
- [yes] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [yes] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [yes] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [yes] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [yes] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [yes] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Exclude latency samples from daily WooCommerce feed jobs to prevent inflated metrics for unchanged products.


## Test Plan

external_update_time is an optional field, so shouldn't impact any ingestion