### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/auto-add-pr-label-for-internal.yml
+++ b/.github/workflows/auto-add-pr-label-for-internal.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add changelog label to internal CodeMod PRs
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/final-qa-checks.yml
+++ b/.github/workflows/final-qa-checks.yml
@@ -14,7 +14,7 @@ jobs:
     environment: Deployment
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get NPM Version
         id: package-version
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload diff output
         if: steps.compare.outputs.match == 'false'
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v6
         continue-on-error: true
         with:
           name: plugin-diff-output

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -36,7 +36,7 @@ jobs:
         run: sudo apt-get install subversion -y
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -53,7 +53,7 @@ jobs:
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -193,7 +193,7 @@ jobs:
 
       - name: Archive Test Results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results
           path: |
@@ -204,7 +204,7 @@ jobs:
 
       - name: Archive Error Logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: error-logs
           path: |

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version-file: 'package.json'
           cache: 'npm'
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload coverage reports
         if: steps.install.outputs.dependencies_installed == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: js-coverage-report
           path: coverage/coverage-summary.json

--- a/.github/workflows/php-cs-on-changes.yml
+++ b/.github/workflows/php-cs-on-changes.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -25,7 +25,7 @@ jobs:
         run: sudo apt-get install subversion -y
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Prepare PHP
         uses: woocommerce/grow/prepare-php@actions-v1
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload coverage reports
         if: steps.phpunit.outputs.test_status == 'passed'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: php-coverage-report PHP - ${{ matrix.php }}, WP - ${{ matrix.wp-version }} , WC - ${{ matrix.wc-version }}
           path: coverage.xml

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
             token: ${{ secrets.GITHUB_TOKEN }}
             fetch-depth: 0
@@ -31,7 +31,7 @@ jobs:
         run: echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Check if branch exists
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
         with:
@@ -59,7 +59,7 @@ jobs:
 
       - name: Get latest release tag
         id: get_release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const latestRelease = await github.rest.repos.getLatestRelease({
@@ -80,7 +80,7 @@ jobs:
 
       - name: Build changelog from PRs
         id: changelog
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           COMMITS: ${{ steps.get_commits.outputs.commits }}
           NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
@@ -155,7 +155,7 @@ jobs:
           git diff
 
       - name: Update changelog.txt
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           CHANGELOG_TEXT: ${{ steps.changelog.outputs.changelog }}
         with:
@@ -175,7 +175,7 @@ jobs:
           sed -i -E "s/^(Stable tag:)[[:space:]]*[0-9.]+/\1 $CURRENT_STABLE/" "readme.txt"
 
       - name: Update readme.txt
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           CHANGELOG_TEXT: ${{ steps.changelog.outputs.changelog }}
         with:

--- a/.github/workflows/product-creation-tests.yml
+++ b/.github/workflows/product-creation-tests.yml
@@ -77,10 +77,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: 'package.json'
           cache: 'npm'
@@ -523,7 +523,7 @@ jobs:
           fi
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: playwright-report
@@ -531,7 +531,7 @@ jobs:
           retention-days: 7
 
       - name: Upload captured events
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: CAPI Pixel Captured events
@@ -550,7 +550,7 @@ jobs:
           fi
 
       - name: Upload PHP logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: php-debug-logs
@@ -558,7 +558,7 @@ jobs:
           retention-days: 7
 
       - name: Upload test videos/screenshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: test-failures

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: Deployment
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get NPM Version
         id: package-version
@@ -30,7 +30,7 @@ jobs:
           tools: composer
       
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version-file: 'package.json'
           cache-dependency-path: './package-lock.json'
@@ -74,7 +74,7 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       - name: Store built plugin
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v6
         with:
           name: facebook-for-woocommerce
           path: facebook-for-woocommerce.zip
@@ -114,7 +114,7 @@ jobs:
           svn commit -m "Deploy new version ${{ steps.package-version.outputs.current-version}}" --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --no-auth-cache --non-interactive
 
       - name: Create a new release on GitHub
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           VERSION: ${{ steps.package-version.outputs.current-version}}
           COMMIT_SHA: ${{ github.sha }}
@@ -170,7 +170,7 @@ jobs:
             fs.writeFileSync(releaseIdFile, release.data.id.toString());
             
       - name: Upload release ID as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-id
           path: release-id.txt

--- a/.github/workflows/set-stable-tag.yml
+++ b/.github/workflows/set-stable-tag.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: Deployment
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Fail if not on a release publish branch
         run: |

--- a/.github/workflows/shared-build-plugin-artifact.yml
+++ b/.github/workflows/shared-build-plugin-artifact.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
       
@@ -31,7 +31,7 @@ jobs:
           tools: composer
       
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version-file: 'package.json'
           cache-dependency-path: './package-lock.json'
@@ -46,7 +46,7 @@ jobs:
         run: npm run build
       
       - name: Store built plugin
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v6
         continue-on-error: true
         with:
           name: facebook-for-woocommerce
@@ -67,7 +67,7 @@ jobs:
         
       - name: Post build info comment on PR
         if: inputs.pr_number
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         env:
           PR_NUMBER: ${{ inputs.pr_number }}
         with:

--- a/.github/workflows/validate-pr-labels.yml
+++ b/.github/workflows/validate-pr-labels.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const allowedLabels = ['feature', 'bug', 'chore'];


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [``](https://github.com/actions/cache/releases/tag/) | [`v5`](https://github.com/actions/cache/releases/tag/v5) | [Release](https://github.com/actions/cache/releases/tag/v5) |  |
| `actions/checkout` | [``](https://github.com/actions/checkout/releases/tag/) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) |  |
| `actions/github-script` | [``](https://github.com/actions/github-script/releases/tag/) | [`v8`](https://github.com/actions/github-script/releases/tag/v8) | [Release](https://github.com/actions/github-script/releases/tag/v8) |  |
| `actions/setup-node` | [``](https://github.com/actions/setup-node/releases/tag/) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Release](https://github.com/actions/setup-node/releases/tag/v6) |  |
| `actions/upload-artifact` | [``](https://github.com/actions/upload-artifact/releases/tag/) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) |  |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
