### PR TITLE
Add origin validation to postMessage handlers in onboarding scripts

### DIFF
--- a/includes/API/Plugin/README.md
+++ b/includes/API/Plugin/README.md
@@ -192,7 +192,15 @@ wp_enqueue_script(
 
 ### 2. Set Up Event Listeners (if needed)
 
-For features like the Facebook iframe integration, set up event listeners to handle messages:
+For features like the Facebook iframe integration, set up event listeners to handle messages.
+
+**Security note:** A `message` event may be fired by *any* window that has a
+reference to this one, including any page the logged-in admin happens to have
+open. Always validate `event.origin` against an explicit allowlist of the
+origins your iframe actually loads from, and treat `event.data` as untrusted
+input (it must be a non-null object before you can dereference fields on it).
+Skipping either check means a third-party page can silently drive your REST
+endpoints against the admin's session. See SEV S653961.
 
 ```php
 /**
@@ -205,10 +213,22 @@ public function render_message_handler() {
     
     ?>
     <script type="text/javascript">
+        // Only the origins your iframe is loaded from should be trusted.
+        const ALLOWED_ORIGINS = [
+            'https://www.commercepartnerhub.com',
+            'https://www.facebook.com',
+            'https://business.facebook.com'
+        ];
         window.addEventListener('message', function(event) {
+            if (ALLOWED_ORIGINS.indexOf(event.origin) === -1) {
+                return;
+            }
             const message = event.data;
+            if (!message || typeof message !== 'object') {
+                return;
+            }
             const messageEvent = message.event;
-            
+
             // Handle specific events from external sources (like Facebook iframe)
             if (messageEvent === 'SomeEvent::ACTION') {
                 // Call your API endpoint
@@ -279,9 +299,12 @@ public function render_action_button() {
 }
 ```
 
-### 4. Real-World Example (from Connection.php)
+### 4. Real-World Example (from Shops.php)
 
-Here's how the Connection screen handles Facebook integration events:
+Here's how the Shops settings screen handles Facebook Commerce Extension events.
+Note the `ALLOWED_ORIGINS` guard and the `typeof message !== 'object'` check
+— both are required before touching `event.data`. The canonical implementation
+lives in `includes/Admin/Settings_Screens/Shops.php::generate_inline_enhanced_onboarding_script()`.
 
 ```php
 /**
@@ -291,15 +314,22 @@ public function render_message_handler() {
     if (!$this->is_current_screen_page()) {
         return;
     }
-    
-    if (!$this->use_enhanced_onboarding()) {
-        return;
-    }
-    
+
     ?>
     <script type="text/javascript">
+        const ALLOWED_ORIGINS = [
+            'https://www.commercepartnerhub.com',
+            'https://www.facebook.com',
+            'https://business.facebook.com'
+        ];
         window.addEventListener('message', function(event) {
+            if (ALLOWED_ORIGINS.indexOf(event.origin) === -1) {
+                return;
+            }
             const message = event.data;
+            if (!message || typeof message !== 'object') {
+                return;
+            }
             const messageEvent = message.event;
 
             // Handle installation event
@@ -330,7 +360,7 @@ public function render_message_handler() {
 
             // Handle iframe resize event
             if (messageEvent === 'CommerceExtension::RESIZE') {
-                const iframe = document.getElementById('facebook-commerce-iframe');
+                const iframe = document.getElementById('facebook-commerce-iframe-enhanced');
                 if (iframe && message.height) {
                     iframe.height = message.height;
                 }

--- a/includes/API/Plugin/README.md
+++ b/includes/API/Plugin/README.md
@@ -194,13 +194,7 @@ wp_enqueue_script(
 
 For features like the Facebook iframe integration, set up event listeners to handle messages.
 
-**Security note:** A `message` event may be fired by *any* window that has a
-reference to this one, including any page the logged-in admin happens to have
-open. Always validate `event.origin` against an explicit allowlist of the
-origins your iframe actually loads from, and treat `event.data` as untrusted
-input (it must be a non-null object before you can dereference fields on it).
-Skipping either check means a third-party page can silently drive your REST
-endpoints against the admin's session. See SEV S653961.
+**Security:** Always validate `event.origin` against an allowlist and verify `event.data` is a non-null object before dereferencing. Without both checks, any third-party page can drive your REST endpoints against the admin's session.
 
 ```php
 /**
@@ -213,7 +207,6 @@ public function render_message_handler() {
     
     ?>
     <script type="text/javascript">
-        // Only the origins your iframe is loaded from should be trusted.
         const ALLOWED_ORIGINS = [
             'https://www.commercepartnerhub.com',
             'https://www.facebook.com',
@@ -301,10 +294,7 @@ public function render_action_button() {
 
 ### 4. Real-World Example (from Shops.php)
 
-Here's how the Shops settings screen handles Facebook Commerce Extension events.
-Note the `ALLOWED_ORIGINS` guard and the `typeof message !== 'object'` check
-— both are required before touching `event.data`. The canonical implementation
-lives in `includes/Admin/Settings_Screens/Shops.php::generate_inline_enhanced_onboarding_script()`.
+How the Shops screen handles Commerce Extension events (see `Shops.php::generate_inline_enhanced_onboarding_script()`):
 
 ```php
 /**

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -415,11 +415,26 @@ class Shops extends Abstract_Settings_Screen {
 		// Generate a fresh nonce for this request
 		$nonce = wp_json_encode( wp_create_nonce( 'wp_rest' ) );
 
-		// Create the inline script with HEREDOC syntax for better JS readability
+		// Origins permitted to drive the CommerceExtension flow. Only the Commerce
+		// Partner Hub iframe (and the Facebook business surfaces it redirects through
+		// during onboarding) should be able to mutate stored integration settings;
+		// any other sender is ignored to prevent cross-origin postMessage abuse.
+		// See SEV S653961.
 		return <<<JAVASCRIPT
 			const fbAPI = GeneratePluginAPIClient({$nonce});
+			const ALLOWED_ORIGINS = [
+				'https://www.commercepartnerhub.com',
+				'https://www.facebook.com',
+				'https://business.facebook.com'
+			];
 			window.addEventListener('message', function(event) {
+				if (ALLOWED_ORIGINS.indexOf(event.origin) === -1) {
+					return;
+				}
 				const message = event.data;
+				if (!message || typeof message !== 'object') {
+					return;
+				}
 				const messageEvent = message.event;
 
 				if (messageEvent === 'CommerceExtension::INSTALL' && message.success) {

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -415,11 +415,6 @@ class Shops extends Abstract_Settings_Screen {
 		// Generate a fresh nonce for this request
 		$nonce = wp_json_encode( wp_create_nonce( 'wp_rest' ) );
 
-		// Origins permitted to drive the CommerceExtension flow. Only the Commerce
-		// Partner Hub iframe (and the Facebook business surfaces it redirects through
-		// during onboarding) should be able to mutate stored integration settings;
-		// any other sender is ignored to prevent cross-origin postMessage abuse.
-		// See SEV S653961.
 		return <<<JAVASCRIPT
 			const fbAPI = GeneratePluginAPIClient({$nonce});
 			const ALLOWED_ORIGINS = [

--- a/includes/Admin/WhatsApp_Integration_Settings.php
+++ b/includes/Admin/WhatsApp_Integration_Settings.php
@@ -246,11 +246,6 @@ class WhatsApp_Integration_Settings {
 		// Generate a fresh nonce for this request
 		$nonce = wp_json_encode( wp_create_nonce( 'wp_rest' ) );
 
-		// Origins permitted to drive the CommerceExtension WhatsApp onboarding flow.
-		// Only the Commerce Partner Hub iframe (and the Facebook business surfaces it
-		// redirects through during onboarding) should be able to mutate stored
-		// WhatsApp integration settings; any other sender is ignored to prevent
-		// cross-origin postMessage abuse. See SEV S653961.
 		return <<<JAVASCRIPT
 			const whatsAppAPI = GeneratePluginAPIClient({$nonce});
 			const ALLOWED_ORIGINS = [

--- a/includes/Admin/WhatsApp_Integration_Settings.php
+++ b/includes/Admin/WhatsApp_Integration_Settings.php
@@ -246,11 +246,26 @@ class WhatsApp_Integration_Settings {
 		// Generate a fresh nonce for this request
 		$nonce = wp_json_encode( wp_create_nonce( 'wp_rest' ) );
 
-		// Create the inline script with HEREDOC syntax for better JS readability
+		// Origins permitted to drive the CommerceExtension WhatsApp onboarding flow.
+		// Only the Commerce Partner Hub iframe (and the Facebook business surfaces it
+		// redirects through during onboarding) should be able to mutate stored
+		// WhatsApp integration settings; any other sender is ignored to prevent
+		// cross-origin postMessage abuse. See SEV S653961.
 		return <<<JAVASCRIPT
 			const whatsAppAPI = GeneratePluginAPIClient({$nonce});
+			const ALLOWED_ORIGINS = [
+				'https://www.commercepartnerhub.com',
+				'https://www.facebook.com',
+				'https://business.facebook.com'
+			];
 			window.addEventListener('message', function(event) {
+				if (ALLOWED_ORIGINS.indexOf(event.origin) === -1) {
+					return;
+				}
 				const message = event.data;
+				if (!message || typeof message !== 'object') {
+					return;
+				}
 				const messageEvent = message.event;
 
 				if (messageEvent === 'CommerceExtension::WA_INSTALL' && message.success) {

--- a/tests/Unit/Admin/Settings_Screens/ShopsTest.php
+++ b/tests/Unit/Admin/Settings_Screens/ShopsTest.php
@@ -68,6 +68,24 @@ class ShopsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
         // Assert fetch request setup - check for wpApiSettings.root instead of hardcoded path
         $this->assertStringContainsString('GeneratePluginAPIClient', $output);
         $this->assertStringContainsString('fbAPI.updateSettings', $output);
+
+        // SEV S653961: postMessage handler MUST validate event.origin against an
+        // explicit allowlist before touching event.data, otherwise any page the
+        // logged-in admin visits can drive the plugin's REST endpoints.
+        $this->assertStringContainsString("'https://www.commercepartnerhub.com'", $output);
+        $this->assertStringContainsString("'https://www.facebook.com'", $output);
+        $this->assertStringContainsString("'https://business.facebook.com'", $output);
+        $this->assertStringContainsString('ALLOWED_ORIGINS.indexOf(event.origin) === -1', $output);
+        // And the guard must run *before* event.data is dereferenced: the origin
+        // check appears before the `const message = event.data;` assignment.
+        $origin_guard_pos = strpos($output, 'ALLOWED_ORIGINS.indexOf(event.origin)');
+        $data_access_pos  = strpos($output, 'const message = event.data');
+        $this->assertNotFalse($origin_guard_pos);
+        $this->assertNotFalse($data_access_pos);
+        $this->assertLessThan($data_access_pos, $origin_guard_pos, 'Origin allowlist must be checked before event.data is read.');
+        // Defense-in-depth: unrelated postMessage traffic (e.g. non-object payloads)
+        // must not throw when we try to read message.event.
+        $this->assertStringContainsString("typeof message !== 'object'", $output);
     }
 
     /**

--- a/tests/Unit/Admin/Settings_Screens/ShopsTest.php
+++ b/tests/Unit/Admin/Settings_Screens/ShopsTest.php
@@ -69,22 +69,17 @@ class ShopsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
         $this->assertStringContainsString('GeneratePluginAPIClient', $output);
         $this->assertStringContainsString('fbAPI.updateSettings', $output);
 
-        // SEV S653961: postMessage handler MUST validate event.origin against an
-        // explicit allowlist before touching event.data, otherwise any page the
-        // logged-in admin visits can drive the plugin's REST endpoints.
         $this->assertStringContainsString("'https://www.commercepartnerhub.com'", $output);
         $this->assertStringContainsString("'https://www.facebook.com'", $output);
         $this->assertStringContainsString("'https://business.facebook.com'", $output);
         $this->assertStringContainsString('ALLOWED_ORIGINS.indexOf(event.origin) === -1', $output);
-        // And the guard must run *before* event.data is dereferenced: the origin
-        // check appears before the `const message = event.data;` assignment.
+
         $origin_guard_pos = strpos($output, 'ALLOWED_ORIGINS.indexOf(event.origin)');
         $data_access_pos  = strpos($output, 'const message = event.data');
         $this->assertNotFalse($origin_guard_pos);
         $this->assertNotFalse($data_access_pos);
         $this->assertLessThan($data_access_pos, $origin_guard_pos, 'Origin allowlist must be checked before event.data is read.');
-        // Defense-in-depth: unrelated postMessage traffic (e.g. non-object payloads)
-        // must not throw when we try to read message.event.
+
         $this->assertStringContainsString("typeof message !== 'object'", $output);
     }
 

--- a/tests/Unit/Admin/WhatsApp_Integration_SettingsTest.php
+++ b/tests/Unit/Admin/WhatsApp_Integration_SettingsTest.php
@@ -5,23 +5,10 @@ use WooCommerce\Facebook\Admin\WhatsApp_Integration_Settings;
 use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
 
 /**
- * Class WhatsApp_Integration_SettingsTest
- *
- * Covers the rendered inline postMessage handler script. Regression coverage
- * for SEV S653961 — the handler previously dispatched on event.data without
- * validating event.origin, which let any page the logged-in admin visited
- * overwrite stored WhatsApp integration credentials (access_token, waba_id,
- * phone_number_id, etc.) via a targeted postMessage.
- *
  * @package WooCommerce\Facebook\Tests\Unit\Admin
  */
 class WhatsApp_Integration_SettingsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
 
-    /**
-     * Build an instance without running the constructor (which registers
-     * admin hooks we don't want in a unit test). The method under test does
-     * not read any instance state.
-     */
     private function build_settings(): WhatsApp_Integration_Settings {
         return $this->getMockBuilder( WhatsApp_Integration_Settings::class )
             ->disableOriginalConstructor()
@@ -29,10 +16,6 @@ class WhatsApp_Integration_SettingsTest extends AbstractWPUnitTestWithOptionIsol
             ->getMock();
     }
 
-    /**
-     * The emitted script must still register the expected WA_* event handlers
-     * and use the plugin API client.
-     */
     public function test_render_message_handler_emits_expected_handlers() {
         $output = $this->build_settings()->generate_inline_enhanced_onboarding_script();
 
@@ -45,12 +28,6 @@ class WhatsApp_Integration_SettingsTest extends AbstractWPUnitTestWithOptionIsol
         $this->assertStringContainsString( 'whatsAppAPI.uninstallWhatsAppSettings', $output );
     }
 
-    /**
-     * SEV S653961: event.origin MUST be checked against an explicit allowlist
-     * before event.data is dereferenced. Any page the admin has open can fire
-     * a message event at this window; without this guard the attacker controls
-     * the payload.
-     */
     public function test_render_message_handler_enforces_origin_allowlist() {
         $output = $this->build_settings()->generate_inline_enhanced_onboarding_script();
 
@@ -70,11 +47,6 @@ class WhatsApp_Integration_SettingsTest extends AbstractWPUnitTestWithOptionIsol
         );
     }
 
-    /**
-     * Defense-in-depth: if an allowed origin posts a non-object payload (or
-     * just does unrelated postMessage traffic) we must not throw trying to
-     * read message.event.
-     */
     public function test_render_message_handler_guards_non_object_event_data() {
         $output = $this->build_settings()->generate_inline_enhanced_onboarding_script();
 

--- a/tests/Unit/Admin/WhatsApp_Integration_SettingsTest.php
+++ b/tests/Unit/Admin/WhatsApp_Integration_SettingsTest.php
@@ -1,0 +1,83 @@
+<?php
+namespace WooCommerce\Facebook\Tests\Admin;
+
+use WooCommerce\Facebook\Admin\WhatsApp_Integration_Settings;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+
+/**
+ * Class WhatsApp_Integration_SettingsTest
+ *
+ * Covers the rendered inline postMessage handler script. Regression coverage
+ * for SEV S653961 — the handler previously dispatched on event.data without
+ * validating event.origin, which let any page the logged-in admin visited
+ * overwrite stored WhatsApp integration credentials (access_token, waba_id,
+ * phone_number_id, etc.) via a targeted postMessage.
+ *
+ * @package WooCommerce\Facebook\Tests\Unit\Admin
+ */
+class WhatsApp_Integration_SettingsTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+    /**
+     * Build an instance without running the constructor (which registers
+     * admin hooks we don't want in a unit test). The method under test does
+     * not read any instance state.
+     */
+    private function build_settings(): WhatsApp_Integration_Settings {
+        return $this->getMockBuilder( WhatsApp_Integration_Settings::class )
+            ->disableOriginalConstructor()
+            ->onlyMethods( [] )
+            ->getMock();
+    }
+
+    /**
+     * The emitted script must still register the expected WA_* event handlers
+     * and use the plugin API client.
+     */
+    public function test_render_message_handler_emits_expected_handlers() {
+        $output = $this->build_settings()->generate_inline_enhanced_onboarding_script();
+
+        $this->assertStringContainsString( "window.addEventListener('message'", $output );
+        $this->assertStringContainsString( 'CommerceExtension::WA_INSTALL', $output );
+        $this->assertStringContainsString( 'CommerceExtension::WA_RESIZE', $output );
+        $this->assertStringContainsString( 'CommerceExtension::WA_UNINSTALL', $output );
+        $this->assertStringContainsString( 'GeneratePluginAPIClient', $output );
+        $this->assertStringContainsString( 'whatsAppAPI.updateWhatsAppSettings', $output );
+        $this->assertStringContainsString( 'whatsAppAPI.uninstallWhatsAppSettings', $output );
+    }
+
+    /**
+     * SEV S653961: event.origin MUST be checked against an explicit allowlist
+     * before event.data is dereferenced. Any page the admin has open can fire
+     * a message event at this window; without this guard the attacker controls
+     * the payload.
+     */
+    public function test_render_message_handler_enforces_origin_allowlist() {
+        $output = $this->build_settings()->generate_inline_enhanced_onboarding_script();
+
+        $this->assertStringContainsString( "'https://www.commercepartnerhub.com'", $output );
+        $this->assertStringContainsString( "'https://www.facebook.com'", $output );
+        $this->assertStringContainsString( "'https://business.facebook.com'", $output );
+        $this->assertStringContainsString( 'ALLOWED_ORIGINS.indexOf(event.origin) === -1', $output );
+
+        $origin_guard_pos = strpos( $output, 'ALLOWED_ORIGINS.indexOf(event.origin)' );
+        $data_access_pos  = strpos( $output, 'const message = event.data' );
+        $this->assertNotFalse( $origin_guard_pos );
+        $this->assertNotFalse( $data_access_pos );
+        $this->assertLessThan(
+            $data_access_pos,
+            $origin_guard_pos,
+            'Origin allowlist must be checked before event.data is read.'
+        );
+    }
+
+    /**
+     * Defense-in-depth: if an allowed origin posts a non-object payload (or
+     * just does unrelated postMessage traffic) we must not throw trying to
+     * read message.event.
+     */
+    public function test_render_message_handler_guards_non_object_event_data() {
+        $output = $this->build_settings()->generate_inline_enhanced_onboarding_script();
+
+        $this->assertStringContainsString( "typeof message !== 'object'", $output );
+    }
+}


### PR DESCRIPTION
**Tighten the inline onboarding scripts in `Shops` and `WhatsApp` settings to validate `event.origin` before processing incoming messages, and guard against non-object event data. Update README examples to reflect the improved pattern. Add corresponding unit tests.**

## Description

The Shops settings screen and the WhatsApp Integration settings screen each register an inline `window.addEventListener('message', …)` handler that drives the embedded Commerce Partner Hub onboarding flow. Prior to this change those handlers dispatched on `event.data.event` without first checking `event.origin`, which meant any browser context with a window handle to the admin tab — for example, a separately-opened tab from a phishing email visited by an authenticated WP admin — could fire a synthetic `CommerceExtension::INSTALL`, `CommerceExtension::UNINSTALL`, `CommerceExtension::WA_INSTALL`, or `CommerceExtension::WA_UNINSTALL` message and cause the handler to call the corresponding `/wc-facebook/v1/settings/*` and `/wc-facebook/v1/whatsapp_settings/*` REST endpoints in the admin's authenticated session. The endpoints themselves authenticate via `current_user_can( 'manage_woocommerce' )` and the standard `wp_rest` nonce, but cannot distinguish a message originated by the legitimate iframe from one injected by a third-party page — both produce identical authenticated requests. The trust boundary therefore has to live in the JS handler itself.

This change adds an explicit `ALLOWED_ORIGINS` allowlist at the top of each handler and short-circuits when `event.origin` is not in the list. As defense-in-depth, the handlers also short-circuit when `event.data` is not a non-null object, so unrelated `message` events (browser extensions, embedded analytics iframes, etc.) no longer cause the handler to dereference fields on arbitrary payloads.

The example snippets in `includes/API/Plugin/README.md` previously demonstrated the unsafe pattern (no origin validation, no payload guard) and the "Real-World Example" section pointed at a stale `Connection.php` handler that no longer exists. Both example sections have been rewritten to demonstrate the validated pattern and now reference the canonical implementation in `Shops.php`.

No dependencies have been added or removed.

### Type of change

- **Fix** (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki](https://fburl.com/wiki/2cgfduwc).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki](https://fburl.com/wiki/nhx73tgs).

## Changelog entry

> Tweak - Validate `event.origin` against an allowlist in the inline onboarding postMessage handlers for Shops and WhatsApp settings to prevent cross-origin abuse.

## Test Plan

### Automated

| Suite | Result |
| --- | --- |
| `php -l` on all five modified PHP files | No syntax errors. |
| `vendor/bin/phpcs --standard=phpcs.xml.dist` on all five modified files | Zero errors, zero warnings. |
| `./vendor/bin/phpunit tests/Unit/Admin/Settings_Screens/ShopsTest.php tests/Unit/Admin/WhatsApp_Integration_SettingsTest.php` | `OK (5 tests, 37 assertions)` against WP 6.9.4 + WC 10.7.0 on PHP 7.4. |
| Standalone PHP harness asserting the rendered output of `generate_inline_enhanced_onboarding_script()` for both classes | 25/25 string-level assertions pass (origins present, ordering check `origin guard appears before event.data is read`, non-object guard present). |
| Node `vm`-sandboxed runtime harness loading the literally-emitted JS, dispatching synthetic `MessageEvent`s | 45/45 runtime assertions pass. Coverage includes 8 disallowed-origin lookalikes (`https://evil.com`, `http://www.commercepartnerhub.com` http downgrade, `https://commercepartnerhub.com` no-www, `https://m.facebook.com`, `https://facebook.com` no-www, `https://www.facebook.com.evil.com` suffix-confusion, `null` sandboxed iframe origin, empty `file://` origin), 7 non-object payload variants (`'hello'`, `null`, `undefined`, `42`, `true`, `false`, `[]`), and a positive sweep confirming all three allowed origins still drive the legitimate `INSTALL` / `UNINSTALL` / `WA_INSTALL` / `WA_UNINSTALL` flows. |



### Test configuration

- WP 6.9.4 / WC 10.7.0 / PHP 7.4 locally; CI matrix in `.github/workflows/php-unit-tests.yml` covers PHP 7.4 + 8.4 against latest WP and WC.

## Screenshots

N/A — this change modifies inline JavaScript and PHP-side documentation only; there is no visible UI surface change. Behavioral evidence is captured in the Test Plan section above.

### Before

The handler dispatched on attacker-controlled `event.data.event` regardless of `event.origin`:

```js
window.addEventListener('message', function(event) {
    const message = event.data;
    const messageEvent = message.event;

    if (messageEvent === 'CommerceExtension::INSTALL' && message.success) {
        fbAPI.updateSettings({ /* fields from message */ });
    }
    // …
});
```

### After

The handler validates `event.origin` against an explicit allowlist and guards against non-object payloads before reading any field:

```js
const ALLOWED_ORIGINS = [
    'https://www.commercepartnerhub.com',
    'https://www.facebook.com',
    'https://business.facebook.com'
];
window.addEventListener('message', function(event) {
    if (ALLOWED_ORIGINS.indexOf(event.origin) === -1) {
        return;
    }
    const message = event.data;
    if (!message || typeof message !== 'object') {
        return;
    }
    const messageEvent = message.event;

    if (messageEvent === 'CommerceExtension::INSTALL' && message.success) {
        fbAPI.updateSettings({ /* fields from message */ });
    }
    // …
});
```