### PR TITLE
Add unit tests for Admin.php and WCFacebookProductFeedTest.php

### DIFF
--- a/tests/Unit/AdminTest.php
+++ b/tests/Unit/AdminTest.php
@@ -24,6 +24,123 @@ class AdminTest extends \WP_UnitTestCase {
      */
     private const TEST_MATERIAL_ATTRIBUTE_ID = '123';
 
+    /**
+     * Test SYNC_MODE_SYNC_AND_SHOW constant.
+     */
+    public function test_sync_mode_sync_and_show_constant(): void {
+        $this->assertSame(
+            'sync_and_show',
+            Admin::SYNC_MODE_SYNC_AND_SHOW,
+            'SYNC_MODE_SYNC_AND_SHOW constant should have correct value'
+        );
+    }
+
+    /**
+     * Test SYNC_MODE_SYNC_AND_HIDE constant.
+     */
+    public function test_sync_mode_sync_and_hide_constant(): void {
+        $this->assertSame(
+            'sync_and_hide',
+            Admin::SYNC_MODE_SYNC_AND_HIDE,
+            'SYNC_MODE_SYNC_AND_HIDE constant should have correct value'
+        );
+    }
+
+    /**
+     * Test SYNC_MODE_SYNC_DISABLED constant.
+     */
+    public function test_sync_mode_sync_disabled_constant(): void {
+        $this->assertSame(
+            'sync_disabled',
+            Admin::SYNC_MODE_SYNC_DISABLED,
+            'SYNC_MODE_SYNC_DISABLED constant should have correct value'
+        );
+    }
+
+    /**
+     * Test INCLUDE_FACEBOOK_SYNC constant.
+     */
+    public function test_include_facebook_sync_constant(): void {
+        $this->assertSame(
+            'fb_sync_enabled',
+            Admin::INCLUDE_FACEBOOK_SYNC,
+            'INCLUDE_FACEBOOK_SYNC constant should have correct value'
+        );
+    }
+
+    /**
+     * Test EXCLUDE_FACEBOOK_SYNC constant.
+     */
+    public function test_exclude_facebook_sync_constant(): void {
+        $this->assertSame(
+            'fb_sync_disabled',
+            Admin::EXCLUDE_FACEBOOK_SYNC,
+            'EXCLUDE_FACEBOOK_SYNC constant should have correct value'
+        );
+    }
+
+    /**
+     * Test BULK_EDIT_SYNC constant.
+     */
+    public function test_bulk_edit_sync_constant(): void {
+        $this->assertSame(
+            'bulk_edit_sync',
+            Admin::BULK_EDIT_SYNC,
+            'BULK_EDIT_SYNC constant should have correct value'
+        );
+    }
+
+    /**
+     * Test BULK_EDIT_DELETE constant.
+     */
+    public function test_bulk_edit_delete_constant(): void {
+        $this->assertSame(
+            'bulk_edit_delete',
+            Admin::BULK_EDIT_DELETE,
+            'BULK_EDIT_DELETE constant should have correct value'
+        );
+    }
+
+    /**
+     * Test all sync mode constants are distinct.
+     */
+    public function test_sync_mode_constants_are_distinct(): void {
+        $sync_modes = [
+            Admin::SYNC_MODE_SYNC_AND_SHOW,
+            Admin::SYNC_MODE_SYNC_AND_HIDE,
+            Admin::SYNC_MODE_SYNC_DISABLED,
+        ];
+
+        $unique_modes = array_unique($sync_modes);
+        $this->assertCount(
+            3,
+            $unique_modes,
+            'All sync mode constants should have unique values'
+        );
+    }
+
+    /**
+     * Test bulk edit constants are distinct.
+     */
+    public function test_bulk_edit_constants_are_distinct(): void {
+        $this->assertNotSame(
+            Admin::BULK_EDIT_SYNC,
+            Admin::BULK_EDIT_DELETE,
+            'BULK_EDIT_SYNC and BULK_EDIT_DELETE should have different values'
+        );
+    }
+
+    /**
+     * Test sync filter constants are distinct.
+     */
+    public function test_sync_filter_constants_are_distinct(): void {
+        $this->assertNotSame(
+            Admin::INCLUDE_FACEBOOK_SYNC,
+            Admin::EXCLUDE_FACEBOOK_SYNC,
+            'INCLUDE_FACEBOOK_SYNC and EXCLUDE_FACEBOOK_SYNC should have different values'
+        );
+    }
+
     public function setUp() : void {
         parent::setUp();
 
@@ -949,5 +1066,811 @@ class AdminTest extends \WP_UnitTestCase {
 		// Clean up
 		$variable_product->delete( true );
 		unset($GLOBALS['wc_facebook_commerce']);
+	}
+
+	/**
+	 * Test add_product_list_table_columns adds Facebook columns.
+	 */
+	public function test_add_product_list_table_columns(): void {
+		$existing_columns = array(
+			'cb'           => '<input type="checkbox" />',
+			'thumb'        => '<span class="wc-image tips">Image</span>',
+			'name'         => 'Name',
+			'sku'          => 'SKU',
+			'is_in_stock'  => 'Stock',
+			'price'        => 'Price',
+			'product_cat'  => 'Categories',
+			'product_tag'  => 'Tags',
+			'date'         => 'Date',
+		);
+
+		$result = $this->admin->add_product_list_table_columns( $existing_columns );
+
+		// The mock class returns the columns as-is since it skips the parent constructor
+		// Verify original columns are preserved
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'cb', $result );
+		$this->assertArrayHasKey( 'name', $result );
+		$this->assertArrayHasKey( 'price', $result );
+	}
+
+	/**
+	 * Test add_product_list_table_columns returns array.
+	 */
+	public function test_add_product_list_table_columns_returns_array(): void {
+		$result = $this->admin->add_product_list_table_columns( array() );
+
+		$this->assertIsArray( $result );
+	}
+
+	/**
+	 * Test add_product_list_table_columns with empty input.
+	 */
+	public function test_add_product_list_table_columns_with_empty_input(): void {
+		$result = $this->admin->add_product_list_table_columns( array() );
+
+		// Should return an array
+		$this->assertIsArray( $result );
+	}
+
+	/**
+	 * Test add_products_sync_bulk_actions adds sync actions.
+	 */
+	public function test_add_products_sync_bulk_actions(): void {
+		$existing_actions = array(
+			'edit'   => 'Edit',
+			'delete' => 'Move to Trash',
+		);
+
+		$result = $this->admin->add_products_sync_bulk_actions( $existing_actions );
+
+		// Should return array with bulk actions
+		$this->assertIsArray( $result );
+
+		// Should preserve existing actions
+		$this->assertArrayHasKey( 'edit', $result );
+		$this->assertArrayHasKey( 'delete', $result );
+	}
+
+	/**
+	 * Test add_products_sync_bulk_actions with empty array.
+	 */
+	public function test_add_products_sync_bulk_actions_with_empty_array(): void {
+		$result = $this->admin->add_products_sync_bulk_actions( array() );
+
+		$this->assertIsArray( $result );
+	}
+
+	/**
+	 * Test add_product_settings_tab adds Facebook tab.
+	 */
+	public function test_add_product_settings_tab(): void {
+		$existing_tabs = array(
+			'general'        => array(
+				'label'    => 'General',
+				'target'   => 'general_product_data',
+				'class'    => array(),
+				'priority' => 10,
+			),
+			'inventory'      => array(
+				'label'    => 'Inventory',
+				'target'   => 'inventory_product_data',
+				'class'    => array(),
+				'priority' => 20,
+			),
+		);
+
+		$result = $this->admin->add_product_settings_tab( $existing_tabs );
+
+		// Should return array
+		$this->assertIsArray( $result );
+
+		// Should add Facebook tab
+		$this->assertArrayHasKey( 'fb_commerce_tab', $result );
+
+		// Verify Facebook tab has required properties
+		$fb_tab = $result['fb_commerce_tab'];
+		$this->assertArrayHasKey( 'label', $fb_tab );
+		$this->assertArrayHasKey( 'target', $fb_tab );
+	}
+
+	/**
+	 * Test add_product_settings_tab preserves existing tabs.
+	 */
+	public function test_add_product_settings_tab_preserves_existing(): void {
+		$existing_tabs = array(
+			'general'   => array( 'label' => 'General' ),
+			'inventory' => array( 'label' => 'Inventory' ),
+		);
+
+		$result = $this->admin->add_product_settings_tab( $existing_tabs );
+
+		// Should preserve existing tabs
+		$this->assertArrayHasKey( 'general', $result );
+		$this->assertArrayHasKey( 'inventory', $result );
+	}
+
+	/**
+	 * Test filter_products_by_sync_enabled with no filter.
+	 */
+	public function test_filter_products_by_sync_enabled_no_filter(): void {
+		$query_vars = array(
+			'post_type' => 'product',
+		);
+
+		$result = $this->admin->filter_products_by_sync_enabled( $query_vars );
+
+		// Should return unchanged query vars when no filter applied
+		$this->assertIsArray( $result );
+		$this->assertEquals( 'product', $result['post_type'] );
+	}
+
+	/**
+	 * Test filter_products_by_sync_enabled with include filter.
+	 */
+	public function test_filter_products_by_sync_enabled_include(): void {
+		$_GET['fb_sync_enabled'] = Admin::INCLUDE_FACEBOOK_SYNC;
+
+		$query_vars = array(
+			'post_type' => 'product',
+		);
+
+		$result = $this->admin->filter_products_by_sync_enabled( $query_vars );
+
+		$this->assertIsArray( $result );
+
+		unset( $_GET['fb_sync_enabled'] );
+	}
+
+	/**
+	 * Test filter_products_by_sync_enabled with exclude filter.
+	 */
+	public function test_filter_products_by_sync_enabled_exclude(): void {
+		$_GET['fb_sync_enabled'] = Admin::EXCLUDE_FACEBOOK_SYNC;
+
+		$query_vars = array(
+			'post_type' => 'product',
+		);
+
+		$result = $this->admin->filter_products_by_sync_enabled( $query_vars );
+
+		$this->assertIsArray( $result );
+
+		unset( $_GET['fb_sync_enabled'] );
+	}
+
+	/**
+	 * Test filter_products_by_sync_enabled with invalid filter.
+	 */
+	public function test_filter_products_by_sync_enabled_invalid_filter(): void {
+		$_GET['fb_sync_enabled'] = 'invalid_value';
+
+		$query_vars = array(
+			'post_type' => 'product',
+		);
+
+		$result = $this->admin->filter_products_by_sync_enabled( $query_vars );
+
+		$this->assertIsArray( $result );
+
+		unset( $_GET['fb_sync_enabled'] );
+	}
+
+	/**
+	 * Test add_products_by_sync_enabled_input_filter outputs select dropdown.
+	 */
+	public function test_add_products_by_sync_enabled_input_filter(): void {
+		// Set up global screen
+		global $current_screen;
+		$current_screen = (object) array( 'id' => 'edit-product', 'post_type' => 'product' );
+		set_current_screen( 'edit-product' );
+
+		ob_start();
+		$this->admin->add_products_by_sync_enabled_input_filter( 'product' );
+		$output = ob_get_clean();
+
+		// Should contain the filter dropdown
+		$this->assertStringContainsString( 'fb_sync_enabled', $output );
+		$this->assertStringContainsString( 'select', $output );
+
+		// Reset screen
+		$current_screen = null;
+	}
+
+	/**
+	 * Test add_products_by_sync_enabled_input_filter for non-product post type.
+	 */
+	public function test_add_products_by_sync_enabled_input_filter_non_product(): void {
+		ob_start();
+		$this->admin->add_products_by_sync_enabled_input_filter( 'post' );
+		$output = ob_get_clean();
+
+		// Should output nothing for non-product post types
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * Test add_facebook_sync_bulk_edit_dropdown_at_bottom method exists.
+	 */
+	public function test_add_facebook_sync_bulk_edit_dropdown_at_bottom(): void {
+		// Verify the method exists and can be called
+		$this->assertTrue(
+			method_exists( $this->admin, 'add_facebook_sync_bulk_edit_dropdown_at_bottom' ),
+			'add_facebook_sync_bulk_edit_dropdown_at_bottom method should exist'
+		);
+
+		// Call the method - it should not throw an error
+		ob_start();
+		$this->admin->add_facebook_sync_bulk_edit_dropdown_at_bottom();
+		$output = ob_get_clean();
+
+		$this->assertIsString( $output );
+	}
+
+	/**
+	 * Test handle_products_sync_bulk_actions with sync_and_show action.
+	 */
+	public function test_handle_products_sync_bulk_actions_sync_and_show(): void {
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'Bulk Test Product' );
+		$product->set_regular_price( '10' );
+		$product->save();
+
+		$product_id = $product->get_id();
+		$this->assertGreaterThan( 0, $product_id, 'Product should be saved with valid ID' );
+
+		$_REQUEST['wc_facebook_sync_mode'] = Admin::SYNC_MODE_SYNC_AND_SHOW;
+
+		$this->admin->handle_products_sync_bulk_actions( $product );
+
+		// Verify product still exists and wasn't corrupted
+		$reloaded_product = wc_get_product( $product_id );
+		$this->assertInstanceOf( \WC_Product::class, $reloaded_product );
+		$this->assertEquals( 'Bulk Test Product', $reloaded_product->get_name() );
+
+		// Clean up
+		$product->delete( true );
+		unset( $_REQUEST['wc_facebook_sync_mode'] );
+	}
+
+	/**
+	 * Test handle_products_sync_bulk_actions with sync_disabled action.
+	 */
+	public function test_handle_products_sync_bulk_actions_sync_disabled(): void {
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'Bulk Disable Test Product' );
+		$product->set_regular_price( '15' );
+		$product->save();
+
+		$product_id = $product->get_id();
+		$this->assertGreaterThan( 0, $product_id, 'Product should be saved with valid ID' );
+
+		$_REQUEST['wc_facebook_sync_mode'] = Admin::SYNC_MODE_SYNC_DISABLED;
+
+		$this->admin->handle_products_sync_bulk_actions( $product );
+
+		// Verify product still exists and wasn't corrupted
+		$reloaded_product = wc_get_product( $product_id );
+		$this->assertInstanceOf( \WC_Product::class, $reloaded_product );
+		$this->assertEquals( '15', $reloaded_product->get_regular_price() );
+
+		// Clean up
+		$product->delete( true );
+		unset( $_REQUEST['wc_facebook_sync_mode'] );
+	}
+
+	/**
+	 * Test handle_products_sync_bulk_actions with no action.
+	 */
+	public function test_handle_products_sync_bulk_actions_no_action(): void {
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'No Action Test Product' );
+		$product->set_regular_price( '20' );
+		$product->save();
+
+		$product_id = $product->get_id();
+
+		// Don't set sync mode - ensure REQUEST is clean
+		unset( $_REQUEST['wc_facebook_sync_mode'] );
+
+		$this->admin->handle_products_sync_bulk_actions( $product );
+
+		// Verify product is unchanged when no sync mode is set
+		$reloaded_product = wc_get_product( $product_id );
+		$this->assertEquals( 'No Action Test Product', $reloaded_product->get_name() );
+		$this->assertEquals( '20', $reloaded_product->get_regular_price() );
+
+		// Clean up
+		$product->delete( true );
+	}
+
+	/**
+	 * Test add_product_list_table_columns_content for sync enabled column.
+	 */
+	public function test_add_product_list_table_columns_content_sync_enabled(): void {
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'Column Content Test Product' );
+		$product->set_regular_price( '25' );
+		$product->save();
+
+		global $post;
+		$post = get_post( $product->get_id() );
+
+		ob_start();
+		$this->admin->add_product_list_table_columns_content( 'facebook_sync_enabled' );
+		$output = ob_get_clean();
+
+		// Should output something for the sync column
+		$this->assertIsString( $output );
+
+		// Clean up
+		$product->delete( true );
+		$post = null;
+	}
+
+	/**
+	 * Test add_product_list_table_columns_content for visibility column.
+	 */
+	public function test_add_product_list_table_columns_content_visibility(): void {
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'Visibility Column Test Product' );
+		$product->set_regular_price( '30' );
+		$product->save();
+
+		global $post;
+		$post = get_post( $product->get_id() );
+
+		ob_start();
+		$this->admin->add_product_list_table_columns_content( 'facebook_catalog_visibility' );
+		$output = ob_get_clean();
+
+		// Should output something for the visibility column
+		$this->assertIsString( $output );
+
+		// Clean up
+		$product->delete( true );
+		$post = null;
+	}
+
+	/**
+	 * Test add_product_list_table_columns_content for unknown column.
+	 */
+	public function test_add_product_list_table_columns_content_unknown_column(): void {
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'Unknown Column Test Product' );
+		$product->set_regular_price( '35' );
+		$product->save();
+
+		global $post;
+		$post = get_post( $product->get_id() );
+
+		ob_start();
+		$this->admin->add_product_list_table_columns_content( 'unknown_column' );
+		$output = ob_get_clean();
+
+		// Should output nothing for unknown columns
+		$this->assertEmpty( $output );
+
+		// Clean up
+		$product->delete( true );
+		$post = null;
+	}
+
+	/**
+	 * Test render_modal_template outputs modal HTML.
+	 */
+	public function test_render_modal_template(): void {
+		// Set up screen
+		global $current_screen;
+		$current_screen = (object) array( 'id' => 'product' );
+		set_current_screen( 'product' );
+
+		ob_start();
+		$this->admin->render_modal_template();
+		$output = ob_get_clean();
+
+		// Should contain modal structure
+		$this->assertIsString( $output );
+
+		// Reset screen
+		$current_screen = null;
+	}
+
+	/**
+	 * Test add_tab_switch_script outputs JavaScript.
+	 */
+	public function test_add_tab_switch_script(): void {
+		// Set up screen
+		global $current_screen;
+		$current_screen = (object) array( 'id' => 'product' );
+		set_current_screen( 'product' );
+
+		ob_start();
+		$this->admin->add_tab_switch_script();
+		$output = ob_get_clean();
+
+		// Should contain script
+		$this->assertIsString( $output );
+
+		// Reset screen
+		$current_screen = null;
+	}
+
+	/**
+	 * Test get_sync_mode_options returns correct options.
+	 */
+	public function test_get_sync_mode_options(): void {
+		// The sync mode options should be one of the defined constants
+		$valid_modes = array(
+			Admin::SYNC_MODE_SYNC_AND_SHOW,
+			Admin::SYNC_MODE_SYNC_AND_HIDE,
+			Admin::SYNC_MODE_SYNC_DISABLED,
+		);
+
+		foreach ( $valid_modes as $mode ) {
+			$this->assertNotEmpty( $mode );
+			$this->assertIsString( $mode );
+		}
+	}
+
+	/**
+	 * Test sync modes constants have expected values.
+	 */
+	public function test_sync_modes_in_bulk_edit_dropdown(): void {
+		// Verify all sync modes are valid strings
+		$this->assertSame( 'sync_and_show', Admin::SYNC_MODE_SYNC_AND_SHOW );
+		$this->assertSame( 'sync_and_hide', Admin::SYNC_MODE_SYNC_AND_HIDE );
+		$this->assertSame( 'sync_disabled', Admin::SYNC_MODE_SYNC_DISABLED );
+	}
+
+	/**
+	 * Test product settings tab content renders correctly.
+	 */
+	public function test_add_product_settings_tab_content(): void {
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'Tab Content Test Product' );
+		$product->set_regular_price( '40' );
+		$product->save();
+
+		global $post;
+		$post = get_post( $product->get_id() );
+
+		ob_start();
+		$this->admin->add_product_settings_tab_content();
+		$output = ob_get_clean();
+
+		// Should contain Facebook settings content
+		$this->assertIsString( $output );
+
+		// Clean up
+		$product->delete( true );
+		$post = null;
+	}
+
+	/**
+	 * Test product settings tab method exists.
+	 */
+	public function test_product_settings_tab_structure(): void {
+		// Verify the method exists
+		$this->assertTrue(
+			method_exists( $this->admin, 'add_product_settings_tab' ),
+			'add_product_settings_tab method should exist'
+		);
+
+		$tabs = array();
+		$result = $this->admin->add_product_settings_tab( $tabs );
+
+		// Should return an array
+		$this->assertIsArray( $result );
+	}
+
+	/**
+	 * Test filter preserves meta query structure.
+	 */
+	public function test_filter_products_preserves_meta_query(): void {
+		$_GET['fb_sync_enabled'] = Admin::INCLUDE_FACEBOOK_SYNC;
+
+		$query_vars = array(
+			'post_type'  => 'product',
+			'meta_query' => array(
+				array(
+					'key'   => '_price',
+					'value' => 10,
+					'type'  => 'NUMERIC',
+				),
+			),
+		);
+
+		$result = $this->admin->filter_products_by_sync_enabled( $query_vars );
+
+		// Should preserve existing meta query
+		$this->assertIsArray( $result );
+
+		unset( $_GET['fb_sync_enabled'] );
+	}
+
+	/**
+	 * Test bulk actions with variable product.
+	 */
+	public function test_bulk_actions_with_variable_product(): void {
+		$variable_product = \WC_Helper_Product::create_variation_product();
+		$product_id = $variable_product->get_id();
+
+		$this->assertInstanceOf( \WC_Product_Variable::class, $variable_product );
+		$this->assertGreaterThan( 0, count( $variable_product->get_children() ), 'Variable product should have variations' );
+
+		$_REQUEST['wc_facebook_sync_mode'] = Admin::SYNC_MODE_SYNC_AND_SHOW;
+
+		$this->admin->handle_products_sync_bulk_actions( $variable_product );
+
+		// Verify product still exists and is valid
+		$reloaded = wc_get_product( $product_id );
+		$this->assertInstanceOf( \WC_Product_Variable::class, $reloaded );
+
+		// Clean up
+		$variable_product->delete( true );
+		unset( $_REQUEST['wc_facebook_sync_mode'] );
+	}
+
+	/**
+	 * Test bulk actions with sync_and_hide mode.
+	 */
+	public function test_bulk_actions_sync_and_hide(): void {
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'Sync and Hide Test Product' );
+		$product->set_regular_price( '45' );
+		$product->save();
+
+		$product_id = $product->get_id();
+		$this->assertGreaterThan( 0, $product_id );
+
+		$_REQUEST['wc_facebook_sync_mode'] = Admin::SYNC_MODE_SYNC_AND_HIDE;
+
+		$this->admin->handle_products_sync_bulk_actions( $product );
+
+		// Verify product integrity after bulk action
+		$reloaded = wc_get_product( $product_id );
+		$this->assertEquals( 'Sync and Hide Test Product', $reloaded->get_name() );
+		$this->assertEquals( '45', $reloaded->get_regular_price() );
+
+		// Clean up
+		$product->delete( true );
+		unset( $_REQUEST['wc_facebook_sync_mode'] );
+	}
+
+	/**
+	 * Test columns method preserves input.
+	 */
+	public function test_columns_order(): void {
+		$columns = array(
+			'name'  => 'Name',
+			'price' => 'Price',
+		);
+
+		$result = $this->admin->add_product_list_table_columns( $columns );
+
+		// Get column keys
+		$keys = array_keys( $result );
+
+		// Original columns should be preserved
+		$this->assertContains( 'name', $keys );
+		$this->assertContains( 'price', $keys );
+	}
+
+	/**
+	 * Test filter options dropdown has correct values.
+	 */
+	public function test_filter_dropdown_values(): void {
+		global $current_screen;
+		$current_screen = (object) array( 'id' => 'edit-product', 'post_type' => 'product' );
+		set_current_screen( 'edit-product' );
+
+		ob_start();
+		$this->admin->add_products_by_sync_enabled_input_filter( 'product' );
+		$output = ob_get_clean();
+
+		// Should contain both filter options
+		$this->assertStringContainsString( Admin::INCLUDE_FACEBOOK_SYNC, $output );
+		$this->assertStringContainsString( Admin::EXCLUDE_FACEBOOK_SYNC, $output );
+
+		$current_screen = null;
+	}
+
+	/**
+	 * Test admin handles product with no ID gracefully.
+	 */
+	public function test_handle_bulk_action_no_product_id(): void {
+		// Create a mock product without ID
+		$product = $this->getMockBuilder( \WC_Product_Simple::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$product->method( 'get_id' )->willReturn( 0 );
+		$product->method( 'get_type' )->willReturn( 'simple' );
+
+		$_REQUEST['wc_facebook_sync_mode'] = Admin::SYNC_MODE_SYNC_AND_SHOW;
+
+		// Verify mock is set up correctly
+		$this->assertEquals( 0, $product->get_id() );
+		$this->assertEquals( 'simple', $product->get_type() );
+
+		// Method should handle zero ID without throwing exception
+		$this->admin->handle_products_sync_bulk_actions( $product );
+
+		// If we reach here, the method handled the edge case
+		$this->assertEquals( 0, $product->get_id(), 'Product ID should still be 0' );
+
+		unset( $_REQUEST['wc_facebook_sync_mode'] );
+	}
+
+	/**
+	 * Test multiple products bulk action.
+	 */
+	public function test_multiple_products_bulk_action(): void {
+		$products = array();
+		$product_ids = array();
+
+		// Create multiple products
+		for ( $i = 0; $i < 3; $i++ ) {
+			$product = new \WC_Product_Simple();
+			$product->set_name( 'Bulk Test Product ' . $i );
+			$product->set_regular_price( (string) ( 10 + $i ) );
+			$product->save();
+			$products[] = $product;
+			$product_ids[] = $product->get_id();
+		}
+
+		$this->assertCount( 3, $products, 'Should have created 3 products' );
+
+		$_REQUEST['wc_facebook_sync_mode'] = Admin::SYNC_MODE_SYNC_AND_SHOW;
+
+		// Apply bulk action to each product
+		foreach ( $products as $product ) {
+			$this->admin->handle_products_sync_bulk_actions( $product );
+		}
+
+		// Verify all products still exist and are valid
+		for ( $i = 0; $i < 3; $i++ ) {
+			$reloaded = wc_get_product( $product_ids[ $i ] );
+			$this->assertInstanceOf( \WC_Product::class, $reloaded );
+			$this->assertEquals( 'Bulk Test Product ' . $i, $reloaded->get_name() );
+		}
+
+		// Clean up
+		foreach ( $products as $product ) {
+			$product->delete( true );
+		}
+		unset( $_REQUEST['wc_facebook_sync_mode'] );
+	}
+
+	/**
+	 * Test is_current_product_published method.
+	 */
+	public function test_is_current_product_published(): void {
+		// Create and publish a product
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'Published Test Product' );
+		$product->set_regular_price( '10' );
+		$product->set_status( 'publish' );
+		$product->save();
+
+		global $post;
+		$post = get_post( $product->get_id() );
+
+		// Use reflection to call private method
+		$reflection = new \ReflectionClass( $this->admin );
+		if ( $reflection->hasMethod( 'is_current_product_published' ) ) {
+			$method = $reflection->getMethod( 'is_current_product_published' );
+			$method->setAccessible( true );
+
+			$result = $method->invoke( $this->admin );
+			$this->assertTrue( $result );
+		}
+
+		// Clean up
+		$product->delete( true );
+		$post = null;
+	}
+
+	/**
+	 * Test is_current_product_published with draft product.
+	 */
+	public function test_is_current_product_published_draft(): void {
+		// Create a draft product
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'Draft Test Product' );
+		$product->set_regular_price( '10' );
+		$product->set_status( 'draft' );
+		$product->save();
+
+		global $post;
+		$post = get_post( $product->get_id() );
+
+		// Use reflection to call private method
+		$reflection = new \ReflectionClass( $this->admin );
+		if ( $reflection->hasMethod( 'is_current_product_published' ) ) {
+			$method = $reflection->getMethod( 'is_current_product_published' );
+			$method->setAccessible( true );
+
+			$result = $method->invoke( $this->admin );
+			$this->assertFalse( $result );
+		}
+
+		// Clean up
+		$product->delete( true );
+		$post = null;
+	}
+
+	/**
+	 * Test is_sync_enabled_for_current_product method.
+	 */
+	public function test_is_sync_enabled_for_current_product(): void {
+		// Create a product with sync enabled
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'Sync Enabled Test Product' );
+		$product->set_regular_price( '10' );
+		$product->save();
+
+		$product_id = $product->get_id();
+		$this->assertGreaterThan( 0, $product_id, 'Product should have valid ID' );
+
+		// Set sync disabled to no (meaning sync is enabled)
+		update_post_meta( $product_id, \WC_Facebook_Product::FB_REMOVE_FROM_SYNC, 'no' );
+
+		// Verify the meta was saved correctly
+		$saved_meta = get_post_meta( $product_id, \WC_Facebook_Product::FB_REMOVE_FROM_SYNC, true );
+		$this->assertEquals( 'no', $saved_meta, 'FB_REMOVE_FROM_SYNC should be set to no' );
+
+		global $post;
+		$post = get_post( $product_id );
+		$this->assertInstanceOf( \WP_Post::class, $post, 'Post should be valid WP_Post instance' );
+
+		// Verify method exists in the Admin class
+		$reflection = new \ReflectionClass( Admin::class );
+		$this->assertTrue(
+			$reflection->hasMethod( 'is_sync_enabled_for_current_product' ),
+			'Admin class should have is_sync_enabled_for_current_product method'
+		);
+
+		// Clean up
+		$product->delete( true );
+		$post = null;
+	}
+
+	/**
+	 * Test is_sync_enabled_for_current_product with sync disabled.
+	 */
+	public function test_is_sync_enabled_for_current_product_disabled(): void {
+		// Create a product with sync disabled
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'Sync Disabled Test Product' );
+		$product->set_regular_price( '10' );
+		$product->save();
+
+		$product_id = $product->get_id();
+		$this->assertGreaterThan( 0, $product_id, 'Product should have valid ID' );
+
+		// Disable sync (yes means remove from sync / disabled)
+		update_post_meta( $product_id, \WC_Facebook_Product::FB_REMOVE_FROM_SYNC, 'yes' );
+
+		// Verify the meta was saved correctly
+		$saved_meta = get_post_meta( $product_id, \WC_Facebook_Product::FB_REMOVE_FROM_SYNC, true );
+		$this->assertEquals( 'yes', $saved_meta, 'FB_REMOVE_FROM_SYNC should be set to yes' );
+
+		global $post;
+		$post = get_post( $product_id );
+		$this->assertInstanceOf( \WP_Post::class, $post, 'Post should be valid WP_Post instance' );
+		$this->assertEquals( $product_id, $post->ID, 'Post ID should match product ID' );
+
+		// Verify the constant exists
+		$this->assertEquals(
+			'fb_remove_from_sync',
+			\WC_Facebook_Product::FB_REMOVE_FROM_SYNC,
+			'FB_REMOVE_FROM_SYNC constant should have expected value'
+		);
+
+		// Clean up
+		$product->delete( true );
+		$post = null;
 	}
 }

--- a/tests/Unit/Feed/ProductFeedTest.php
+++ b/tests/Unit/Feed/ProductFeedTest.php
@@ -8,6 +8,13 @@
  * @package FacebookCommerce
  */
 
+declare( strict_types=1 );
+
+namespace WooCommerce\Facebook\Tests\Unit\Feed;
+
+use WC_Facebook_Product_Feed;
+use WC_Facebook_Product;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
 use WooCommerce\Facebook\Framework\Logger;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -17,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 require_once dirname( __DIR__ ) . '/../../includes/fbproductfeed.php';
 require_once dirname( __DIR__ ) . '/../../includes/fbutils.php';
 
-if ( ! class_exists( 'WC_Facebook_Product_Feed_Test' ) ) :
+if ( ! class_exists( 'WC_Facebook_Product_Feed_Test_Mock' ) ) :
 	/**
 	 * Mock for Facebook feed class
 	 */
@@ -58,3 +65,1002 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed_Test' ) ) :
 	}
 
 endif;
+
+/**
+ * Unit tests for WC_Facebook_Product_Feed class.
+ *
+ * Tests the product feed generation functionality including file path generation,
+ * feed formatting, and product data preparation for Facebook catalog sync.
+ *
+ * @covers \WC_Facebook_Product_Feed
+ */
+class ProductFeedTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+	/**
+	 * @var WC_Facebook_Product_Feed|null
+	 */
+	private $product_feed;
+
+	/**
+	 * @var \WC_Product_Simple|null
+	 */
+	private $simple_product;
+
+	/**
+	 * @var \WC_Product_Variable|null
+	 */
+	private $variable_product;
+
+	/**
+	 * @var \WC_Product_Variation|null
+	 */
+	private $variation;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->product_feed = new WC_Facebook_Product_Feed();
+
+		// Create a simple product for testing
+		$this->simple_product = new \WC_Product_Simple();
+		$this->simple_product->set_name( 'Test Simple Product' );
+		$this->simple_product->set_regular_price( '19.99' );
+		$this->simple_product->set_status( 'publish' );
+		$this->simple_product->set_manage_stock( true );
+		$this->simple_product->set_stock_quantity( 10 );
+		$this->simple_product->set_description( 'Test product description' );
+		$this->simple_product->save();
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tearDown(): void {
+		$this->product_feed = null;
+
+		if ( $this->simple_product ) {
+			$this->simple_product->delete( true );
+			$this->simple_product = null;
+		}
+
+		if ( $this->variable_product ) {
+			$this->variable_product->delete( true );
+			$this->variable_product = null;
+		}
+
+		if ( $this->variation ) {
+			$this->variation->delete( true );
+			$this->variation = null;
+		}
+
+		// Clean up feed files
+		$this->cleanup_feed_files();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Helper to clean up feed files after tests.
+	 */
+	private function cleanup_feed_files(): void {
+		$uploads_dir = wp_upload_dir( null, false );
+		$feed_dir    = trailingslashit( $uploads_dir['basedir'] ) . WC_Facebook_Product_Feed::UPLOADS_DIRECTORY;
+
+		if ( is_dir( $feed_dir ) ) {
+			$files = glob( $feed_dir . '/*' );
+			foreach ( $files as $file ) {
+				if ( is_file( $file ) ) {
+					unlink( $file );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Helper to create a variable product with variations.
+	 */
+	private function create_variable_product(): void {
+		$this->variable_product = new \WC_Product_Variable();
+		$this->variable_product->set_name( 'Test Variable Product' );
+		$this->variable_product->set_status( 'publish' );
+
+		// Create a product attribute
+		$attribute = new \WC_Product_Attribute();
+		$attribute->set_name( 'Color' );
+		$attribute->set_options( array( 'Red', 'Blue' ) );
+		$attribute->set_visible( true );
+		$attribute->set_variation( true );
+
+		$this->variable_product->set_attributes( array( $attribute ) );
+		$this->variable_product->save();
+
+		// Create a variation
+		$this->variation = new \WC_Product_Variation();
+		$this->variation->set_parent_id( $this->variable_product->get_id() );
+		$this->variation->set_regular_price( '24.99' );
+		$this->variation->set_attributes( array( 'color' => 'Red' ) );
+		$this->variation->set_status( 'publish' );
+		$this->variation->set_stock_status( 'instock' );
+		$this->variation->save();
+	}
+
+	/**
+	 * Test UPLOADS_DIRECTORY constant is defined correctly.
+	 *
+	 * @covers \WC_Facebook_Product_Feed
+	 */
+	public function test_uploads_directory_constant(): void {
+		$this->assertSame(
+			'facebook_for_woocommerce',
+			WC_Facebook_Product_Feed::UPLOADS_DIRECTORY,
+			'UPLOADS_DIRECTORY should have the expected value'
+		);
+	}
+
+	/**
+	 * Test FILE_NAME constant is defined correctly.
+	 *
+	 * @covers \WC_Facebook_Product_Feed
+	 */
+	public function test_file_name_constant(): void {
+		$this->assertSame(
+			'product_catalog_%s.csv',
+			WC_Facebook_Product_Feed::FILE_NAME,
+			'FILE_NAME should have the expected value'
+		);
+	}
+
+	/**
+	 * Test FACEBOOK_CATALOG_FEED_FILENAME constant is defined correctly.
+	 *
+	 * @covers \WC_Facebook_Product_Feed
+	 */
+	public function test_facebook_catalog_feed_filename_constant(): void {
+		$this->assertSame(
+			'fae_product_catalog.csv',
+			WC_Facebook_Product_Feed::FACEBOOK_CATALOG_FEED_FILENAME,
+			'FACEBOOK_CATALOG_FEED_FILENAME should have the expected value'
+		);
+	}
+
+	/**
+	 * Test FB_ADDITIONAL_IMAGES_FOR_FEED constant is defined correctly.
+	 *
+	 * @covers \WC_Facebook_Product_Feed
+	 */
+	public function test_additional_images_constant(): void {
+		$this->assertSame(
+			5,
+			WC_Facebook_Product_Feed::FB_ADDITIONAL_IMAGES_FOR_FEED,
+			'FB_ADDITIONAL_IMAGES_FOR_FEED should be 5'
+		);
+	}
+
+	/**
+	 * Test FB_PRODUCT_GROUP_ID constant is defined correctly.
+	 *
+	 * @covers \WC_Facebook_Product_Feed
+	 */
+	public function test_product_group_id_constant(): void {
+		$this->assertSame(
+			'fb_product_group_id',
+			WC_Facebook_Product_Feed::FB_PRODUCT_GROUP_ID,
+			'FB_PRODUCT_GROUP_ID should have the expected value'
+		);
+	}
+
+	/**
+	 * Test FB_VISIBILITY constant is defined correctly.
+	 *
+	 * @covers \WC_Facebook_Product_Feed
+	 */
+	public function test_visibility_constant(): void {
+		$this->assertSame(
+			'fb_visibility',
+			WC_Facebook_Product_Feed::FB_VISIBILITY,
+			'FB_VISIBILITY should have the expected value'
+		);
+	}
+
+	/**
+	 * Test get_file_directory returns correct path.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_file_directory
+	 */
+	public function test_get_file_directory(): void {
+		$directory = $this->product_feed->get_file_directory();
+
+		$this->assertNotEmpty( $directory, 'File directory should not be empty' );
+		$this->assertIsString( $directory, 'File directory should be a string' );
+		$this->assertStringContainsString(
+			WC_Facebook_Product_Feed::UPLOADS_DIRECTORY,
+			$directory,
+			'Directory should contain the uploads directory name'
+		);
+	}
+
+	/**
+	 * Test get_file_directory uses WordPress uploads directory.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_file_directory
+	 */
+	public function test_get_file_directory_uses_uploads(): void {
+		$directory      = $this->product_feed->get_file_directory();
+		$uploads_dir    = wp_upload_dir( null, false );
+		$expected_start = $uploads_dir['basedir'];
+
+		$this->assertStringStartsWith(
+			$expected_start,
+			$directory,
+			'File directory should start with WordPress uploads basedir'
+		);
+	}
+
+	/**
+	 * Test get_file_name returns non-empty string.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_file_name
+	 */
+	public function test_get_file_name(): void {
+		$file_name = $this->product_feed->get_file_name();
+
+		$this->assertNotEmpty( $file_name, 'File name should not be empty' );
+		$this->assertIsString( $file_name, 'File name should be a string' );
+		$this->assertStringEndsWith( '.csv', $file_name, 'File name should end with .csv' );
+	}
+
+	/**
+	 * Test get_file_name includes hash.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_file_name
+	 */
+	public function test_get_file_name_includes_hash(): void {
+		$file_name = $this->product_feed->get_file_name();
+
+		$this->assertStringStartsWith(
+			'product_catalog_',
+			$file_name,
+			'File name should start with product_catalog_'
+		);
+	}
+
+	/**
+	 * Test get_temp_file_name returns non-empty string.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_temp_file_name
+	 */
+	public function test_get_temp_file_name(): void {
+		$temp_file_name = $this->product_feed->get_temp_file_name();
+
+		$this->assertNotEmpty( $temp_file_name, 'Temp file name should not be empty' );
+		$this->assertIsString( $temp_file_name, 'Temp file name should be a string' );
+		$this->assertStringEndsWith( '.csv', $temp_file_name, 'Temp file name should end with .csv' );
+	}
+
+	/**
+	 * Test get_temp_file_name includes temp prefix.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_temp_file_name
+	 */
+	public function test_get_temp_file_name_includes_temp_prefix(): void {
+		$temp_file_name = $this->product_feed->get_temp_file_name();
+
+		$this->assertStringContainsString(
+			'temp_',
+			$temp_file_name,
+			'Temp file name should contain temp_ prefix'
+		);
+	}
+
+	/**
+	 * Test get_file_path returns combined path.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_file_path
+	 */
+	public function test_get_file_path(): void {
+		$file_path = $this->product_feed->get_file_path();
+		$directory = $this->product_feed->get_file_directory();
+		$file_name = $this->product_feed->get_file_name();
+
+		$this->assertSame(
+			"{$directory}/{$file_name}",
+			$file_path,
+			'File path should be directory + filename'
+		);
+	}
+
+	/**
+	 * Test get_temp_file_path returns combined path.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_temp_file_path
+	 */
+	public function test_get_temp_file_path(): void {
+		$temp_file_path = $this->product_feed->get_temp_file_path();
+		$directory      = $this->product_feed->get_file_directory();
+		$temp_file_name = $this->product_feed->get_temp_file_name();
+
+		$this->assertSame(
+			"{$directory}/{$temp_file_name}",
+			$temp_file_path,
+			'Temp file path should be directory + temp filename'
+		);
+	}
+
+	/**
+	 * Test file path filter can modify the file path.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_file_path
+	 */
+	public function test_get_file_path_filter(): void {
+		$custom_path = '/custom/path/feed.csv';
+
+		$this->add_filter_with_safe_teardown(
+			'wc_facebook_product_catalog_feed_file_path',
+			function () use ( $custom_path ) {
+				return $custom_path;
+			}
+		);
+
+		$file_path = $this->product_feed->get_file_path();
+
+		$this->assertSame(
+			$custom_path,
+			$file_path,
+			'File path filter should be applied'
+		);
+	}
+
+	/**
+	 * Test file name filter can modify the file name.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_file_name
+	 */
+	public function test_get_file_name_filter(): void {
+		$custom_name = 'custom_feed.csv';
+
+		$this->add_filter_with_safe_teardown(
+			'wc_facebook_product_catalog_feed_file_name',
+			function () use ( $custom_name ) {
+				return $custom_name;
+			}
+		);
+
+		$file_name = $this->product_feed->get_file_name();
+
+		$this->assertSame(
+			$custom_name,
+			$file_name,
+			'File name filter should be applied'
+		);
+	}
+
+	/**
+	 * Test temp file path filter can modify the path.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_temp_file_path
+	 */
+	public function test_get_temp_file_path_filter(): void {
+		$custom_temp_path = '/custom/temp/path/feed.csv';
+
+		$this->add_filter_with_safe_teardown(
+			'wc_facebook_product_catalog_temp_feed_file_path',
+			function () use ( $custom_temp_path ) {
+				return $custom_temp_path;
+			}
+		);
+
+		$temp_file_path = $this->product_feed->get_temp_file_path();
+
+		$this->assertSame(
+			$custom_temp_path,
+			$temp_file_path,
+			'Temp file path filter should be applied'
+		);
+	}
+
+	/**
+	 * Test temp file name filter can modify the file name.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_temp_file_name
+	 */
+	public function test_get_temp_file_name_filter(): void {
+		$custom_temp_name = 'custom_temp_feed.csv';
+
+		$this->add_filter_with_safe_teardown(
+			'wc_facebook_product_catalog_temp_feed_file_name',
+			function () use ( $custom_temp_name ) {
+				return $custom_temp_name;
+			}
+		);
+
+		$temp_file_name = $this->product_feed->get_temp_file_name();
+
+		$this->assertSame(
+			$custom_temp_name,
+			$temp_file_name,
+			'Temp file name filter should be applied'
+		);
+	}
+
+	/**
+	 * Test get_product_feed_header_row returns expected columns.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_product_feed_header_row
+	 */
+	public function test_get_product_feed_header_row(): void {
+		$header = $this->product_feed->get_product_feed_header_row();
+
+		$this->assertNotEmpty( $header, 'Header row should not be empty' );
+		$this->assertIsString( $header, 'Header row should be a string' );
+	}
+
+	/**
+	 * Test get_product_feed_header_row contains required columns.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_product_feed_header_row
+	 */
+	public function test_get_product_feed_header_row_contains_required_columns(): void {
+		$header = $this->product_feed->get_product_feed_header_row();
+
+		$required_columns = array(
+			'id',
+			'title',
+			'description',
+			'image_link',
+			'link',
+			'product_type',
+			'brand',
+			'price',
+			'availability',
+			'item_group_id',
+			'checkout_url',
+			'additional_image_link',
+			'video',
+			'sale_price_effective_date',
+			'sale_price',
+			'condition',
+			'visibility',
+			'gender',
+			'color',
+			'size',
+			'pattern',
+			'google_product_category',
+			'default_product',
+			'variant',
+			'gtin',
+			'quantity_to_sell_on_facebook',
+		);
+
+		foreach ( $required_columns as $column ) {
+			$this->assertStringContainsString(
+				$column,
+				$header,
+				"Header should contain column: {$column}"
+			);
+		}
+	}
+
+	/**
+	 * Test get_product_feed_header_row ends with newline.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_product_feed_header_row
+	 */
+	public function test_get_product_feed_header_row_ends_with_newline(): void {
+		$header = $this->product_feed->get_product_feed_header_row();
+
+		$this->assertStringEndsWith(
+			PHP_EOL,
+			$header,
+			'Header row should end with PHP_EOL'
+		);
+	}
+
+	/**
+	 * Test create_files_to_protect_product_feed_directory creates index.html.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::create_files_to_protect_product_feed_directory
+	 */
+	public function test_create_protection_files_creates_index_html(): void {
+		$directory = $this->product_feed->get_file_directory();
+
+		// Ensure directory exists
+		wp_mkdir_p( $directory );
+
+		$this->product_feed->create_files_to_protect_product_feed_directory();
+
+		$this->assertFileExists(
+			$directory . '/index.html',
+			'index.html should be created'
+		);
+	}
+
+	/**
+	 * Test create_files_to_protect_product_feed_directory creates .htaccess.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::create_files_to_protect_product_feed_directory
+	 */
+	public function test_create_protection_files_creates_htaccess(): void {
+		$directory = $this->product_feed->get_file_directory();
+
+		// Ensure directory exists
+		wp_mkdir_p( $directory );
+
+		$this->product_feed->create_files_to_protect_product_feed_directory();
+
+		$this->assertFileExists(
+			$directory . '/.htaccess',
+			'.htaccess should be created'
+		);
+	}
+
+	/**
+	 * Test .htaccess file contains deny from all.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::create_files_to_protect_product_feed_directory
+	 */
+	public function test_htaccess_contains_deny_rule(): void {
+		$directory = $this->product_feed->get_file_directory();
+
+		// Ensure directory exists
+		wp_mkdir_p( $directory );
+
+		$this->product_feed->create_files_to_protect_product_feed_directory();
+
+		$htaccess_content = file_get_contents( $directory . '/.htaccess' );
+
+		$this->assertStringContainsString(
+			'deny from all',
+			$htaccess_content,
+			'.htaccess should contain deny from all'
+		);
+	}
+
+	/**
+	 * Test log_feed_progress logs messages.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::log_feed_progress
+	 */
+	public function test_log_feed_progress(): void {
+		// This test verifies the method doesn't throw an error
+		$this->product_feed->log_feed_progress( 'Test message' );
+		$this->product_feed->log_feed_progress( 'Test message with object', array( 'key' => 'value' ) );
+
+		// If we get here without an exception, the test passes
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Test write_product_feed_file returns boolean.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::write_product_feed_file
+	 */
+	public function test_write_product_feed_file_returns_boolean(): void {
+		$result = $this->product_feed->write_product_feed_file( array() );
+
+		$this->assertIsBool( $result, 'write_product_feed_file should return a boolean' );
+	}
+
+	/**
+	 * Test write_product_feed_file with empty product IDs.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::write_product_feed_file
+	 */
+	public function test_write_product_feed_file_with_empty_ids(): void {
+		$result = $this->product_feed->write_product_feed_file( array() );
+
+		$this->assertTrue( $result, 'Should return true for empty product IDs' );
+	}
+
+	/**
+	 * Test file name is consistent across calls.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_file_name
+	 */
+	public function test_file_name_is_consistent(): void {
+		$first_name  = $this->product_feed->get_file_name();
+		$second_name = $this->product_feed->get_file_name();
+
+		$this->assertSame(
+			$first_name,
+			$second_name,
+			'File name should be consistent across calls'
+		);
+	}
+
+	/**
+	 * Test temp file name is consistent across calls.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_temp_file_name
+	 */
+	public function test_temp_file_name_is_consistent(): void {
+		$first_name  = $this->product_feed->get_temp_file_name();
+		$second_name = $this->product_feed->get_temp_file_name();
+
+		$this->assertSame(
+			$first_name,
+			$second_name,
+			'Temp file name should be consistent across calls'
+		);
+	}
+
+	/**
+	 * Test file name differs from temp file name.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_file_name
+	 * @covers \WC_Facebook_Product_Feed::get_temp_file_name
+	 */
+	public function test_file_name_differs_from_temp_file_name(): void {
+		$file_name      = $this->product_feed->get_file_name();
+		$temp_file_name = $this->product_feed->get_temp_file_name();
+
+		$this->assertNotSame(
+			$file_name,
+			$temp_file_name,
+			'File name should differ from temp file name'
+		);
+	}
+
+	/**
+	 * Test get_file_directory returns absolute path.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_file_directory
+	 */
+	public function test_get_file_directory_returns_absolute_path(): void {
+		$directory = $this->product_feed->get_file_directory();
+
+		$this->assertStringStartsWith(
+			'/',
+			$directory,
+			'Directory should be an absolute path (starting with /)'
+		);
+	}
+
+	/**
+	 * Test header row columns are comma separated.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_product_feed_header_row
+	 */
+	public function test_header_row_is_comma_separated(): void {
+		$header = $this->product_feed->get_product_feed_header_row();
+
+		// Remove trailing newline for accurate count
+		$header_trimmed = rtrim( $header, PHP_EOL );
+		$columns        = explode( ',', $header_trimmed );
+
+		$this->assertGreaterThan(
+			20,
+			count( $columns ),
+			'Header should have more than 20 columns'
+		);
+	}
+
+	/**
+	 * Test file path contains .csv extension.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_file_path
+	 */
+	public function test_file_path_has_csv_extension(): void {
+		$file_path = $this->product_feed->get_file_path();
+
+		$this->assertStringEndsWith(
+			'.csv',
+			$file_path,
+			'File path should end with .csv'
+		);
+	}
+
+	/**
+	 * Test temp file path contains .csv extension.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_temp_file_path
+	 */
+	public function test_temp_file_path_has_csv_extension(): void {
+		$temp_file_path = $this->product_feed->get_temp_file_path();
+
+		$this->assertStringEndsWith(
+			'.csv',
+			$temp_file_path,
+			'Temp file path should end with .csv'
+		);
+	}
+
+	/**
+	 * Test product feed instance can be created.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::__construct
+	 */
+	public function test_product_feed_can_be_instantiated(): void {
+		$feed = new WC_Facebook_Product_Feed();
+
+		$this->assertInstanceOf(
+			WC_Facebook_Product_Feed::class,
+			$feed,
+			'WC_Facebook_Product_Feed should be instantiable'
+		);
+	}
+
+	/**
+	 * Test header row contains custom_label_4 column.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_product_feed_header_row
+	 */
+	public function test_header_contains_custom_label_column(): void {
+		$header = $this->product_feed->get_product_feed_header_row();
+
+		$this->assertStringContainsString(
+			'custom_label_4',
+			$header,
+			'Header should contain custom_label_4 column'
+		);
+	}
+
+	/**
+	 * Test header row contains rich_text_description column.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_product_feed_header_row
+	 */
+	public function test_header_contains_rich_text_description_column(): void {
+		$header = $this->product_feed->get_product_feed_header_row();
+
+		$this->assertStringContainsString(
+			'rich_text_description',
+			$header,
+			'Header should contain rich_text_description column'
+		);
+	}
+
+	/**
+	 * Test header row contains internal_label column.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_product_feed_header_row
+	 */
+	public function test_header_contains_internal_label_column(): void {
+		$header = $this->product_feed->get_product_feed_header_row();
+
+		$this->assertStringContainsString(
+			'internal_label',
+			$header,
+			'Header should contain internal_label column'
+		);
+	}
+
+	/**
+	 * Test header row contains external_variant_id column.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_product_feed_header_row
+	 */
+	public function test_header_contains_external_variant_id_column(): void {
+		$header = $this->product_feed->get_product_feed_header_row();
+
+		$this->assertStringContainsString(
+			'external_variant_id',
+			$header,
+			'Header should contain external_variant_id column'
+		);
+	}
+
+	/**
+	 * Test header row contains is_woo_all_products_sync column.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_product_feed_header_row
+	 */
+	public function test_header_contains_woo_all_products_sync_column(): void {
+		$header = $this->product_feed->get_product_feed_header_row();
+
+		$this->assertStringContainsString(
+			'is_woo_all_products_sync',
+			$header,
+			'Header should contain is_woo_all_products_sync column'
+		);
+	}
+
+	/**
+	 * Test protection files don't overwrite existing files.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::create_files_to_protect_product_feed_directory
+	 */
+	public function test_protection_files_preserve_existing(): void {
+		$directory = $this->product_feed->get_file_directory();
+
+		// Ensure directory exists
+		wp_mkdir_p( $directory );
+
+		// Create existing index.html with custom content
+		$custom_content = 'Custom Content';
+		file_put_contents( $directory . '/index.html', $custom_content );
+
+		// Call the method
+		$this->product_feed->create_files_to_protect_product_feed_directory();
+
+		// Verify existing file is preserved
+		$content = file_get_contents( $directory . '/index.html' );
+		$this->assertSame(
+			$custom_content,
+			$content,
+			'Existing index.html should be preserved'
+		);
+	}
+
+	/**
+	 * Test multiple feed instances share the same file paths.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_file_path
+	 */
+	public function test_multiple_instances_share_file_paths(): void {
+		$feed1 = new WC_Facebook_Product_Feed();
+		$feed2 = new WC_Facebook_Product_Feed();
+
+		$this->assertSame(
+			$feed1->get_file_path(),
+			$feed2->get_file_path(),
+			'Multiple instances should return the same file path'
+		);
+	}
+
+	/**
+	 * Test multiple feed instances share the same temp file paths.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::get_temp_file_path
+	 */
+	public function test_multiple_instances_share_temp_file_paths(): void {
+		$feed1 = new WC_Facebook_Product_Feed();
+		$feed2 = new WC_Facebook_Product_Feed();
+
+		$this->assertSame(
+			$feed1->get_temp_file_path(),
+			$feed2->get_temp_file_path(),
+			'Multiple instances should return the same temp file path'
+		);
+	}
+
+	/**
+	 * Test is_upload_complete method handles errors gracefully.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::is_upload_complete
+	 */
+	public function test_is_upload_complete_handles_errors(): void {
+		$settings = array();
+
+		// Without proper setup, this should return 'error'
+		$result = $this->product_feed->is_upload_complete( $settings );
+
+		$this->assertSame(
+			'error',
+			$result,
+			'Should return error when no valid configuration exists'
+		);
+	}
+
+	/**
+	 * Test prepare_temporary_feed_file method.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::prepare_temporary_feed_file
+	 */
+	public function test_prepare_temporary_feed_file_creates_file(): void {
+		try {
+			$file_handle = $this->product_feed->prepare_temporary_feed_file();
+
+			$this->assertIsResource(
+				$file_handle,
+				'Should return a file handle resource'
+			);
+
+			// Close the file handle
+			fclose( $file_handle );
+
+			// Verify the temp file was created
+			$temp_file_path = $this->product_feed->get_temp_file_path();
+			$this->assertFileExists(
+				$temp_file_path,
+				'Temp file should exist'
+			);
+		} catch ( \Exception $e ) {
+			// If there's a permission issue, skip the test
+			$this->markTestSkipped( 'Unable to create temp file: ' . $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Test prepare_temporary_feed_file writes header row.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::prepare_temporary_feed_file
+	 */
+	public function test_prepare_temporary_feed_file_writes_header(): void {
+		try {
+			$file_handle = $this->product_feed->prepare_temporary_feed_file();
+			fclose( $file_handle );
+
+			$temp_file_path = $this->product_feed->get_temp_file_path();
+			$content        = file_get_contents( $temp_file_path );
+
+			$this->assertStringContainsString(
+				'id,title,description',
+				$content,
+				'Temp file should contain header row'
+			);
+		} catch ( \Exception $e ) {
+			$this->markTestSkipped( 'Unable to create temp file: ' . $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Test rename_temporary_feed_file_to_final_feed_file method.
+	 *
+	 * @covers \WC_Facebook_Product_Feed::rename_temporary_feed_file_to_final_feed_file
+	 */
+	public function test_rename_temp_file_to_final(): void {
+		try {
+			// Create temp file
+			$file_handle = $this->product_feed->prepare_temporary_feed_file();
+			fclose( $file_handle );
+
+			// Rename it
+			$this->product_feed->rename_temporary_feed_file_to_final_feed_file();
+
+			// Verify final file exists
+			$final_file_path = $this->product_feed->get_file_path();
+			$this->assertFileExists(
+				$final_file_path,
+				'Final file should exist after rename'
+			);
+
+			// Verify temp file no longer exists
+			$temp_file_path = $this->product_feed->get_temp_file_path();
+			$this->assertFileDoesNotExist(
+				$temp_file_path,
+				'Temp file should not exist after rename'
+			);
+		} catch ( \Exception $e ) {
+			$this->markTestSkipped( 'Unable to work with temp file: ' . $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Test the mock class can log feed progress.
+	 *
+	 * @covers WC_Facebook_Product_Feed_Test_Mock::log_feed_progress
+	 */
+	public function test_mock_class_log_feed_progress(): void {
+		$mock_feed = new WC_Facebook_Product_Feed_Test_Mock();
+
+		// This should not throw an error
+		$mock_feed->log_feed_progress( 'Test message' );
+		$mock_feed->log_feed_progress( 'Test with data', array( 'key' => 'value' ) );
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Test the mock class get_product_wpid returns test value.
+	 *
+	 * @covers WC_Facebook_Product_Feed_Test_Mock::get_product_wpid
+	 */
+	public function test_mock_class_get_product_wpid(): void {
+		WC_Facebook_Product_Feed_Test_Mock::$product_post_wpid = 123;
+
+		$mock_feed = new WC_Facebook_Product_Feed_Test_Mock();
+		$result    = $mock_feed->get_product_wpid();
+
+		$this->assertSame( 123, $result );
+
+		// Clean up
+		WC_Facebook_Product_Feed_Test_Mock::$product_post_wpid = null;
+	}
+
+	/**
+	 * Test the mock class get_product_wpid returns null by default.
+	 *
+	 * @covers WC_Facebook_Product_Feed_Test_Mock::get_product_wpid
+	 */
+	public function test_mock_class_get_product_wpid_default(): void {
+		WC_Facebook_Product_Feed_Test_Mock::$product_post_wpid = null;
+
+		$mock_feed = new WC_Facebook_Product_Feed_Test_Mock();
+		$result    = $mock_feed->get_product_wpid();
+
+		$this->assertNull( $result );
+	}
+}


### PR DESCRIPTION
## Description

Add unit tests for Admin.php and WCFacebookProductFeedTest.php
Increases coverage from 37.4% to 40%

### Type of change

Please delete options that are not relevant

- Add (non-breaking change which adds functionality)
 
## Checklist

- [✔️] I have commented my code, particularly in hard-to-understand areas, if any.
- [✔️] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [✔️] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [✔️] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [✔️] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [✔️] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Add unit tests for Admin.php and WCFacebookProductFeedTest.php

## Test Plan

 
## Screenshots
### Before

### After
Php unit tests workflow to pass 