### PR TITLE
Fix: Use minimum variation price for variable products in product feed

### DIFF
--- a/includes/Products.php
+++ b/includes/Products.php
@@ -367,6 +367,11 @@ class Products {
 		// use the user defined Facebook price if set
 		if ( is_numeric( $facebook_price ) ) {
 			$price = $facebook_price;
+		} elseif ( $product->is_type( 'variable' ) ) {
+
+			// Use minimum variation price for variable products (consistent with tracking events)
+			$price = $product->get_variation_price( 'min' );
+
 		} elseif ( $product->is_type( 'composite' ) ) {
 
 			$price = $product->get_composite_price( 'min', true );


### PR DESCRIPTION
## Description

This PR fixes an inconsistency between the product feed pricing and tracking event pricing for variable products. Previously, variable products used the parent product's regular price in the feed, while tracking events used `get_variation_price('min')`. This discrepancy could cause mismatches between catalog prices and event data sent to Facebook.

The fix updates the `Products::get_product_price()` method to use the minimum variation price for variable products, making it consistent with the tracking event behavior (line 650 in `facebook-commerce-events-tracker.php`).

This change follows the same pricing pattern already used for composite, bundle, and mix-and-match product types.

**Fixes #2790**

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices.
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary).

## Changelog entry

Fix: Use minimum variation price for variable products in product feed to match tracking events

## Test Plan

### Manual Testing
1. Create a variable product with multiple variations having different prices (e.g., Small: $10, Medium: $15, Large: $20)
2. Sync the product to Facebook catalog
3. Verify that the product feed shows the minimum price ($10) for the parent variable product
4. Trigger a ViewContent event for the variable product
5. Confirm that both the feed price and event price match (both showing $10)

### Validation Steps
- **Before:** Variable product shows parent's regular price in feed, while events show minimum variation price
- **After:** Both feed and events show minimum variation price consistently

### Code Review
- Review the change in `includes/Products.php` at lines 370-373
- Confirm the pattern matches existing implementations for composite, bundle, and mix-and-match products
- Verify that `get_variation_price('min')` is the correct WooCommerce method for this use case

### Compatibility
- Change is backward compatible - only affects pricing consistency
- No database changes required
- Follows existing patterns in the codebase

## Screenshots

Not applicable - this is a pricing logic fix. The change ensures consistency between:
- Product feed data sent to Facebook catalog
- Tracking event data sent to Facebook Pixel

### Before
Variable product feed uses parent product's regular price, which may not match the minimum variation price used in tracking events.

### After
Variable product feed uses minimum variation price, consistent with tracking events and other product types (composite, bundle, mix-and-match).