### PR TITLE
[WIFI][Customer Events] Support additional order statuses

### DIFF
--- a/facebook-commerce-iframe-whatsapp-utility-event.php
+++ b/facebook-commerce-iframe-whatsapp-utility-event.php
@@ -21,6 +21,10 @@ class WC_Facebookcommerce_Iframe_Whatsapp_Utility_Event {
 		'processing' => 'ORDER_PLACED',
 		'completed'  => 'ORDER_FULFILLED',
 		'refunded'   => 'ORDER_REFUNDED',
+		'pending'    => 'ORDER_PENDING_PAYMENT',
+		'on-hold'    => 'ORDER_ON_HOLD',
+		'cancelled'  => 'ORDER_CANCELLED',
+		'failed'     => 'ORDER_PAYMENT_FAILED',
 	);
 
 	/** @var \WC_Facebookcommerce */

--- a/includes/Handlers/WhatsAppExtension.php
+++ b/includes/Handlers/WhatsAppExtension.php
@@ -64,7 +64,7 @@ class WhatsAppExtension {
 				'app_id'                => self::APP_ID,
 				'app_owner_business_id' => self::TP_BUSINESS_ID,
 				'external_business_id'  => $external_wa_id,
-				'locale' => get_user_locale() ?? self::DEFAULT_LANGUAGE,
+				'locale'                => get_user_locale() ?? self::DEFAULT_LANGUAGE,
 			),
 			self::COMMERCE_HUB_URL . 'whatsapp_utility_integration/splash/'
 		);
@@ -181,7 +181,14 @@ class WhatsAppExtension {
 			$refund_value,
 			$currency
 		);
-		$options            = array(
+		$event_base_object  = array(
+			'id'   => "#{$order_id}",
+			'type' => $event,
+		);
+		if ( ! empty( $event_object ) ) {
+			$event_base_object[ $event_lowercase ] = $event_object;
+		}
+		$options = array(
 			'headers' => array(
 				'Authorization' => 'Bearer ' . $bisu_token,
 			),
@@ -193,11 +200,7 @@ class WhatsAppExtension {
 					'country_code' => $country_code,
 					'language'     => get_user_locale(),
 				),
-				'event'    => array(
-					'id'             => "#{$order_id}",
-					'type'           => $event,
-					$event_lowercase => $event_object,
-				),
+				'event'    => $event_base_object,
 			),
 			'timeout' => 3000, // 5 minutes
 		);
@@ -251,6 +254,8 @@ class WhatsAppExtension {
 					'amount_1000' => $refund_value,
 					'currency'    => $currency,
 				);
+			default:
+				return array();
 		}
 	}
 }


### PR DESCRIPTION
Call Customer Events API for additional statuses for logging and to inform prioritization of new templates

## Description
Call Customer Events API for additional order statuses. In this PR, I added the remaining order statuses (pending, on-hold, cancelled. failed) except draft to call Customer Events API


### Type of change
- Add (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).


## Changelog entry

Added additional order status events

## Test Plan
1. Complete WhatsApp Onboarding 
2. Switch on Order Placed, Order Shipped and Order Refunded Events
3. Place order on WooCommerce site
4. Update order status
5. Validate WhatsApp Message is sent for processing, completed and refunded status
6. Validate no WhatsApp Message is sent for other statuses

## Screen Recording
https://github.com/user-attachments/assets/d04a6a67-e4f6-480c-9dfb-3fb5442d3479

## Screenshots
### WhatsApp
<img width="1620" height="918" alt="Screenshot 2025-11-07 at 5 00 34 PM" src="https://github.com/user-attachments/assets/2b9816ac-cfd0-48c9-8dac-27550c7dd74f" />

### Logs
<img width="1623" height="886" alt="Screenshot 2025-11-07 at 4 45 07 PM" src="https://github.com/user-attachments/assets/9ccc38b0-dc63-44e2-82f0-f7e1d964ef3b" />
