### PR TITLE
Fix: Apply WordPress filters to post content, excerpt, and title in get_fb_description()

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -751,9 +751,9 @@ class WC_Facebook_Product {
 		// If no description is found from meta or variation, get from post
 		if ( empty( $description ) ) {
 			$post         = $this->get_post_data();
-			$post_content = WC_Facebookcommerce_Utils::clean_string( $post->post_content );
-			$post_excerpt = WC_Facebookcommerce_Utils::clean_string( $post->post_excerpt );
-			$post_title   = WC_Facebookcommerce_Utils::clean_string( $post->post_title );
+			$post_content = WC_Facebookcommerce_Utils::clean_string( apply_filters( 'the_content', $post->post_content ) );
+			$post_excerpt = WC_Facebookcommerce_Utils::clean_string( get_the_excerpt( $post ) );
+			$post_title   = WC_Facebookcommerce_Utils::clean_string( get_the_title( $post ) );
 
 			// Prioritize content, then excerpt, then title
 			if ( ! empty( $post_content ) ) {


### PR DESCRIPTION
## Description

Fixes #1712

Previously, `get_fb_description()` was directly accessing post properties (`$post->post_content`, `$post->post_excerpt`, `$post->post_title`) which bypassed WordPress and third-party plugin filters.

This caused issues when plugins used filters like `the_content`, `the_excerpt`, or `get_the_title` to modify product descriptions, as these modifications were not reflected in the Facebook catalog.

### Changes Made

- Replace `$post->post_content` with `apply_filters('the_content', $post->post_content)`
- Replace `$post->post_excerpt` with `get_the_excerpt($post)`
- Replace `$post->post_title` with `get_the_title($post)`

This ensures that all WordPress filters are properly applied and third-party plugins that modify post content, excerpts, or titles will now work correctly with Facebook product descriptions.

### Type of change

- [x] Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices.
- [ ] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary).

## Changelog entry

Fix - Apply WordPress filters to post content, excerpt, and title when generating Facebook product descriptions

## Test Plan

### Manual Testing Steps:

1. Install a plugin that modifies product titles using WordPress filters (or add this code to functions.php):
   ```php
   add_filter('the_title', function($title, $post_id) {
       $post = get_post($post_id);
       if ($post && $post->post_type === 'product') {
           return 'Modified: ' . $title;
       }
       return $title;
   }, 10, 2);
   ```

2. Create or edit a WooCommerce product
3. Sync the product to Facebook catalog
4. Verify the modified title (with "Modified: " prefix) appears in Facebook Commerce Manager
5. Remove the test filter and verify normal titles work correctly

### Expected Behavior:

**Before:** Product titles/descriptions in Facebook catalog ignored WordPress filters
**After:** Product titles/descriptions in Facebook catalog properly apply all WordPress filters, allowing third-party plugins to modify the content sent to Facebook

### Compatibility:

- Maintains backward compatibility - if no filters are present, behavior is identical to before
- Does not break existing functionality
- Allows plugins like multilingual plugins, SEO plugins, etc. to properly modify Facebook product data

## Related Issues

Closes #1712 (reported November 2020 - 5 years old!)