### PR TITLE
Fix intermittent connection save issue in /settings/update flow for missing page/ad account IDs

### DIFF
--- a/includes/API/Plugin/Settings/Handler.php
+++ b/includes/API/Plugin/Settings/Handler.php
@@ -175,6 +175,10 @@ class Handler extends AbstractRESTEndpoint {
 			$options[ \WC_Facebookcommerce_Integration::OPTION_MERCHANT_ACCESS_TOKEN ] = $params['merchant_access_token'];
 		}
 
+		if ( ! empty( $params['page_access_token'] ) ) {
+			$options[ \WC_Facebookcommerce_Integration::OPTION_PAGE_ACCESS_TOKEN ] = $params['page_access_token'];
+		}
+
 		if ( ! empty( $params['page_id'] ) ) {
 			update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, $params['page_id'] );
 		}
@@ -212,6 +216,10 @@ class Handler extends AbstractRESTEndpoint {
 
 		if ( ! empty( $params['business_manager_id'] ) ) {
 			$options[ \WC_Facebookcommerce_Integration::OPTION_BUSINESS_MANAGER_ID ] = $params['business_manager_id'];
+		}
+
+		if ( ! empty( $params['ad_account_id'] ) ) {
+			$options[ \WC_Facebookcommerce_Integration::OPTION_AD_ACCOUNT_ID ] = $params['ad_account_id'];
 		}
 
 		return $options;
@@ -276,6 +284,7 @@ class Handler extends AbstractRESTEndpoint {
 			\WC_Facebookcommerce_Integration::OPTION_HAS_CONNECTED_FBE_2,
 			\WC_Facebookcommerce_Integration::OPTION_INSTALLED_FEATURES,
 			\WC_Facebookcommerce_Integration::OPTION_MERCHANT_ACCESS_TOKEN,
+			\WC_Facebookcommerce_Integration::OPTION_PAGE_ACCESS_TOKEN,
 			\WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID,
 			\WC_Facebookcommerce_Integration::OPTION_PROFILES,
 			\WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID,

--- a/includes/API/Plugin/Settings/Handler.php
+++ b/includes/API/Plugin/Settings/Handler.php
@@ -175,6 +175,10 @@ class Handler extends AbstractRESTEndpoint {
 			$options[ \WC_Facebookcommerce_Integration::OPTION_MERCHANT_ACCESS_TOKEN ] = $params['merchant_access_token'];
 		}
 
+		if ( ! empty( $params['page_access_token'] ) ) {
+			$options[ \WC_Facebookcommerce_Integration::OPTION_PAGE_ACCESS_TOKEN ] = $params['page_access_token'];
+		}
+
 		if ( ! empty( $params['page_id'] ) ) {
 			update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, $params['page_id'] );
 		}
@@ -194,6 +198,10 @@ class Handler extends AbstractRESTEndpoint {
 
 		if ( ! empty( $params['business_manager_id'] ) ) {
 			$options[ \WC_Facebookcommerce_Integration::OPTION_BUSINESS_MANAGER_ID ] = $params['business_manager_id'];
+		}
+
+		if ( ! empty( $params['ad_account_id'] ) ) {
+			$options[ \WC_Facebookcommerce_Integration::OPTION_AD_ACCOUNT_ID ] = $params['ad_account_id'];
 		}
 
 		return $options;
@@ -255,6 +263,7 @@ class Handler extends AbstractRESTEndpoint {
 			\WC_Facebookcommerce_Integration::OPTION_HAS_CONNECTED_FBE_2,
 			\WC_Facebookcommerce_Integration::OPTION_INSTALLED_FEATURES,
 			\WC_Facebookcommerce_Integration::OPTION_MERCHANT_ACCESS_TOKEN,
+			\WC_Facebookcommerce_Integration::OPTION_PAGE_ACCESS_TOKEN,
 			\WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID,
 			\WC_Facebookcommerce_Integration::OPTION_PROFILES,
 			\WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID,


### PR DESCRIPTION
## Description

This PR fixes missing persistence for connection fields coming from the settings payload in the plugin settings REST handler.

Specifically, it updates `includes/API/Plugin/Settings/Handler.php` to:
- persist page_access_token to `OPTION_PAGE_ACCESS_TOKEN`
- persist ad_account_id to `OPTION_AD_ACCOUNT_ID`

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fix connection settings persistence by saving missing page_access_token and ad_account_id values from the settings payload.

## Test Plan

1. Connect plugin using the settings API flow (or replay a settings save request) with payload including:
    - page_access_token
    - ad_account_id
2. Verify options are stored in wp_options:
    - wc_facebook_page_access_token
    - wc_facebook_ad_account_id
3. Disconnect/uninstall integration via handler path and verify cleanup removes:
    - wc_facebook_page_access_token
4. Sanity check: existing saved connection fields (access_token, pixel_id, product_catalog_id, etc.) continue to persist as before.
