### PR TITLE
Fix: CRON error calling is_master_sync_on() on null plugin_render_han…

### DIFF
--- a/includes/ExternalVersionUpdate/Update.php
+++ b/includes/ExternalVersionUpdate/Update.php
@@ -17,6 +17,7 @@ use WC_Facebookcommerce_Utils;
 use WooCommerce\Facebook\Utilities\Heartbeat;
 use WooCommerce\Facebook\Framework\Logger;
 use WooCommerce\Facebook\Framework\LogHandlerBase;
+use WooCommerce\Facebook\Handlers\PluginRender;
 use WooCommerce\Facebook\Integrations\IntegrationRegistry;
 
 /**
@@ -151,7 +152,7 @@ class Update {
 		// Send the request to the Meta server with the latest plugin version.
 		try {
 			$external_business_id         = $plugin->get_connection_handler()->get_external_business_id();
-			$is_woo_all_product_opted_out = $plugin->get_plugin_render_handler()->is_master_sync_on() === false;
+			$is_woo_all_product_opted_out = PluginRender::is_master_sync_on() === false;
 			$response                     = $plugin->get_api()->update_plugin_version_configuration( $external_business_id, $is_woo_all_product_opted_out, WC_Facebookcommerce_Utils::PLUGIN_VERSION );
 			if ( $response->has_api_error() ) {
 				// If the request fails, we should retry it in the next heartbeat.


### PR DESCRIPTION
## Description

Fixes a critical bug where the CRON job `facebook_for_woocommerce_daily_heartbeat` fails with error: `Call to a member function is_master_sync_on() on null`.

### Issue
The bug was introduced in version 3.5.0 (PR #3220) when the opt-out sync experience feature was added. The `plugin_render_handler` is only initialized in admin context (`is_admin()`), but CRON jobs don't run in admin context, causing `get_plugin_render_handler()` to return null.

### Solution
Changed the call from instance method `$plugin->get_plugin_render_handler()->is_master_sync_on()` to static method `PluginRender::is_master_sync_on()`. This is the correct approach since `is_master_sync_on()` is a static method that only checks a WordPress option and doesn't require an instance.

### Changes
- Added `use WooCommerce\Facebook\Handlers\PluginRender;` import statement
- Updated line 155 in `includes/ExternalVersionUpdate/Update.php` to call the static method directly

**Related Issue:** https://wordpress.org/support/topic/error-on-cron-actions-for-the-plugin/

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Changelog entry

Fix - Fixed CRON error when checking master sync status in daily heartbeat

## Test Plan

### Manual Testing
1. Ensure the plugin is connected to Meta
2. Run the CRON job manually: `wp cron event run facebook_for_woocommerce_daily_heartbeat`
3. Check debug logs - should see no errors
4. Verify the version update is sent to Meta successfully

### Automated Testing
1. Run existing unit tests: `vendor/bin/phpunit tests/Unit/ExternalVersionUpdate/UpdateTest.php`
2. All tests should pass

### Verification
- PHP syntax check passes: `php -l includes/ExternalVersionUpdate/Update.php`
- No new linter errors introduced
- The static method `PluginRender::is_master_sync_on()` works in both admin and CRON contexts

## Screenshots

### Before
CRON error in logs: