### PR TITLE
Add Signal state controls for Pixel and CAPI

### DIFF
--- a/assets/js/facebook-for-woocommerce-signals.js
+++ b/assets/js/facebook-for-woocommerce-signals.js
@@ -1,0 +1,144 @@
+/**
+ * Facebook for WooCommerce - Signals helper.
+ *
+ * Exposes `window.fbwcsignal` so a CMP or theme integration can hold or
+ * release signal delivery while keeping the plugin loaded.
+ *
+ * @package FacebookCommerce
+ */
+( function () {
+	'use strict';
+
+	var COOKIE_NAME = 'wc_facebook_signals_state';
+	var STATE_ACTIVE = 'active';
+	var STATE_HELD = 'held';
+
+	/**
+	 * Minimal cookie setter.
+	 *
+	 * @param {string} name
+	 * @param {string} value
+	 * @param {number} days
+	 */
+	function setCookie( name, value, days ) {
+		var d = new Date();
+		d.setTime( d.getTime() + days * 86400000 );
+		document.cookie =
+			name +
+			'=' +
+			encodeURIComponent( value ) +
+			';expires=' +
+			d.toUTCString() +
+			';path=/;SameSite=Lax';
+	}
+
+	/**
+	 * Read a cookie value.
+	 *
+	 * @param {string} name
+	 * @return {string|null}
+	 */
+	function getCookie( name ) {
+		var match = document.cookie.match(
+			new RegExp( '(?:^|;\\s*)' + name + '=([^;]*)' )
+		);
+		return match ? decodeURIComponent( match[ 1 ] ) : null;
+	}
+
+	/**
+	 * Update the stored signal state and sync it to PHP.
+	 *
+	 * @param {string} state `active` or `held`.
+	 * @return {Promise} Resolves with the backend response.
+	 */
+	function updateState( state ) {
+		setCookie( COOKIE_NAME, state, 365 );
+
+		var params = wc_facebook_signals_params; // localized by PHP.
+
+		return new Promise( function ( resolve, reject ) {
+			var xhr = new XMLHttpRequest();
+			xhr.open( 'POST', params.ajax_url, true );
+			xhr.setRequestHeader(
+				'Content-Type',
+				'application/x-www-form-urlencoded; charset=UTF-8'
+			);
+			xhr.onload = function () {
+				if ( xhr.status >= 200 && xhr.status < 300 ) {
+					try {
+						var data = JSON.parse( xhr.responseText );
+						resolve( data );
+					} catch ( e ) {
+						reject( e );
+					}
+				} else {
+					reject( new Error( 'AJAX failed: ' + xhr.status ) );
+				}
+			};
+			xhr.onerror = function () {
+				reject( new Error( 'Network error' ) );
+			};
+			xhr.send(
+				'action=' +
+					encodeURIComponent( params.action ) +
+					'&security=' +
+					encodeURIComponent( params.nonce ) +
+					'&state=' +
+					encodeURIComponent( state )
+			);
+		} );
+	}
+
+	/**
+	 * Hold browser/server signals for subsequent requests.
+	 *
+	 * @return {Promise}
+	 */
+	function hold() {
+		return updateState( STATE_HELD );
+	}
+
+	/**
+	 * Release held signals and flush any queued browser events.
+	 *
+	 * @return {Promise}
+	 */
+	function release() {
+		return updateState( STATE_ACTIVE ).then( function ( data ) {
+			if (
+				window.FacebookSignals &&
+				window.FacebookSignals._held
+			) {
+				return window.FacebookSignals.release().then(
+					function () {
+						return data;
+					},
+					function () {
+						return data;
+					}
+				);
+			}
+
+			return data;
+		} );
+	}
+
+	/**
+	 * Read the current signal state from the cookie.
+	 *
+	 * @return {string|null} `active`, `held`, or `null`.
+	 */
+	function getState() {
+		var val = getCookie( COOKIE_NAME );
+		if ( val === null ) {
+			return null;
+		}
+
+		return val === STATE_ACTIVE ? STATE_ACTIVE : STATE_HELD;
+	}
+
+	window.fbwcsignal = window.fbwcsignal || {};
+	window.fbwcsignal.hold = hold;
+	window.fbwcsignal.release = release;
+	window.fbwcsignal.getState = getState;
+} )();

--- a/assets/js/facebook-for-woocommerce-signals.js
+++ b/assets/js/facebook-for-woocommerce-signals.js
@@ -1,4 +1,13 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+/**
  * Facebook for WooCommerce - Signals helper.
  *
  * Exposes `window.fbwcsignal` so a CMP or theme integration can hold or

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -147,6 +147,12 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	 */
 	private $debug_tools;
 
+	/** @var WooCommerce\Facebook\Signals */
+	private $signals;
+
+	/** @var WooCommerce\Facebook\Events\ReleaseSignalsAjax */
+	private $release_signals_ajax;
+
 	/**
 	 * Constructs the plugin.
 	 *
@@ -207,22 +213,25 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 
 			$this->heartbeat = new Heartbeat( WC()->queue() );
 			$this->heartbeat->init();
-			$this->feed_manager                     = new WooCommerce\Facebook\Feed\FeedManager();
-			$this->checkout                         = new WooCommerce\Facebook\Checkout();
-			$this->product_feed                     = new WooCommerce\Facebook\Products\Feed();
-			$this->language_override_feed           = new WooCommerce\Facebook\Feed\Localization\LanguageOverrideFeed();
-			$this->products_stock_handler           = new WooCommerce\Facebook\Products\Stock();
-			$this->products_sync_handler            = new WooCommerce\Facebook\Products\Sync();
-			$this->sync_background_handler          = new WooCommerce\Facebook\Products\Sync\Background();
-			$this->configuration_detection          = new WooCommerce\Facebook\Feed\FeedConfigurationDetection();
-			$this->product_sets_sync_handler        = new WooCommerce\Facebook\ProductSets\ProductSetSync();
-			$this->commerce_handler                 = new WooCommerce\Facebook\Commerce();
-			$this->fb_categories                    = new WooCommerce\Facebook\Products\FBCategories();
-			$this->external_version_update          = new WooCommerce\Facebook\ExternalVersionUpdate\Update();
-			$this->fbcollection_handler             = new WooCommerce\Facebook\CollectionPage();
+			$this->feed_manager              = new WooCommerce\Facebook\Feed\FeedManager();
+			$this->checkout                  = new WooCommerce\Facebook\Checkout();
+			$this->product_feed              = new WooCommerce\Facebook\Products\Feed();
+			$this->language_override_feed    = new WooCommerce\Facebook\Feed\Localization\LanguageOverrideFeed();
+			$this->products_stock_handler    = new WooCommerce\Facebook\Products\Stock();
+			$this->products_sync_handler     = new WooCommerce\Facebook\Products\Sync();
+			$this->sync_background_handler   = new WooCommerce\Facebook\Products\Sync\Background();
+			$this->configuration_detection   = new WooCommerce\Facebook\Feed\FeedConfigurationDetection();
+			$this->product_sets_sync_handler = new WooCommerce\Facebook\ProductSets\ProductSetSync();
+			$this->commerce_handler          = new WooCommerce\Facebook\Commerce();
+			$this->fb_categories             = new WooCommerce\Facebook\Products\FBCategories();
+			$this->external_version_update   = new WooCommerce\Facebook\ExternalVersionUpdate\Update();
+			$this->fbcollection_handler      = new WooCommerce\Facebook\CollectionPage();
 			if ( wp_doing_ajax() ) {
 				$this->ajax = new WooCommerce\Facebook\AJAX();
 			}
+
+			$this->signals              = new WooCommerce\Facebook\Signals();
+			$this->release_signals_ajax = new WooCommerce\Facebook\Events\ReleaseSignalsAjax();
 
 			// Load integrations.
 			new WooCommerce\Facebook\WPMLInjector();
@@ -244,9 +253,9 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 			$this->whatsapp_connection_handler = new WooCommerce\Facebook\Handlers\WhatsAppConnection( $this );
 			new WooCommerce\Facebook\Handlers\WhatsAppExtension();
 			new WooCommerce\Facebook\Handlers\MetaExtension();
-			$this->webhook_handler          = new WooCommerce\Facebook\Handlers\WebHook();
-			$this->tracker                  = new WooCommerce\Facebook\Utilities\Tracker();
-			$this->rollout_switches         = new WooCommerce\Facebook\RolloutSwitches( $this );
+			$this->webhook_handler  = new WooCommerce\Facebook\Handlers\WebHook();
+			$this->tracker          = new WooCommerce\Facebook\Utilities\Tracker();
+			$this->rollout_switches = new WooCommerce\Facebook\RolloutSwitches( $this );
 
 			// Init jobs
 			$this->job_manager = new WooCommerce\Facebook\Jobs\JobManager();
@@ -525,6 +534,17 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	}
 
 	/**
+	 * Gets the signals handler.
+	 *
+	 * @since 3.6.0
+	 *
+	 * @return WooCommerce\Facebook\Signals
+	 */
+	public function get_signals_handler() {
+		return $this->signals;
+	}
+
+	/**
 	 * Gets the connection handler.
 	 *
 	 * @since 2.0.0
@@ -740,7 +760,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	 */
 	public function is_plugin_settings() {
 		$page_value = Helper::get_requested_value( 'page' );
-		return is_admin() && in_array( $page_value, [ WooCommerce\Facebook\Admin\Settings::PAGE_ID, WooCommerce\Facebook\Admin\WhatsApp_Integration_Settings::PAGE_ID ] );
+		return is_admin() && in_array( $page_value, [ WooCommerce\Facebook\Admin\Settings::PAGE_ID, WooCommerce\Facebook\Admin\WhatsApp_Integration_Settings::PAGE_ID ], true );
 	}
 
 	/** Utility methods *******************************************************************************************/

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -143,13 +143,31 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 				$param_builder = self::get_param_builder();
 
-				// When signals are held, still run ParamBuilder to capture fbclid for
-				// attribution, but skip setting cookies until signals are released.
+				// When signals are held, still run ParamBuilder so it can generate
+				// attribution IDs, but do not write cookies until signals are released.
 				if ( FacebookSignalsState::is_held() ) {
+					$fbc    = $param_builder->getFbc();
+					$fbp    = $param_builder->getFbp();
 					$fbclid = isset( $_GET['fbclid'] ) ? sanitize_text_field( wp_unslash( $_GET['fbclid'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+					if ( ! empty( $fbc ) ) {
+						FacebookSignalsState::set_attribution_data( 'fbc', $fbc );
+					}
+					if ( ! empty( $fbp ) ) {
+						FacebookSignalsState::set_attribution_data( 'fbp', $fbp );
+					}
 					if ( ! empty( $fbclid ) ) {
 						FacebookSignalsState::set_attribution_data( 'fbclid', $fbclid );
 					}
+
+					foreach ( $param_builder->getCookiesToSet() as $cookie ) {
+						if ( '_fbp' === $cookie->name ) {
+							FacebookSignalsState::set_attribution_data( 'fbp_domain', $cookie->domain );
+						} elseif ( '_fbc' === $cookie->name ) {
+							FacebookSignalsState::set_attribution_data( 'fbc_domain', $cookie->domain );
+						}
+					}
+
 					return;
 				}
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -9,6 +9,7 @@
  */
 
 use WooCommerce\Facebook\Events\Event;
+use WooCommerce\Facebook\Events\FacebookSignalsState;
 use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
 use WooCommerce\Facebook\Framework\Helper;
 use WooCommerce\Facebook\Framework\Logger;
@@ -102,11 +103,12 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		public static function get_param_builder() {
 			if ( null === self::$param_builder ) {
 				try {
-					$site_url = get_site_url();
+					$site_url            = get_site_url();
 					self::$param_builder = new \FacebookAds\ParamBuilder( array( $site_url ) );
 
 					self::$param_builder->processRequest(
 						$site_url,
+						// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Param builder intentionally inspects current request query parameters.
 						$_GET,
 						$_COOKIE,
 						isset( $_SERVER['HTTP_REFERER'] ) ?
@@ -118,9 +120,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 						'Error initializing CAPI Parameter Builder: ' . $exception->getMessage(),
 						array(),
 						array(
-							'should_send_log_to_meta'        => true,
+							'should_send_log_to_meta' => true,
 							'should_save_log_in_woocommerce' => true,
-							'woocommerce_log_level'          => \WC_Log_Levels::ERROR,
+							'woocommerce_log_level'   => \WC_Log_Levels::ERROR,
 						)
 					);
 				}
@@ -139,7 +141,19 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 					return;
 				}
 
-				$cookie_to_set = self::get_param_builder()->getCookiesToSet();
+				$param_builder = self::get_param_builder();
+
+				// When signals are held, still run ParamBuilder to capture fbclid for
+				// attribution, but skip setting cookies until signals are released.
+				if ( FacebookSignalsState::is_held() ) {
+					$fbclid = isset( $_GET['fbclid'] ) ? sanitize_text_field( wp_unslash( $_GET['fbclid'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+					if ( ! empty( $fbclid ) ) {
+						FacebookSignalsState::set_attribution_data( 'fbclid', $fbclid );
+					}
+					return;
+				}
+
+				$cookie_to_set = $param_builder->getCookiesToSet();
 
 				if ( ! headers_sent() ) {
 					foreach ( $cookie_to_set as $cookie ) {
@@ -285,13 +299,13 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				return;
 			}
 
-			wp_enqueue_script(
-				'facebook-capi-param-builder',
-				self::CAPI_PARAM_BUILDER_JS_URL,
-				array(),
-				null,
-				true
-			);
+				wp_enqueue_script(
+					'facebook-capi-param-builder',
+					self::CAPI_PARAM_BUILDER_JS_URL,
+					array(),
+					\WC_Facebookcommerce::PLUGIN_VERSION,
+					true
+				);
 			// Add inline script that executes after the external script has loaded
 			wp_add_inline_script(
 				'facebook-capi-param-builder',
@@ -786,7 +800,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			// Store pending pixel event for WooCommerce Blocks Store API
 			// Reuse custom_data and add event_id for deduplication
-			$pending_pixel_params = array_merge( $custom_data, array( 'event_id' => $event->get_id() ) );
+			$pending_pixel_params                = array_merge( $custom_data, array( 'event_id' => $event->get_id() ) );
 			$this->pending_store_api_pixel_event = array(
 				'event'  => 'AddToCart',
 				'params' => $pending_pixel_params,
@@ -965,7 +979,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function get_store_api_pixel_event_data() {
 			if ( ! empty( $this->pending_store_api_pixel_event ) ) {
-				$pending_event = $this->pending_store_api_pixel_event;
+				$pending_event                       = $this->pending_store_api_pixel_event;
 				$this->pending_store_api_pixel_event = null;
 				return $pending_event;
 			}
@@ -1071,17 +1085,12 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function inject_purchase_event( $order_id ) {
 
-			if ( \WC_Facebookcommerce_Utils::is_admin_user() ) {
+			if ( \WC_Facebookcommerce_Utils::is_admin_user() || ! $this->is_pixel_enabled() ) {
 				return;
 			}
 
-			$event_name = 'Purchase';
-
+			$event_name                  = 'Purchase';
 			$valid_purchase_order_states = array( 'processing', 'completed', 'on-hold', 'pending' );
-
-			if ( ! $this->is_pixel_enabled() ) {
-				return;
-			}
 
 			$order = wc_get_order( $order_id );
 
@@ -1103,8 +1112,6 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			// Get the status of the order to ensure we track the actual purchases and not the ones that have a failed payment.
 			$order_state = $order->get_status();
-
-			// Return if this Purchase event order state is invalid.
 			if ( ! in_array( $order_state, $valid_purchase_order_states, true ) ) {
 				return;
 			}
@@ -1171,14 +1178,13 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 						$content_type = 'product_group';
 					}
 
-					$quantity = $item->get_quantity();
+					$quantity   = $item->get_quantity();
 					$products[] = array(
 						'product' => $product,
-						'qty' => $quantity,
+						'qty'     => $quantity,
 					);
 
-					$content  = new \stdClass();
-
+					$content           = new \stdClass();
 					$content->id       = \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product );
 					$content->quantity = $quantity;
 
@@ -1251,24 +1257,24 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				// TODO consider 'StartTrial' event for free trial Subscriptions, which is the same as here (minus sign_up_fee) and tracks "when a person starts a free trial of a product or service" {FN 2020-03-20}
 				$event_name = 'Subscribe';
 
-				// TODO consider including (int|float) 'predicted_ltv': "Predicted lifetime value of a subscriber as defined by the advertiser and expressed as an exact value." {FN 2020-03-20}
-				$event_data = array(
-					'event_name'  => $event_name,
-					'custom_data' => array(
-						'sign_up_fee' => $subscription->get_sign_up_fee(),
-						'value'       => $subscription->get_total(),
-						'currency'    => ( method_exists( $subscription, 'get_currency' ) ? $subscription->get_currency() : get_woocommerce_currency() ),
-					),
-					'user_data'   => $this->pixel->get_user_info(),
-				);
+					// TODO: consider adding predicted_ltv for subscription events.
+					$event_data = array(
+						'event_name'  => $event_name,
+						'custom_data' => array(
+							'sign_up_fee' => $subscription->get_sign_up_fee(),
+							'value'       => $subscription->get_total(),
+							'currency'    => ( method_exists( $subscription, 'get_currency' ) ? $subscription->get_currency() : get_woocommerce_currency() ),
+						),
+						'user_data'   => $this->pixel->get_user_info(),
+					);
 
-				$event = new Event( $event_data );
+					$event = new Event( $event_data );
 
-				$this->send_api_event( $event );
+					$this->send_api_event( $event );
 
-				$event_data['event_id'] = $event->get_id();
+					$event_data['event_id'] = $event->get_id();
 
-				$this->pixel->inject_event( $event_name, $event_data );
+					$this->pixel->inject_event( $event_name, $event_data );
 			}
 		}
 
@@ -1300,6 +1306,12 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		protected function send_api_event( Event $event, bool $send_now = true ) {
 			$this->tracked_events[] = $event;
+
+			// Skip CAPI sends for frontend requests while signals are held.
+			// Backend/cron events (e.g. admin order status changes) still fire.
+			if ( FacebookSignalsState::is_held() && ! is_admin() && ! wp_doing_cron() ) {
+				return;
+			}
 
 			if ( $send_now ) {
 				try {
@@ -1459,15 +1471,15 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		}
 
 		/**
-		 * Checks the value, if it's not null, updates the array at array_key with value
+		 * Checks the value, if it's not null, updates the target array entry.
 		 *
-		 * @param mixed  $value
-		 * @param array  $array
-		 * @param string $array_key
+		 * @param mixed  $value        Value to set when not empty.
+		 * @param array  $target_array Target array to update.
+		 * @param string $array_key    Target array key.
 		 */
-		private static function update_array_if_not_null( $value, &$array, $array_key ) {
+		private static function update_array_if_not_null( $value, &$target_array, $array_key ) {
 			if ( ! empty( $value ) ) {
-				$array[ $array_key ] = $value;
+				$target_array[ $array_key ] = $value;
 			}
 		}
 
@@ -1493,6 +1505,11 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 * Send pending events.
 		 */
 		public function send_pending_events() {
+
+			// Don't batch-send pending events while signals are held.
+			if ( FacebookSignalsState::is_held() && ! is_admin() && ! wp_doing_cron() ) {
+				return;
+			}
 
 			$pending_events = $this->get_pending_events();
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -299,13 +299,13 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				return;
 			}
 
-				wp_enqueue_script(
-					'facebook-capi-param-builder',
-					self::CAPI_PARAM_BUILDER_JS_URL,
-					array(),
-					\WC_Facebookcommerce::PLUGIN_VERSION,
-					true
-				);
+			wp_enqueue_script(
+				'facebook-capi-param-builder',
+				self::CAPI_PARAM_BUILDER_JS_URL,
+				array(),
+				\WC_Facebookcommerce::PLUGIN_VERSION,
+				true
+			);
 			// Add inline script that executes after the external script has loaded
 			wp_add_inline_script(
 				'facebook-capi-param-builder',

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -146,18 +146,14 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				// When signals are held, still run ParamBuilder so it can generate
 				// attribution IDs, but do not write cookies until signals are released.
 				if ( FacebookSignalsState::is_held() ) {
-					$fbc    = $param_builder->getFbc();
-					$fbp    = $param_builder->getFbp();
-					$fbclid = isset( $_GET['fbclid'] ) ? sanitize_text_field( wp_unslash( $_GET['fbclid'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+					$fbc = $param_builder->getFbc();
+					$fbp = $param_builder->getFbp();
 
 					if ( ! empty( $fbc ) ) {
 						FacebookSignalsState::set_attribution_data( 'fbc', $fbc );
 					}
 					if ( ! empty( $fbp ) ) {
 						FacebookSignalsState::set_attribution_data( 'fbp', $fbp );
-					}
-					if ( ! empty( $fbclid ) ) {
-						FacebookSignalsState::set_attribution_data( 'fbclid', $fbclid );
 					}
 
 					foreach ( $param_builder->getCookiesToSet() as $cookie ) {

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -1310,6 +1310,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			// Skip CAPI sends for frontend requests while signals are held.
 			// Backend/cron events (e.g. admin order status changes) still fire.
 			if ( FacebookSignalsState::is_held() && ! is_admin() && ! wp_doing_cron() ) {
+				FacebookSignalsState::queue_event( $event );
 				return;
 			}
 

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -9,6 +9,7 @@
  */
 
 use WooCommerce\Facebook\Events\Event;
+use WooCommerce\Facebook\Events\FacebookSignalsState;
 
 /**
  * Class WC_Facebookcommerce_Pixel
@@ -335,6 +336,8 @@ class WC_Facebookcommerce_Pixel {
 
 		ob_start();
 
+		$is_held = FacebookSignalsState::is_held();
+
 		?>
 			<script <?php echo self::get_script_attributes(); ?>>
 				!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
@@ -346,7 +349,25 @@ class WC_Facebookcommerce_Pixel {
 			<!-- WooCommerce Facebook Integration Begin -->
 			<script <?php echo self::get_script_attributes(); ?>>
 
+				<?php echo self::get_facebook_signals_js(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+
+				<?php if ( $is_held ) : ?>
+				fbq('consent', 'revoke');
+				<?php endif; ?>
+
 				<?php echo $this->get_pixel_init_code(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+
+				<?php if ( $is_held ) : ?>
+				FacebookSignals.init({
+					held: true,
+					ajaxUrl: <?php echo wp_json_encode( admin_url( 'admin-ajax.php' ) ); ?>,
+					nonce: <?php echo wp_json_encode( wp_create_nonce( 'facebook_release_signals' ) ); ?>,
+					action: 'facebook_release_signals',
+					pixelId: <?php echo wp_json_encode( self::get_pixel_id() ); ?>
+				});
+				<?php else : ?>
+				FacebookSignals.init({ held: false });
+				<?php endif; ?>
 
 				document.addEventListener( 'DOMContentLoaded', function() {
 					// Insert placeholder for events injected when a product is added to the cart through AJAX.
@@ -393,6 +414,162 @@ class WC_Facebookcommerce_Pixel {
 			<?php
 
 			return ob_get_clean();
+	}
+
+
+	/**
+	 * Gets the inline FacebookSignals JS API definition.
+	 *
+	 * @since 3.6.0
+	 *
+	 * @return string JavaScript code defining window.FacebookSignals.
+	 */
+	private static function get_facebook_signals_js() {
+		// phpcs:disable
+		return <<<'JS'
+window.FacebookSignals = window.FacebookSignals || {
+	_held: false,
+	_queue: [],
+	_config: {},
+	_fbclid: (function() {
+		try {
+			var m = window.location.search.match(/[?&]fbclid=([^&]*)/);
+			return m ? decodeURIComponent(m[1]) : null;
+		} catch(e) { return null; }
+	})(),
+
+	init: function(config) {
+		this._config = config || {};
+		this._held = !!config.held;
+	},
+
+	queueEvent: function(eventData) {
+		if (!eventData || !eventData.event_name) return;
+		eventData.event_time = eventData.event_time || Math.floor(Date.now() / 1000);
+		this._queue.push(eventData);
+	},
+
+	trackEvent: function(name, params, userData) {
+		if (this._held) {
+			this.queueEvent({
+				event_name: name,
+				custom_data: params || {},
+				user_data: userData || {},
+				event_id: (params && params.eventID) || null,
+				event_time: Math.floor(Date.now() / 1000)
+			});
+		} else {
+			if (params && params.eventID) {
+				fbq('track', name, params, { eventID: params.eventID });
+			} else {
+				fbq('track', name, params);
+			}
+		}
+	},
+
+	release: function() {
+		var self = this;
+		if (!self._held || !self._config.ajaxUrl) {
+			return Promise.resolve({ success: true, data: { sent_count: 0 } });
+		}
+
+		var payload = JSON.stringify({
+			security: self._config.nonce,
+			events: self._queue,
+			fbclid: self._fbclid
+		});
+
+		// Pass action as a query parameter so WordPress can route the request.
+		var url = self._config.ajaxUrl +
+			(self._config.ajaxUrl.indexOf('?') === -1 ? '?' : '&') +
+			'action=' + encodeURIComponent(self._config.action);
+
+		return new Promise(function(resolve, reject) {
+			var xhr = new XMLHttpRequest();
+			xhr.open('POST', url, true);
+			xhr.setRequestHeader('Content-Type', 'application/json');
+			xhr.onload = function() {
+				if (xhr.status >= 200 && xhr.status < 300) {
+						try {
+							var resp = JSON.parse(xhr.responseText);
+							self._handleReleaseResponse(resp.data || {});
+							resolve(resp);
+						} catch(e) { reject(e); }
+					} else {
+						reject(new Error('Signal release AJAX failed: ' + xhr.status));
+					}
+				};
+			xhr.onerror = function() { reject(new Error('Network error')); };
+			xhr.send(payload);
+		});
+	},
+
+	_handleReleaseResponse: function(data) {
+		// Set attribution cookies from backend response, using the same domain
+		// that the PHP param_builder_server_setup() uses so both paths produce
+		// a single cookie with consistent scoping (e.g. '.example.com').
+		var domainAttr = data.fbp_domain ? ';domain=' + data.fbp_domain : '';
+		if (data.fbp) {
+			document.cookie = '_fbp=' + data.fbp + ';path=/;max-age=7776000' + domainAttr + ';SameSite=Lax';
+		}
+		if (data.fbc) {
+			document.cookie = '_fbc=' + data.fbc + ';path=/;max-age=7776000' + domainAttr + ';SameSite=Lax';
+		}
+
+		// Re-enable the browser signal path so fbevents.js starts firing.
+		fbq('consent', 'grant');
+
+		// Replay queued events via the pixel.
+		var queue = this._queue;
+		for (var i = 0; i < queue.length; i++) {
+			var ev = queue[i];
+			if (ev.event_id) {
+				fbq('track', ev.event_name, ev.custom_data || {}, { eventID: ev.event_id });
+			} else {
+				fbq('track', ev.event_name, ev.custom_data || {});
+			}
+		}
+
+		// Clear the queue and mark signals as active again.
+		this._queue = [];
+		this._held = false;
+	}
+};
+JS;
+		// phpcs:enable
+	}
+
+
+	/**
+	 * Gets JS code that queues an event via FacebookSignals while signals are held.
+	 *
+	 * Captures PII at event-generation time so it's included when events are replayed.
+	 *
+	 * @since 3.6.0
+	 *
+	 * @param string $event_name The event name.
+	 * @param array  $params     Event parameters including custom_data, user_data, event_id.
+	 * @return string JavaScript code.
+	 */
+	public function get_queued_event_code( $event_name, $params ) {
+		$this->last_event = $event_name;
+
+		$queue_data = array(
+			'event_name'  => $event_name,
+			'custom_data' => isset( $params['custom_data'] ) ? $params['custom_data'] : $params,
+			'event_id'    => isset( $params['event_id'] ) ? $params['event_id'] : null,
+			'event_time'  => time(),
+		);
+
+		if ( isset( $params['user_data'] ) ) {
+			$queue_data['user_data'] = $params['user_data'];
+		}
+
+		return sprintf(
+			"/* %s Facebook Integration Event Queueing */\nFacebookSignals.queueEvent(%s);",
+			\WC_Facebookcommerce_Utils::get_integration_name(),
+			wp_json_encode( $queue_data )
+		);
 	}
 
 
@@ -453,7 +630,13 @@ class WC_Facebookcommerce_Pixel {
 		?>
 			<!-- Facebook Pixel Event Code -->
 			<script <?php echo self::get_script_attributes(); ?>>
-			<?php echo $this->get_event_code( $event_name, $params, $method ); ?>
+			<?php
+			if ( FacebookSignalsState::is_held() ) {
+				echo $this->get_queued_event_code( $event_name, $params ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			} else {
+				echo $this->get_event_code( $event_name, $params, $method ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			}
+			?>
 			</script>
 			<!-- End Facebook Pixel Event Code -->
 			<?php
@@ -479,8 +662,20 @@ class WC_Facebookcommerce_Pixel {
 	 * phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 	 */
 	public function inject_event( $event_name, $params, $method = 'track' ) {
-		// Note: We will be adding a consent mechanism that checks user consent
-		// before inject_event() is called.
+		// When signals are held, queue events in the browser instead of firing them.
+		if ( FacebookSignalsState::is_held() ) {
+			$code = $this->get_queued_event_code( $event_name, $params );
+			if ( WC_Facebookcommerce_Utils::is_woocommerce_integration() ) {
+				WC_Facebookcommerce_Utils::enqueue_inline_js( $code );
+			} else {
+				printf(
+					'<!-- Facebook Pixel Event Code --><script %s>%s</script><!-- End Facebook Pixel Event Code -->',
+					self::get_script_attributes(), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					$code // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				);
+			}
+			return;
+		}
 		if ( WC_Facebookcommerce_Utils::is_woocommerce_integration() ) {
 			// Check rollout switch for isolated pixel execution.
 			// When enabled, pixel events are output via external JS file (wp_localize_script)
@@ -497,7 +692,7 @@ class WC_Facebookcommerce_Pixel {
 			if ( $is_isolated_pixel_execution_enabled ) {
 				// Isolated execution: Use external JS via wp_localize_script.
 				// Set last_event here since we don't call get_event_code() in this path.
-				$this->last_event = $event_name;
+				$this->last_event                                      = $event_name;
 				[ 'params' => $event_params, 'event_id' => $event_id ] = self::prepare_event_params( $params, $event_name );
 
 				if ( $is_deferred ) {
@@ -540,8 +735,29 @@ class WC_Facebookcommerce_Pixel {
 		 */
 	public function get_conditional_event_script( $event_name, $params, $listener, $jsonified_pii ) {
 
-		$code             = self::build_event( $event_name, $params, 'track' );
 		$this->last_event = $event_name;
+
+		// When signals are held, use FacebookSignals.trackEvent() to queue the event.
+		if ( FacebookSignalsState::is_held() ) {
+			$user_data_js = $jsonified_pii ? $jsonified_pii : '{}';
+			ob_start();
+			?>
+			<!-- Facebook Pixel Event Code -->
+			<script <?php echo self::get_script_attributes(); ?>>
+				document.addEventListener( '<?php echo esc_js( $listener ); ?>', function (event) {
+					FacebookSignals.trackEvent(
+						<?php echo wp_json_encode( $event_name ); ?>,
+						<?php echo wp_json_encode( $params ); ?>,
+						<?php echo $user_data_js; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					);
+				}, false );
+			</script>
+			<!-- End Facebook Pixel Event Code -->
+			<?php
+			return ob_get_clean();
+		}
+
+		$code = self::build_event( $event_name, $params, 'track' );
 
 		/**
 		 * TODO: use the settings stored by {@see \WC_Facebookcommerce_Integration}.
@@ -604,6 +820,24 @@ class WC_Facebookcommerce_Pixel {
 		 * phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 		 */
 	public function get_conditional_one_time_event_script( $event_name, $params, $listened_event ) {
+
+		// When signals are held, queue via FacebookSignals.trackEvent().
+		if ( FacebookSignalsState::is_held() ) {
+			$this->last_event = $event_name;
+			ob_start();
+			?>
+			<!-- Facebook Pixel Event Code -->
+			<script <?php echo self::get_script_attributes(); ?>>
+				function handle<?php echo $event_name; ?>Event() {
+					FacebookSignals.trackEvent(<?php echo wp_json_encode( $event_name ); ?>, <?php echo wp_json_encode( $params ); ?>);
+					jQuery( document.body ).off( '<?php echo esc_js( $listened_event ); ?>', handle<?php echo $event_name; ?>Event );
+				}
+				jQuery( document.body ).one( '<?php echo esc_js( $listened_event ); ?>', handle<?php echo $event_name; ?>Event );
+			</script>
+			<!-- End Facebook Pixel Event Code -->
+			<?php
+			return ob_get_clean();
+		}
 
 		$code = $this->get_event_code( $event_name, $params );
 

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -367,7 +367,6 @@ class WC_Facebookcommerce_Pixel {
 					attribution: {
 						fbp: <?php echo wp_json_encode( FacebookSignalsState::get_attribution_data( 'fbp' ) ); ?>,
 						fbc: <?php echo wp_json_encode( FacebookSignalsState::get_attribution_data( 'fbc' ) ); ?>,
-						fbclid: <?php echo wp_json_encode( FacebookSignalsState::get_attribution_data( 'fbclid' ) ); ?>,
 						fbpDomain: <?php echo wp_json_encode( FacebookSignalsState::get_attribution_data( 'fbp_domain' ) ); ?>,
 						fbcDomain: <?php echo wp_json_encode( FacebookSignalsState::get_attribution_data( 'fbc_domain' ) ); ?>
 					}
@@ -452,7 +451,7 @@ window.FacebookSignals = window.FacebookSignals || {
 		this._config = config;
 		this._attribution = config.attribution || {};
 		this._held = !!config.held;
-		this._fbclid = this._fbclid || this._attribution.fbclid || null;
+		this._fbclid = this._fbclid || null;
 
 		try {
 			var raw = window.sessionStorage.getItem('wc_facebook_signals_seen_event_ids');
@@ -507,11 +506,9 @@ window.FacebookSignals = window.FacebookSignals || {
 		var payload = JSON.stringify({
 			security: self._config.nonce,
 			events: self._queue,
-			fbclid: self._fbclid,
 			attribution: {
 				fbp: self._attribution.fbp || null,
-				fbc: self._attribution.fbc || null,
-				fbclid: self._fbclid || self._attribution.fbclid || null
+				fbc: self._attribution.fbc || null
 			}
 		});
 

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -431,6 +431,7 @@ window.FacebookSignals = window.FacebookSignals || {
 	_held: false,
 	_queue: [],
 	_config: {},
+	_seenEventIds: {},
 	_fbclid: (function() {
 		try {
 			var m = window.location.search.match(/[?&]fbclid=([^&]*)/);
@@ -441,12 +442,31 @@ window.FacebookSignals = window.FacebookSignals || {
 	init: function(config) {
 		this._config = config || {};
 		this._held = !!config.held;
+
+		try {
+			var raw = window.sessionStorage.getItem('wc_facebook_signals_seen_event_ids');
+			this._seenEventIds = raw ? JSON.parse(raw) : {};
+		} catch (e) {
+			this._seenEventIds = this._seenEventIds || {};
+		}
 	},
 
 	queueEvent: function(eventData) {
 		if (!eventData || !eventData.event_name) return;
+		if (eventData.event_id && this._seenEventIds[eventData.event_id]) return;
+
 		eventData.event_time = eventData.event_time || Math.floor(Date.now() / 1000);
 		this._queue.push(eventData);
+
+		if (eventData.event_id) {
+			this._seenEventIds[eventData.event_id] = 1;
+			try {
+				window.sessionStorage.setItem(
+					'wc_facebook_signals_seen_event_ids',
+					JSON.stringify(this._seenEventIds)
+				);
+			} catch (e) {}
+		}
 	},
 
 	trackEvent: function(name, params, userData) {

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -554,15 +554,24 @@ JS;
 	public function get_queued_event_code( $event_name, $params ) {
 		$this->last_event = $event_name;
 
-		$queue_data = array(
-			'event_name'  => $event_name,
-			'custom_data' => isset( $params['custom_data'] ) ? $params['custom_data'] : $params,
-			'event_id'    => isset( $params['event_id'] ) ? $params['event_id'] : null,
-			'event_time'  => time(),
-		);
+		$event_id   = isset( $params['event_id'] ) ? $params['event_id'] : null;
+		$queue_data = ! empty( $event_id ) ? FacebookSignalsState::get_queued_event( $event_id ) : null;
 
-		if ( isset( $params['user_data'] ) ) {
-			$queue_data['user_data'] = $params['user_data'];
+		if ( ! is_array( $queue_data ) ) {
+			$queue_data = array(
+				'event_name'  => $event_name,
+				'custom_data' => isset( $params['custom_data'] ) ? $params['custom_data'] : $params,
+				'event_id'    => $event_id,
+				'event_time'  => time(),
+			);
+
+			if ( isset( $params['user_data'] ) ) {
+				$queue_data['user_data'] = $params['user_data'];
+			}
+		}
+
+		if ( empty( $queue_data['event_name'] ) ) {
+			$queue_data['event_name'] = $event_name;
 		}
 
 		return sprintf(

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -363,7 +363,14 @@ class WC_Facebookcommerce_Pixel {
 					ajaxUrl: <?php echo wp_json_encode( admin_url( 'admin-ajax.php' ) ); ?>,
 					nonce: <?php echo wp_json_encode( wp_create_nonce( 'facebook_release_signals' ) ); ?>,
 					action: 'facebook_release_signals',
-					pixelId: <?php echo wp_json_encode( self::get_pixel_id() ); ?>
+					pixelId: <?php echo wp_json_encode( self::get_pixel_id() ); ?>,
+					attribution: {
+						fbp: <?php echo wp_json_encode( FacebookSignalsState::get_attribution_data( 'fbp' ) ); ?>,
+						fbc: <?php echo wp_json_encode( FacebookSignalsState::get_attribution_data( 'fbc' ) ); ?>,
+						fbclid: <?php echo wp_json_encode( FacebookSignalsState::get_attribution_data( 'fbclid' ) ); ?>,
+						fbpDomain: <?php echo wp_json_encode( FacebookSignalsState::get_attribution_data( 'fbp_domain' ) ); ?>,
+						fbcDomain: <?php echo wp_json_encode( FacebookSignalsState::get_attribution_data( 'fbc_domain' ) ); ?>
+					}
 				});
 				<?php else : ?>
 				FacebookSignals.init({ held: false });
@@ -431,6 +438,7 @@ window.FacebookSignals = window.FacebookSignals || {
 	_held: false,
 	_queue: [],
 	_config: {},
+	_attribution: {},
 	_seenEventIds: {},
 	_fbclid: (function() {
 		try {
@@ -440,8 +448,11 @@ window.FacebookSignals = window.FacebookSignals || {
 	})(),
 
 	init: function(config) {
-		this._config = config || {};
+		config = config || {};
+		this._config = config;
+		this._attribution = config.attribution || {};
 		this._held = !!config.held;
+		this._fbclid = this._fbclid || this._attribution.fbclid || null;
 
 		try {
 			var raw = window.sessionStorage.getItem('wc_facebook_signals_seen_event_ids');
@@ -496,7 +507,12 @@ window.FacebookSignals = window.FacebookSignals || {
 		var payload = JSON.stringify({
 			security: self._config.nonce,
 			events: self._queue,
-			fbclid: self._fbclid
+			fbclid: self._fbclid,
+			attribution: {
+				fbp: self._attribution.fbp || null,
+				fbc: self._attribution.fbc || null,
+				fbclid: self._fbclid || self._attribution.fbclid || null
+			}
 		});
 
 		// Pass action as a query parameter so WordPress can route the request.
@@ -525,16 +541,7 @@ window.FacebookSignals = window.FacebookSignals || {
 	},
 
 	_handleReleaseResponse: function(data) {
-		// Set attribution cookies from backend response, using the same domain
-		// that the PHP param_builder_server_setup() uses so both paths produce
-		// a single cookie with consistent scoping (e.g. '.example.com').
-		var domainAttr = data.fbp_domain ? ';domain=' + data.fbp_domain : '';
-		if (data.fbp) {
-			document.cookie = '_fbp=' + data.fbp + ';path=/;max-age=7776000' + domainAttr + ';SameSite=Lax';
-		}
-		if (data.fbc) {
-			document.cookie = '_fbc=' + data.fbc + ';path=/;max-age=7776000' + domainAttr + ';SameSite=Lax';
-		}
+		this._syncAttributionCookies(data || {});
 
 		// Re-enable the browser signal path so fbevents.js starts firing.
 		fbq('consent', 'grant');
@@ -553,6 +560,53 @@ window.FacebookSignals = window.FacebookSignals || {
 		// Clear the queue and mark signals as active again.
 		this._queue = [];
 		this._held = false;
+	},
+
+	_syncAttributionCookies: function(data) {
+		var clientParams = {};
+
+		if (typeof clientParamBuilder !== 'undefined') {
+			try {
+				// Let the client-side ParamBuilder generate/set missing attribution
+				// cookies using its normal domain-scoping logic.
+				clientParams = clientParamBuilder.processAndCollectParams(this._getAttributionUrl()) || {};
+			} catch (e) {}
+		}
+
+		var fbp = data.fbp || clientParams._fbp || (typeof clientParamBuilder !== 'undefined' ? clientParamBuilder.getFbp() : null);
+		var fbc = data.fbc || clientParams._fbc || (typeof clientParamBuilder !== 'undefined' ? clientParamBuilder.getFbc() : null);
+
+		// If the backend supplied exact values used for CAPI, write them so Pixel
+		// replay and CAPI use matching attribution.
+		if (data.fbp) {
+			this._setAttributionCookie('_fbp', fbp, data.fbp_domain || data.cookie_domain || this._attribution.fbpDomain);
+		}
+		if (data.fbc) {
+			this._setAttributionCookie('_fbc', fbc, data.fbc_domain || data.cookie_domain || this._attribution.fbcDomain || this._attribution.fbpDomain);
+		}
+	},
+
+	_setAttributionCookie: function(name, value, domain) {
+		if (!value) return;
+
+		var domainAttr = domain ? ';domain=' + domain : '';
+		document.cookie = name + '=' + encodeURIComponent(value) + ';path=/;max-age=7776000' + domainAttr + ';SameSite=Lax';
+	},
+
+	_getAttributionUrl: function() {
+		if (!this._fbclid) {
+			return window.location.href;
+		}
+
+		try {
+			var url = new URL(window.location.href);
+			if (!url.searchParams.get('fbclid')) {
+				url.searchParams.set('fbclid', this._fbclid);
+			}
+			return url.toString();
+		} catch (e) {
+			return window.location.href;
+		}
 	}
 };
 JS;

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -388,6 +388,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		}
 
 		if ( $this->get_facebook_pixel_id() ) {
+			// Apply the current signal state before EventsTracker initializes.
+			if ( \WooCommerce\Facebook\Signals::should_hold_signals() ) {
+				\WooCommerce\Facebook\Events\FacebookSignalsState::hold();
+			}
+
 			$aam_settings         = $this->load_aam_settings_of_pixel();
 			$user_info            = WC_Facebookcommerce_Utils::get_user_info( $aam_settings );
 			$this->events_tracker = new WC_Facebookcommerce_EventsTracker( $user_info, $aam_settings );
@@ -649,7 +654,8 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			do {
 				$product_item_ids += $response->get_ids();
 				// get up to two additional pages of results
-			} while ( $response = $this->facebook_for_woocommerce->get_api()->next( $response, 2 ) );
+				$response = $this->facebook_for_woocommerce->get_api()->next( $response, 2 );
+			} while ( $response );
 		} catch ( ApiException $e ) {
 			$message = sprintf( 'Meta APIs thrown APIException while fetching the Product Items in the Product Group %s: %s', $product_group_id, $e->getMessage() );
 			Logger::log(
@@ -743,7 +749,8 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			'wc_facebook_infobanner_jsx',
 			$this->facebook_for_woocommerce->get_asset_build_dir_url() . '/admin/infobanner.js',
 			array(),
-			\WC_Facebookcommerce::PLUGIN_VERSION
+			\WC_Facebookcommerce::PLUGIN_VERSION,
+			true
 		);
 		wp_localize_script( 'wc_facebook_infobanner_jsx', 'wc_facebook_infobanner_jsx', $ajax_data );
 
@@ -1541,7 +1548,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				);
 
 				// Check if currently processed variation exist in the catalog.
-				if ( ! in_array( $fb_retailer_id, $existing_catalog_variations_retailer_ids ) ) {
+				if ( ! in_array( $fb_retailer_id, $existing_catalog_variations_retailer_ids, true ) ) {
 					continue;
 				}
 
@@ -2057,18 +2064,18 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			$woo_product  = new WC_Facebook_Product( $post_id );
 			$product_data = $woo_product->prepare_product();
 
-			$feed_item = array(
-				'title'        => strip_tags( $product_data['name'] ),
-				'availability' => $woo_product->is_in_stock() ? 'in stock' :
-					'out of stock',
-				'description'  => strip_tags( $product_data['description'] ),
-				'id'           => $product_data['retailer_id'],
-				'image_link'   => $product_data['image_url'],
-				'brand'        => Helper::str_truncate( wp_strip_all_tags( WC_Facebookcommerce_Utils::get_store_name() ), 100 ),
-				'link'         => $product_data['url'],
-				'price'        => $product_data['price'] . ' ' . get_woocommerce_currency(),
-			);
-			array_push( $items, $feed_item );
+				$feed_item = array(
+					'title'        => wp_strip_all_tags( $product_data['name'] ),
+					'availability' => $woo_product->is_in_stock() ? 'in stock' :
+						'out of stock',
+					'description'  => wp_strip_all_tags( $product_data['description'] ),
+					'id'           => $product_data['retailer_id'],
+					'image_link'   => $product_data['image_url'],
+					'brand'        => Helper::str_truncate( wp_strip_all_tags( WC_Facebookcommerce_Utils::get_store_name() ), 100 ),
+					'link'         => $product_data['url'],
+					'price'        => $product_data['price'] . ' ' . get_woocommerce_currency(),
+				);
+				array_push( $items, $feed_item );
 		}
 		// https://codex.wordpress.org/Function_Reference/wp_reset_postdata
 		wp_reset_postdata();
@@ -3177,7 +3184,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			$this->update_fb_visibility( $product, $visibility );
 		}
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- WooCommerce bulk edit verifies the request before this hook fires.
 		if ( ! empty( $_REQUEST['post'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- WooCommerce bulk edit verifies the request before this hook fires.
 			$bulk_product_edit_ids = $_REQUEST['post'];
 		}
 

--- a/includes/API/Pixel/Events/Request.php
+++ b/includes/API/Pixel/Events/Request.php
@@ -51,9 +51,8 @@ class Request extends API\Request {
 	public function get_data() {
 
 		$data = array(
-			'data'            => array(),
-			'partner_agent'   => Event::get_platform_identifier(),
-			'test_event_code' => 'TEST60508', // TODO: Remove before merging — temporary for testing.
+			'data'          => array(),
+			'partner_agent' => Event::get_platform_identifier(),
 		);
 
 		foreach ( $this->events as $event ) {

--- a/includes/API/Pixel/Events/Request.php
+++ b/includes/API/Pixel/Events/Request.php
@@ -53,7 +53,7 @@ class Request extends API\Request {
 		$data = array(
 			'data'            => array(),
 			'partner_agent'   => Event::get_platform_identifier(),
-			'test_event_code' => 'TEST42451', // TODO: Remove before merging — temporary for testing.
+			'test_event_code' => 'TEST60508', // TODO: Remove before merging — temporary for testing.
 		);
 
 		foreach ( $this->events as $event ) {

--- a/includes/API/Pixel/Events/Request.php
+++ b/includes/API/Pixel/Events/Request.php
@@ -51,8 +51,9 @@ class Request extends API\Request {
 	public function get_data() {
 
 		$data = array(
-			'data'          => array(),
-			'partner_agent' => Event::get_platform_identifier(),
+			'data'            => array(),
+			'partner_agent'   => Event::get_platform_identifier(),
+			'test_event_code' => 'TEST42451', // TODO: Remove before merging — temporary for testing.
 		);
 
 		foreach ( $this->events as $event ) {

--- a/includes/Events/FacebookSignalsState.php
+++ b/includes/Events/FacebookSignalsState.php
@@ -25,6 +25,9 @@ class FacebookSignalsState {
 	/** @var bool Whether signals are currently held for this request. */
 	private static $held = false;
 
+	/** @var array<string, array> Queued CAPI events keyed by event ID. */
+	private static $queued_events = array();
+
 	/** @var array Attribution data captured while signals are held (e.g. fbclid). */
 	private static $attribution_data = array();
 
@@ -40,6 +43,30 @@ class FacebookSignalsState {
 	 */
 	public static function release() {
 		self::$held = false;
+	}
+
+	/**
+	 * Queue a CAPI event for release when signals are unheld.
+	 *
+	 * @param Event $event Event to queue.
+	 */
+	public static function queue_event( Event $event ) {
+		$event_id = $event->get_id();
+		if ( empty( $event_id ) ) {
+			return;
+		}
+
+		self::$queued_events[ $event_id ] = $event->get_data();
+	}
+
+	/**
+	 * Get a queued CAPI event by event ID.
+	 *
+	 * @param string $event_id Event ID.
+	 * @return array|null
+	 */
+	public static function get_queued_event( $event_id ) {
+		return isset( self::$queued_events[ $event_id ] ) ? self::$queued_events[ $event_id ] : null;
 	}
 
 	/**

--- a/includes/Events/FacebookSignalsState.php
+++ b/includes/Events/FacebookSignalsState.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace WooCommerce\Facebook\Events;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Static per-request state for held signal delivery.
+ *
+ * When signals are held, frontend events are queued and public-request CAPI
+ * sends are suppressed until those signals are released again.
+ *
+ * @since 3.6.0
+ */
+class FacebookSignalsState {
+
+	/** @var bool Whether signals are currently held for this request. */
+	private static $held = false;
+
+	/** @var array Attribution data captured while signals are held (e.g. fbclid). */
+	private static $attribution_data = array();
+
+	/**
+	 * Hold signals for the current request.
+	 */
+	public static function hold() {
+		self::$held = true;
+	}
+
+	/**
+	 * Release signals for the current request.
+	 */
+	public static function release() {
+		self::$held = false;
+	}
+
+	/**
+	 * Whether signals are currently held.
+	 *
+	 * Exposes a filter so external code can control the held state.
+	 *
+	 * @return bool
+	 */
+	public static function is_held() {
+		/**
+		 * Filters whether Facebook signals are currently held.
+		 *
+		 * @since 3.6.0
+		 *
+		 * @param bool $held Whether signals are held.
+		 */
+		return (bool) apply_filters( 'facebook_signals_held', self::$held );
+	}
+
+	/**
+	 * Store attribution data captured while signals are held.
+	 *
+	 * @param string $key   Data key (e.g. 'fbclid').
+	 * @param string $value Data value.
+	 */
+	public static function set_attribution_data( $key, $value ) {
+		self::$attribution_data[ $key ] = $value;
+	}
+
+	/**
+	 * Retrieve stored attribution data.
+	 *
+	 * @param string $key Data key.
+	 * @return string|null
+	 */
+	public static function get_attribution_data( $key ) {
+		return isset( self::$attribution_data[ $key ] ) ? self::$attribution_data[ $key ] : null;
+	}
+}

--- a/includes/Events/ReleaseSignalsAjax.php
+++ b/includes/Events/ReleaseSignalsAjax.php
@@ -36,6 +36,12 @@ class ReleaseSignalsAjax {
 	/** @var int Maximum age of an event in seconds (30 minutes). */
 	const MAX_EVENT_AGE = 1800;
 
+	/** @var int Default rate-limit window in seconds (5 minutes). */
+	const RATE_LIMIT_WINDOW = 300;
+
+	/** @var int Default maximum accepted events per IP per window. */
+	const RATE_LIMIT_MAX_EVENTS = 80;
+
 	/** @var array Allowed event names. */
 	const ALLOWED_EVENTS = array(
 		'PageView',
@@ -71,6 +77,10 @@ class ReleaseSignalsAjax {
 		$nonce = isset( $body['security'] ) ? sanitize_text_field( $body['security'] ) : '';
 		if ( ! wp_verify_nonce( $nonce, self::NONCE_ACTION ) ) {
 			wp_send_json_error( array( 'message' => 'Invalid nonce.' ), 403 );
+		}
+
+		if ( $this->is_rate_limited() ) {
+			wp_send_json_error( array( 'message' => 'Rate limit exceeded.' ), 429 );
 		}
 
 		$events = isset( $body['events'] ) && is_array( $body['events'] ) ? $body['events'] : array();
@@ -128,6 +138,8 @@ class ReleaseSignalsAjax {
 		}
 
 		if ( ! empty( $valid_events ) ) {
+			$this->record_rate_limit_usage( count( $valid_events ) );
+
 			try {
 				$api->send_pixel_events( $pixel_id, $valid_events );
 				$sent_count = count( $valid_events );
@@ -275,5 +287,63 @@ class ReleaseSignalsAjax {
 		}
 
 		return $server_event_data;
+	}
+
+	/**
+	 * Whether the current client is over its release-events rate limit.
+	 *
+	 * Counts accepted events (not requests) per IP per window. Both the
+	 * window length and the cap are filterable.
+	 *
+	 * @since 3.6.0
+	 *
+	 * @return bool
+	 */
+	private function is_rate_limited() {
+		$max = (int) apply_filters( 'wc_facebook_release_signals_rate_limit_max', self::RATE_LIMIT_MAX_EVENTS );
+
+		if ( $max <= 0 ) {
+			return false;
+		}
+
+		$key   = $this->get_rate_limit_key();
+		$count = (int) get_transient( $key );
+
+		return $count >= $max;
+	}
+
+	/**
+	 * Records that the current client just had N events accepted, for rate-limit accounting.
+	 *
+	 * @since 3.6.0
+	 *
+	 * @param int $accepted_event_count Number of events accepted in this request.
+	 */
+	private function record_rate_limit_usage( $accepted_event_count ) {
+		if ( $accepted_event_count <= 0 ) {
+			return;
+		}
+
+		$window = (int) apply_filters( 'wc_facebook_release_signals_rate_limit_window', self::RATE_LIMIT_WINDOW );
+		if ( $window <= 0 ) {
+			return;
+		}
+
+		$key   = $this->get_rate_limit_key();
+		$count = (int) get_transient( $key );
+
+		set_transient( $key, $count + (int) $accepted_event_count, $window );
+	}
+
+	/**
+	 * Builds a transient key scoped to the requesting client IP.
+	 *
+	 * @since 3.6.0
+	 *
+	 * @return string
+	 */
+	private function get_rate_limit_key() {
+		$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+		return 'wc_fb_release_signals_rl_' . md5( $ip );
 	}
 }

--- a/includes/Events/ReleaseSignalsAjax.php
+++ b/includes/Events/ReleaseSignalsAjax.php
@@ -112,6 +112,7 @@ class ReleaseSignalsAjax {
 			$fbc = 'fb.1.' . time() . '.' . $fbclid;
 		}
 
+		$valid_events = array();
 		foreach ( $events as $event_data ) {
 			if ( ! $this->validate_event( $event_data, $now ) ) {
 				continue;
@@ -123,13 +124,15 @@ class ReleaseSignalsAjax {
 
 			$server_event_data = $this->build_server_event_data( $event_data, $user_data, $fbc, $fbp );
 
-			$event = new Event( $server_event_data );
+			$valid_events[] = new Event( $server_event_data );
+		}
 
+		if ( ! empty( $valid_events ) ) {
 			try {
-				$api->send_pixel_events( $pixel_id, array( $event ) );
-				++$sent_count;
+				$api->send_pixel_events( $pixel_id, $valid_events );
+				$sent_count = count( $valid_events );
 			} catch ( ApiException $e ) {
-				facebook_for_woocommerce()->log( 'Release signals: could not send event: ' . $e->getMessage() );
+				facebook_for_woocommerce()->log( 'Release signals: could not send events: ' . $e->getMessage() );
 			}
 		}
 

--- a/includes/Events/ReleaseSignalsAjax.php
+++ b/includes/Events/ReleaseSignalsAjax.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace WooCommerce\Facebook\Events;
+
+use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * AJAX endpoint for releasing held signals.
+ *
+ * Receives queued browser events and sends them to CAPI, then returns
+ * FBC/FBP attribution values for the frontend to set as cookies.
+ *
+ * @since 3.6.0
+ */
+class ReleaseSignalsAjax {
+
+	/** @var string AJAX action name. */
+	const ACTION = 'facebook_release_signals';
+
+	/** @var string Nonce action. */
+	const NONCE_ACTION = 'facebook_release_signals';
+
+	/** @var int Maximum number of events per request. */
+	const MAX_EVENTS = 20;
+
+	/** @var int Maximum age of an event in seconds (30 minutes). */
+	const MAX_EVENT_AGE = 1800;
+
+	/** @var array Allowed event names. */
+	const ALLOWED_EVENTS = array(
+		'PageView',
+		'ViewContent',
+		'ViewCategory',
+		'Search',
+		'AddToCart',
+		'InitiateCheckout',
+		'Purchase',
+		'Lead',
+		'Subscribe',
+	);
+
+	/**
+	 * Constructor — registers AJAX hooks.
+	 */
+	public function __construct() {
+		add_action( 'wp_ajax_' . self::ACTION, array( $this, 'handle' ) );
+		add_action( 'wp_ajax_nopriv_' . self::ACTION, array( $this, 'handle' ) );
+	}
+
+	/**
+	 * Handles the release-signals AJAX request.
+	 */
+	public function handle() {
+		$raw_body = file_get_contents( 'php://input' );
+		$body     = json_decode( $raw_body, true );
+
+		if ( ! is_array( $body ) ) {
+			wp_send_json_error( array( 'message' => 'Invalid request body.' ), 400 );
+		}
+
+		$nonce = isset( $body['security'] ) ? sanitize_text_field( $body['security'] ) : '';
+		if ( ! wp_verify_nonce( $nonce, self::NONCE_ACTION ) ) {
+			wp_send_json_error( array( 'message' => 'Invalid nonce.' ), 403 );
+		}
+
+		$events = isset( $body['events'] ) && is_array( $body['events'] ) ? $body['events'] : array();
+		$fbclid = isset( $body['fbclid'] ) ? sanitize_text_field( $body['fbclid'] ) : '';
+
+		$events = array_slice( $events, 0, self::MAX_EVENTS );
+
+		$sent_count = 0;
+		$now        = time();
+
+		try {
+			$pixel_id = facebook_for_woocommerce()->get_integration()->get_facebook_pixel_id();
+			$api      = facebook_for_woocommerce()->get_api();
+		} catch ( \Exception $e ) {
+			wp_send_json_error( array( 'message' => 'Plugin not configured.' ), 500 );
+		}
+
+		$fbp        = null;
+		$fbc        = null;
+		$fbp_domain = null;
+
+		try {
+			$param_builder = \WC_Facebookcommerce_EventsTracker::get_param_builder();
+			$fbp           = $param_builder->getFbp();
+			$fbc           = $param_builder->getFbc();
+
+			foreach ( $param_builder->getCookiesToSet() as $cookie ) {
+				if ( '_fbp' === $cookie->name ) {
+					$fbp_domain = $cookie->domain;
+					break;
+				}
+			}
+		// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Attribution is best-effort here.
+		} catch ( \Exception $e ) {
+			// Silently continue — attribution is best-effort.
+		}
+
+		if ( empty( $fbc ) && ! empty( $fbclid ) ) {
+			$fbc = 'fb.1.' . time() . '.' . $fbclid;
+		}
+
+		foreach ( $events as $event_data ) {
+			if ( ! $this->validate_event( $event_data, $now ) ) {
+				continue;
+			}
+
+			$user_data = isset( $event_data['user_data'] ) && is_array( $event_data['user_data'] )
+				? $this->sanitize_user_data( $event_data['user_data'] )
+				: array();
+
+			if ( ! empty( $fbc ) ) {
+				$user_data['click_id'] = $fbc;
+			}
+			if ( ! empty( $fbp ) ) {
+				$user_data['browser_id'] = $fbp;
+			}
+
+			$server_event_data = array(
+				'event_name'  => sanitize_text_field( $event_data['event_name'] ),
+				'custom_data' => isset( $event_data['custom_data'] ) && is_array( $event_data['custom_data'] )
+					? $this->sanitize_custom_data( $event_data['custom_data'] )
+					: array(),
+				'user_data'   => $user_data,
+			);
+
+			if ( ! empty( $event_data['event_id'] ) ) {
+				$server_event_data['event_id'] = sanitize_text_field( $event_data['event_id'] );
+			}
+
+			if ( ! empty( $event_data['event_time'] ) ) {
+				$server_event_data['event_time'] = absint( $event_data['event_time'] );
+			}
+
+			$event = new Event( $server_event_data );
+
+			try {
+				$api->send_pixel_events( $pixel_id, array( $event ) );
+				++$sent_count;
+			} catch ( ApiException $e ) {
+				facebook_for_woocommerce()->log( 'Release signals: could not send event: ' . $e->getMessage() );
+			}
+		}
+
+		wp_send_json_success(
+			array(
+				'fbp'        => $fbp,
+				'fbc'        => $fbc,
+				'fbp_domain' => $fbp_domain,
+				'sent_count' => $sent_count,
+			)
+		);
+	}
+
+	/**
+	 * Validates a single event from the queue.
+	 *
+	 * @param mixed $event_data The event data.
+	 * @param int   $now        Current timestamp.
+	 * @return bool
+	 */
+	private function validate_event( $event_data, $now ) {
+		if ( ! is_array( $event_data ) ) {
+			return false;
+		}
+
+		if ( empty( $event_data['event_name'] ) ) {
+			return false;
+		}
+
+		if ( ! in_array( $event_data['event_name'], self::ALLOWED_EVENTS, true ) ) {
+			return false;
+		}
+
+		if ( ! empty( $event_data['event_time'] ) ) {
+			$event_time = absint( $event_data['event_time'] );
+			if ( ( $now - $event_time ) > self::MAX_EVENT_AGE ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Sanitizes custom data values.
+	 *
+	 * @param array $data Custom data.
+	 * @return array
+	 */
+	private function sanitize_custom_data( $data ) {
+		$sanitized = array();
+		foreach ( $data as $key => $value ) {
+			$key = sanitize_text_field( $key );
+			if ( is_array( $value ) ) {
+				$sanitized[ $key ] = $this->sanitize_custom_data( $value );
+			} elseif ( is_numeric( $value ) ) {
+				$sanitized[ $key ] = $value;
+			} else {
+				$sanitized[ $key ] = sanitize_text_field( $value );
+			}
+		}
+		return $sanitized;
+	}
+
+	/**
+	 * Sanitizes user data values.
+	 *
+	 * @param array $data User data.
+	 * @return array
+	 */
+	private function sanitize_user_data( $data ) {
+		$allowed_keys = array( 'em', 'fn', 'ln', 'ph', 'ct', 'st', 'zp', 'country', 'external_id' );
+		$sanitized    = array();
+		foreach ( $data as $key => $value ) {
+			$key = sanitize_text_field( $key );
+			if ( in_array( $key, $allowed_keys, true ) ) {
+				$sanitized[ $key ] = sanitize_text_field( $value );
+			}
+		}
+		return $sanitized;
+	}
+}

--- a/includes/Events/ReleaseSignalsAjax.php
+++ b/includes/Events/ReleaseSignalsAjax.php
@@ -87,8 +87,6 @@ class ReleaseSignalsAjax {
 
 		$events      = isset( $body['events'] ) && is_array( $body['events'] ) ? $body['events'] : array();
 		$attribution = isset( $body['attribution'] ) && is_array( $body['attribution'] ) ? $body['attribution'] : array();
-		$fbclid      = isset( $body['fbclid'] ) ? sanitize_text_field( $body['fbclid'] ) : '';
-		$fbclid      = ! empty( $fbclid ) ? $fbclid : $this->sanitize_attribution_value( $attribution, 'fbclid' );
 		$fbc         = $this->sanitize_attribution_value( $attribution, 'fbc' );
 		$fbp         = $this->sanitize_attribution_value( $attribution, 'fbp' );
 
@@ -108,12 +106,11 @@ class ReleaseSignalsAjax {
 
 		// Expose held attribution to Event::get_click_id()/get_browser_id(), so
 		// released events use the same attribution path as normal CAPI events.
-		$restore_request_fbclid = $this->temporarily_set_superglobal_value( '_REQUEST', 'fbclid', $fbclid );
-		$restore_cookie_fbc     = $this->temporarily_set_superglobal_value( '_COOKIE', '_fbc', $fbc );
-		$restore_cookie_fbp     = $this->temporarily_set_superglobal_value( '_COOKIE', '_fbp', $fbp );
+		$restore_cookie_fbc = $this->temporarily_set_superglobal_value( '_COOKIE', '_fbc', $fbc );
+		$restore_cookie_fbp = $this->temporarily_set_superglobal_value( '_COOKIE', '_fbp', $fbp );
 
-		// Resolve attribution once via Event so fbc-from-fbclid synthesis and
-		// cookie reads go through the same path as normal CAPI events.
+		// Resolve attribution once via Event so cookie reads go through the same
+		// path as normal CAPI events.
 		$this->resolve_attribution_defaults( $fbc, $fbp );
 
 		$valid_events = array();
@@ -129,7 +126,6 @@ class ReleaseSignalsAjax {
 			$valid_events[] = $this->build_server_event( $event_data, $user_data );
 		}
 
-		$this->restore_superglobal_value( '_REQUEST', 'fbclid', $restore_request_fbclid );
 		$this->restore_superglobal_value( '_COOKIE', '_fbc', $restore_cookie_fbc );
 		$this->restore_superglobal_value( '_COOKIE', '_fbp', $restore_cookie_fbp );
 
@@ -325,8 +321,7 @@ class ReleaseSignalsAjax {
 
 	/**
 	 * Resolves missing fbc/fbp values via Event so released signals share the
-	 * same attribution path (cookies + fbc-from-fbclid synthesis) as normal
-	 * CAPI events.
+	 * same attribution path (cookies) as normal CAPI events.
 	 *
 	 * @param string $fbc Attribution click ID reference.
 	 * @param string $fbp Attribution browser ID reference.

--- a/includes/Events/ReleaseSignalsAjax.php
+++ b/includes/Events/ReleaseSignalsAjax.php
@@ -121,28 +121,7 @@ class ReleaseSignalsAjax {
 				? $this->sanitize_user_data( $event_data['user_data'] )
 				: array();
 
-			if ( ! empty( $fbc ) ) {
-				$user_data['click_id'] = $fbc;
-			}
-			if ( ! empty( $fbp ) ) {
-				$user_data['browser_id'] = $fbp;
-			}
-
-			$server_event_data = array(
-				'event_name'  => sanitize_text_field( $event_data['event_name'] ),
-				'custom_data' => isset( $event_data['custom_data'] ) && is_array( $event_data['custom_data'] )
-					? $this->sanitize_custom_data( $event_data['custom_data'] )
-					: array(),
-				'user_data'   => $user_data,
-			);
-
-			if ( ! empty( $event_data['event_id'] ) ) {
-				$server_event_data['event_id'] = sanitize_text_field( $event_data['event_id'] );
-			}
-
-			if ( ! empty( $event_data['event_time'] ) ) {
-				$server_event_data['event_time'] = absint( $event_data['event_time'] );
-			}
+			$server_event_data = $this->build_server_event_data( $event_data, $user_data, $fbc, $fbp );
 
 			$event = new Event( $server_event_data );
 
@@ -222,7 +201,21 @@ class ReleaseSignalsAjax {
 	 * @return array
 	 */
 	private function sanitize_user_data( $data ) {
-		$allowed_keys = array( 'em', 'fn', 'ln', 'ph', 'ct', 'st', 'zp', 'country', 'external_id' );
+		$allowed_keys = array(
+			'em',
+			'fn',
+			'ln',
+			'ph',
+			'ct',
+			'st',
+			'zp',
+			'country',
+			'external_id',
+			'click_id',
+			'browser_id',
+			'client_ip_address',
+			'client_user_agent',
+		);
 		$sanitized    = array();
 		foreach ( $data as $key => $value ) {
 			$key = sanitize_text_field( $key );
@@ -231,5 +224,53 @@ class ReleaseSignalsAjax {
 			}
 		}
 		return $sanitized;
+	}
+
+	/**
+	 * Builds a sanitized event payload for CAPI delivery.
+	 *
+	 * @param array       $event_data Raw event data from the queue.
+	 * @param array       $user_data Sanitized user data.
+	 * @param string|null $fbc Attribution click ID.
+	 * @param string|null $fbp Attribution browser ID.
+	 * @return array
+	 */
+	private function build_server_event_data( $event_data, $user_data, $fbc, $fbp ) {
+		if ( ! empty( $fbc ) ) {
+			$user_data['click_id'] = $fbc;
+		}
+		if ( ! empty( $fbp ) ) {
+			$user_data['browser_id'] = $fbp;
+		}
+
+		$server_event_data = array(
+			'event_name'  => sanitize_text_field( $event_data['event_name'] ),
+			'custom_data' => isset( $event_data['custom_data'] ) && is_array( $event_data['custom_data'] )
+				? $this->sanitize_custom_data( $event_data['custom_data'] )
+				: array(),
+			'user_data'   => $user_data,
+		);
+
+		if ( ! empty( $event_data['action_source'] ) ) {
+			$server_event_data['action_source'] = sanitize_text_field( $event_data['action_source'] );
+		}
+
+		if ( ! empty( $event_data['event_source_url'] ) ) {
+			$server_event_data['event_source_url'] = esc_url_raw( $event_data['event_source_url'] );
+		}
+
+		if ( ! empty( $event_data['referrer_url'] ) ) {
+			$server_event_data['referrer_url'] = esc_url_raw( $event_data['referrer_url'] );
+		}
+
+		if ( ! empty( $event_data['event_id'] ) ) {
+			$server_event_data['event_id'] = sanitize_text_field( $event_data['event_id'] );
+		}
+
+		if ( ! empty( $event_data['event_time'] ) ) {
+			$server_event_data['event_time'] = absint( $event_data['event_time'] );
+		}
+
+		return $server_event_data;
 	}
 }

--- a/includes/Events/ReleaseSignalsAjax.php
+++ b/includes/Events/ReleaseSignalsAjax.php
@@ -60,6 +60,8 @@ class ReleaseSignalsAjax {
 	 */
 	public function __construct() {
 		add_action( 'wp_ajax_' . self::ACTION, array( $this, 'handle' ) );
+
+		// Signal release must work for guest shoppers as well as logged-in users.
 		add_action( 'wp_ajax_nopriv_' . self::ACTION, array( $this, 'handle' ) );
 	}
 
@@ -83,8 +85,12 @@ class ReleaseSignalsAjax {
 			wp_send_json_error( array( 'message' => 'Rate limit exceeded.' ), 429 );
 		}
 
-		$events = isset( $body['events'] ) && is_array( $body['events'] ) ? $body['events'] : array();
-		$fbclid = isset( $body['fbclid'] ) ? sanitize_text_field( $body['fbclid'] ) : '';
+		$events      = isset( $body['events'] ) && is_array( $body['events'] ) ? $body['events'] : array();
+		$attribution = isset( $body['attribution'] ) && is_array( $body['attribution'] ) ? $body['attribution'] : array();
+		$fbclid      = isset( $body['fbclid'] ) ? sanitize_text_field( $body['fbclid'] ) : '';
+		$fbclid      = ! empty( $fbclid ) ? $fbclid : $this->sanitize_attribution_value( $attribution, 'fbclid' );
+		$fbc         = $this->sanitize_attribution_value( $attribution, 'fbc' );
+		$fbp         = $this->sanitize_attribution_value( $attribution, 'fbp' );
 
 		$events = array_slice( $events, 0, self::MAX_EVENTS );
 
@@ -98,29 +104,17 @@ class ReleaseSignalsAjax {
 			wp_send_json_error( array( 'message' => 'Plugin not configured.' ), 500 );
 		}
 
-		$fbp        = null;
-		$fbc        = null;
-		$fbp_domain = null;
+		$cookie_domains = $this->get_attribution_cookie_domains();
 
-		try {
-			$param_builder = \WC_Facebookcommerce_EventsTracker::get_param_builder();
-			$fbp           = $param_builder->getFbp();
-			$fbc           = $param_builder->getFbc();
+		// Expose held attribution to Event::get_click_id()/get_browser_id(), so
+		// released events use the same attribution path as normal CAPI events.
+		$restore_request_fbclid = $this->temporarily_set_superglobal_value( '_REQUEST', 'fbclid', $fbclid );
+		$restore_cookie_fbc     = $this->temporarily_set_superglobal_value( '_COOKIE', '_fbc', $fbc );
+		$restore_cookie_fbp     = $this->temporarily_set_superglobal_value( '_COOKIE', '_fbp', $fbp );
 
-			foreach ( $param_builder->getCookiesToSet() as $cookie ) {
-				if ( '_fbp' === $cookie->name ) {
-					$fbp_domain = $cookie->domain;
-					break;
-				}
-			}
-		// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Attribution is best-effort here.
-		} catch ( \Exception $e ) {
-			// Silently continue — attribution is best-effort.
-		}
-
-		if ( empty( $fbc ) && ! empty( $fbclid ) ) {
-			$fbc = 'fb.1.' . time() . '.' . $fbclid;
-		}
+		// Resolve attribution once via Event so fbc-from-fbclid synthesis and
+		// cookie reads go through the same path as normal CAPI events.
+		$this->resolve_attribution_defaults( $fbc, $fbp );
 
 		$valid_events = array();
 		foreach ( $events as $event_data ) {
@@ -132,10 +126,12 @@ class ReleaseSignalsAjax {
 				? $this->sanitize_user_data( $event_data['user_data'] )
 				: array();
 
-			$server_event_data = $this->build_server_event_data( $event_data, $user_data, $fbc, $fbp );
-
-			$valid_events[] = new Event( $server_event_data );
+			$valid_events[] = $this->build_server_event( $event_data, $user_data );
 		}
+
+		$this->restore_superglobal_value( '_REQUEST', 'fbclid', $restore_request_fbclid );
+		$this->restore_superglobal_value( '_COOKIE', '_fbc', $restore_cookie_fbc );
+		$this->restore_superglobal_value( '_COOKIE', '_fbp', $restore_cookie_fbp );
 
 		if ( ! empty( $valid_events ) ) {
 			$this->record_rate_limit_usage( count( $valid_events ) );
@@ -152,7 +148,8 @@ class ReleaseSignalsAjax {
 			array(
 				'fbp'        => $fbp,
 				'fbc'        => $fbc,
-				'fbp_domain' => $fbp_domain,
+				'fbp_domain' => $cookie_domains['fbp'],
+				'fbc_domain' => $cookie_domains['fbc'],
 				'sent_count' => $sent_count,
 			)
 		);
@@ -234,7 +231,7 @@ class ReleaseSignalsAjax {
 		$sanitized    = array();
 		foreach ( $data as $key => $value ) {
 			$key = sanitize_text_field( $key );
-			if ( in_array( $key, $allowed_keys, true ) ) {
+			if ( in_array( $key, $allowed_keys, true ) && ! is_array( $value ) && ! is_object( $value ) ) {
 				$sanitized[ $key ] = sanitize_text_field( $value );
 			}
 		}
@@ -242,22 +239,123 @@ class ReleaseSignalsAjax {
 	}
 
 	/**
-	 * Builds a sanitized event payload for CAPI delivery.
+	 * Sanitizes a single attribution value from the request payload.
 	 *
-	 * @param array       $event_data Raw event data from the queue.
-	 * @param array       $user_data Sanitized user data.
-	 * @param string|null $fbc Attribution click ID.
-	 * @param string|null $fbp Attribution browser ID.
-	 * @return array
+	 * @param array  $data Attribution data.
+	 * @param string $key  Attribution key.
+	 * @return string
 	 */
-	private function build_server_event_data( $event_data, $user_data, $fbc, $fbp ) {
-		if ( ! empty( $fbc ) ) {
-			$user_data['click_id'] = $fbc;
-		}
-		if ( ! empty( $fbp ) ) {
-			$user_data['browser_id'] = $fbp;
+	private function sanitize_attribution_value( $data, $key ) {
+		if ( ! isset( $data[ $key ] ) || is_array( $data[ $key ] ) || is_object( $data[ $key ] ) ) {
+			return '';
 		}
 
+		return sanitize_text_field( $data[ $key ] );
+	}
+
+	/**
+	 * Gets the cookie domains ParamBuilder would use for attribution cookies.
+	 *
+	 * This is returned to the browser when backend-provided attribution values
+	 * need to be written after release, so they use the same domain scope as the
+	 * normal ParamBuilder cookie path.
+	 *
+	 * @return array{fbp:string|null,fbc:string|null}
+	 */
+	private function get_attribution_cookie_domains() {
+		$domains = array(
+			'fbp' => null,
+			'fbc' => null,
+		);
+
+		try {
+			$param_builder = \WC_Facebookcommerce_EventsTracker::get_param_builder();
+
+			foreach ( $param_builder->getCookiesToSet() as $cookie ) {
+				if ( '_fbp' === $cookie->name ) {
+					$domains['fbp'] = $cookie->domain;
+				} elseif ( '_fbc' === $cookie->name ) {
+					$domains['fbc'] = $cookie->domain;
+				}
+			}
+		// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Attribution cookie domains are best-effort.
+		} catch ( \Exception $e ) {
+			// Silently continue — attribution cookie domains are best-effort.
+		}
+
+		return $domains;
+	}
+
+	/**
+	 * Temporarily sets a superglobal value and returns data needed to restore it.
+	 *
+	 * @param string $superglobal Superglobal name without dollar sign.
+	 * @param string $key         Key to set.
+	 * @param string $value       Value to set.
+	 * @return array
+	 */
+	private function temporarily_set_superglobal_value( $superglobal, $key, $value ) {
+		$had_value = isset( $GLOBALS[ $superglobal ][ $key ] );
+		$original  = $had_value ? $GLOBALS[ $superglobal ][ $key ] : null;
+
+		if ( '' !== $value && null !== $value ) {
+			$GLOBALS[ $superglobal ][ $key ] = $value;
+		}
+
+		return array(
+			'had_value' => $had_value,
+			'original'  => $original,
+		);
+	}
+
+	/**
+	 * Restores a superglobal value saved by temporarily_set_superglobal_value().
+	 *
+	 * @param string $superglobal Superglobal name without dollar sign.
+	 * @param string $key         Key to restore.
+	 * @param array  $restore     Restore data.
+	 */
+	private function restore_superglobal_value( $superglobal, $key, $restore ) {
+		if ( ! empty( $restore['had_value'] ) ) {
+			$GLOBALS[ $superglobal ][ $key ] = $restore['original'];
+		} else {
+			unset( $GLOBALS[ $superglobal ][ $key ] );
+		}
+	}
+
+	/**
+	 * Resolves missing fbc/fbp values via Event so released signals share the
+	 * same attribution path (cookies + fbc-from-fbclid synthesis) as normal
+	 * CAPI events.
+	 *
+	 * @param string $fbc Attribution click ID reference.
+	 * @param string $fbp Attribution browser ID reference.
+	 */
+	private function resolve_attribution_defaults( &$fbc, &$fbp ) {
+		if ( ! empty( $fbc ) && ! empty( $fbp ) ) {
+			return;
+		}
+
+		$resolver  = new Event( array( 'event_name' => 'PageView' ) );
+		$user_data = $resolver->get_user_data();
+
+		if ( empty( $fbc ) && ! empty( $user_data['click_id'] ) ) {
+			$fbc = $user_data['click_id'];
+		}
+
+		if ( empty( $fbp ) && ! empty( $user_data['browser_id'] ) ) {
+			$fbp = $user_data['browser_id'];
+		}
+	}
+
+	/**
+	 * Builds a sanitized Event object for CAPI delivery.
+	 *
+	 * @param array $event_data Raw event data from the queue.
+	 * @param array $user_data  Sanitized user data.
+	 * @return Event
+	 */
+	private function build_server_event( $event_data, $user_data ) {
 		$server_event_data = array(
 			'event_name'  => sanitize_text_field( $event_data['event_name'] ),
 			'custom_data' => isset( $event_data['custom_data'] ) && is_array( $event_data['custom_data'] )
@@ -286,7 +384,7 @@ class ReleaseSignalsAjax {
 			$server_event_data['event_time'] = absint( $event_data['event_time'] );
 		}
 
-		return $server_event_data;
+		return new Event( $server_event_data );
 	}
 
 	/**

--- a/includes/Signals.php
+++ b/includes/Signals.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace WooCommerce\Facebook;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles the public signal state for Meta Pixel/CAPI delivery.
+ *
+ * Stores a small first-party cookie and exposes a frontend bridge that can
+ * hold or release signal delivery on the current site.
+ *
+ * @since 3.6.0
+ */
+class Signals {
+
+	/** @var string Cookie name for signal state. */
+	const COOKIE_NAME = 'wc_facebook_signals_state';
+
+	/** @var string AJAX action for updating signal state. */
+	const AJAX_ACTION = 'wc_facebook_update_signals_state';
+
+	/** @var string Nonce action for signal state AJAX. */
+	const NONCE_ACTION = 'wc_facebook_signals_state_nonce';
+
+	/** @var string Signals are active. */
+	const STATE_ACTIVE = 'active';
+
+	/** @var string Signals are held. */
+	const STATE_HELD = 'held';
+
+	/**
+	 * Constructor — registers hooks.
+	 */
+	public function __construct() {
+		add_action( 'wp_ajax_' . self::AJAX_ACTION, array( $this, 'handle_update_state' ) );
+		add_action( 'wp_ajax_nopriv_' . self::AJAX_ACTION, array( $this, 'handle_update_state' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_script' ) );
+	}
+
+	/**
+	 * Returns the current signal state from the cookie.
+	 *
+	 * @return string|null
+	 */
+	public static function get_signal_state() {
+		if ( ! isset( $_COOKIE[ self::COOKIE_NAME ] ) ) {
+			return null;
+		}
+
+		$state = sanitize_text_field( wp_unslash( $_COOKIE[ self::COOKIE_NAME ] ) );
+
+		if ( in_array( $state, array( self::STATE_ACTIVE, self::STATE_HELD ), true ) ) {
+			return $state;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Whether signals are currently active.
+	 *
+	 * @return bool
+	 */
+	public static function is_signals_active() {
+		return self::STATE_ACTIVE === self::get_signal_state();
+	}
+
+	/**
+	 * AJAX handler: updates the signal-state cookie.
+	 *
+	 * Expected POST params:
+	 *  - security : nonce
+	 *  - state    : 'active' or 'held'
+	 */
+	public function handle_update_state() {
+		check_ajax_referer( self::NONCE_ACTION, 'security' );
+
+		$state = isset( $_POST['state'] ) ? sanitize_text_field( wp_unslash( $_POST['state'] ) ) : self::STATE_HELD;
+		$state = $this->normalize_state( $state );
+
+		$this->set_cookie( $state );
+
+		// Populate $_COOKIE so any downstream code in this same request can read it.
+		$_COOKIE[ self::COOKIE_NAME ] = $state;
+
+		wp_send_json_success(
+			array(
+				'state' => $state,
+			)
+		);
+	}
+
+	/**
+	 * Sets the signal-state cookie.
+	 *
+	 * @param string $state Signal state.
+	 */
+	private function set_cookie( string $state ) {
+		$expires = time() + YEAR_IN_SECONDS;
+
+		setcookie(
+			self::COOKIE_NAME,
+			$state,
+			$expires,
+			COOKIEPATH,
+			COOKIE_DOMAIN,
+			is_ssl(),
+			false // httponly=false so JS can read it
+		);
+	}
+
+	/**
+	 * Whether signal delivery should currently be held.
+	 *
+	 * Undefined state is treated as active.
+	 *
+	 * @return bool
+	 */
+	public static function should_hold_signals(): bool {
+		return self::STATE_HELD === self::get_signal_state();
+	}
+
+	/**
+	 * Enqueues the frontend signal-state helper.
+	 */
+	public function enqueue_script() {
+		if ( ! facebook_for_woocommerce()->get_connection_handler()->is_connected() ) {
+			return;
+		}
+
+		wp_enqueue_script(
+			'wc-facebook-signals',
+			plugins_url( 'assets/js/facebook-for-woocommerce-signals.js', __DIR__ ),
+			array(),
+			\WC_Facebookcommerce::PLUGIN_VERSION,
+			true
+		);
+
+		wp_localize_script(
+			'wc-facebook-signals',
+			'wc_facebook_signals_params',
+			array(
+				'ajax_url' => admin_url( 'admin-ajax.php' ),
+				'nonce'    => wp_create_nonce( self::NONCE_ACTION ),
+				'action'   => self::AJAX_ACTION,
+			)
+		);
+	}
+
+	/**
+	 * Normalizes a signal state value.
+	 *
+	 * @param string $state Candidate state.
+	 * @return string
+	 */
+	private function normalize_state( string $state ) {
+		return self::STATE_ACTIVE === $state ? self::STATE_ACTIVE : self::STATE_HELD;
+	}
+}


### PR DESCRIPTION
## Description

This changeset adds first-party signal hold/release controls so a plugin or theme integration can pause Pixel + CAPI delivery on the current site and replay queued events when signals are released.

- New public JS bridge: `window.fbwcsignal.hold()`, `release()`, `getState()`.
- Frontend events fired while held are queued in the browser; CAPI sends are suppressed for public requests (admin/cron events still fire).
- On release, queued events are flushed to CAPI in one batched Graph call, attribution cookies (`_fbp`, `_fbc`) are written using the same domain scope the PHP param builder uses, and the browser pixel is re-armed so `fbevents.js` resumes firing.
- AddToCart event-ID dedup fix so repeated identical IDs no longer collide in the held queue.

## Implementation

- `includes/Signals.php` — cookie-backed state + AJAX endpoint to update it.
- `includes/Events/FacebookSignalsState.php` — per-request held flag, queued-event registry, attribution capture.
- `includes/Events/ReleaseSignalsAjax.php` — release endpoint that validates, sanitizes, and forwards queued events to CAPI in a single batched call.
- `assets/js/facebook-for-woocommerce-signals.js` — public bridge.
- `facebook-commerce-pixel-event.php` / `facebook-commerce-events-tracker.php` — inline `FacebookSignals` JS, queueing of inline pixel emissions while held, CAPI suppression on public requests while held.

## Optimization

- Per-IP rate limit on the release endpoint (transient-based, 80 events / 5 min by default, filterable, returns 429).
- Released events sent in a single Graph request instead of N requests.
- Removed an accidental `test_event_code` from the base CAPI request payload.

### Type of change

Please delete options that are not relevant

- Add (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Add Signal state controls for Pixel and CAPI


## Test Plan

- With signals active (default), Pixel and CAPI events fire as before.
- Call `fbwcsignal.hold()`, browse, add to cart — no CAPI requests for the public request, no `fbq('track', ...)` calls fire client-side.
- Call `fbwcsignal.release()` — queued events flush in one CAPI request, `_fbp` / `_fbc` cookies are set with the expected domain.
- Hammer the release endpoint past 80 events from one IP within 5 min — get HTTP 429.
- Admin order status changes still trigger CAPI while held.
- Repeated `AddToCart` with the same event ID does not duplicate in the held queue.