### PR TITLE
set unique SKU for composite product E2E test

### DIFF
--- a/tests/e2e/product-creation.spec.js
+++ b/tests/e2e/product-creation.spec.js
@@ -440,6 +440,14 @@ test.describe('Facebook for WooCommerce - Product Creation E2E Tests', () => {
       await regularPriceField.fill('49.99');
       console.log('✅ Set regular price');
 
+      await page.click('li.inventory_tab a');
+      // Set SKU to ensure unique retailer ID
+      const skuField = page.locator('#_sku');
+      await skuField.waitFor({ state: 'visible', timeout: 10000 });
+      const uniqueSku = generateUniqueSKU('simple');
+      await skuField.fill(uniqueSku);
+      console.log(`✅ Set unique SKU: ${uniqueSku}`);
+
       // Go to "Components" tab
       await componentsTab.click();
       const addComponentBtn = page.locator('.wooco_add_component');


### PR DESCRIPTION
## Description

Fix bug to set unique SKU during composite product creation E2E test

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have commented my code, particularly in hard-to-understand areas, if any.
- [X] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [X] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [X] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [X] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [X] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [X] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry
Fix bug to set unique SKU during composite product creation E2E test

## Test Plan
