### PR TITLE
Fix TypeError: array_map(): Argument #2 must be of type array, string given in fbproduct.php:1775

### DIFF
--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -247,7 +247,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 			$product = wc_get_product( $wpid );
 
 			if ( ! $product ) {
-				return 'Invalid product ID';
+				return [];
 			}
 
 			return $product->get_category_ids();

--- a/tests/Unit/fbUtilsTest.php
+++ b/tests/Unit/fbUtilsTest.php
@@ -300,4 +300,42 @@ class fbUtilsTest extends \WP_UnitTestCase {
 			);
 		}
 	}
+
+	/**
+	 * Test get_product_category_ids returns array for valid product
+	 */
+	public function test_get_product_category_ids_returns_array_for_valid_product() {
+		$result = \WC_Facebookcommerce_Utils::get_product_category_ids($this->product->get_id());
+		$this->assertIsArray($result);
+	}
+
+	/**
+	 * Test get_product_category_ids returns empty array for invalid product ID
+	 */
+	public function test_get_product_category_ids_returns_empty_array_for_invalid_product() {
+		$result = \WC_Facebookcommerce_Utils::get_product_category_ids(999999999);
+		$this->assertIsArray($result);
+		$this->assertEmpty($result);
+	}
+
+	/**
+	 * Test get_product_category_ids returns category IDs for product with categories
+	 */
+	public function test_get_product_category_ids_returns_category_ids() {
+		// Create a category
+		$category_id = wp_insert_term('Test Category', 'product_cat');
+		$category_id = $category_id['term_id'];
+
+		// Assign category to product
+		$this->product->set_category_ids([$category_id]);
+		$this->product->save();
+
+		$result = \WC_Facebookcommerce_Utils::get_product_category_ids($this->product->get_id());
+
+		$this->assertIsArray($result);
+		$this->assertContains($category_id, $result);
+
+		// Cleanup
+		wp_delete_term($category_id, 'product_cat');
+	}
 }


### PR DESCRIPTION
## Description
Fix TypeError: array_map(): Argument 2 must be of type array, string given in `fbproduct.php:1775`.

#### Bug
- The `get_product_category_ids()` method in fbutils.php was returning the string 'Invalid product ID' when a product doesn't exist, but the only caller in fbproduct.php passes this return value directly to array_map(), which expects an array.
- Root cause: When E2E tests (or any code path) call `prepare_product()` on a deleted/non-existent product ID, the call chain reaches `get_product_category_ids()` which returned a string instead of an empty array.

#### Fix
Return `[]` instead of 'Invalid product ID' to match:
- The method's docblock which specifies @return Array
- The sibling method `get_excluded_product_tags_ids()` which already returns `[]` for invalid products
- The expectation of the only caller (`array_map()`)

### Type of change
- Fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have commented my code, particularly in hard-to-understand areas, if any.
- [X] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [X] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [X] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [X] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [X] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [X] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry
Fix TypeError: array_map(): Argument 2 must be of type array, string given in `fbproduct.php:1775`.

## Test Plan
All GH actions checks should PASS

### Before
```
Uncaught TypeError: array_map(): Argument 2 ($array) must be of type array, string given
in /includes/fbproduct.php:1775
```
### After
No error - method returns empty array for non-existent products, consistent with sibling method behavior.