### PR TITLE
fix for unused variable

### DIFF
--- a/facebook-commerce-iframe-whatsapp-utility-event.php
+++ b/facebook-commerce-iframe-whatsapp-utility-event.php
@@ -88,7 +88,8 @@ class WC_Facebookcommerce_Iframe_Whatsapp_Utility_Event {
 		$shipping_phone_number = $order->get_shipping_phone();
 		$phone_number          = $billing_phone_number ?? $shipping_phone_number;
 		// Get Country Code from Billing and Shipping Country to override Country Calling Code
-		$country_code = $should_use_billing_info ? $order->get_billing_country() : $order->get_shipping_country();
+		$should_use_billing_info = ! empty( $billing_phone_number );
+		$country_code            = $should_use_billing_info ? $order->get_billing_country() : $order->get_shipping_country();
 		// Get Customer first name
 		$first_name = $order->get_billing_first_name();
 		// Get Total Refund Amount for Order Refunded event


### PR DESCRIPTION
## Description

unused variable warning & bug fix - https://wordpress.org/support/topic/plugin-throws-a-warning/

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [] I have commented my code, particularly in hard-to-understand areas, if any.
- [] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

One liner entry to be surfaced in changelog.txt


## Test Plan
