### PR TITLE
Release/3.6.3

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -8,6 +8,9 @@ on:
       version:
         description: "Version number to be released"
         required: true
+  push:
+    branches:
+      - 'release/[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
   contents: write
@@ -17,6 +20,7 @@ permissions:
 jobs:
   prepare-release:
     name: Prepare Release
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -390,6 +394,7 @@ jobs:
 
   build-and-upload:
     needs: prepare-release
+    if: always() && (needs.prepare-release.result == 'success' || needs.prepare-release.result == 'skipped')
     uses: ./.github/workflows/shared-build-plugin-artifact.yml
     with:
-      ref: ${{ format('refs/heads/release/{0}', github.event.inputs.version) }}
+      ref: ${{ github.event_name == 'push' && github.ref || format('refs/heads/release/{0}', github.event.inputs.version) }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,5 +1,5 @@
 name: "Prepare New Release"
-run-name: Prepare New Release release/${{ github.event.inputs.version }}` from by @${{ github.actor }}
+run-name: Prepare New Release ${{ github.event.inputs.version && format('release/{0}', github.event.inputs.version) || github.ref_name }} by @${{ github.actor }}
 
 
 on:

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -124,7 +124,7 @@ jobs:
         run: |
           gh release create "v$VERSION" \
             facebook-for-woocommerce.zip \
-            --repo woocommerce/facebook-for-woocommerce \
+            --repo facebook/facebook-for-woocommerce \
             --target "${{ github.sha }}" \
             --title "Release $VERSION" \
             --notes "$RELEASE_NOTES" \

--- a/.github/workflows/set-stable-tag.yml
+++ b/.github/workflows/set-stable-tag.yml
@@ -44,12 +44,12 @@ jobs:
           curl -sL "https://downloads.wordpress.org/plugin/facebook-for-woocommerce.zip" -o "$TEMP_DIR/marketplace.zip"
 
           # Download GitHub artifact
-          RUN_ID=$(gh run list --repo woocommerce/facebook-for-woocommerce --workflow prepare-release.yml --branch "release/$VERSION" --status success --json databaseId --jq '.[0].databaseId')
+          RUN_ID=$(gh run list --repo facebook/facebook-for-woocommerce --workflow prepare-release.yml --branch "release/$VERSION" --status success --json databaseId --jq '.[0].databaseId')
           if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
               echo "❌ No successful build found for release/$VERSION"
               exit 1
           fi
-          gh run download "$RUN_ID" --repo woocommerce/facebook-for-woocommerce --dir "$TEMP_DIR/artifact"
+          gh run download "$RUN_ID" --repo facebook/facebook-for-woocommerce --dir "$TEMP_DIR/artifact"
 
           # Find and prepare GitHub zip
           ARTIFACT_ZIP=$(find "$TEMP_DIR/artifact" -name "*.zip" -type f | head -1)
@@ -152,7 +152,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release edit "v$VERSION" \
-            --repo woocommerce/facebook-for-woocommerce \
+            --repo facebook/facebook-for-woocommerce \
             --draft=false \
             --prerelease=false \
             --latest
@@ -161,9 +161,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release view "v$VERSION" --repo woocommerce/facebook-for-woocommerce --json body --jq '.body' > /tmp/release-notes.md
+          gh release view "v$VERSION" --repo facebook/facebook-for-woocommerce --json body --jq '.body' > /tmp/release-notes.md
           gh pr create \
-            --repo woocommerce/facebook-for-woocommerce \
+            --repo facebook/facebook-for-woocommerce \
             --base main \
             --head "release/$VERSION" \
             --title "Release $VERSION" \

--- a/.github/workflows/set-stable-tag.yml
+++ b/.github/workflows/set-stable-tag.yml
@@ -3,7 +3,7 @@ name: Set Stable Tag
 on: workflow_dispatch
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:
@@ -157,14 +157,22 @@ jobs:
             --prerelease=false \
             --latest
 
-      - name: Create pull request
+      - name: Create or update pull request
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release view "v$VERSION" --repo facebook/facebook-for-woocommerce --json body --jq '.body' > /tmp/release-notes.md
-          gh pr create \
-            --repo facebook/facebook-for-woocommerce \
-            --base main \
-            --head "release/$VERSION" \
-            --title "Release $VERSION" \
-            --body-file /tmp/release-notes.md
+          EXISTING_PR=$(gh pr list --repo facebook/facebook-for-woocommerce --head "release/$VERSION" --base main --json number --jq '.[0].number')
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr edit "$EXISTING_PR" \
+              --repo facebook/facebook-for-woocommerce \
+              --title "Release $VERSION" \
+              --body-file /tmp/release-notes.md
+          else
+            gh pr create \
+              --repo facebook/facebook-for-woocommerce \
+              --base main \
+              --head "release/$VERSION" \
+              --title "Release $VERSION" \
+              --body-file /tmp/release-notes.md
+          fi

--- a/.github/workflows/set-stable-tag.yml
+++ b/.github/workflows/set-stable-tag.yml
@@ -44,7 +44,7 @@ jobs:
           curl -sL "https://downloads.wordpress.org/plugin/facebook-for-woocommerce.zip" -o "$TEMP_DIR/marketplace.zip"
 
           # Download GitHub artifact
-          RUN_ID=$(gh run list --repo woocommerce/facebook-for-woocommerce --workflow prepare-release.yml --status success --json databaseId,displayTitle --jq '.[] | select(.displayTitle | contains("release/'"$VERSION"'")) | .databaseId' | head -1)
+          RUN_ID=$(gh run list --repo woocommerce/facebook-for-woocommerce --workflow prepare-release.yml --branch "release/$VERSION" --status success --json databaseId --jq '.[0].databaseId')
           if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
               echo "❌ No successful build found for release/$VERSION"
               exit 1

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 *** Meta for WooCommerce Changelog ***
 
+= 3.6.3 - 2026-04-10 =
+* Fix - Fix minimatch vulnerability (CVE-2026-27903) by @vahidkay-meta in #3897
+* Fix - Added checks and safeguards. by @vahidkay-meta in #3887
+* Dev - Migrate CAPI Param Builder script to unpkg CDN by @cshing-meta in #3895
+* Dev - Bump tar-fs from 3.1.0 to 3.1.2 by @mrharel in #3896
+* Add - Add WooCommerce Blocks Store API support for AddToCart Pixel events by @cshing-meta in #3888
+* Dev - Dev/break down e2e tests and automate supported version bumpup by @vahidkay-meta in #3876
+
 = 3.6.2 - 2026-03-26 =
 * Dev - minor security fixes and updates
 
@@ -26,7 +34,6 @@
 * Dev - Dev - break down e2e tests and automate supported version bumpup by @vahidkay-meta in #3856
 * Fix - Fix Google Product Category dropdowns not rendering on product pages by @rafael-curran in #3866
 * Add - [Rebranding]Update all references of Facebook for WooCommerce to Meta for WooCommerce by @sharunaanandraj in #3865
-
 = 3.5.17 - 2026-02-17 =
 * Fix - Fix - Removed the prefix from retailer id. by @vahidkay-meta in #3858
 * Add - [WooCommernce] [Rich Order] Add rich-order payload gating and simplify per-item amount for events. by @ashutoshbondre in #3848

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "facebookincubator/facebook-for-woocommerce",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "description": "Grow your business with Meta for WooCommerce! This plugin will install a Facebook Pixel and optionally create a shop on your Facebook page.",
   "type": "wordpress-plugin",
   "license": "GPL-2.0+",

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -10,14 +10,14 @@
  * Description: Grow your business on Meta platforms! Use this official plugin to help sell more of your products using Facebook and Instagram. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products.
  * Author: Meta
  * Author URI: https://www.meta.com/
- * Version: 3.6.2
+ * Version: 3.6.3
  * Requires at least: 5.6
  * Requires PHP: 7.4
  * Text Domain: facebook-for-woocommerce
  * Requires Plugins: woocommerce
  * Tested up to: 6.9.4
  * WC requires at least: 6.4
- * WC tested up to: 10.6.1
+ * WC tested up to: 10.6.2
  *
  * @package MetaCommerce
  */
@@ -50,7 +50,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '3.6.2'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '3.6.3'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.4.0';

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -46,6 +46,9 @@ class Admin {
 	/** @var string the "exclude" sync mode for bulk edit */
 	const BULK_EDIT_DELETE = 'bulk_edit_delete';
 
+	/** @var string message ID for dismissing the WordPress.com update notice */
+	const ADMIN_DISMISS_WPCOM_UPDATE_NOTICE = 'dismiss_wpcom_update_notice';
+
 	/** @var Product_Categories the product category admin handler */
 	protected $product_categories;
 
@@ -72,6 +75,13 @@ class Admin {
 
 		// enqueue admin scripts
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+
+		// handle dismiss action for WordPress.com update notice (runs before admin_notices)
+		add_action( 'admin_init', array( $this, 'handle_wpcom_update_notice_dismiss' ) );
+
+		// add admin notice about WordPress.com automatic updates ending (always check, regardless of connection status)
+		// Note: check is deferred to admin_notices time so the dismiss handler (admin_init) runs first
+		add_action( 'admin_notices', array( $this, 'maybe_show_wpcom_update_notice' ) );
 
 		$plugin = facebook_for_woocommerce();
 		// only alter the admin UI if the plugin is connected to Facebook and ready to sync products
@@ -2555,5 +2565,109 @@ class Admin {
 			wp_send_json_success( $synced_fields );
 		}
 		wp_send_json_error( 'Invalid product ID' );
+	}
+
+	/**
+	 * Conditionally displays the WordPress.com update notice.
+	 *
+	 * Registered as the admin_notices callback so the check runs after admin_init,
+	 * which is where the dismiss handler saves user meta. Evaluating in the
+	 * constructor would cause the notice to flash once on the dismiss redirect page.
+	 *
+	 * @since 3.5.3
+	 *
+	 * @return void
+	 */
+	public function maybe_show_wpcom_update_notice(): void {
+		if ( $this->should_show_wpcom_update_notice() ) {
+			$this->wpcom_update_notice();
+		}
+	}
+
+	/**
+	 * Determines whether the WordPress.com update notice should be shown.
+	 *
+	 * @since 3.5.3
+	 *
+	 * @return bool Whether the WordPress.com update notice should be shown.
+	 */
+	public function should_show_wpcom_update_notice() {
+		if ( 1 !== (int) get_option( 'is_wordpress_com_hosted' ) ) {
+			return false;
+		}
+
+		return ! get_user_meta(
+			get_current_user_id(),
+			self::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE,
+			true
+		);
+	}
+
+	/**
+	 * Returns the WordPress.com update notice message.
+	 *
+	 * @since 3.5.3
+	 *
+	 * @return string The WordPress.com update notice message.
+	 */
+	public function get_wpcom_update_notice_message() {
+		$plugin_url = 'https://wordpress.org/plugins/facebook-for-woocommerce/';
+		return sprintf(
+			/* translators: %s: WordPress.org plugin page URL */
+			__(
+				'After April 30th, 2026, Meta for WooCommerce will no longer receive automatic updates on WordPress.com-hosted websites. <a href="%s">Download the latest version from WordPress.org</a> and install it manually via <strong>Plugins</strong> &rsaquo; <strong>Add New Plugin</strong> &rsaquo; <strong>Upload Plugin</strong> to ensure you receive future updates.',
+				'facebook-for-woocommerce'
+			),
+			esc_url( $plugin_url )
+		);
+	}
+
+	/**
+	 * Displays a notice about WordPress.com automatic updates ending.
+	 *
+	 * Uses an onClick dismiss button that triggers a page reload with a GET parameter,
+	 * ensuring the dismissal is saved server-side before the notice re-renders.
+	 *
+	 * @since 3.5.3
+	 *
+	 * @return void
+	 */
+	public function wpcom_update_notice() {
+		printf(
+			'
+<div class="notice notice-warning is-dismissible">
+	<p>%s</p>
+	<button
+		type="button"
+		class="notice-dismiss"
+		onClick="location.href=\'%s\'">
+		<span class="screen-reader-text">%s</span>
+	</button>
+</div>
+			',
+			wp_kses_post( $this->get_wpcom_update_notice_message() ),
+			esc_url( add_query_arg( self::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE, '1' ) ),
+			esc_html__( 'Dismiss this notice.', 'facebook-for-woocommerce' )
+		);
+	}
+
+	/**
+	 * Handles the dismiss action for the WordPress.com update notice.
+	 *
+	 * @since 3.5.3
+	 *
+	 * @return void
+	 */
+	public function handle_wpcom_update_notice_dismiss() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET[ self::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE ] ) ) {
+			return;
+		}
+
+		update_user_meta(
+			get_current_user_id(),
+			self::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE,
+			1
+		);
 	}
 }

--- a/includes/Framework/Utilities/BackgroundJobHandler.php
+++ b/includes/Framework/Utilities/BackgroundJobHandler.php
@@ -636,6 +636,9 @@ abstract class BackgroundJobHandler extends AsyncRequest {
 		do {
 			// Get next job in the queue
 			$job = $this->get_job();
+			if ( ! $job ) {
+				break;
+			}
 			// handle PHP errors from here on out
 			register_shutdown_function( [ $this, 'handle_shutdown' ], $job );
 			// Start processing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "author": "Meta",
   "homepage": "https://woocommerce.com/products/facebook/",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: meta
 Tags: meta, facebook, whatsapp, conversions api, catalog sync
 Requires at least: 5.6
 Tested up to: 6.9.4
-Stable tag: 3.6.0
+Stable tag: 3.6.2
 Requires PHP: 7.4
 MySQL: 5.6 or greater
 License: GPLv2 or later
@@ -42,7 +42,12 @@ To suggest technical improvements, you can raise an issue on our [Github reposit
 
 == Changelog ==
 
-= 3.6.2 - 2026-03-26 =
-* Dev - minor security fixes and updates
+= 3.6.3 - 2026-04-10 =
+* Fix - Fix minimatch vulnerability (CVE-2026-27903) by @vahidkay-meta in #3897
+* Fix - Added checks and safeguards. by @vahidkay-meta in #3887
+* Dev - Migrate CAPI Param Builder script to unpkg CDN by @cshing-meta in #3895
+* Dev - Bump tar-fs from 3.1.0 to 3.1.2 by @mrharel in #3896
+* Add - Add WooCommerce Blocks Store API support for AddToCart Pixel events by @cshing-meta in #3888
+* Dev - Dev/break down e2e tests and automate supported version bumpup by @vahidkay-meta in #3876
 
 [See changelog for all versions](https://raw.githubusercontent.com/facebook/facebook-for-woocommerce/refs/heads/main/changelog.txt).

--- a/tests/Unit/AdminTest.php
+++ b/tests/Unit/AdminTest.php
@@ -141,6 +141,180 @@ class AdminTest extends \WP_UnitTestCase {
         );
     }
 
+    /**
+     * Test ADMIN_DISMISS_WPCOM_UPDATE_NOTICE constant.
+     */
+    public function test_admin_dismiss_wpcom_update_notice_constant(): void {
+        $this->assertSame(
+            'dismiss_wpcom_update_notice',
+            Admin::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE,
+            'ADMIN_DISMISS_WPCOM_UPDATE_NOTICE constant should have correct value'
+        );
+    }
+
+    /**
+     * Tests that the WordPress.com update notice message includes manual install steps.
+     */
+    public function test_wpcom_update_notice_message_includes_manual_install_steps(): void {
+        $admin = $this->createAdminInstance();
+
+        $message = $admin->get_wpcom_update_notice_message();
+
+        $this->assertStringContainsString(
+            'After April 30th, 2026',
+            $message
+        );
+        $this->assertStringContainsString(
+            'wordpress.org/plugins/facebook-for-woocommerce/',
+            $message
+        );
+        $this->assertStringContainsString(
+            'Upload Plugin',
+            $message
+        );
+    }
+
+    /**
+     * Tests that the WordPress.com update notice is shown only for
+     * WordPress.com-hosted sites when it has not been dismissed.
+     */
+    public function test_wpcom_update_notice_visibility_for_hosted_sites(): void {
+        update_option( 'is_wordpress_com_hosted', 1 );
+
+        $admin = $this->createAdminInstance();
+
+        $this->assertTrue( $admin->should_show_wpcom_update_notice() );
+    }
+
+    /**
+     * Tests that the WordPress.com update notice is hidden for
+     * non-WordPress.com-hosted sites.
+     */
+    public function test_wpcom_update_notice_hidden_for_non_hosted_sites(): void {
+        update_option( 'is_wordpress_com_hosted', 0 );
+
+        $admin = $this->createAdminInstance();
+
+        $this->assertFalse( $admin->should_show_wpcom_update_notice() );
+    }
+
+    /**
+     * Tests that the WordPress.com update notice is hidden when the option is not set.
+     */
+    public function test_wpcom_update_notice_hidden_when_option_not_set(): void {
+        delete_option( 'is_wordpress_com_hosted' );
+
+        $admin = $this->createAdminInstance();
+
+        $this->assertFalse( $admin->should_show_wpcom_update_notice() );
+    }
+
+    /**
+     * Tests that the WordPress.com update notice is hidden after dismissal.
+     */
+    public function test_wpcom_update_notice_hidden_after_dismiss(): void {
+        $user_id = self::factory()->user->create();
+        wp_set_current_user( $user_id );
+
+        update_option( 'is_wordpress_com_hosted', 1 );
+        delete_user_meta( $user_id, Admin::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE );
+
+        $admin = $this->createAdminInstance();
+
+        // Initially should show
+        $this->assertTrue( $admin->should_show_wpcom_update_notice() );
+
+        // Simulate dismissal
+        update_user_meta( $user_id, Admin::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE, 1 );
+
+        // Should now be hidden
+        $this->assertFalse( $admin->should_show_wpcom_update_notice() );
+    }
+
+    /**
+     * Tests that handle_wpcom_update_notice_dismiss saves user meta when GET param is present.
+     */
+    public function test_handle_wpcom_update_notice_dismiss_saves_meta(): void {
+        $user_id = self::factory()->user->create();
+        wp_set_current_user( $user_id );
+        delete_user_meta( $user_id, Admin::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE );
+
+        // Set GET parameter
+        $_GET[ Admin::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE ] = '1';
+
+        $admin = $this->createAdminInstance();
+        $admin->handle_wpcom_update_notice_dismiss();
+
+        // Verify meta was saved
+        $this->assertEquals(
+            '1',
+            get_user_meta( $user_id, Admin::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE, true )
+        );
+
+        // Cleanup
+        unset( $_GET[ Admin::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE ] );
+    }
+
+    /**
+     * Tests that handle_wpcom_update_notice_dismiss does nothing when GET param is absent.
+     */
+    public function test_handle_wpcom_update_notice_dismiss_no_action_without_get(): void {
+        $user_id = get_current_user_id();
+        delete_user_meta( $user_id, Admin::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE );
+
+        // Ensure GET parameter is not set
+        unset( $_GET[ Admin::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE ] );
+
+        $admin = $this->createAdminInstance();
+        $admin->handle_wpcom_update_notice_dismiss();
+
+        // Verify meta was not saved
+        $this->assertEmpty(
+            get_user_meta( $user_id, Admin::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE, true )
+        );
+    }
+
+    /**
+     * Tests that maybe_show_wpcom_update_notice outputs the notice when conditions are met,
+     * and suppresses it after dismissal — verifying the dismiss/render ordering is correct.
+     */
+    public function test_maybe_show_wpcom_update_notice_suppresses_after_dismiss(): void {
+        $user_id = self::factory()->user->create();
+        wp_set_current_user( $user_id );
+
+        update_option( 'is_wordpress_com_hosted', 1 );
+        delete_user_meta( $user_id, Admin::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE );
+
+        $admin = $this->createAdminInstance();
+
+        // Before dismiss: should output the notice
+        ob_start();
+        $admin->maybe_show_wpcom_update_notice();
+        $output = ob_get_clean();
+        $this->assertStringContainsString( 'notice-warning', $output );
+
+        // Simulate what handle_wpcom_update_notice_dismiss does on admin_init
+        update_user_meta( $user_id, Admin::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE, 1 );
+
+        // After dismiss: maybe_show_wpcom_update_notice must produce no output
+        // (this is what runs on admin_notices, after admin_init has saved the meta)
+        ob_start();
+        $admin->maybe_show_wpcom_update_notice();
+        $output = ob_get_clean();
+        $this->assertEmpty( $output, 'Notice must not render after dismissal — dismiss handler runs on admin_init, before admin_notices' );
+    }
+
+    /**
+     * Creates a testable Admin instance without triggering the full constructor.
+     */
+    private function createAdminInstance(): Admin {
+        return new class() extends Admin {
+            public function __construct() {
+                // Skip parent constructor to avoid dependencies
+            }
+        };
+    }
+
     public function setUp() : void {
         parent::setUp();
 

--- a/tests/e2e/helpers/js/index.js
+++ b/tests/e2e/helpers/js/index.js
@@ -64,7 +64,7 @@ const {
 // =============================================================================
 const {
   validateFacebookSync,
-  validateFacebookDeletion,
+  processPendingSyncJobs,
   validateCategorySync
 } = require('./plugin/sync');
 
@@ -183,7 +183,7 @@ const categories = {
 
 const facebook = {
   validateFacebookSync,
-  validateFacebookDeletion,
+  processPendingSyncJobs,
   validateCategorySync,
   getConnectionStatus,
   disconnectAndVerify,
@@ -277,7 +277,7 @@ module.exports = {
 
   // Facebook - Sync
   validateFacebookSync,
-  validateFacebookDeletion,
+  processPendingSyncJobs,
   validateCategorySync,
 
   // Facebook - Connection

--- a/tests/e2e/helpers/js/index.js
+++ b/tests/e2e/helpers/js/index.js
@@ -64,6 +64,7 @@ const {
 // =============================================================================
 const {
   validateFacebookSync,
+  validateFacebookDeletion,
   validateCategorySync
 } = require('./plugin/sync');
 
@@ -182,6 +183,7 @@ const categories = {
 
 const facebook = {
   validateFacebookSync,
+  validateFacebookDeletion,
   validateCategorySync,
   getConnectionStatus,
   disconnectAndVerify,
@@ -275,6 +277,7 @@ module.exports = {
 
   // Facebook - Sync
   validateFacebookSync,
+  validateFacebookDeletion,
   validateCategorySync,
 
   // Facebook - Connection

--- a/tests/e2e/helpers/js/plugin/sync.js
+++ b/tests/e2e/helpers/js/plugin/sync.js
@@ -106,49 +106,41 @@ async function validateCategorySync(categoryId, categoryName = null, waitSeconds
 }
 
 /**
- * Validate that a product has been removed from the Facebook catalog.
- * Retries until the product is no longer found, or until maxAttempts is exhausted.
+ * Process pending Facebook sync background jobs directly.
  *
- * @param {number} productId - Product ID to validate
- * @param {string} productName - Product name for display
- * @param {number} initialWaitSeconds - Seconds to wait before first check
- * @param {number} maxAttempts - Maximum polling attempts
- * @param {number} intervalSeconds - Seconds between retries
- * @returns {Promise<Object>} Last validation result (success should be false with 0 products compared)
+ * The background job handler normally dispatches via a loopback HTTP request
+ * to admin-ajax.php, which doesn't work on single-threaded PHP servers (like
+ * the built-in dev server used in CI). This function bypasses the loopback by
+ * invoking the job handler directly via CLI.
+ *
+ * @returns {Promise<Object>} Processing result
  */
-async function validateFacebookDeletion(productId, productName, initialWaitSeconds = 30, maxAttempts = 6, intervalSeconds = 10) {
-  const displayName = productName ? `"${productName}" (ID: ${productId})` : `ID: ${productId}`;
-  let lastResult = null;
+async function processPendingSyncJobs() {
+  console.log('🔄 Processing pending Facebook sync background jobs...');
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    const waitSec = attempt === 1 ? initialWaitSeconds : intervalSeconds;
-    lastResult = await validateFacebookSync(productId, productName, waitSec, 0);
-
-    if (!lastResult) {
-      console.log(`🗑️ Deletion validated for ${displayName}: validator returned null (product not found)`);
-      return { success: false, debug: ['Compared fields for 0 products, found 0 total mismatches'] };
-    }
-
-    const isGone = !lastResult.success && lastResult.debug && lastResult.debug.some(
-      (msg) => msg === 'Compared fields for 0 products, found 0 total mismatches'
+  try {
+    const phpDir = path.resolve(__dirname, '../../php');
+    const { stdout, stderr } = await execAsync(
+      'php process-sync-jobs.php',
+      { cwd: phpDir, timeout: 120000 }
     );
 
-    if (isGone) {
-      console.log(`🗑️ Deletion validated for ${displayName} on attempt ${attempt}/${maxAttempts}`);
-      return lastResult;
+    const result = JSON.parse(stdout);
+    if (result.success) {
+      console.log(`✅ Processed ${result.jobs_processed} sync job(s)`);
+    } else {
+      console.warn(`⚠️ Sync job processing issue: ${result.message}`);
     }
+    return result;
 
-    if (attempt < maxAttempts) {
-      console.log(`⏳ Product ${displayName} still on Facebook, retrying (${attempt}/${maxAttempts})...`);
-    }
+  } catch (error) {
+    console.warn(`⚠️ Sync job processing error: ${error.message}`);
+    return { success: false, error: error.message };
   }
-
-  console.warn(`⚠️ Product ${displayName} still found on Facebook after ${maxAttempts} attempts`);
-  return lastResult;
 }
 
 module.exports = {
   validateFacebookSync,
-  validateFacebookDeletion,
+  processPendingSyncJobs,
   validateCategorySync
 };

--- a/tests/e2e/helpers/js/plugin/sync.js
+++ b/tests/e2e/helpers/js/plugin/sync.js
@@ -105,7 +105,50 @@ async function validateCategorySync(categoryId, categoryName = null, waitSeconds
   }
 }
 
+/**
+ * Validate that a product has been removed from the Facebook catalog.
+ * Retries until the product is no longer found, or until maxAttempts is exhausted.
+ *
+ * @param {number} productId - Product ID to validate
+ * @param {string} productName - Product name for display
+ * @param {number} initialWaitSeconds - Seconds to wait before first check
+ * @param {number} maxAttempts - Maximum polling attempts
+ * @param {number} intervalSeconds - Seconds between retries
+ * @returns {Promise<Object>} Last validation result (success should be false with 0 products compared)
+ */
+async function validateFacebookDeletion(productId, productName, initialWaitSeconds = 30, maxAttempts = 6, intervalSeconds = 10) {
+  const displayName = productName ? `"${productName}" (ID: ${productId})` : `ID: ${productId}`;
+  let lastResult = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const waitSec = attempt === 1 ? initialWaitSeconds : intervalSeconds;
+    lastResult = await validateFacebookSync(productId, productName, waitSec, 0);
+
+    if (!lastResult) {
+      console.log(`🗑️ Deletion validated for ${displayName}: validator returned null (product not found)`);
+      return { success: false, debug: ['Compared fields for 0 products, found 0 total mismatches'] };
+    }
+
+    const isGone = !lastResult.success && lastResult.debug && lastResult.debug.some(
+      (msg) => msg === 'Compared fields for 0 products, found 0 total mismatches'
+    );
+
+    if (isGone) {
+      console.log(`🗑️ Deletion validated for ${displayName} on attempt ${attempt}/${maxAttempts}`);
+      return lastResult;
+    }
+
+    if (attempt < maxAttempts) {
+      console.log(`⏳ Product ${displayName} still on Facebook, retrying (${attempt}/${maxAttempts})...`);
+    }
+  }
+
+  console.warn(`⚠️ Product ${displayName} still found on Facebook after ${maxAttempts} attempts`);
+  return lastResult;
+}
+
 module.exports = {
   validateFacebookSync,
+  validateFacebookDeletion,
   validateCategorySync
 };

--- a/tests/e2e/helpers/php/process-sync-jobs.php
+++ b/tests/e2e/helpers/php/process-sync-jobs.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * E2E Helper — Process pending Facebook sync background jobs directly.
+ *
+ * The background job handler dispatches via a loopback HTTP request to
+ * admin-ajax.php, which fails on single-threaded PHP servers (like the
+ * built-in dev server used in CI). This script bypasses the loopback by
+ * invoking the job handler directly.
+ *
+ * Usage: php process-sync-jobs.php
+ */
+
+// Simulate cron context so is_queue_empty() doesn't bail early.
+define( 'DOING_CRON', true );
+
+$wp_path = getenv( 'WORDPRESS_PATH' ) . '/wp-load.php';
+
+if ( ! file_exists( $wp_path ) ) {
+	echo json_encode( [ 'success' => false, 'error' => 'WordPress not found at: ' . $wp_path ] );
+	exit( 1 );
+}
+
+require_once $wp_path;
+
+try {
+	if ( ! function_exists( 'facebook_for_woocommerce' ) ) {
+		throw new Exception( 'Facebook plugin not loaded' );
+	}
+
+	$handler        = facebook_for_woocommerce()->get_products_sync_background_handler();
+	$jobs_processed = 0;
+
+	while ( true ) {
+		$job = $handler->get_job();
+		if ( ! $job ) {
+			break;
+		}
+
+		$handler->process_job( $job );
+		$jobs_processed++;
+	}
+
+	echo json_encode( [
+		'success'        => true,
+		'jobs_processed' => $jobs_processed,
+		'message'        => $jobs_processed > 0
+			? "Processed {$jobs_processed} job(s)"
+			: 'No pending jobs found',
+	] );
+
+} catch ( Exception $e ) {
+	echo json_encode( [
+		'success' => false,
+		'error'   => $e->getMessage(),
+	] );
+	exit( 1 );
+}

--- a/tests/e2e/product-deletion.spec.js
+++ b/tests/e2e/product-deletion.spec.js
@@ -9,6 +9,7 @@ const {
   logTestStart,
   logTestEnd,
   validateFacebookSync,
+  validateFacebookDeletion,
   createTestProduct,
   filterProducts,
   clickFirstProduct,
@@ -171,24 +172,11 @@ test.describe('Meta for WooCommerce - Product Deletion E2E Tests', () => {
       }
 
       const [simpleProductValidationResult, variableProductValidationResult] = await Promise.all([
-        validateFacebookSync(simpleProductId, simpleProduct.productName, 30, 0),
-        validateFacebookSync(variableProductId, variableProduct.productName, 30, 0)
+        validateFacebookDeletion(simpleProductId, simpleProduct.productName, 30),
+        validateFacebookDeletion(variableProductId, variableProduct.productName, 30)
       ]);
       expect(simpleProductValidationResult['success']).toBe(false);
-      // Check if any debug message contains the expected text about 0 products and 0 mismatches
-      expect(
-        simpleProductValidationResult['debug'].some(
-          // For each message in the debug array, check if it includes the specific string
-          (msg) => msg === 'Compared fields for 0 products, found 0 total mismatches'
-        )
-      ).toBe(true);
-
       expect(variableProductValidationResult['success']).toBe(false);
-      expect(
-        variableProductValidationResult['debug'].some(
-          (msg) => msg === 'Compared fields for 0 products, found 0 total mismatches'
-        )
-      ).toBe(true);
       console.log('✅ Both products successfully deleted from Facebook catalog');
       logTestEnd(testInfo, true);
     } catch (error) {
@@ -379,24 +367,14 @@ test.describe('Meta for WooCommerce - Product Deletion E2E Tests', () => {
       // and the products are removed from catalog
       console.log('🔍 Validating Facebook sync status after bulk exclusion...');
       const [simpleProductSyncResultAfter, variableProductSyncResultAfter] = await Promise.all([
-        validateFacebookSync(simpleProductId, simpleProduct.productName, 30, 0),
-        validateFacebookSync(variableProductId, variableProduct.productName, 30, 0)
+        validateFacebookDeletion(simpleProductId, simpleProduct.productName, 30),
+        validateFacebookDeletion(variableProductId, variableProduct.productName, 30)
       ]);
 
       expect(simpleProductSyncResultAfter['success']).toBe(false);
-      expect(
-        simpleProductSyncResultAfter['debug'].some(
-          (msg) => msg === 'Compared fields for 0 products, found 0 total mismatches'
-        )
-      ).toBe(true);
       console.log('✅ Simple product successfully removed from Facebook catalog');
 
       expect(variableProductSyncResultAfter['success']).toBe(false);
-      expect(
-        variableProductSyncResultAfter['debug'].some(
-          (msg) => msg === 'Compared fields for 0 products, found 0 total mismatches'
-        )
-      ).toBe(true);
       console.log('✅ Variable product successfully removed from Facebook catalog');
       logTestEnd(testInfo, true);
     } catch (error) {

--- a/tests/e2e/product-deletion.spec.js
+++ b/tests/e2e/product-deletion.spec.js
@@ -9,7 +9,7 @@ const {
   logTestStart,
   logTestEnd,
   validateFacebookSync,
-  validateFacebookDeletion,
+  processPendingSyncJobs,
   createTestProduct,
   filterProducts,
   clickFirstProduct,
@@ -133,47 +133,15 @@ test.describe('Meta for WooCommerce - Product Deletion E2E Tests', () => {
       await page.waitForLoadState('networkidle', { timeout: TIMEOUTS.MAX });
       console.log('✅ Products moved to trash');
 
-      // Navigate to Marketing > Facebook > Troubleshooting
-      console.log('🔧 Navigating to Marketing > Facebook > Troubleshooting...');
-
-      // First, navigate to Marketing > Facebook page
-      await page.goto(`${baseURL}/wp-admin/admin.php?page=wc-facebook`, {
-        waitUntil: 'domcontentloaded',
-        timeout: TIMEOUTS.MAX
-      });
-      console.log('✅ Navigated to Facebook page');
-
-      // Click on Troubleshooting tab
-      console.log('🔍 Looking for Troubleshooting tab...');
-      const troubleshootingTab = page.locator('a:has-text("Troubleshooting"), button:has-text("Troubleshooting")');
-
-      if (await troubleshootingTab.isVisible({ timeout: TIMEOUTS.LONG })) {
-        await troubleshootingTab.click();
-        console.log('✅ Clicked Troubleshooting tab');
-        await page.waitForTimeout(TIMEOUTS.NORMAL);
-      }
-      else {
-        console.warn('⚠️ Troubleshooting tab not found');
-      }
-
-      // Click on Product Data Sync "Sync now" button
-      console.log('🔄 Looking for Product Data Sync "Sync now" button...');
-      const syncNowButton = page.locator('#woocommerce-facebook-settings-sync-products');
-
-      if (await syncNowButton.isVisible({ timeout: TIMEOUTS.LONG })) {
-        await syncNowButton.click();
-        console.log('✅ Clicked "Sync now" button');
-
-        // Wait for sync to process
-        await page.waitForTimeout(TIMEOUTS.MEDIUM);
-        console.log('✅ Sync initiated');
-      } else {
-        console.warn('⚠️ "Sync now" button not found');
-      }
+      // Process the pending DELETE sync jobs directly.
+      // The background job handler dispatches via a loopback HTTP request which
+      // doesn't work on single-threaded PHP servers (like the built-in dev
+      // server used in CI), so we invoke the job handler directly via CLI.
+      await processPendingSyncJobs();
 
       const [simpleProductValidationResult, variableProductValidationResult] = await Promise.all([
-        validateFacebookDeletion(simpleProductId, simpleProduct.productName, 30),
-        validateFacebookDeletion(variableProductId, variableProduct.productName, 30)
+        validateFacebookSync(simpleProductId, simpleProduct.productName, 30, 0),
+        validateFacebookSync(variableProductId, variableProduct.productName, 30, 0)
       ]);
       expect(simpleProductValidationResult['success']).toBe(false);
       expect(variableProductValidationResult['success']).toBe(false);
@@ -221,6 +189,10 @@ test.describe('Meta for WooCommerce - Product Deletion E2E Tests', () => {
       const newDescription = 'This product is out of sync with Facebook';
       await setProductDescription(page, newDescription);
       await publishProduct(page);
+
+      // Process the pending DELETE sync job directly (loopback doesn't work
+      // on single-threaded PHP servers in CI).
+      await processPendingSyncJobs();
 
       const syncResultAfter = await validateFacebookSync(simpleProductId, simpleProduct.productName, 30, 0);
       expect(syncResultAfter['success']).toBe(false);
@@ -363,12 +335,15 @@ test.describe('Meta for WooCommerce - Product Deletion E2E Tests', () => {
       await page.waitForLoadState('domcontentloaded', { timeout: TIMEOUTS.MAX });
       console.log('✅ Bulk edit completed');
 
-      // Validate that "Synced to Meta catalog" is updated to "Not synced"
-      // and the products are removed from catalog
+      // Process the pending DELETE sync jobs directly (loopback doesn't work
+      // on single-threaded PHP servers in CI).
+      await processPendingSyncJobs();
+
+      // Validate that products are removed from the Facebook catalog
       console.log('🔍 Validating Facebook sync status after bulk exclusion...');
       const [simpleProductSyncResultAfter, variableProductSyncResultAfter] = await Promise.all([
-        validateFacebookDeletion(simpleProductId, simpleProduct.productName, 30),
-        validateFacebookDeletion(variableProductId, variableProduct.productName, 30)
+        validateFacebookSync(simpleProductId, simpleProduct.productName, 30, 0),
+        validateFacebookSync(variableProductId, variableProduct.productName, 30, 0)
       ]);
 
       expect(simpleProductSyncResultAfter['success']).toBe(false);


### PR DESCRIPTION
## Summary
Merge release/3.6.3 back to main after successful wordpress.org deployment.

- Version bump to 3.6.3
- feat(admin): add WordPress.com update notice
- fix(compat): replace str_ends_with with substr for PHP 7 support
- Put the safeguards behind a switch