### PR TITLE
fix: recursion call bug

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -763,7 +763,10 @@ class WC_Facebook_Product {
 
 		// If no description is found from meta or variation, get from post
 		if ( empty( $description ) ) {
-			$post         = $this->get_post_data();
+			$post = $this->get_post_data();
+			if ( ! $post ) {
+				return apply_filters( 'facebook_for_woocommerce_fb_product_description', '', $this->id );
+			}
 			$post_content = WC_Facebookcommerce_Utils::clean_string( $post->post_content );
 			$post_excerpt = WC_Facebookcommerce_Utils::clean_string( $post->post_excerpt );
 			$post_title   = WC_Facebookcommerce_Utils::clean_string( $post->post_title );
@@ -839,7 +842,10 @@ class WC_Facebook_Product {
 		}
 
 		// Use the product's short description (excerpt) from WooCommerce
-		$post         = $this->get_post_data();
+		$post = $this->get_post_data();
+		if ( ! $post ) {
+			return apply_filters( 'facebook_for_woocommerce_fb_product_short_description', '', $this->id );
+		}
 		$post_excerpt = WC_Facebookcommerce_Utils::clean_string( $post->post_excerpt );
 
 		if ( ! empty( $post_excerpt ) ) {


### PR DESCRIPTION
## Description

Fixed a latent infinite recursion bug in WC_Facebook_Product::get_post_data() where the method would call itself recursively when get_post is not callable, potentially leading to a stack overflow.

Changes
Changed the fallback return from $this->get_post_data() to null in includes/fbproduct.php.


Returns null instead of recursively calling itself in the edge case
Adds null checks in the two calling methods (get_fb_description() and get_fb_short_description()) to handle the null return gracefully by returning an empty string through the existing filters

Risk: Minimal - only affects an edge case that would previously crash.

### Type of change

Please delete options that are not relevant

- Tweak (non-breaking change which fixes code modularity, linting or phpcs issues)

## Checklist

- [yes] I have commented my code, particularly in hard-to-understand areas, if any.
- [yes] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [yes] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [yes] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [yes] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [yes] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [yes] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

fixed recursive function call for get_post_data()

