### PR TITLE
Revert PR #3688: Prevent integer overflow in Facebook product IDs

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1401,7 +1401,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				update_post_meta(
 					$woo_product->get_id(),
 					self::FB_PRODUCT_GROUP_ID,
-					(string) $fb_product_group_id
+					$fb_product_group_id
 				);
 
 				return $fb_product_group_id;
@@ -1471,7 +1471,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				update_post_meta(
 					$woo_product->get_id(),
 					self::FB_PRODUCT_ITEM_ID,
-					(string) $fb_product_item_id
+					$fb_product_item_id
 				);
 
 				$this->display_success_message(


### PR DESCRIPTION
## Summary
This PR reverts PR #3688 which introduced string casting that caused test failures.

## Reason for Reversion
The string cast implementation has caused test failures that need to be addressed separately before we can proceed with the integer overflow fix.

## Related
- Reverts #3688

## Test plan
- Verify existing tests pass after reversion
- Address test failures in a follow-up PR before re-implementing the fix