### PR TITLE
remove tests.describe.serial

### DIFF
--- a/.github/workflows/product-creation-tests.yml
+++ b/.github/workflows/product-creation-tests.yml
@@ -96,7 +96,7 @@ jobs:
           extensions: mysqli, zip, gd, curl, dom, fileinfo, mbstring
           ini-values: |
             date.timezone=UTC
-            memory_limit=512M
+            memory_limit=1024M
             max_execution_time=300
 
       - name: Configure hostname
@@ -547,15 +547,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y xvfb
 
-      - name: Run Plugin level tests
+      - name: Run Plugin level tests (sequential)
         run: |
           cd ${{ env.PLUGIN_PATH }}
-          npx playwright test "plugin-.*\.spec\.js" --project=chromium-wp-admin
+          npx playwright test plugin-level-tests.spec.js --project=chromium-wp-admin --workers=1
 
-      - name: Run CAPI Pixel E2E tests
+      - name: Run CAPI Pixel E2E tests (sequential)
         run: |
           cd ${{ env.PLUGIN_PATH }}
-          xvfb-run --auto-servernum npx playwright test events-test*.spec.js --headed --project=chromium-wp-customer
+          xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=chromium-wp-customer --workers=1
 
       - name: Cleanup test product
         if: always()
@@ -568,11 +568,20 @@ jobs:
             echo "ℹ️ No test product to delete"
           fi
 
-      - name: Run E2E tests
-        continue-on-error: true
+      - name: Run Product CRUD tests (parallel)
         run: |
           cd ${{ env.PLUGIN_PATH }}
-          npx playwright test "product-.*\.spec\.js" --project=chromium-wp-admin
+          npx playwright test "product-(creation|modification|deletion).spec.js" --project=chromium-wp-admin --workers=2
+
+      - name: Run Product Batch tests (sequential)
+        run: |
+          cd ${{ env.PLUGIN_PATH }}
+          npx playwright test product-batch.spec.js --project=chromium-wp-admin --workers=1
+
+      - name: Run Product Category tests (sequential)
+        run: |
+          cd ${{ env.PLUGIN_PATH }}
+          npx playwright test product-category.spec.js --project=chromium-wp-admin --workers=1
 
       - name: Disconnect from catalog
         if: always()

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -5,7 +5,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 2 : 2,
+  workers: process.env.CI ? 1 : 1,
   reporter: 'html',
   // Global test timeout - increased to 5 minutes for complex WordPress operations
   timeout: 1000000,

--- a/tests/e2e/plugin-level-tests.spec.js
+++ b/tests/e2e/plugin-level-tests.spec.js
@@ -10,7 +10,7 @@ const COMPAT_PLUGINS = [
   { slug: 'subscriptions-for-woocommerce', name: 'Subscriptions For WooCommerce' },
 ];
 
-test.describe.serial('WooCommerce Plugin level tests', () => {
+test.describe('WooCommerce Plugin level tests', () => {
 
   test.beforeEach(async ({ page }, testInfo) => {
     // Log test start first for proper chronological order

--- a/tests/e2e/product-category.spec.js
+++ b/tests/e2e/product-category.spec.js
@@ -15,7 +15,7 @@ const {
     cleanupCategory
 } = require('./test-helpers');
 
-test.describe.serial('Facebook for WooCommerce - Product Category E2E Tests', () => {
+test.describe('Facebook for WooCommerce - Product Category E2E Tests', () => {
 
     test.beforeEach(async ({ page }, testInfo) => {
         // Log test start first for proper chronological order


### PR DESCRIPTION
## Description

pw serial mode retries all the tests in a file if a single test fails better way to enforce sequential execution is using --workers=1

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have commented my code, particularly in hard-to-understand areas, if any.
- [X] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [X] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [X] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [X] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [X] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [X] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Replace test.describe.serial with --workers=1 to prevent Playwright from retrying all tests in a file when a single test fails

## Test Plan
N parallel E2E test runs should all PASS and take roughly the same time to execute.

