### PR TITLE
Fix: Prevent integer overflow in Facebook product IDs

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1401,7 +1401,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				update_post_meta(
 					$woo_product->get_id(),
 					self::FB_PRODUCT_GROUP_ID,
-					$fb_product_group_id
+					(string) $fb_product_group_id
 				);
 
 				return $fb_product_group_id;
@@ -1471,7 +1471,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				update_post_meta(
 					$woo_product->get_id(),
 					self::FB_PRODUCT_ITEM_ID,
-					$fb_product_item_id
+					(string) $fb_product_item_id
 				);
 
 				$this->display_success_message(


### PR DESCRIPTION
## Description

This PR fixes an integer overflow issue where large Facebook product IDs (e.g., `8643851039008202`) were being stored as numeric types and could overflow to scientific notation (`6.19203E+15`) on 32-bit systems or in certain PHP configurations. This caused sync and tracking issues for affected stores.

The fix adds explicit `(string)` type casting when storing Facebook product IDs via `update_post_meta()`, following the same pattern already used in the `get_existing_fbid()` method (lines 1998-2010).

**Fixes #2825**

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices.
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary).

## Changelog entry

Fix: Prevent integer overflow in Facebook product IDs by explicitly casting to string

## Test Plan

### Manual Testing
1. Create a test scenario that simulates receiving a large Facebook product ID (e.g., `8643851039008202`)
2. Verify that the ID is stored correctly in post meta without conversion to scientific notation
3. Confirm that product sync continues to work correctly

### Code Review
- Review the two locations where the fix was applied (lines 1404 and 1474 in `facebook-commerce.php`)
- Confirm the pattern matches the existing implementation in `get_existing_fbid()` (lines 1998-2010)
- Verify that `(string)` casting is safe and non-breaking for all ID formats

### Compatibility
- The change is backward compatible - string casting works for all numeric ID formats
- No changes to external APIs or data structures
- No database migrations required

## Screenshots

Not applicable - this is a data type handling fix with no UI changes.

### Before
Facebook product IDs could overflow to scientific notation (e.g., `6.19203E+15`) when stored in post meta.

### After
Facebook product IDs are explicitly cast to strings, preventing overflow regardless of system architecture or PHP configuration.