### PR TITLE
updated thresholds for unit test coverage during normal PRs and releases

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -89,7 +89,16 @@ jobs:
         if: steps.phpunit.outputs.test_status == 'passed'
         run: |
           COVERAGE="${{ steps.phpunit.outputs.coverage_summary }}"
-          MIN_THRESHOLD=35
+
+          # Default threshold for regular PRs
+          MIN_THRESHOLD=40
+
+          # Higher threshold for release branches
+          # Matches: release/X.Y.Z, release/X.Y.Z/publish, etc.
+          if [[ "${{ github.ref }}" =~ ^refs/heads/release/ ]]; then
+            MIN_THRESHOLD=45
+            echo "🚀 Release branch detected - using higher coverage threshold"
+          fi
 
           echo "📈 Coverage: $COVERAGE%"
           echo "🎯 Threshold: $MIN_THRESHOLD%"

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -89,16 +89,16 @@ jobs:
         if: steps.phpunit.outputs.test_status == 'passed'
         run: |
           COVERAGE="${{ steps.phpunit.outputs.coverage_summary }}"
-
-          # Default threshold for regular PRs
           MIN_THRESHOLD=40
 
-          # Higher threshold for release branches
-          # For pushes: check github.ref (e.g., refs/heads/release/1.0.0)
-          # For PRs: check github.base_ref (the target branch, e.g., release/1.0.0)
-          if [[ "${{ github.ref }}" =~ ^refs/heads/release/ ]] || [[ "${{ github.base_ref }}" =~ ^release/ ]]; then
+          # Determine the target branch:
+          # - PRs: github.base_ref
+          # - Pushes: github.ref (strip refs/heads/)
+          TARGET_BRANCH="${{ github.base_ref || github.ref_name }}"
+
+          if [[ "$TARGET_BRANCH" =~ ^release/ ]]; then
             MIN_THRESHOLD=45
-            echo "🚀 Release branch detected - using higher coverage threshold"
+            echo "🚀 Release context detected (branch=$TARGET_BRANCH)"
           fi
 
           echo "📈 Coverage: $COVERAGE%"

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -94,8 +94,9 @@ jobs:
           MIN_THRESHOLD=40
 
           # Higher threshold for release branches
-          # Matches: release/X.Y.Z, release/X.Y.Z/publish, etc.
-          if [[ "${{ github.ref }}" =~ ^refs/heads/release/ ]]; then
+          # For pushes: check github.ref (e.g., refs/heads/release/1.0.0)
+          # For PRs: check github.base_ref (the target branch, e.g., release/1.0.0)
+          if [[ "${{ github.ref }}" =~ ^refs/heads/release/ ]] || [[ "${{ github.base_ref }}" =~ ^release/ ]]; then
             MIN_THRESHOLD=45
             echo "🚀 Release branch detected - using higher coverage threshold"
           fi


### PR DESCRIPTION
## Description

updated thresholds for unit test coverage during normal PRs and releases
Regular PRs - minimum coverage needed is 40%
Release PRs - minimum coverage needed is 45% 

This change is to push the team to write more unit tests and iteratively increase coverage , maintain better code quality standards and push reliable changes.

### Type of change


- Add (non-breaking change which adds functionality)

## Checklist

- [✔️] I have commented my code, particularly in hard-to-understand areas, if any.
- [✔️] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [✔️] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [✔️] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [✔️] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [✔️] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

updated thresholds for unit test coverage during normal PRs and releases

## Test Plan

GH actions - php unit test workflow passes on this PR but expected to fail on a PR to release branch (as current coverage is only at 40%) 

## Screenshots
### Before

### After
