### PR TITLE
Restrict E2E tests to facebook repo and add daily schedule

### DIFF
--- a/.github/workflows/product-creation-tests.yml
+++ b/.github/workflows/product-creation-tests.yml
@@ -18,6 +18,9 @@ on:
           default: false
   pull_request:
     branches: [ main, master, develop ]
+  schedule:
+    # Run daily at 8am UTC (only runs when required secrets are configured)
+    - cron: '0 8 * * *'
 
 env:
   # Test environment configuration
@@ -63,7 +66,36 @@ env:
   ERROR_WHITELIST: 'WC_Facebook_Google_Product_Category_Fields is not defined'
 
 jobs:
+  # Job to check if secrets are configured and emit warning if not
+  check-secrets:
+    runs-on: ubuntu-latest
+    outputs:
+      secrets-configured: ${{ steps.check.outputs.configured }}
+    steps:
+      - name: Check if required secrets are configured
+        id: check
+        env:
+          TEST_SITE_HOST: ${{ secrets.TEST_SITE_HOST }}
+          FB_TEST_META_BUSINESS_ASSETS: ${{ secrets.FB_TEST_META_BUSINESS_ASSETS }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO_OWNER: ${{ github.repository_owner }}
+        run: |
+          if [ -n "$TEST_SITE_HOST" ] && [ -n "$FB_TEST_META_BUSINESS_ASSETS" ]; then
+            echo "configured=true" >> $GITHUB_OUTPUT
+            echo "✅ Required secrets are configured"
+          else
+            echo "configured=false" >> $GITHUB_OUTPUT
+            # Fail if this is a scheduled run on the facebook repository
+            if [ "$EVENT_NAME" = "schedule" ] && [ "$REPO_OWNER" = "facebook" ]; then
+              echo "::error title=E2E Tests Failed::Scheduled run on facebook repository but required secrets (TEST_SITE_HOST, FB_TEST_META_BUSINESS_ASSETS) are not configured."
+              exit 1
+            fi
+            echo "::warning title=E2E Tests Skipped::E2E tests require TEST_SITE_HOST and FB_TEST_META_BUSINESS_ASSETS secrets to be configured. After merge, E2E tests will run daily to validate functionality."
+          fi
+
   e2e-tests:
+    needs: check-secrets
+    if: ${{ needs.check-secrets.outputs.secrets-configured == 'true' }}
     runs-on: ubuntu-latest
     continue-on-error: true
 


### PR DESCRIPTION
Summary:
## Description

This change restricts E2E test execution to only run when the repository owner is `facebook`, preventing unnecessary test runs on forks. For non-facebook repository owners, a warning is displayed informing contributors that E2E tests will run daily after merge. Additionally, a daily scheduled run at 8am UTC ensures continuous validation of the plugin functionality.

### Type of change

- Tweak (non-breaking change which fixes code modularity, linting or phpcs issues)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices.
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary).

## Changelog entry

Restrict E2E tests to facebook repository owner and add daily scheduled runs at 8am UTC.

Differential Revision: D89731710


