### PR TITLE
Fix: Prevent integer overflow in Facebook product IDs

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1401,7 +1401,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				update_post_meta(
 					$woo_product->get_id(),
 					self::FB_PRODUCT_GROUP_ID,
-					$fb_product_group_id
+					(string) $fb_product_group_id
 				);
 
 				return $fb_product_group_id;
@@ -1471,7 +1471,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				update_post_meta(
 					$woo_product->get_id(),
 					self::FB_PRODUCT_ITEM_ID,
-					$fb_product_item_id
+					(string) $fb_product_item_id
 				);
 
 				$this->display_success_message(


### PR DESCRIPTION
## Summary
Explicitly cast Facebook product IDs to strings when storing in post meta to prevent integer overflow issues on 32-bit systems or with large IDs.

Facebook product IDs like 8643851039008202 were being stored as numeric types and could overflow to scientific notation (6.19203E+15), causing sync and tracking issues.

This fix applies the same (string) casting pattern already used in the `get_existing_fbid()` method to two additional locations where product IDs are stored.

## Related Issues
Fixes #2825

## Previous PR
This is a resubmission of PR #3688

## Test plan
- [ ] Verify that large Facebook product IDs are stored as strings in post meta
- [ ] Confirm no integer overflow occurs on systems with large product IDs
- [ ] Test product sync functionality with large IDs