### PR TITLE
Feature/Purchase use order currency

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -1091,7 +1091,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 					'custom_data' => array(
 						'sign_up_fee' => $subscription->get_sign_up_fee(),
 						'value'       => $subscription->get_total(),
-						'currency'    => (method_exists( $subscription, 'get_currency' ) ? $subscription->get_currency() : get_woocommerce_currency() ),
+						'currency'    => ( method_exists( $subscription, 'get_currency' ) ? $subscription->get_currency() : get_woocommerce_currency() ),
 					),
 					'user_data'   => $this->pixel->get_user_info(),
 				);


### PR DESCRIPTION
## Description

This PR updates the Purchase and Subscribe events to use the currency from the order or subscription object, falling back to the store default currency if unavailable.

Previously, the code used `get_woocommerce_currency()` for all events, which could cause inconsistencies when multiple currency extensions were used (e.g., WooPayments Multi-Currency, WPML, Curcy Multi-Currency). This change ensures the correct currency is sent for each order and subscription event.

### Type of change

- Add (non-breaking change which adds functionality)

## Checklist

- [X] I have commented my code, particularly in hard-to-understand areas, if any.
- [X] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [X] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [X] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [X] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [X] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Use order or subscription currency for Purchase and Subscribe events.

## Test Plan

1. Test with WooPayments Multi-Currency setup: place an order in different currencies.
2. Test with WPML multi-currency plugin: place an order in different currencies.
3. Test with Curcy Multi-Currency plugin: place an order in different currencies.
4. Check WooCommerce logs for the payloads of Purchase and Subscribe events before sending to Pixel.
5. Verify that the currency in the logs matches the order/subscription currency.