### PR TITLE
Add param_builder_server_setup test (#3790)

### DIFF
--- a/tests/Unit/Events/FacebookCommerceEventsTrackerTest.php
+++ b/tests/Unit/Events/FacebookCommerceEventsTrackerTest.php
@@ -6,6 +6,7 @@ namespace WooCommerce\Facebook\Tests\Unit\Events;
 use WooCommerce\Facebook\Events\AAMSettings;
 use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSafeFiltering;
 use WC_Facebookcommerce_EventsTracker;
+use ReflectionClass;
 
 /**
  * Unit tests for WC_Facebookcommerce_EventsTracker class.
@@ -220,7 +221,6 @@ class FacebookCommerceEventsTrackerTest extends AbstractWPUnitTestWithSafeFilter
 
 		$this->assertTrue( true, 'inject_add_to_cart_event should handle disabled pixel' );
 	}
-
 	/**
 	 * Test that inject_add_to_cart_event does nothing with invalid product_id.
 	 *
@@ -694,5 +694,124 @@ class FacebookCommerceEventsTrackerTest extends AbstractWPUnitTestWithSafeFilter
 
 		// Restore
 		$post = $original_post;
+	}
+
+	/**
+	 * Set up a mock param_builder that returns test cookies.
+	 *
+	 * @param string $cookie_name The name of the test cookie to return.
+	 * @return mixed the mock param_builder
+	 */
+	private function create_mock_param_builder_with_cookies( string $cookie_name ) {
+		$mock_cookie        = new \stdClass();
+		$mock_cookie->name  = $cookie_name;
+		$mock_cookie->value = 'test_value';
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$mock_cookie->max_age = 3600;
+		$mock_cookie->domain  = '';
+
+		$mock_param_builder = new class( $mock_cookie ) {
+			private $cookie;
+			private $was_called = false;
+			public function __construct( $cookie ) {
+				$this->cookie = $cookie;
+			}
+
+			public function getCookiesToSet() {
+				$this->was_called = true;
+				return array( $this->cookie );
+			}
+
+			public function wasGetCookiesToSetCalled() {
+				return $this->was_called;
+			}
+
+			public function getFbc() {
+				return null;
+			}
+
+			public function getFbp() {
+				return null;
+			}
+		};
+		return $mock_param_builder;
+	}
+
+	/**
+	 * Set the param_builder static value and return the original.
+	 *
+	 * @param mixed $param_builder The value to update param_builder to.
+	 * @return mixed The previous param_builder value
+	 */
+	private function install_param_builder_mock( $param_builder ) {
+		$original_param_builder = null;
+		if ( class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) {
+			$ref = new ReflectionClass( 'WC_Facebookcommerce_EventsTracker' );
+			if ( $ref->hasProperty( 'param_builder' ) ) {
+				$prop = $ref->getProperty( 'param_builder' );
+				$prop->setAccessible( true );
+				$original_param_builder = $prop->getValue();
+				$prop->setValue( null, $param_builder );
+			}
+		}
+
+		return $original_param_builder;
+	}
+
+	/**
+	 * Data provider for testing setcookie behavior based on pixel enabled filter.
+	 *
+	 * @return array Test cases with format: [pixel_enabled, expected_setcookie_called]
+	 */
+	public function setcookie_behavior_provider(): array {
+		return array(
+			'pixel enabled - setcookie should be called'     => array(
+				'pixel_enabled'   => true,
+				'expected_called' => true,
+			),
+			'pixel disabled - setcookie should not be called' => array(
+				'pixel_enabled'   => false,
+				'expected_called' => false,
+			),
+		);
+	}
+
+	/**
+	 * Test that param_builder_server_setup calls setcookie when pixel is enabled
+	 * and does not call setcookie when pixel is disabled.
+	 *
+	 * @dataProvider setcookie_behavior_provider
+	 * @covers WC_Facebookcommerce_EventsTracker::param_builder_server_setup
+	 *
+	 * @param bool $pixel_enabled Whether the pixel should be enabled via the filter.
+	 * @param bool $expected_setcookie_called Whether setcookie is expected to be called.
+	 */
+	public function test_param_builder_server_setup_setcookie_behavior( bool $pixel_enabled, bool $expected_called ): void {
+		$test_cookie_name = 'fbp_test_' . uniqid();
+
+		// Set up mock param_builder before creating the tracker.
+		$mock_param_builder = $this->create_mock_param_builder_with_cookies( $test_cookie_name );
+		$original_param_builder = $this->install_param_builder_mock( $mock_param_builder );
+
+		// Create tracker with appropriate pixel setting.
+		if ( $pixel_enabled ) {
+			$this->create_tracker_with_pixel_enabled();
+		} else {
+			$this->create_tracker_with_pixel_disabled();
+		}
+
+		$wasCalled = $mock_param_builder->wasGetCookiesToSetCalled();
+
+		// Restore original param_builder.
+		$this->install_param_builder_mock( $original_param_builder );
+
+		// Assert the expected behavior.
+		$this->assertEquals(
+			$expected_called,
+			$wasCalled,
+			$pixel_enabled
+				? 'param_builder_server_setup should complete when pixel is enabled'
+				: 'param_builder_server_setup should return early when pixel is disabled'
+		);
 	}
 }


### PR DESCRIPTION
Summary:

## Description

Adds a test to validate the apply_filters change from 3.5.14 that ensures setcookie is only called in param_builder_server_setup when the facebook_for_woocommerce_integration_pixel_enabled filter returns true. 

The test uses a data provider to verify both enabled and disabled cases.

### Type of change

Please delete options that are not relevant

- Tweak (non-breaking change which fixes code modularity, linting or phpcs issues)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Add additional test coverage for excluding cookies when pixel disabled


## Test Plan

```
$ ./vendor/bin/phpunit tests/Unit/Events/FacebookCommerceEventsTrackerTest.php

Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
Loading Polylang for localization integration tests...
Installing WooCommerce...
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
PHPUnit 9.6.28 by Sebastian Bergmann and contributors.

............                                                      12 / 12 (100%)

Time: 00:00.761, Memory: 85.00 MB

OK (12 tests, 13 assertions)
```

Differential Revision: D89679204


