### PR TITLE
Tweak - Improve Set Stable Tag by white-listing only release/*/publish branches

### DIFF
--- a/.github/workflows/set-stable-tag.yml
+++ b/.github/workflows/set-stable-tag.yml
@@ -6,7 +6,7 @@ on:
       - 'release/p*/publish'
     inputs:
       instructions:
-        description: 'Choose from branches that follow this pattern: release/p*/release'
+        description: 'Choose from branches that follow this pattern: release/p*/publish'
         required: false
         default: ''
 

--- a/.github/workflows/set-stable-tag.yml
+++ b/.github/workflows/set-stable-tag.yml
@@ -3,7 +3,7 @@ name: Set Stable Tag
 on:
   workflow_dispatch:
     branches:
-      - 'release/p*/release'
+      - 'release/p*/publish'
     inputs:
       instructions:
         description: 'Choose from branches that follow this pattern: release/p*/release'
@@ -27,8 +27,8 @@ jobs:
         run: |
           echo "Current ref: ${{ github.ref }}"
           BRANCH="${{ github.ref }}"
-          if [[ ! $BRANCH == refs/heads/release/p*/release ]]; then
-            echo "❌ This workflow can only be run on release/p*/release branches."
+          if [[ ! $BRANCH == refs/heads/release/p*/publish ]]; then
+            echo "❌ This workflow can only be run on release/p*/publish branches."
             exit 1
           fi
 

--- a/.github/workflows/set-stable-tag.yml
+++ b/.github/workflows/set-stable-tag.yml
@@ -1,6 +1,14 @@
 name: Set Stable Tag
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    branches:
+      - 'release/p*/release'
+    inputs:
+      instructions:
+        description: 'Choose from branches that follow this pattern: release/p*/release'
+        required: false
+        default: ''
 
 permissions:
   contents: write
@@ -19,8 +27,8 @@ jobs:
         run: |
           echo "Current ref: ${{ github.ref }}"
           BRANCH="${{ github.ref }}"
-          if [[ ! $BRANCH == refs/heads/release/*/publish ]]; then
-            echo "❌ This workflow can only be run on release/*/publish branches."
+          if [[ ! $BRANCH == refs/heads/release/p*/release ]]; then
+            echo "❌ This workflow can only be run on release/p*/release branches."
             exit 1
           fi
 


### PR DESCRIPTION

## Description

Added a filter to only allow release/*/publish branches to be chosen for Set Stable Tag target. Also added a description to its modal to ensure it is clear to the user

### Type of change

Please delete options that are not relevant

- Tweak (non-breaking change which fixes code modularity, linting or phpcs issues)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Tweak - Improve Set Stable Tag by white-listing only release/*/publish branches