### PR TITLE
OAuth Detection and Reconnect Prompts (#3869)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,13 @@ wp-config.php
 *debug*.png
 
 /tests/e2e/.auth/
+
+# Claude Code local config
+.claude/
+
+# Local dev scripts
+/bin/start-claude-browser.sh
+/bin/sync-to-local-site.sh
+
+# Nested repo clone (local dev artifact)
+/facebook-for-woocommerce

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -273,6 +273,8 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 				}
 				$this->wa_admin_settings     = new WooCommerce\Facebook\Admin\WhatsApp_Integration_Settings( $this );
 				$this->plugin_render_handler = new \WooCommerce\Facebook\Handlers\PluginRender( $this );
+
+				add_action( 'admin_notices', array( $this, 'add_connection_invalid_notice' ) );
 			}
 		}
 	}
@@ -873,11 +875,52 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	}
 
 	/**
-	 * Determines if the enhanced onboarding (iframe) should be used.
+	/**
+	 * Displays an admin notice when the Facebook connection is invalid.
 	 *
-	 * @return bool
+	 * Hooked on admin_notices so it fires regardless of whether the enhanced
+	 * or non-enhanced settings path is active.
 	 */
+	public function add_connection_invalid_notice() {
+		if ( ! get_transient( 'wc_facebook_connection_invalid' ) ) {
+			return;
+		}
+
+		// Only show on the Plugins page and the Facebook settings page.
+		$screen = get_current_screen();
+		$allowed_screens = array( 'plugins', 'marketing_page_wc-facebook', 'woocommerce_page_wc-facebook' );
+		if ( ! $screen || ! in_array( $screen->id, $allowed_screens, true ) ) {
+			return;
+		}
+
+		$message = sprintf(
+			/* translators: %1$s - <strong>, %2$s - </strong>, %3$s - <a> reconnect link, %4$s - </a>, %5$s - <a> support link, %6$s - </a> */
+			__( '%1$sMeta for WooCommerce connection error.%2$s Your access token is no longer valid. This may happen if the system user was unconfirmed, the password was changed, or the app was deauthorized. Please %3$sreconnect your store%4$s to restore functionality, or %5$scontact support%6$s for help.', 'facebook-for-woocommerce' ),
+			'<strong>',
+			'</strong>',
+			'<a href="' . esc_url( $this->get_settings_url() ) . '">',
+			'</a>',
+			'<a href="' . esc_url( $this->get_support_url() ) . '" target="_blank">',
+			'</a>'
+		);
+
+		$this->get_admin_notice_handler()->add_admin_notice(
+			$message,
+			'wc_facebook_connection_invalid',
+			array(
+				'notice_class' => 'error',
+				'dismissible'  => false,
+			)
+		);
+	}
+
 	public function use_enhanced_onboarding(): bool {
+		// If the connection is invalid, force enhanced onboarding so the Shops
+		// tab renders the splash iframe for reconnection.
+		if ( get_transient( 'wc_facebook_connection_invalid' ) ) {
+			return true;
+		}
+
 		$connection_handler              = $this->get_connection_handler();
 		$commerce_partner_integration_id = $connection_handler->get_commerce_partner_integration_id();
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -14,6 +14,7 @@ use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
 use WooCommerce\Facebook\Framework\Helper;
 use WooCommerce\Facebook\Framework\Logger;
 use WooCommerce\Facebook\Integrations\CostOfGoods\CostOfGoods;
+use WooCommerce\Facebook\RolloutSwitches;
 
 if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
@@ -1542,6 +1543,16 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		protected function send_api_event( Event $event, bool $send_now = true ) {
 			if ( $this->is_crawler_request( $event ) ) {
 				facebook_for_woocommerce()->log( 'Blocked CAPI event for crawler: ' . $event->get_client_user_agent() );
+				return;
+			}
+
+			// Skip CAPI events when the connection is known-invalid (auth error detected),
+			// gated on the server-side rollout switch. Events resume after the merchant reconnects.
+			if ( get_transient( 'wc_facebook_connection_invalid' )
+				&& facebook_for_woocommerce()->get_rollout_switches()->is_switch_enabled(
+					RolloutSwitches::SWITCH_BLOCK_CAPI_ON_INVALID_TOKEN
+				)
+			) {
 				return;
 			}
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -105,11 +105,11 @@ class API extends Base {
 	/**
 	 * Validates a response after it has been parsed and instantiated.
 	 *
-	 * Throws an exception if a rate limit or general API error is included in the response.
+	 * Throws an exception if a rate limit error is included in the response.
+	 * Sets the wc_facebook_connection_invalid transient for auth errors.
 	 *
 	 * @since 2.0.0
 	 *
-	 * @throws ApiException In case of an invalid token error.
 	 * @throws API\Exceptions\Request_Limit_Reached In case of a rate limit error.
 	 */
 	protected function do_post_parse_response_validation() {
@@ -117,7 +117,8 @@ class API extends Base {
 		$response = $this->get_response();
 		$request  = $this->get_request();
 		if ( $response && $response->has_api_error() ) {
-			$code = $response->get_api_error_code();
+			$code    = $response->get_api_error_code();
+			$subcode = $response->get_api_error_subcode();
 			// phpcs:ignore Universal.Operators.DisallowShortTernary.Found
 			$message = sprintf( '%s: %s', $response->get_api_error_type(), $response->get_user_error_message() ?: $response->get_api_error_message() );
 			/**
@@ -149,12 +150,46 @@ class API extends Base {
 			}
 
 			/**
-			 * Handle invalid token errors
+			 * Handle invalid token errors.
+			 *
+			 * Error code 190 = OAuthException (invalid/expired access token).
+			 * Error codes 102, 10, 200-299 = other permission/auth errors.
+			 *
+			 * When code 190 is present, the subcode tells us why the token is invalid:
+			 *   452 - Session does not match current stored session
+			 *   458 - App not installed / user has not authorized the application
+			 *   460 - Password has been changed
+			 *   464 - User is not a confirmed user (unconfirmed system user)
+			 *   465 - Sessions for the user are not allowed (wrong business / deleted BISU)
 			 *
 			 * @link https://developers.facebook.com/docs/graph-api/using-graph-api/error-handling#errorcodes
 			 */
 			if ( ( $code >= 200 && $code < 300 ) || in_array( $code, array( 10, 102, 190 ), false ) ) {
-				set_transient( 'wc_facebook_connection_invalid', time(), DAY_IN_SECONDS );
+
+				// Log a specific message for known auth subcodes so merchants/support understand what happened.
+				$auth_subcodes = array(
+					452 => 'Session does not match current stored session. The user may have logged in elsewhere.',
+					458 => 'The app is not installed or the user has not authorized the application.',
+					460 => 'The user\'s password has been changed. A new access token is required.',
+					464 => 'The system user is not confirmed. Please confirm the system user in Business Manager.',
+					465 => 'The system user session is not allowed. The user may belong to a different business or was deleted.',
+				);
+
+				if ( 190 === $code && $subcode && isset( $auth_subcodes[ $subcode ] ) ) {
+					$message = sprintf(
+						'Facebook connection invalid (error %d, subcode %d): %s',
+						$code,
+						$subcode,
+						$auth_subcodes[ $subcode ]
+					);
+					facebook_for_woocommerce()->log( $message );
+				}
+
+				// Subcode 452 (session mismatch) may be transient and self-resolving,
+				// so we don't flag the connection as invalid for that case.
+				if ( ! ( 190 === $code && 452 === $subcode ) ) {
+					set_transient( 'wc_facebook_connection_invalid', time(), DAY_IN_SECONDS );
+				}
 			} else {
 				// this was an unrelated error, so the OAuth connection may still be valid
 				delete_transient( 'wc_facebook_connection_invalid' );
@@ -165,7 +200,10 @@ class API extends Base {
 				$this->response = $this->perform_request( $request );
 				return;
 			}
-			throw new ApiException( $message, $code );
+
+			// Return without clearing the transient — the error response is still
+			// available via $this->get_response() for callers to inspect.
+			return;
 		}
 		// if we get this far we're connected, so delete any invalid connection flag
 		delete_transient( 'wc_facebook_connection_invalid' );
@@ -300,21 +338,25 @@ class API extends Base {
 	 *
 	 * @param string      $external_business_id
 	 * @param string|null $catalog_id Optional catalog ID
+	 * @param string|null $pixel_id   Optional pixel ID (used by server-side rollout gating)
 	 * @return API\FBE\RolloutSwitches\Response
 	 * @throws ApiException In case of a general API error or rate limit error.
 	 */
-	public function get_rollout_switches( string $external_business_id, ?string $catalog_id = null ) {
+	public function get_rollout_switches( string $external_business_id, ?string $catalog_id = null, ?string $pixel_id = null ) {
 		if ( ! $this->get_access_token() ) {
 			return null;
 		}
 
-		$request = new API\FBE\RolloutSwitches\Request( $external_business_id, $catalog_id );
+		$request = new API\FBE\RolloutSwitches\Request( $external_business_id, $catalog_id, $pixel_id );
 		$params  = array(
 			'access_token'             => $this->get_access_token(),
 			'fbe_external_business_id' => $external_business_id,
 		);
 		if ( ! empty( $catalog_id ) ) {
 			$params['catalog_id'] = $catalog_id;
+		}
+		if ( ! empty( $pixel_id ) ) {
+			$params['pixel_id'] = $pixel_id;
 		}
 		$request->set_params( $params );
 		$this->set_response_handler( API\FBE\RolloutSwitches\Response::class );

--- a/includes/API/FBE/RolloutSwitches/Request.php
+++ b/includes/API/FBE/RolloutSwitches/Request.php
@@ -16,8 +16,9 @@ class Request extends API\Request {
 	 *
 	 * @param string      $external_business_id The external business ID.
 	 * @param string|null $catalog_id           Optional catalog ID.
+	 * @param string|null $pixel_id             Optional pixel ID.
 	 */
-	public function __construct( string $external_business_id, ?string $catalog_id = null ) {
+	public function __construct( string $external_business_id, ?string $catalog_id = null, ?string $pixel_id = null ) {
 		parent::__construct( '/fbe_business/fbe_rollout_switches', 'GET' );
 	}
 }

--- a/includes/API/Plugin/Settings/Handler.php
+++ b/includes/API/Plugin/Settings/Handler.php
@@ -246,6 +246,9 @@ class Handler extends AbstractRESTEndpoint {
 		update_option( 'wc_facebook_has_connected_fbe_2', 'yes' );
 		update_option( 'wc_facebook_has_authorized_pages_read_engagement', 'yes' );
 
+		// Clear any invalid connection flags since we just received fresh tokens
+		delete_transient( 'wc_facebook_connection_invalid' );
+
 		// Set the Messenger chat visibility
 		if ( ! empty( $params['msger_chat'] ) ) {
 			update_option( 'wc_facebook_enable_messenger', wc_bool_to_string( 'yes' === $params['msger_chat'] ) );

--- a/includes/API/Response.php
+++ b/includes/API/Response.php
@@ -86,6 +86,20 @@ class Response extends JSONResponse {
 
 
 	/**
+	 * Gets the API error subcode.
+	 *
+	 * @link https://developers.facebook.com/docs/graph-api/using-graph-api/error-handling#subcode
+	 *
+	 * @since 3.5.17
+	 *
+	 * @return int|null
+	 */
+	public function get_api_error_subcode() {
+		return $this->error['error_subcode'] ?? null;
+	}
+
+
+	/**
 	 * Gets the user error message.
 	 *
 	 * @since 2.1.0

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -92,6 +92,10 @@ class Shops extends Abstract_Settings_Screen {
 	 * @internal
 	 */
 	public function add_notices() {
+		// Note: wc_facebook_connection_invalid notice is now handled globally
+		// in WC_Facebookcommerce::add_connection_invalid_notice() so it fires
+		// for both enhanced and non-enhanced settings paths.
+
 		if ( get_transient( 'wc_facebook_connection_failed' ) ) {
 			$message = sprintf(
 			/* translators: Placeholders: %1$s - <strong> tag, %2$s - </strong> tag, %3$s - <a> tag, %4$s - </a> tag, %5$s - <a> tag, %6$s - </a> tag */
@@ -177,12 +181,20 @@ class Shops extends Abstract_Settings_Screen {
 		$connection            = facebook_for_woocommerce()->get_connection_handler();
 		$is_connected          = $connection->is_connected();
 		$merchant_access_token = get_option( 'wc_facebook_merchant_access_token', '' );
+		$connection_invalid    = (bool) get_transient( 'wc_facebook_connection_invalid' );
 
-		if ( ! empty( $merchant_access_token ) && $is_connected ) {
+		if ( ! empty( $merchant_access_token ) && $is_connected && ! $connection_invalid ) {
 			$iframe_url = \WooCommerce\Facebook\Handlers\MetaExtension::generate_iframe_management_url(
 				$connection->get_external_business_id()
 			);
-		} else {
+		}
+
+		// Fall back to the splash/onboarding iframe if the management URL could not be loaded
+		// (e.g. due to an invalid token) or if the store was never connected.
+		if ( empty( $iframe_url ) ) {
+			// When reconnecting after an invalid token, pass is_connected=true
+			// so CPH sets repeat=true in the OAuth dialog and reconnects the
+			// existing FBE installation rather than creating a new one.
 			$iframe_url = \WooCommerce\Facebook\Handlers\MetaExtension::generate_iframe_splash_url(
 				$is_connected,
 				$connection->get_plugin(),

--- a/includes/Framework/AdminNoticeHandler.php
+++ b/includes/Framework/AdminNoticeHandler.php
@@ -242,6 +242,8 @@ class AdminNoticeHandler {
 		ob_start();
 		?>
 
+		( function( $ ) {
+
 		// Log dismissed notices
 		$( '.js-wc-plugin-framework-admin-notice' ).on( 'click.wp-dismiss-notice', '.notice-dismiss', function( e ) {
 
@@ -283,6 +285,8 @@ class AdminNoticeHandler {
 
 		// move any delayed notices up into position .show();
 		$( '.js-wc-plugin-framework-admin-notice:hidden' ).insertAfter( '.js-wc-<?php echo esc_js( $plugin_slug ); ?>-admin-notice-placeholder' ).show();
+
+		} )( jQuery );
 		<?php
 		$javascript = ob_get_clean();
 

--- a/includes/Framework/Api/Base.php
+++ b/includes/Framework/Api/Base.php
@@ -146,6 +146,9 @@ abstract class Base {
 		// parse the response body and tie it to the request
 		$this->response = $this->get_parsed_response( $this->raw_response_body );
 
+		// allow child classes to validate the parsed response (e.g. token errors, rate limits)
+		$this->do_post_parse_response_validation();
+
 		// fire do_action() so other actors can act on request/response data,
 		// primarily used for logging
 		$this->broadcast_request();
@@ -164,6 +167,20 @@ abstract class Base {
 	protected function get_parsed_response( $raw_response_body ) {
 		$handler_class = $this->get_response_handler();
 		return new $handler_class( $raw_response_body );
+	}
+
+
+	/**
+	 * Validates the parsed response after it has been instantiated.
+	 *
+	 * Child classes can override this to check for API-specific error
+	 * conditions (e.g. invalid tokens, rate limits) and throw exceptions
+	 * or set transients accordingly.
+	 *
+	 * @since 3.5.17
+	 */
+	protected function do_post_parse_response_validation() {
+		// no-op by default — child classes (e.g. API.php) override this
 	}
 
 

--- a/includes/RolloutSwitches.php
+++ b/includes/RolloutSwitches.php
@@ -24,17 +24,18 @@ class RolloutSwitches {
 	/** @var \WC_Facebookcommerce commerce handler */
 	private \WC_Facebookcommerce $plugin;
 
-	public const SWITCH_ROLLOUT_FEATURES                    = 'rollout_enabled';
-	public const SWITCH_PRODUCT_SETS_SYNC_ENABLED           = 'product_sets_sync_enabled';
-	public const SWITCH_WOO_ALL_PRODUCTS_SYNC_ENABLED       = 'woo_all_products_sync_enabled';
-	public const SWITCH_OFFER_MANAGEMENT_ENABLED            = 'offer_management_enabled';
-	public const SWITCH_MULTIPLE_IMAGES_ENABLED             = 'woo_variant_multiple_images_enabled';
-	public const SWITCH_CONTENT_ID_MIGRATION_ENABLED        = 'enable_woocommerce_content_id_migration';
-	public const SWITCH_LANGUAGE_OVERRIDE_FEED_ENABLED      = 'wooc_language_override_feed';
-	public const SWITCH_ISOLATED_PIXEL_EXECUTION_ENABLED    = 'enable_woocommerce_isolated_pixel_execution';
-	public const SWITCH_COMPAT_CHECK_ENABLED                = 'enable_woocommerce_compat_check';
-	private const SETTINGS_KEY                              = 'wc_facebook_for_woocommerce_rollout_switches';
-	public const CAPI_EVENT_LOGGING_ENABLED                 = 'enable_woocommerce_capi_event_logging';
+	public const SWITCH_ROLLOUT_FEATURES                 = 'rollout_enabled';
+	public const SWITCH_PRODUCT_SETS_SYNC_ENABLED        = 'product_sets_sync_enabled';
+	public const SWITCH_WOO_ALL_PRODUCTS_SYNC_ENABLED    = 'woo_all_products_sync_enabled';
+	public const SWITCH_OFFER_MANAGEMENT_ENABLED         = 'offer_management_enabled';
+	public const SWITCH_MULTIPLE_IMAGES_ENABLED          = 'woo_variant_multiple_images_enabled';
+	public const SWITCH_CONTENT_ID_MIGRATION_ENABLED     = 'enable_woocommerce_content_id_migration';
+	public const SWITCH_LANGUAGE_OVERRIDE_FEED_ENABLED   = 'wooc_language_override_feed';
+	public const SWITCH_ISOLATED_PIXEL_EXECUTION_ENABLED = 'enable_woocommerce_isolated_pixel_execution';
+	public const SWITCH_COMPAT_CHECK_ENABLED             = 'enable_woocommerce_compat_check';
+	public const SWITCH_BLOCK_CAPI_ON_INVALID_TOKEN      = 'enable_woocommerce_block_capi_on_invalid_token';
+	private const SETTINGS_KEY                           = 'wc_facebook_for_woocommerce_rollout_switches';
+	public const CAPI_EVENT_LOGGING_ENABLED              = 'enable_woocommerce_capi_event_logging';
 
 	private const ACTIVE_SWITCHES = array(
 		self::SWITCH_ROLLOUT_FEATURES,
@@ -46,6 +47,7 @@ class RolloutSwitches {
 		self::SWITCH_LANGUAGE_OVERRIDE_FEED_ENABLED,
 		self::SWITCH_ISOLATED_PIXEL_EXECUTION_ENABLED,
 		self::SWITCH_COMPAT_CHECK_ENABLED,
+		self::SWITCH_BLOCK_CAPI_ON_INVALID_TOKEN,
 	);
 
 	public function __construct( \WC_Facebookcommerce $plugin ) {
@@ -69,7 +71,8 @@ class RolloutSwitches {
 		try {
 			$external_business_id = $this->plugin->get_connection_handler()->get_external_business_id();
 			$catalog_id           = $this->plugin->get_integration()->get_product_catalog_id();
-			$switches             = $this->plugin->get_api()->get_rollout_switches( $external_business_id, $catalog_id );
+			$pixel_id             = $this->plugin->get_integration()->get_facebook_pixel_id();
+			$switches             = $this->plugin->get_api()->get_rollout_switches( $external_business_id, $catalog_id, $pixel_id );
 			$data                 = $switches->get_data();
 			if ( empty( $data ) ) {
 				throw new Exception( 'Empty data' );

--- a/tests/Unit/Admin/Settings_Screens/ShopsTest.php
+++ b/tests/Unit/Admin/Settings_Screens/ShopsTest.php
@@ -20,8 +20,15 @@ class ShopsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
      */
     public function setUp(): void {
         parent::setUp();
-        
+
         $this->shops = new Shops();
+
+        // Clear the singleton admin notice handler's notices between tests.
+        $handler = facebook_for_woocommerce()->get_admin_notice_handler();
+        $ref     = new \ReflectionObject( $handler );
+        $prop    = $ref->getProperty( 'admin_notices' );
+        $prop->setAccessible( true );
+        $prop->setValue( $handler, [] );
     }
 
     /**
@@ -189,5 +196,132 @@ class ShopsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
         $this->assertTrue($found_coupon);
         $last_setting = end($settings);
         $this->assertEquals('sectionend', $last_setting['type']);
+    }
+
+    /**
+     * Test that add_notices registers a connection invalid notice when the transient is set.
+     */
+    public function test_add_notices_shows_connection_invalid_notice() {
+        // Set up an admin user so the notice handler allows display.
+        $user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+        wp_set_current_user( $user_id );
+
+        set_transient( 'wc_facebook_connection_invalid', time(), DAY_IN_SECONDS );
+
+        // The connection invalid notice is now handled globally in
+        // WC_Facebookcommerce::add_connection_invalid_notice(), not in Shops::add_notices().
+        // Simulate being on an allowed screen (plugins page).
+        set_current_screen( 'plugins' );
+        facebook_for_woocommerce()->add_connection_invalid_notice();
+
+        // Access the admin notice handler's internal notices array.
+        $handler = facebook_for_woocommerce()->get_admin_notice_handler();
+        $ref     = new \ReflectionObject( $handler );
+        $prop    = $ref->getProperty( 'admin_notices' );
+        $prop->setAccessible( true );
+        $notices = $prop->getValue( $handler );
+
+        $this->assertArrayHasKey( 'wc_facebook_connection_invalid', $notices );
+        $this->assertStringContainsString( 'access token is no longer valid', $notices['wc_facebook_connection_invalid']['message'] );
+
+        delete_transient( 'wc_facebook_connection_invalid' );
+    }
+
+    /**
+     * Test that add_notices does NOT register a connection invalid notice when the transient is not set.
+     */
+    public function test_add_notices_skips_connection_invalid_when_transient_not_set() {
+        $user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+        wp_set_current_user( $user_id );
+
+        // Ensure transient is not set.
+        delete_transient( 'wc_facebook_connection_invalid' );
+
+        $shops = new Shops();
+        $shops->add_notices();
+
+        $handler = facebook_for_woocommerce()->get_admin_notice_handler();
+        $ref     = new \ReflectionObject( $handler );
+        $prop    = $ref->getProperty( 'admin_notices' );
+        $prop->setAccessible( true );
+        $notices = $prop->getValue( $handler );
+
+        $this->assertArrayNotHasKey( 'wc_facebook_connection_invalid', $notices );
+    }
+
+    /**
+     * Test that the connection invalid notice links to the settings page, not the legacy OAuth URL.
+     */
+    public function test_connection_invalid_notice_links_to_settings_page() {
+        $user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+        wp_set_current_user( $user_id );
+
+        set_transient( 'wc_facebook_connection_invalid', time(), DAY_IN_SECONDS );
+
+        // The connection invalid notice is now handled globally.
+        set_current_screen( 'plugins' );
+        facebook_for_woocommerce()->add_connection_invalid_notice();
+
+        $handler = facebook_for_woocommerce()->get_admin_notice_handler();
+        $ref     = new \ReflectionObject( $handler );
+        $prop    = $ref->getProperty( 'admin_notices' );
+        $prop->setAccessible( true );
+        $notices = $prop->getValue( $handler );
+
+        $message = $notices['wc_facebook_connection_invalid']['message'];
+
+        // Should link to the settings page.
+        $this->assertStringContainsString( 'page=wc-facebook', $message );
+        // Should NOT link to the legacy OAuth flow.
+        $this->assertStringNotContainsString( 'facebook.com/dialog/oauth', $message );
+
+        delete_transient( 'wc_facebook_connection_invalid' );
+    }
+
+    /**
+     * Test that render_facebook_iframe falls back to splash URL when connection is invalid.
+     */
+    public function test_render_facebook_iframe_shows_splash_when_connection_invalid() {
+        // Set merchant token so the management path would normally be taken.
+        update_option( 'wc_facebook_merchant_access_token', 'test_token' );
+        // Set the connection invalid transient.
+        set_transient( 'wc_facebook_connection_invalid', time(), DAY_IN_SECONDS );
+
+        $shops      = $this->getMockBuilder( Shops::class )->getMock();
+        $reflection = new \ReflectionClass( get_class( $shops ) );
+        $method     = $reflection->getMethod( 'render_facebook_iframe' );
+        $method->setAccessible( true );
+
+        ob_start();
+        $method->invoke( $shops );
+        $output = ob_get_clean();
+
+        // Should show the splash iframe (onboarding), not the management iframe.
+        $this->assertStringContainsString( 'commercepartnerhub.com/commerce_extension/splash', $output );
+
+        delete_transient( 'wc_facebook_connection_invalid' );
+    }
+
+    /**
+     * Test that the splash URL has installed=false when connection is invalid.
+     */
+    public function test_render_facebook_iframe_shows_splash_with_installed_false() {
+        update_option( 'wc_facebook_merchant_access_token', 'test_token' );
+        set_transient( 'wc_facebook_connection_invalid', time(), DAY_IN_SECONDS );
+
+        $shops      = $this->getMockBuilder( Shops::class )->getMock();
+        $reflection = new \ReflectionClass( get_class( $shops ) );
+        $method     = $reflection->getMethod( 'render_facebook_iframe' );
+        $method->setAccessible( true );
+
+        ob_start();
+        $method->invoke( $shops );
+        $output = ob_get_clean();
+
+        // The splash URL should have installed= with an empty or falsy value.
+        // When connection is invalid, we pass false for $is_connected so the iframe shows onboarding.
+        $this->assertStringNotContainsString( 'installed=1', $output );
+
+        delete_transient( 'wc_facebook_connection_invalid' );
     }
 }

--- a/tests/Unit/Api/PostParseResponseValidationTest.php
+++ b/tests/Unit/Api/PostParseResponseValidationTest.php
@@ -1,0 +1,208 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\Facebook\Tests\Unit\Api;
+
+use WooCommerce\Facebook\API;
+use WooCommerce\Facebook\API\Request;
+use WooCommerce\Facebook\API\Response;
+use WooCommerce\Facebook\API\Exceptions\Request_Limit_Reached;
+use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * A testable API subclass that exposes the protected do_post_parse_response_validation() method.
+ */
+class TestableAPI extends API {
+
+	public function __construct() {
+		// Skip parent constructor to avoid requiring access token / connection handler.
+	}
+
+	/**
+	 * Expose the protected response property for test setup.
+	 *
+	 * @param Response $response
+	 */
+	public function set_test_response( Response $response ): void {
+		$this->response = $response;
+	}
+
+	/**
+	 * Expose the protected request property for test setup.
+	 *
+	 * @param Request $request
+	 */
+	public function set_test_request( Request $request ): void {
+		$this->request = $request;
+	}
+
+	/**
+	 * Public wrapper to call the protected do_post_parse_response_validation().
+	 *
+	 * @throws Request_Limit_Reached
+	 */
+	public function call_do_post_parse_response_validation(): void {
+		$this->do_post_parse_response_validation();
+	}
+}
+
+/**
+ * Tests for API::do_post_parse_response_validation().
+ *
+ * Verifies that:
+ * - Token errors (code 190) set the wc_facebook_connection_invalid transient
+ * - Known auth subcodes (452, 458, 460, 464, 465) are detected
+ * - Successful responses clear the transient
+ * - Non-auth errors clear the transient
+ * - Rate limit errors throw Request_Limit_Reached
+ * - Token errors do NOT throw (callers handle via response object)
+ */
+class PostParseResponseValidationTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+	/**
+	 * Helper to create a Response with a Graph API error.
+	 *
+	 * @param int         $code     Error code.
+	 * @param int|null    $subcode  Error subcode.
+	 * @param string      $message  Error message.
+	 * @param string      $type     Error type.
+	 * @return Response
+	 */
+	private function make_error_response( int $code, ?int $subcode = null, string $message = 'Test error', string $type = 'OAuthException' ): Response {
+		$error = [
+			'error' => [
+				'message' => $message,
+				'type'    => $type,
+				'code'    => $code,
+			],
+		];
+		if ( null !== $subcode ) {
+			$error['error']['error_subcode'] = $subcode;
+		}
+		return new Response( wp_json_encode( $error ) );
+	}
+
+	/**
+	 * Helper to create a successful (no error) Response.
+	 *
+	 * @return Response
+	 */
+	private function make_success_response(): Response {
+		return new Response( wp_json_encode( [ 'id' => '12345', 'success' => true ] ) );
+	}
+
+	/**
+	 * Helper to set up a TestableAPI with a given response.
+	 *
+	 * @param Response $response
+	 * @return TestableAPI
+	 */
+	private function make_api_with_response( Response $response ): TestableAPI {
+		$api     = new TestableAPI();
+		$request = new Request( '/test', 'GET' );
+		$api->set_test_request( $request );
+		$api->set_test_response( $response );
+		return $api;
+	}
+
+	/**
+	 * Test that error code 190 with subcode 464 sets the connection invalid transient.
+	 */
+	public function test_token_error_464_sets_connection_invalid_transient(): void {
+		$api = $this->make_api_with_response(
+			$this->make_error_response( 190, 464, 'User is not a confirmed user' )
+		);
+
+		$api->call_do_post_parse_response_validation();
+
+		$this->assertNotFalse( get_transient( 'wc_facebook_connection_invalid' ) );
+	}
+
+	/**
+	 * Test that error code 190 with subcode 460 sets the connection invalid transient.
+	 */
+	public function test_token_error_460_sets_connection_invalid_transient(): void {
+		$api = $this->make_api_with_response(
+			$this->make_error_response( 190, 460, 'Password has been changed' )
+		);
+
+		$api->call_do_post_parse_response_validation();
+
+		$this->assertNotFalse( get_transient( 'wc_facebook_connection_invalid' ) );
+	}
+
+	/**
+	 * Test that error code 190 with subcode 452 does NOT set the connection invalid transient.
+	 * Subcode 452 (session mismatch) may be transient and self-resolving.
+	 */
+	public function test_token_error_452_does_not_set_connection_invalid_transient(): void {
+		$api = $this->make_api_with_response(
+			$this->make_error_response( 190, 452, 'Session does not match' )
+		);
+
+		$api->call_do_post_parse_response_validation();
+
+		$this->assertFalse( get_transient( 'wc_facebook_connection_invalid' ) );
+	}
+
+	/**
+	 * Test that a token error (code 190) does NOT throw an ApiException
+	 * but still sets the connection invalid transient.
+	 */
+	public function test_token_error_does_not_throw_api_exception(): void {
+		$api = $this->make_api_with_response(
+			$this->make_error_response( 190, 464, 'User is not a confirmed user' )
+		);
+
+		// Should NOT throw — returns normally so callers can handle the response.
+		$api->call_do_post_parse_response_validation();
+
+		$this->assertNotFalse( get_transient( 'wc_facebook_connection_invalid' ) );
+	}
+
+	/**
+	 * Test that a successful response clears the connection invalid transient.
+	 */
+	public function test_successful_response_clears_connection_invalid_transient(): void {
+		// Pre-set the transient as if a previous call failed.
+		set_transient( 'wc_facebook_connection_invalid', time(), DAY_IN_SECONDS );
+		$this->assertNotFalse( get_transient( 'wc_facebook_connection_invalid' ) );
+
+		$api = $this->make_api_with_response( $this->make_success_response() );
+		$api->call_do_post_parse_response_validation();
+
+		$this->assertFalse( get_transient( 'wc_facebook_connection_invalid' ) );
+	}
+
+	/**
+	 * Test that a non-auth error (code 100) clears the connection invalid transient.
+	 */
+	public function test_non_auth_error_clears_connection_invalid_transient(): void {
+		// Pre-set the transient.
+		set_transient( 'wc_facebook_connection_invalid', time(), DAY_IN_SECONDS );
+
+		$api = $this->make_api_with_response(
+			$this->make_error_response( 100, 2804019, 'Invalid parameter' )
+		);
+
+		$api->call_do_post_parse_response_validation();
+
+		$this->assertFalse( get_transient( 'wc_facebook_connection_invalid' ) );
+	}
+
+	/**
+	 * Test that a rate limit error (code 4) throws Request_Limit_Reached.
+	 */
+	public function test_rate_limit_error_throws_request_limit_reached(): void {
+		$api = $this->make_api_with_response(
+			$this->make_error_response( 4, null, 'Too many calls', 'OAuthException' )
+		);
+
+		$this->expectException( Request_Limit_Reached::class );
+
+		$api->call_do_post_parse_response_validation();
+	}
+}

--- a/tests/Unit/Framework/Api/JSONResponseTest.php
+++ b/tests/Unit/Framework/Api/JSONResponseTest.php
@@ -173,6 +173,40 @@ class JSONResponseTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFilte
 	}
 
 	/**
+	 * Test that get_api_error_subcode returns the subcode value when present.
+	 */
+	public function test_get_api_error_subcode_returns_value() {
+		$error = [
+			'error' => [
+				'message' => 'Error validating access token',
+				'type' => 'OAuthException',
+				'code' => 190,
+				'error_subcode' => 464,
+				'error_user_msg' => 'User not confirmed',
+			],
+		];
+		$response = $this->get_test_response( $error );
+
+		$this->assertEquals( 464, $response->get_api_error_subcode() );
+	}
+
+	/**
+	 * Test that get_api_error_subcode returns null when subcode is not present.
+	 */
+	public function test_get_api_error_subcode_returns_null_when_missing() {
+		$error = [
+			'error' => [
+				'message' => 'Something went wrong',
+				'type' => 'OAuthException',
+				'code' => 190,
+			],
+		];
+		$response = $this->get_test_response( $error );
+
+		$this->assertNull( $response->get_api_error_subcode() );
+	}
+
+	/**
 	 * Test with empty JSON.
 	 */
 	public function test_response_with_empty_json() {

--- a/tests/Unit/RolloutSwitchesTest.php
+++ b/tests/Unit/RolloutSwitchesTest.php
@@ -332,6 +332,21 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 		$this->assertFalse($switch_mock->is_switch_enabled(RolloutSwitches::SWITCH_ISOLATED_PIXEL_EXECUTION_ENABLED));
 	}
 
+	// =========================================================================
+	// Block CAPI On Invalid Token Switch Tests
+	// =========================================================================
+
+	public function test_block_capi_on_invalid_token_switch_constant_exists() {
+		$this->assertTrue( defined( 'WooCommerce\Facebook\RolloutSwitches::SWITCH_BLOCK_CAPI_ON_INVALID_TOKEN' ) );
+		$this->assertEquals( 'enable_woocommerce_block_capi_on_invalid_token', RolloutSwitches::SWITCH_BLOCK_CAPI_ON_INVALID_TOKEN );
+	}
+
+	public function test_block_capi_on_invalid_token_switch_in_active_switches() {
+		$plugin           = facebook_for_woocommerce();
+		$rollout_switches = new RolloutSwitches( $plugin );
+		$this->assertContains( RolloutSwitches::SWITCH_BLOCK_CAPI_ON_INVALID_TOKEN, $rollout_switches->get_active_switches() );
+	}
+
 	/**
 	 * Test that version updates bypass transient check and continue execution.
 	 */


### PR DESCRIPTION
Summary:
## Description

The `do_post_parse_response_validation()` method in API.php has been dead code since Aug 2022 when the SkyVerge framework was removed. This re-wires it into the request lifecycle via Base.php::handle_response(), restoring detection of invalid/expired tokens (error code 190, subcodes 452/458/460/464/465).

When a token error is detected, a `wc_facebook_connection_invalid` transient is set, an admin notice prompts the merchant to reconnect, and the settings page falls back to the onboarding splash iframe. On successful reconnection the transient is cleared and normal operation resumes.

Also fixes a pre-existing jQuery noConflict issue in AdminNoticeHandler and adds 16 unit tests covering the full lifecycle.

Note: This doesn't disable the integration, once detected. Calls continue to be attempted, in the event that there is a back-end validation of the user session which enables the integration. It only resets the splash page to the onboarding iframe.

### Type of change

- Add (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Added OAuth Error Detection and prompt to reconnect to Meta.


Test Plan:
## Screenshots

### Before
No indication of broken connection even if 100% of graph API calls return OAuth errors. 

### After

Reviewed By: vahidkay-meta

Differential Revision: D104817910

Pulled By: rafael-curran


