### PR TITLE
Filter crawler traffic from CAPI events to close pixel/server event gap

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -1320,6 +1320,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		protected function send_api_event( Event $event, bool $send_now = true ) {
 			if ( $this->is_crawler_request() ) {
+				facebook_for_woocommerce()->log( 'Blocked CAPI event for crawler: ' . sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '' ) ) );
 				return;
 			}
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -1319,6 +1319,10 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 * @param bool  $send_now optional, defaults to true
 		 */
 		protected function send_api_event( Event $event, bool $send_now = true ) {
+			if ( $this->is_crawler_request() ) {
+				return;
+			}
+
 			$this->tracked_events[] = $event;
 
 			// Skip CAPI sends for frontend requests while signals are held.
@@ -1337,6 +1341,61 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			} else {
 				$this->pending_events[] = $event;
 			}
+		}
+
+
+		/**
+		 * Determines whether the current request is from a known crawler.
+		 *
+		 * Checks the User-Agent header against a list of known crawler identifiers
+		 * to prevent server-side events from firing for non-human traffic.
+		 * This helps close the gap between pixel and CAPI event counts,
+		 * since crawlers trigger CAPI events but never execute client-side JavaScript.
+		 *
+		 * @since 3.3.0
+		 *
+		 * @return bool
+		 */
+		private function is_crawler_request(): bool {
+			$user_agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? strtolower( sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) ) : '';
+
+			if ( '' === $user_agent ) {
+				return true;
+			}
+
+			$crawler_patterns = array(
+				// Meta crawlers.
+				'meta-externalagent',
+				'meta-externalads',
+				'meta-webindexer',
+				// Generic crawler identifier.
+				'crawler',
+			);
+
+			/**
+			 * Filters the list of crawler user-agent patterns.
+			 *
+			 * @since 3.3.0
+			 *
+			 * @param string[] $crawler_patterns Array of lowercase crawler identifier strings to match against the User-Agent.
+			 */
+			$crawler_patterns = apply_filters( 'wc_facebook_crawler_user_agent_patterns', $crawler_patterns );
+
+			foreach ( $crawler_patterns as $pattern ) {
+				if ( false !== strpos( $user_agent, $pattern ) ) {
+					return true;
+				}
+			}
+
+			/**
+			 * Filters whether the current request should be treated as a crawler request.
+			 *
+			 * @since 3.3.0
+			 *
+			 * @param bool   $is_crawler Whether the request is from a crawler. Default false after pattern checks pass.
+			 * @param string $user_agent The request User-Agent string.
+			 */
+			return (bool) apply_filters( 'wc_facebook_is_crawler_request', false, $user_agent );
 		}
 
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -1319,8 +1319,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 * @param bool  $send_now optional, defaults to true
 		 */
 		protected function send_api_event( Event $event, bool $send_now = true ) {
-			if ( $this->is_crawler_request() ) {
-				facebook_for_woocommerce()->log( 'Blocked CAPI event for crawler: ' . sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '' ) ) );
+			if ( $this->is_crawler_request( $event ) ) {
+				facebook_for_woocommerce()->log( 'Blocked CAPI event for crawler: ' . $event->get_client_user_agent() );
 				return;
 			}
 
@@ -1355,14 +1355,11 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 *
 		 * @since 3.3.0
 		 *
+		 * @param Event $event Event object to read the User-Agent from.
 		 * @return bool
 		 */
-		private function is_crawler_request(): bool {
-			$user_agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? strtolower( sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) ) : '';
-
-			if ( '' === $user_agent ) {
-				return true;
-			}
+		private function is_crawler_request( Event $event ): bool {
+			$user_agent = strtolower( $event->get_client_user_agent() );
 
 			$crawler_patterns = array(
 				// Meta crawlers.
@@ -1398,7 +1395,6 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			 */
 			return (bool) apply_filters( 'wc_facebook_is_crawler_request', false, $user_agent );
 		}
-
 
 		/**
 		 * Gets the cart content items count.

--- a/includes/Events/Event.php
+++ b/includes/Events/Event.php
@@ -243,7 +243,7 @@ class Event {
 	 *
 	 * @return string
 	 */
-	protected function get_client_user_agent() {
+	public function get_client_user_agent() {
 		return ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? wc_clean( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
 	}
 

--- a/tests/Unit/Events/FacebookCommerceEventsTrackerTest.php
+++ b/tests/Unit/Events/FacebookCommerceEventsTrackerTest.php
@@ -1192,11 +1192,12 @@ class FacebookCommerceEventsTrackerTest extends AbstractWPUnitTestWithSafeFilter
 
 		$_SERVER['HTTP_USER_AGENT'] = $user_agent;
 
+		$event      = new \WooCommerce\Facebook\Events\Event( array( 'event_name' => 'PageView' ) );
 		$reflection = new ReflectionClass( $this->instance );
 		$method     = $reflection->getMethod( 'is_crawler_request' );
 		$method->setAccessible( true );
 
-		$result = $method->invoke( $this->instance );
+		$result = $method->invoke( $this->instance, $event );
 
 		$this->assertSame( $expected, $result, "User agent '{$user_agent}' should " . ( $expected ? '' : 'not ' ) . 'be detected as a crawler' );
 
@@ -1228,7 +1229,7 @@ class FacebookCommerceEventsTrackerTest extends AbstractWPUnitTestWithSafeFilter
 			),
 			'empty user agent'          => array(
 				'',
-				true,
+				false,
 			),
 			'chrome desktop browser'    => array(
 				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
@@ -1259,11 +1260,12 @@ class FacebookCommerceEventsTrackerTest extends AbstractWPUnitTestWithSafeFilter
 
 		unset( $_SERVER['HTTP_USER_AGENT'] );
 
+		$event      = new \WooCommerce\Facebook\Events\Event( array( 'event_name' => 'PageView' ) );
 		$reflection = new ReflectionClass( $this->instance );
 		$method     = $reflection->getMethod( 'is_crawler_request' );
 		$method->setAccessible( true );
 
-		$this->assertTrue( $method->invoke( $this->instance ), 'Missing user agent should be detected as crawler' );
+		$this->assertFalse( $method->invoke( $this->instance, $event ), 'Missing user agent should not be detected as crawler' );
 	}
 
 	/**
@@ -1340,11 +1342,12 @@ class FacebookCommerceEventsTrackerTest extends AbstractWPUnitTestWithSafeFilter
 			}
 		);
 
+		$event      = new \WooCommerce\Facebook\Events\Event( array( 'event_name' => 'PageView' ) );
 		$reflection = new ReflectionClass( $this->instance );
 		$method     = $reflection->getMethod( 'is_crawler_request' );
 		$method->setAccessible( true );
 
-		$this->assertTrue( $method->invoke( $this->instance ), 'Custom pattern should be detected via filter' );
+		$this->assertTrue( $method->invoke( $this->instance, $event ), 'Custom pattern should be detected via filter' );
 
 		unset( $_SERVER['HTTP_USER_AGENT'] );
 	}
@@ -1366,11 +1369,12 @@ class FacebookCommerceEventsTrackerTest extends AbstractWPUnitTestWithSafeFilter
 			}
 		);
 
+		$event      = new \WooCommerce\Facebook\Events\Event( array( 'event_name' => 'PageView' ) );
 		$reflection = new ReflectionClass( $this->instance );
 		$method     = $reflection->getMethod( 'is_crawler_request' );
 		$method->setAccessible( true );
 
-		$this->assertTrue( $method->invoke( $this->instance ), 'Override filter should force crawler detection' );
+		$this->assertTrue( $method->invoke( $this->instance, $event ), 'Override filter should force crawler detection' );
 
 		unset( $_SERVER['HTTP_USER_AGENT'] );
 	}

--- a/tests/Unit/Events/FacebookCommerceEventsTrackerTest.php
+++ b/tests/Unit/Events/FacebookCommerceEventsTrackerTest.php
@@ -28,10 +28,20 @@ class FacebookCommerceEventsTrackerTest extends AbstractWPUnitTestWithSafeFilter
 	private $aam_settings;
 
 	/**
+	 * @var string|null Original HTTP_USER_AGENT value to restore after each test.
+	 */
+	private $original_user_agent;
+
+	/**
 	 * Set up before each test.
 	 */
 	public function setUp(): void {
 		parent::setUp();
+
+		$this->original_user_agent = $_SERVER['HTTP_USER_AGENT'] ?? null;
+
+		// Set a default browser User-Agent so tests are not blocked by crawler detection.
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
 		$this->aam_settings = new AAMSettings( array(
 			'enableAutomaticMatching'        => true,
@@ -46,6 +56,13 @@ class FacebookCommerceEventsTrackerTest extends AbstractWPUnitTestWithSafeFilter
 	public function tearDown(): void {
 		$this->instance     = null;
 		$this->aam_settings = null;
+
+		// Restore original User-Agent.
+		if ( null === $this->original_user_agent ) {
+			unset( $_SERVER['HTTP_USER_AGENT'] );
+		} else {
+			$_SERVER['HTTP_USER_AGENT'] = $this->original_user_agent;
+		}
 
 		parent::tearDown();
 	}
@@ -1160,5 +1177,201 @@ class FacebookCommerceEventsTrackerTest extends AbstractWPUnitTestWithSafeFilter
 		// Clean up
 		WC()->cart->empty_cart();
 		$product->delete( true );
+	}
+	/**
+	 * Test that is_crawler_request detects known crawler user agents.
+	 *
+	 * @covers WC_Facebookcommerce_EventsTracker::is_crawler_request
+	 * @dataProvider crawler_user_agent_provider
+	 *
+	 * @param string $user_agent The user agent string to test.
+	 * @param bool   $expected   Whether the request should be detected as a crawler.
+	 */
+	public function test_is_crawler_request( string $user_agent, bool $expected ): void {
+		$this->instance = $this->create_tracker_with_pixel_enabled();
+
+		$_SERVER['HTTP_USER_AGENT'] = $user_agent;
+
+		$reflection = new ReflectionClass( $this->instance );
+		$method     = $reflection->getMethod( 'is_crawler_request' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $this->instance );
+
+		$this->assertSame( $expected, $result, "User agent '{$user_agent}' should " . ( $expected ? '' : 'not ' ) . 'be detected as a crawler' );
+
+		unset( $_SERVER['HTTP_USER_AGENT'] );
+	}
+
+	/**
+	 * Data provider for crawler detection tests.
+	 *
+	 * @return array
+	 */
+	public function crawler_user_agent_provider(): array {
+		return array(
+			'meta external agent'       => array(
+				'meta-externalagent/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)',
+				true,
+			),
+			'meta external ads'         => array(
+				'meta-externalads/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)',
+				true,
+			),
+			'meta web indexer'          => array(
+				'meta-webindexer/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)',
+				true,
+			),
+			'generic crawler in UA'     => array(
+				'SomeBot/2.0 (compatible; crawler; +http://example.com)',
+				true,
+			),
+			'empty user agent'          => array(
+				'',
+				true,
+			),
+			'chrome desktop browser'    => array(
+				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+				false,
+			),
+			'safari desktop browser'    => array(
+				'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+				false,
+			),
+			'mobile safari browser'     => array(
+				'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+				false,
+			),
+			'firefox browser'           => array(
+				'Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0',
+				false,
+			),
+		);
+	}
+
+	/**
+	 * Test that is_crawler_request returns true when no user agent header is set.
+	 *
+	 * @covers WC_Facebookcommerce_EventsTracker::is_crawler_request
+	 */
+	public function test_is_crawler_request_returns_true_when_no_user_agent(): void {
+		$this->instance = $this->create_tracker_with_pixel_enabled();
+
+		unset( $_SERVER['HTTP_USER_AGENT'] );
+
+		$reflection = new ReflectionClass( $this->instance );
+		$method     = $reflection->getMethod( 'is_crawler_request' );
+		$method->setAccessible( true );
+
+		$this->assertTrue( $method->invoke( $this->instance ), 'Missing user agent should be detected as crawler' );
+	}
+
+	/**
+	 * Test that send_api_event skips tracking for crawler requests.
+	 *
+	 * @covers WC_Facebookcommerce_EventsTracker::send_api_event
+	 */
+	public function test_send_api_event_skips_for_crawler_request(): void {
+		$this->instance = $this->create_tracker_with_pixel_enabled();
+
+		$_SERVER['HTTP_USER_AGENT'] = 'meta-externalagent/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)';
+
+		$event      = new \WooCommerce\Facebook\Events\Event( array( 'event_name' => 'PageView' ) );
+		$reflection = new ReflectionClass( $this->instance );
+		$method     = $reflection->getMethod( 'send_api_event' );
+		$method->setAccessible( true );
+		$method->invoke( $this->instance, $event, false );
+
+		$this->assertEmpty(
+			$this->instance->get_tracked_events(),
+			'Crawler requests should not add to tracked events'
+		);
+		$this->assertEmpty(
+			$this->instance->get_pending_events(),
+			'Crawler requests should not add to pending events'
+		);
+
+		unset( $_SERVER['HTTP_USER_AGENT'] );
+	}
+
+	/**
+	 * Test that send_api_event proceeds for real browser requests.
+	 *
+	 * @covers WC_Facebookcommerce_EventsTracker::send_api_event
+	 */
+	public function test_send_api_event_proceeds_for_real_browser(): void {
+		$this->instance = $this->create_tracker_with_pixel_enabled();
+
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+		$event      = new \WooCommerce\Facebook\Events\Event( array( 'event_name' => 'PageView' ) );
+		$reflection = new ReflectionClass( $this->instance );
+		$method     = $reflection->getMethod( 'send_api_event' );
+		$method->setAccessible( true );
+		$method->invoke( $this->instance, $event, false );
+
+		$this->assertNotEmpty(
+			$this->instance->get_tracked_events(),
+			'Real browser requests should be tracked'
+		);
+		$this->assertNotEmpty(
+			$this->instance->get_pending_events(),
+			'Real browser requests with send_now=false should be pending'
+		);
+
+		unset( $_SERVER['HTTP_USER_AGENT'] );
+	}
+
+	/**
+	 * Test that the wc_facebook_crawler_user_agent_patterns filter can add custom patterns.
+	 *
+	 * @covers WC_Facebookcommerce_EventsTracker::is_crawler_request
+	 */
+	public function test_is_crawler_request_custom_pattern_filter(): void {
+		$this->instance = $this->create_tracker_with_pixel_enabled();
+
+		$_SERVER['HTTP_USER_AGENT'] = 'CustomScraper/1.0';
+
+		$filter = $this->add_filter_with_safe_teardown(
+			'wc_facebook_crawler_user_agent_patterns',
+			function ( $patterns ) {
+				$patterns[] = 'customscraper';
+				return $patterns;
+			}
+		);
+
+		$reflection = new ReflectionClass( $this->instance );
+		$method     = $reflection->getMethod( 'is_crawler_request' );
+		$method->setAccessible( true );
+
+		$this->assertTrue( $method->invoke( $this->instance ), 'Custom pattern should be detected via filter' );
+
+		unset( $_SERVER['HTTP_USER_AGENT'] );
+	}
+
+	/**
+	 * Test that the wc_facebook_is_crawler_request filter can override crawler detection.
+	 *
+	 * @covers WC_Facebookcommerce_EventsTracker::is_crawler_request
+	 */
+	public function test_is_crawler_request_override_filter(): void {
+		$this->instance = $this->create_tracker_with_pixel_enabled();
+
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0.0.0';
+
+		$filter = $this->add_filter_with_safe_teardown(
+			'wc_facebook_is_crawler_request',
+			function () {
+				return true;
+			}
+		);
+
+		$reflection = new ReflectionClass( $this->instance );
+		$method     = $reflection->getMethod( 'is_crawler_request' );
+		$method->setAccessible( true );
+
+		$this->assertTrue( $method->invoke( $this->instance ), 'Override filter should force crawler detection' );
+
+		unset( $_SERVER['HTTP_USER_AGENT'] );
 	}
 }


### PR DESCRIPTION
## Description

CAPI events fire for crawler requests (e.g., meta-externalagent, meta-webindexer, meta-externalads), inflating server event counts ~3x relative to pixel events. Crawlers don't execute JavaScript, so pixel events never fire for these requests, creating a significant gap between pixel and CAPI event counts, specifically affecting PageView and ViewContent events.

Solution:

Checks the User-Agent header against known crawler patterns before sending any CAPI event. Crawler requests return immediately without sending a CAPI event or adding to tracked/pending events.

### Type of change

- Add (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Test Plan

- Verify all these tests passed.
1. Verify normal browser events still fire:
Visit a product / any page in Chrome/Safari
Check that both pixel (via browser Network tab → facebook.com/tr) and CAPI events fire
Check the WooCommerce debug log — no "Blocked CAPI event for crawler:" logs should appear

2. Use curl to simulate a Meta crawler request:
curl -A "meta-externalagent/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)" http://testing.local/product/t-shirt/

curl -A "meta-externalagent/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)" http://testing.local/product/

curl -A "meta-webindexer/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)" http://testing.local/product-category/uncategorized/

curl -A "meta-externalads/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)" http://testing.local/

<img width="1332" height="263" alt="Screenshot 2026-05-05 at 8 55 25 PM" src="https://github.com/user-attachments/assets/22326cf3-cbf8-4573-b90d-1073709f17aa" />


Check the WooCommerce debug log — "Could not send Pixel event" logs should appear