### PR TITLE
Fix: Add validation guard for product object in admin settings tab

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1316,7 +1316,19 @@ class Admin {
 			?>
 
 			<div class='wc-facebook-commerce-options-group options_group google_product_catgory'>
-				<?php \WooCommerce\Facebook\Admin\Products::render_google_product_category_fields_and_enhanced_attributes( $product ); ?>
+				<?php
+				// Ensure $product is valid before calling the function
+				if ( ! $product && isset( $post->ID ) ) {
+					$product = wc_get_product( $post->ID );
+				}
+
+				if ( $product instanceof \WC_Product ) {
+					\WooCommerce\Facebook\Admin\Products::render_google_product_category_fields_and_enhanced_attributes( $product );
+				} else {
+					// Log for debugging purposes
+					error_log( 'Facebook for WooCommerce: Unable to render product fields - invalid product object' );
+				}
+				?>
 			</div>
 		</div>
 		<?php


### PR DESCRIPTION
## Summary

Fixes #2894

Prevents fatal TypeError when `wc_get_product()` returns false by adding defensive type checking before rendering product fields in the admin.

## Problem

The `add_product_settings_tab_content()` function calls `wc_get_product($post)` which can return `false` in certain scenarios:
- Plugin conflicts (e.g., WooCommerce Dynamic Pricing)
- Invalid post types
- Missing product data

This `false` value is then passed to `render_google_product_category_fields_and_enhanced_attributes()` which expects a `WC_Product` type, causing a fatal TypeError that completely blocks product editing.

**Error:**
```
PHP Fatal error: Uncaught TypeError: WooCommerce\Facebook\Admin\Products::render_google_product_category_fields_and_enhanced_attributes(): 
Argument #1 ($product) must be of type WC_Product, bool given
in /wp-content/plugins/facebook-for-woocommerce/includes/Admin/Products.php on line 43
```

## Solution

Added defensive validation in `includes/Admin.php` before calling the render function:

1. **Fallback retrieval**: If `$product` is false/null, attempts to retrieve it using `wc_get_product($post->ID)`
2. **Type guard**: Only calls render function if `$product instanceof \WC_Product`
3. **Error logging**: Logs when product object is invalid for debugging
4. **Graceful degradation**: Page continues to load even if fields can't be rendered

## Changes

**File:** `includes/Admin.php` (lines 1318-1332)
- Added product validation check before rendering Google product category fields
- Included fallback product retrieval attempt
- Added error logging for debugging invalid scenarios

## Testing

- [x] Tested normal product editing with valid products
- [x] Verified no fatal errors occur with plugin conflicts
- [x] Confirmed PHP syntax is valid
- [x] Google product category fields render properly for valid products
- [x] Page loads gracefully when product object is invalid

## Test Plan

1. Edit various product types (simple, variable, grouped)
2. Verify Facebook tab loads without errors
3. Install WooCommerce Dynamic Pricing plugin (or similar)
4. Edit products with the conflicting plugin active
5. Confirm no fatal errors occur
6. Verify Google product category fields render for valid products
7. Check error logs for debugging messages (if product is invalid)

## Risk Assessment

**Risk Level:** Very Low

- Only adds defensive type guards - no logic changes
- Existing functionality fully preserved for valid products
- Prevents fatal errors while maintaining feature availability
- Includes fallback mechanism for edge cases

Closes #2894