### PR TITLE
Fix bug - Remove "Delete all products" button as it calls an unimplemented method

### DIFF
--- a/includes/Utilities/DebugTools.php
+++ b/includes/Utilities/DebugTools.php
@@ -55,13 +55,6 @@ class DebugTools {
 			'callback' => [ $this, 'reset_all_product_fb_settings' ],
 		];
 
-		$tools['wc_facebook_delete_all_products'] = [
-			'name'     => __( 'Facebook: Delete all products from your Facebook Catalog', 'facebook-for-woocommerce' ),
-			'button'   => __( 'Delete all products', 'facebook-for-woocommerce' ),
-			'desc'     => __( 'This tool will delete all products from  your Facebook Catalog.', 'facebook-for-woocommerce' ),
-			'callback' => [ $this, 'delete_all_products' ],
-		];
-
 		return $tools;
 	}
 
@@ -104,17 +97,5 @@ class DebugTools {
 	public function reset_all_product_fb_settings() {
 		facebook_for_woocommerce()->job_manager->reset_all_product_fb_settings->queue_start();
 		return esc_html__( 'Reset products Facebook settings job started!', 'facebook-for-woocommerce' );
-	}
-
-	/**
-	 * Delete products from Facebook catalog.
-	 *
-	 * @since 3.0.5
-	 *
-	 * @return string
-	 */
-	public function delete_all_products() {
-		facebook_for_woocommerce()->job_manager->delete_all_products->queue_start();
-		return esc_html__( 'Delete products from Facebook catalog job started!', 'facebook-for-woocommerce' );
 	}
 }

--- a/tests/Unit/Utilities/DebugToolsTest.php
+++ b/tests/Unit/Utilities/DebugToolsTest.php
@@ -126,7 +126,6 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$this->assertArrayHasKey( 'wc_facebook_settings_reset', $result );
 		$this->assertArrayHasKey( 'wc_facebook_delete_background_jobs', $result );
 		$this->assertArrayHasKey( 'reset_all_product_fb_settings', $result );
-		$this->assertArrayHasKey( 'wc_facebook_delete_all_products', $result );
 		
 		// Check tool structure
 		$this->assertArrayHasKey( 'name', $result['wc_facebook_settings_reset'] );
@@ -138,7 +137,6 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$this->assertIsCallable( $result['wc_facebook_settings_reset']['callback'] );
 		$this->assertIsCallable( $result['wc_facebook_delete_background_jobs']['callback'] );
 		$this->assertIsCallable( $result['reset_all_product_fb_settings']['callback'] );
-		$this->assertIsCallable( $result['wc_facebook_delete_all_products']['callback'] );
 	}
 
 	/**
@@ -251,36 +249,6 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 	}
 
 	/**
-	 * Test delete_all_products method.
-	 */
-	public function test_delete_all_products() {
-		$debug_tools = new DebugTools();
-		
-		// Create a mock job with queue_start method
-		$mock_job = $this->getMockBuilder( \stdClass::class )
-			->addMethods( ['queue_start'] )
-			->getMock();
-		$mock_job->expects( $this->once() )->method( 'queue_start' );
-		
-		// Mock the job manager
-		$mock_job_manager = new \stdClass();
-		$mock_job_manager->delete_all_products = $mock_job;
-		
-		$mock_plugin = $this->createMock( \WC_Facebookcommerce::class );
-		$mock_plugin->job_manager = $mock_job_manager;
-		
-		// Use filter to override the instance
-		$this->add_filter_with_safe_teardown( 'wc_facebook_instance', function() use ( $mock_plugin ) {
-			return $mock_plugin;
-		} );
-		
-		$result = $debug_tools->delete_all_products();
-		
-		// Check result message
-		$this->assertEquals( 'Delete products from Facebook catalog job started!', $result );
-	}
-
-	/**
 	 * Test tool descriptions and labels.
 	 */
 	public function test_tool_descriptions_and_labels() {
@@ -319,11 +287,6 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$this->assertEquals( 'Facebook: Reset all products', $result['reset_all_product_fb_settings']['name'] );
 		$this->assertEquals( 'Reset products Facebook settings', $result['reset_all_product_fb_settings']['button'] );
 		$this->assertStringContainsString( 'reset Facebook settings for all products', $result['reset_all_product_fb_settings']['desc'] );
-		
-		// Test delete all products tool
-		$this->assertEquals( 'Facebook: Delete all products from your Facebook Catalog', $result['wc_facebook_delete_all_products']['name'] );
-		$this->assertEquals( 'Delete all products', $result['wc_facebook_delete_all_products']['button'] );
-		$this->assertStringContainsString( 'delete all products from', $result['wc_facebook_delete_all_products']['desc'] );
 	}
 
 	/**
@@ -366,6 +329,6 @@ class DebugToolsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilteri
 		$this->assertArrayHasKey( 'wc_facebook_settings_reset', $result );
 		$this->assertArrayHasKey( 'wc_facebook_delete_background_jobs', $result );
 		$this->assertArrayHasKey( 'reset_all_product_fb_settings', $result );
-		$this->assertArrayHasKey( 'wc_facebook_delete_all_products', $result );
+		
 	}
 } 


### PR DESCRIPTION
## Description

we removed the feature to delete all products on facebook catalog here - https://github.com/facebook/facebook-for-woocommerce/pull/3623

but the UI still remains - 
<img width="1697" height="188" alt="Screenshot 2025-12-17 at 13 45 49" src="https://github.com/user-attachments/assets/6475a124-a86e-4afa-a52e-1c288c205dcc" />

And when people click on it , it raises this error and the page crashes. 
```
Undefined property: WooCommerce\Facebook\Jobs\JobManager::$delete_all_products in** ~/local-site1/app/public/wp-content/plugins/facebook-for-woocommerce/includes/Utilities/DebugTools.php **on line** 117 **

Fatal error: Uncaught Error: Call to a member function queue_start() 
```
<img width="1742" height="392" alt="Screenshot 2025-12-17 at 13 46 23" src="https://github.com/user-attachments/assets/d80f9901-d25a-4e63-bf64-ae01436cacbb" />

Hence in this change, we remove the button altogether and any relevant tests.

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [✔️] I have commented my code, particularly in hard-to-understand areas, if any.
- [✔️] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [✔️] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [✔️] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [✔️] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [✔️] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fix bug - Remove "Delete all products" button as it calls an unimplemented method

## Test Plan
Tested locally and attached screenshots 
## Screenshots
### Before
<img width="1727" height="303" alt="Screenshot 2025-12-17 at 13 50 38" src="https://github.com/user-attachments/assets/b3a47ab0-7d4c-4128-a36b-8e373e43e264" />

### After
<img width="1261" height="226" alt="Screenshot 2025-12-17 at 13 50 55" src="https://github.com/user-attachments/assets/4dbb1c29-afe2-4c3b-aaf3-0193cedab9ec" />
