### PR TITLE
Fix: Ensure consistent 13px font-size for Remove button 

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -163,6 +163,11 @@
     color: #d63638;
 }
 
+/* Ensure consistent 13px font-size for Remove button in variations */
+.woocommerce_variation .fb-product-images-thumbnails p.image-thumbnail a.remove-image {
+    font-size: 13px;
+}
+
 .fb_product_images_field .button.fb-open-images-library {
     margin-left: 5px;
 }


### PR DESCRIPTION
## Description

This PR fixes a UI consistency issue where the 'Remove' button in the Facebook Product Image multiple images section had a font size of 12px, while 'Remove' buttons in other places throughout the plugin have a font size of 13px.

The fix adds a specific CSS rule targeting the Remove button in the variations multiple images thumbnails to ensure consistent 13px font-size across the entire UI.

**Changes:**
- Added CSS rule for `.woocommerce_variation .fb-product-images-thumbnails p.image-thumbnail a.remove-image` with `font-size: 13px`

**File Modified:**
- `assets/css/admin/facebook-for-woocommerce-products-admin.css`

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki](https://fburl.com/wiki/2cgfduwc).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki](https://fburl.com/wiki/nhx73tgs).

## Changelog entry

Fixed font-size inconsistency for Remove button in Facebook Product Image multiple images section (12px → 13px)

## Test Plan

**Steps to reproduce the issue:**
1. Open any existing Variable product in WooCommerce admin
2. In 'Product data' menu, select 'Variations' tab
3. Click 'Edit' on any variation to expand details
4. Scroll to 'Facebook for WooCommerce' section and click to expand it
5. In 'Facebook Product Image' section, select 'Use multiple images' radio button
6. Click on 'Choose Multiple Images' button
7. In the opened media library modal, select one or more images and click 'Use images'
8. Observe the font size of the 'Remove' button displayed below each selected image

**Expected Result:**
- Remove button text displays with 13px font-size, consistent with other Remove buttons in the admin interface

**Test Configuration:**
- WooCommerce version: [version]
- WordPress version: [version]
- Browser: Chrome/Firefox/Safari

## Screenshots

### Before
The Remove button had 12px font-size (smaller than expected)

### After
The Remove button now has 13px font-size (consistent with other Remove buttons throughout the plugin)