### PR TITLE
Add workflow to auto-label internal PRs

### DIFF
--- a/.github/workflows/auto-add-pr-label-for-internal.yml
+++ b/.github/workflows/auto-add-pr-label-for-internal.yml
@@ -1,4 +1,4 @@
-name: Auto-label Internal PRs
+name: Auto-label Internal CodeMod PRs
 
 on:
   pull_request:
@@ -8,7 +8,7 @@ jobs:
   label-internal-prs:
     runs-on: ubuntu-latest
     steps:
-      - name: Add changelog label to internal PRs
+      - name: Add changelog label to internal CodeMod PRs
         uses: actions/github-script@v7
         with:
           script: |
@@ -27,29 +27,41 @@ jobs:
             const labelNames = labels.map(label => label.name);
 
             // Detect exported PRs from Meta/Facebook by:
-            // Source branch matches export-D.* AND has fb-exported or meta-exported label
+            // 1. Source branch matches export-D.* pattern
+            // 2. Has fb-exported and meta-exported label
+            // 3. Title contains DevmateWooCommerceGenerateTests (LIMITING to CodeMod PRs for now)
             const isExportedPR =
               /^export-D/.test(sourceBranch) &&
-              (labelNames.includes('fb-exported') || labelNames.includes('meta-exported'));
+              labelNames.includes('fb-exported') && labelNames.includes('meta-exported') &&
+              prTitle.includes('DevmateWooCommerceGenerateTests');
 
             if (isExportedPR) {
               console.log(`   Detected exported PR #${prNumber}: ${prTitle}`);
               console.log(`   Source branch: ${sourceBranch}`);
               console.log(`   Labels: ${labelNames.join(', ')}`);
 
-              const hasChangelogLabel = labelNames.some(label =>
+              // Re-fetch labels to avoid race condition where another workflow
+              // may have added a changelog label between initial fetch and this check
+              const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber
+              });
+              const currentLabelNames = currentLabels.map(label => label.name);
+
+              const hasChangelogLabel = currentLabelNames.some(label =>
                 label.startsWith('changelog:')
               );
 
               if (!hasChangelogLabel) {
-                // Add "changelog: add" label (appropriate for internal changes)
+                // Add "changelog: none" label
                 await github.rest.issues.addLabels({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: prNumber,
-                  labels: ['changelog: add']
+                  labels: ['changelog: none']
                 });
-                console.log(' Added "changelog: add" label to internal PR');
+                console.log(' Added "changelog: none" label to internal PR');
               } else {
                 console.log('  PR already has a changelog label, skipping');
               }


### PR DESCRIPTION
## Description

Internal diffs when exported to Github, do not have a changelog label and this fails a validation workflow.
In order to not affect the existing workflow, we have added a new workflow to monitor PRs coming from internal diffs using labels like fb-exported, meta-exported and source branch name pattern.

### Type of change

- Add (non-breaking change which adds functionality)

## Checklist

- [✅] I have commented my code, particularly in hard-to-understand areas, if any.
- [✅] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [✅] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [✅] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [✅] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [✅] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Add workflow to auto-label internal PRs

## Test Plan

Test PR comments show the label being added after checks! 

## Screenshots
### Before

### After
Test PR comments show the label being added after checks!  - https://github.com/facebook/facebook-for-woocommerce/pull/3768