### PR TITLE
Fix: Correct help icon positioning in Facebook product tab

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -193,8 +193,20 @@
 	display: block !important;
 }
 
+#woocommerce-product-data .wc-facebook-google-product-category-wrapper {
+	display: inline-block;
+	position: relative;
+	width: 100%;
+}
+
 #woocommerce-product-data #wc-facebook-google-product-category-fields {
 	width: 50%;
+	display: inline-block;
+	vertical-align: top;
+}
+
+#woocommerce-product-data .wc-facebook-google-product-category-field {
+	margin-bottom: 16px;
 }
 
 #woocommerce-product-data .wc-facebook-google-product-category-field select {
@@ -206,6 +218,33 @@
 #woocommerce-product-data #wc-facebook-google-product-category-fields .select2-container {
 	float: none;
 	width: 100% !important;
+}
+
+#woocommerce-product-data .wc-facebook-google-product-category-help-tip {
+	display: inline-block;
+	vertical-align: top;
+	margin-left: 8px;
+	line-height: 34px;
+}
+
+#woocommerce-product-data .wc-facebook-google-product-category-help-tip .woocommerce-help-tip {
+	margin: 0;
+	vertical-align: middle;
+}
+
+/* Enhanced Catalog Attributes - align input fields and help icons */
+#woocommerce-product-data .wc-facebook-enhanced-catalog-attribute-row input[type="text"],
+#woocommerce-product-data .wc-facebook-enhanced-catalog-attribute-row select {
+	width: 50%;
+	max-width: 50%;
+	display: inline-block;
+	vertical-align: middle;
+}
+
+#woocommerce-product-data .wc-facebook-enhanced-catalog-attribute-row .woocommerce-help-tip {
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: 8px;
 }
 
 .notice .button.js-wc-plugin-framework-notice-dismiss {

--- a/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
+++ b/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
@@ -232,6 +232,7 @@ class Enhanced_Catalog_Attribute_Fields {
 				class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>">
 				<?php $this->render_label( $attr_id, $attribute ); ?>
 				<?php $this->render_field( $attr_id, $attribute ); ?>
+				<span class="woocommerce-help-tip" data-tip="<?php echo esc_attr( $attribute['description'] ); ?>"></span>
 			</p>
 			<?php
 		} else {
@@ -243,6 +244,7 @@ class Enhanced_Catalog_Attribute_Fields {
 				</th>
 				<td>
 					<?php $this->render_field( $attr_id, $attribute ); ?>
+					<span class="woocommerce-help-tip" data-tip="<?php echo esc_attr( $attribute['description'] ); ?>"></span>
 				</td>
 			</tr>
 			<?php
@@ -254,7 +256,6 @@ class Enhanced_Catalog_Attribute_Fields {
 		?>
 		<label for="<?php echo esc_attr( $attr_id ); ?>">
 			<?php echo esc_html( $label ); ?>
-			<span class="woocommerce-help-tip" data-tip="<?php echo esc_attr( $attribute['description'] ); ?>"></span>
 		</label>
 		<?php
 	}

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -97,14 +97,18 @@ class Products {
 		<p class="form-field">
 			<label for="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>">
 				<?php esc_html_e( 'Google Product Category', 'facebook-for-woocommerce' ); ?>
-				<?php echo wc_help_tip( __( 'Choose the Google product category and (optionally) sub-categories associated with this product.', 'facebook-for-woocommerce' ) ); ?>
 			</label>
-			<input
-				id="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"
-				type="hidden"
-				name="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"
-				value="<?php echo esc_attr( Products_Handler::get_google_product_category_id( $product ) ); ?>"
-			/>
+			<span class="wc-facebook-google-product-category-wrapper">
+				<input
+					id="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"
+					type="hidden"
+					name="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"
+					value="<?php echo esc_attr( Products_Handler::get_google_product_category_id( $product ) ); ?>"
+				/>
+				<span class="wc-facebook-google-product-category-help-tip">
+					<?php echo wc_help_tip( __( 'Choose the Google product category and (optionally) sub-categories associated with this product.', 'facebook-for-woocommerce' ) ); ?>
+				</span>
+			</span>
 		</p>
 		<?php
 	}


### PR DESCRIPTION
## Description

This PR fixes the misplaced help icon (tooltip) positioning in the Facebook product tab. Previously, help icons for "Google Product Category" and "Enhanced Catalog Attributes" (Show more attributes section) were positioned next to the field labels instead of to the right of the input fields, breaking the consistent pattern used by other attributes like Pattern, Material, Size, etc.

### Changes Made:
1. **Google Product Category Field** - Moved help tip icon from inside the label to after the input field container
2. **Enhanced Catalog Attributes** - Moved help tip icons from inside labels to after input/select fields  
3. **CSS Updates** - Added proper styling to ensure:
   - All input fields are 50% width (consistent with other fields)
   - Help icons are positioned inline to the right with proper spacing
   - Proper vertical alignment and margins

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [ ] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [ ] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [ ] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Changelog entry

Fixed misplaced help icon positioning for Google Product Category and Enhanced Catalog Attributes in the Facebook product tab to match standard WooCommerce field layout pattern.

## Test Plan

### Steps to Reproduce:
1. Open WooCommerce Products page in WP Admin Dashboard
2. Click "Add new product" 
3. Scroll to Product data section
4. Select "Facebook" tab
5. Scroll to "Google Product Category" field
6. Select a category to reveal Enhanced Catalog Attributes (click "Show more attributes" if needed)

### Expected Results:
- Google Product Category help icon appears to the right of the dropdown fields (not next to the label)
- All Enhanced Catalog Attributes (Storage Capacity, Screen Size, Operating System, etc.) have help icons to the right of their input fields
- All field widths match the Pattern/Material/Color fields above (50% width)
- Help icons are consistently aligned across all fields

### Test Configuration:
- WordPress: Latest version
- WooCommerce: Latest version
- Browser: Chrome/Firefox/Safari

## Screenshots

### Before
![Before - Google Product Category](https://github.com/user-attachments/assets/...) 
_Help icon was misplaced next to the "Google Product Category" label instead of to the right of the dropdown fields_

![Before - Enhanced Attributes](https://github.com/user-attachments/assets/...)
_Help icons for enhanced attributes (Storage Capacity, Screen Size, etc.) were below the input fields_

### After
![After - Google Product Category](https://github.com/user-attachments/assets/...)
_Help icon now properly positioned to the right of the dropdown fields, matching other field patterns_

![After - Enhanced Attributes](https://github.com/user-attachments/assets/...)
_All help icons now consistently positioned to the right of input fields with proper alignment and spacing_