### PR TITLE
Add opt-in non-blocking mode for Pixel event API requests

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -694,24 +694,64 @@ class API extends Base {
 	/**
 	 * Sends Pixel events.
 	 *
+	 * By default, the request is non-blocking to avoid adding 2-3+ seconds of
+	 * latency to page generation. The response is not needed for rendering the
+	 * page, so this is a safe fire-and-forget operation.
+	 *
+	 * Use the {@see 'wc_facebook_pixel_events_blocking'} filter to force
+	 * blocking mode when response inspection is required (e.g. debugging,
+	 * E2E test logging).
+	 *
 	 * @since 2.0.0
 	 *
 	 * @param string  $pixel_id pixel ID
 	 * @param Event[] $events events to send
-	 * @return Response
-	 * @throws ApiException In case of a general API error or rate limit error.
+	 * @return Response|null Response object when blocking, null when non-blocking.
+	 * @throws ApiException In case of a general API error or rate limit error (blocking mode only).
 	 */
 	public function send_pixel_events( $pixel_id, array $events ) {
 		$request = new API\Pixel\Events\Request( $pixel_id, $events );
 
-		$this->set_response_handler( Response::class );
+		/**
+		 * Filters whether the Pixel event API request should block page generation.
+		 *
+		 * When false (default), the request is sent asynchronously and the page is
+		 * not delayed. Set to true to wait for the response — useful for debugging
+		 * or when E2E test logging needs the API response.
+		 *
+		 * @since 3.6.1
+		 *
+		 * @param bool $blocking Whether the request should be blocking. Default false.
+		 */
+		$blocking = (bool) apply_filters( 'wc_facebook_pixel_events_blocking', false );
 
-		$response = $this->perform_request( $request );
+		if ( $blocking ) {
+			$this->set_response_handler( Response::class );
 
-		// Log to E2E test framework
-		$this->log_events_for_tests( $response, $request );
+			$response = $this->perform_request( $request );
 
-		return $response;
+			// Log to E2E test framework (requires a parsed response).
+			$this->log_events_for_tests( $response, $request );
+
+			return $response;
+		}
+
+		// Non-blocking: fire-and-forget via wp_safe_remote_post().
+		wp_safe_remote_post(
+			$this->request_uri . "/{$pixel_id}/events",
+			array(
+				'timeout'   => 0.01,
+				'blocking'  => false,
+				'sslverify' => true,
+				'headers'   => array(
+					'Authorization' => "Bearer {$this->access_token}",
+					'Content-Type'  => 'application/json',
+				),
+				'body'      => $request->to_string(),
+			)
+		);
+
+		return null;
 	}
 
 	/**

--- a/includes/API.php
+++ b/includes/API.php
@@ -728,7 +728,6 @@ class API extends Base {
 			wp_safe_remote_post(
 				$this->request_uri . "/{$pixel_id}/events",
 				array(
-					'timeout'   => 0.01,
 					'blocking'  => false,
 					'sslverify' => true,
 					'headers'   => array(

--- a/includes/API.php
+++ b/includes/API.php
@@ -694,13 +694,10 @@ class API extends Base {
 	/**
 	 * Sends Pixel events.
 	 *
-	 * By default, the request is non-blocking to avoid adding 2-3+ seconds of
-	 * latency to page generation. The response is not needed for rendering the
-	 * page, so this is a safe fire-and-forget operation.
-	 *
-	 * Use the {@see 'wc_facebook_pixel_events_blocking'} filter to force
-	 * blocking mode when response inspection is required (e.g. debugging,
-	 * E2E test logging).
+	 * By default, the request is blocking (preserving existing behaviour).
+	 * Use the {@see 'wc_facebook_pixel_events_non_blocking'} filter to send
+	 * the request asynchronously, which avoids adding 2-3+ seconds of latency
+	 * to page generation at the cost of losing response introspection.
 	 *
 	 * @since 2.0.0
 	 *
@@ -713,45 +710,46 @@ class API extends Base {
 		$request = new API\Pixel\Events\Request( $pixel_id, $events );
 
 		/**
-		 * Filters whether the Pixel event API request should block page generation.
+		 * Filters whether the Pixel event API request should be non-blocking.
 		 *
-		 * When false (default), the request is sent asynchronously and the page is
-		 * not delayed. Set to true to wait for the response — useful for debugging
-		 * or when E2E test logging needs the API response.
+		 * When true, the HTTP request is sent asynchronously and does not delay
+		 * page generation. The trade-off is that API response data (rate-limit
+		 * headers, validation errors, event-match-quality feedback) is not
+		 * available.
 		 *
 		 * @since 3.6.1
 		 *
-		 * @param bool $blocking Whether the request should be blocking. Default false.
+		 * @param bool $non_blocking Whether the request should be non-blocking. Default false.
 		 */
-		$blocking = (bool) apply_filters( 'wc_facebook_pixel_events_blocking', false );
+		$non_blocking = (bool) apply_filters( 'wc_facebook_pixel_events_non_blocking', false );
 
-		if ( $blocking ) {
-			$this->set_response_handler( Response::class );
+		if ( $non_blocking ) {
+			// Non-blocking: fire-and-forget via wp_safe_remote_post().
+			wp_safe_remote_post(
+				$this->request_uri . "/{$pixel_id}/events",
+				array(
+					'timeout'   => 0.01,
+					'blocking'  => false,
+					'sslverify' => true,
+					'headers'   => array(
+						'Authorization' => "Bearer {$this->access_token}",
+						'Content-Type'  => 'application/json',
+					),
+					'body'      => $request->to_string(),
+				)
+			);
 
-			$response = $this->perform_request( $request );
-
-			// Log to E2E test framework (requires a parsed response).
-			$this->log_events_for_tests( $response, $request );
-
-			return $response;
+			return null;
 		}
 
-		// Non-blocking: fire-and-forget via wp_safe_remote_post().
-		wp_safe_remote_post(
-			$this->request_uri . "/{$pixel_id}/events",
-			array(
-				'timeout'   => 0.01,
-				'blocking'  => false,
-				'sslverify' => true,
-				'headers'   => array(
-					'Authorization' => "Bearer {$this->access_token}",
-					'Content-Type'  => 'application/json',
-				),
-				'body'      => $request->to_string(),
-			)
-		);
+		$this->set_response_handler( Response::class );
 
-		return null;
+		$response = $this->perform_request( $request );
+
+		// Log to E2E test framework (requires a parsed response).
+		$this->log_events_for_tests( $response, $request );
+
+		return $response;
 	}
 
 	/**

--- a/tests/Unit/ApiTest.php
+++ b/tests/Unit/ApiTest.php
@@ -997,11 +997,12 @@ class ApiTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSafeFilt
 			}
 		);
 
-		$response = function ( $result, $parsed_args, $url ) use ( $pixel_id ) {
+		$request_fired = false;
+		$response      = function ( $result, $parsed_args, $url ) use ( $pixel_id, &$request_fired ) {
+			$request_fired = true;
 			$this->assertEquals( 'POST', $parsed_args['method'] );
 			$this->assertStringContainsString( "/{$pixel_id}/events", $url );
 			$this->assertFalse( $parsed_args['blocking'] );
-			$this->assertEquals( 0.01, $parsed_args['timeout'] );
 			$this->assertStringContainsString( 'Bearer test-api-key-9678djyad552', $parsed_args['headers']['Authorization'] );
 			$this->assertEquals( 'application/json', $parsed_args['headers']['Content-Type'] );
 			return [
@@ -1023,6 +1024,7 @@ class ApiTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSafeFilt
 
 		$result = $this->api->send_pixel_events( $pixel_id, [ $event ] );
 
+		$this->assertTrue( $request_fired, 'The non-blocking HTTP request was not triggered.' );
 		$this->assertNull( $result );
 	}
 

--- a/tests/Unit/ApiTest.php
+++ b/tests/Unit/ApiTest.php
@@ -948,12 +948,54 @@ class ApiTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSafeFilt
 	}
 
 	/**
-	 * Tests that send_pixel_events sends a non-blocking request by default.
+	 * Tests that send_pixel_events sends a blocking request by default.
+	 *
+	 * @return void
+	 * @throws ApiException In case of a general API error or rate limit error.
+	 */
+	public function test_send_pixel_events_is_blocking_by_default() {
+		$pixel_id = '1964583793745557';
+
+		$response = function ( $result, $parsed_args, $url ) use ( $pixel_id ) {
+			$this->assertStringContainsString( "/{$pixel_id}/events", $url );
+			$this->assertTrue( $parsed_args['blocking'] );
+			return [
+				'body'     => '{"events_received":1}',
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+			];
+		};
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
+
+		$event = $this->createMock( \WooCommerce\Facebook\Events\Event::class );
+		$event->method( 'get_data' )->willReturn(
+			[
+				'event_name' => 'ViewContent',
+				'event_time' => time(),
+			]
+		);
+
+		$result = $this->api->send_pixel_events( $pixel_id, [ $event ] );
+
+		$this->assertNotNull( $result );
+	}
+
+	/**
+	 * Tests that send_pixel_events sends a non-blocking request when filter is set.
 	 *
 	 * @return void
 	 */
-	public function test_send_pixel_events_is_non_blocking_by_default() {
+	public function test_send_pixel_events_is_non_blocking_when_filter_enabled() {
 		$pixel_id = '1964583793745557';
+
+		$this->add_filter_with_safe_teardown(
+			'wc_facebook_pixel_events_non_blocking',
+			function () {
+				return true;
+			}
+		);
 
 		$response = function ( $result, $parsed_args, $url ) use ( $pixel_id ) {
 			$this->assertEquals( 'POST', $parsed_args['method'] );
@@ -982,48 +1024,6 @@ class ApiTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSafeFilt
 		$result = $this->api->send_pixel_events( $pixel_id, [ $event ] );
 
 		$this->assertNull( $result );
-	}
-
-	/**
-	 * Tests that send_pixel_events sends a blocking request when filter is set.
-	 *
-	 * @return void
-	 * @throws ApiException In case of a general API error or rate limit error.
-	 */
-	public function test_send_pixel_events_is_blocking_when_filter_enabled() {
-		$pixel_id = '1964583793745557';
-
-		$this->add_filter_with_safe_teardown(
-			'wc_facebook_pixel_events_blocking',
-			function () {
-				return true;
-			}
-		);
-
-		$response = function ( $result, $parsed_args, $url ) use ( $pixel_id ) {
-			$this->assertStringContainsString( "/{$pixel_id}/events", $url );
-			$this->assertTrue( $parsed_args['blocking'] );
-			return [
-				'body'     => '{"events_received":1}',
-				'response' => [
-					'code'    => 200,
-					'message' => 'OK',
-				],
-			];
-		};
-		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
-
-		$event = $this->createMock( \WooCommerce\Facebook\Events\Event::class );
-		$event->method( 'get_data' )->willReturn(
-			[
-				'event_name' => 'ViewContent',
-				'event_time' => time(),
-			]
-		);
-
-		$result = $this->api->send_pixel_events( $pixel_id, [ $event ] );
-
-		$this->assertNotNull( $result );
 	}
 
 	/**

--- a/tests/Unit/ApiTest.php
+++ b/tests/Unit/ApiTest.php
@@ -948,6 +948,85 @@ class ApiTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSafeFilt
 	}
 
 	/**
+	 * Tests that send_pixel_events sends a non-blocking request by default.
+	 *
+	 * @return void
+	 */
+	public function test_send_pixel_events_is_non_blocking_by_default() {
+		$pixel_id = '1964583793745557';
+
+		$response = function ( $result, $parsed_args, $url ) use ( $pixel_id ) {
+			$this->assertEquals( 'POST', $parsed_args['method'] );
+			$this->assertStringContainsString( "/{$pixel_id}/events", $url );
+			$this->assertFalse( $parsed_args['blocking'] );
+			$this->assertEquals( 0.01, $parsed_args['timeout'] );
+			$this->assertStringContainsString( 'Bearer test-api-key-9678djyad552', $parsed_args['headers']['Authorization'] );
+			$this->assertEquals( 'application/json', $parsed_args['headers']['Content-Type'] );
+			return [
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+			];
+		};
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
+
+		$event = $this->createMock( \WooCommerce\Facebook\Events\Event::class );
+		$event->method( 'get_data' )->willReturn(
+			[
+				'event_name' => 'ViewContent',
+				'event_time' => time(),
+			]
+		);
+
+		$result = $this->api->send_pixel_events( $pixel_id, [ $event ] );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Tests that send_pixel_events sends a blocking request when filter is set.
+	 *
+	 * @return void
+	 * @throws ApiException In case of a general API error or rate limit error.
+	 */
+	public function test_send_pixel_events_is_blocking_when_filter_enabled() {
+		$pixel_id = '1964583793745557';
+
+		$this->add_filter_with_safe_teardown(
+			'wc_facebook_pixel_events_blocking',
+			function () {
+				return true;
+			}
+		);
+
+		$response = function ( $result, $parsed_args, $url ) use ( $pixel_id ) {
+			$this->assertStringContainsString( "/{$pixel_id}/events", $url );
+			$this->assertTrue( $parsed_args['blocking'] );
+			return [
+				'body'     => '{"events_received":1}',
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+			];
+		};
+		$this->add_filter_with_safe_teardown( 'pre_http_request', $response, 10, 3 );
+
+		$event = $this->createMock( \WooCommerce\Facebook\Events\Event::class );
+		$event->method( 'get_data' )->willReturn(
+			[
+				'event_name' => 'ViewContent',
+				'event_time' => time(),
+			]
+		);
+
+		$result = $this->api->send_pixel_events( $pixel_id, [ $event ] );
+
+		$this->assertNotNull( $result );
+	}
+
+	/**
 	 * Tests read product set request to Facebook.
 	 *
 	 * @return void


### PR DESCRIPTION
## Summary

- `send_pixel_events()` sends a **synchronous blocking HTTP request** to the Conversions API during page rendering, adding 2–3+ seconds to page generation time
- Added a `wc_facebook_pixel_events_non_blocking` filter (default: `false`) that lets developers opt into **non-blocking fire-and-forget** mode using `wp_safe_remote_post()` with `blocking => false`
- Default behaviour is **unchanged** (blocking) — no breaking change

```php
// Opt into non-blocking pixel events for better page performance
add_filter( 'wc_facebook_pixel_events_non_blocking', '__return_true' );
```

Fixes #3870

## Trade-offs (when non-blocking is enabled)

| Capability | Blocking (default) | Non-blocking (opt-in) |
|---|---|---|
| Page generation impact | 2–3s+ added | ~0ms |
| Event Match Quality feedback | Available | Not available |
| Rate limit detection | Available | Lost |
| API validation errors | Surfaced | Silent failure |

For store operators where page performance is critical (Core Web Vitals, conversion rates), this trade-off is acceptable.

## Test plan

- [ ] Verify default behaviour is unchanged — pixel events still sent as blocking requests
- [ ] Enable non-blocking mode via filter and confirm page generation time is no longer blocked by the CAPI request (use Query Monitor or profiler)
- [ ] Verify pixel events are still received by Meta when non-blocking (check Events Manager > Test Events)
- [ ] Confirm E2E tests pass (they use the default blocking mode)
- [ ] Unit tests: `test_send_pixel_events_is_blocking_by_default` and `test_send_pixel_events_is_non_blocking_when_filter_enabled`