### PR TITLE
Improve Lead event support for WPForms and Contact Form 7

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -1384,7 +1384,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 * Adds a front-end listener to execute fb_pxl_code returned in WPForms AJAX responses.
 		 */
 		public function inject_wpforms_ajax_listener() {
-			if ( is_admin() ) {
+			if ( is_admin() || ! wp_script_is( 'wpforms', 'enqueued' ) ) {
 				return;
 			}
 			?>

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -270,8 +270,12 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			add_action( 'woocommerce_checkout_update_order_meta', array( $this, 'inject_purchase_event' ), 30 );
 			add_action( 'woocommerce_thankyou', array( $this, 'inject_purchase_event' ), 40 );
 
-			// Lead events through Contact Form 7
-			add_action( 'wpcf7_contact_form', array( $this, 'inject_lead_event_hook' ), 11 );
+			// Lead events through Contact Form 7 / WPForms.
+			add_action( 'wp_footer', array( $this, 'inject_lead_event' ), 11 );
+			add_action( 'wpforms_process_before', array( $this, 'track_wpforms_lead_event' ), 20, 2 );
+			add_filter( 'wpforms_ajax_submit_success_response', array( $this, 'inject_wpforms_lead_event_ajax' ), 20, 3 );
+			add_filter( 'wpforms_ajax_submit_redirect', array( $this, 'inject_wpforms_lead_event_ajax' ), 20, 3 );
+			add_action( 'wp_footer', array( $this, 'inject_wpforms_ajax_listener' ), 9 );
 
 			// Flush pending events on shutdown
 			add_action( 'shutdown', array( $this, 'send_pending_events' ) );
@@ -1293,20 +1297,232 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		}
 
 
-		/** Contact Form 7 Support **/
-		public function inject_lead_event_hook() {
-			add_action( 'wp_footer', array( $this, 'inject_lead_event' ), 11 );
-		}
-
+		/** Contact Form 7 Lead Support **/
 		public function inject_lead_event() {
-			if ( ! is_admin() ) {
-				$this->pixel->inject_conditional_event(
+			if ( is_admin() ) {
+				return;
+			}
+
+			if ( wp_script_is( 'contact-form-7', 'enqueued' ) ) {
+				echo $this->pixel->inject_conditional_event(
 					'Lead',
 					array(),
 					'wpcf7submit',
 					'{ em: event.detail.inputs.filter(ele => ele.name.includes("email"))[0].value }'
 				);
 			}
+		}
+
+		/**
+		 * Tracks WPForms Lead event for server-side delivery.
+		 *
+		 * - server event tracked on wpforms_process_before
+		 * - browser event injected on normal footer path
+		 * - browser event code attached to AJAX success payload
+		 *
+		 * @param array $entry WPForms entry values.
+		 * @param array $form_data WPForms form config.
+		 */
+		public function track_wpforms_lead_event( $entry, $form_data ) {
+			if ( ( is_admin() && ! wp_doing_ajax() ) || ! $this->is_pixel_enabled() ) {
+				return;
+			}
+
+			$event_data = array(
+				'event_name'  => 'Lead',
+				'user_data'   => $this->get_wpforms_user_data( $entry, $form_data ),
+				'custom_data' => array(
+					'fb_integration_tracking' => 'wpforms-lite',
+				),
+			);
+
+			$event = new Event( $event_data );
+			$this->send_api_event( $event );
+
+			// Non-AJAX fallback: inject matching browser event in footer.
+			add_action( 'wp_footer', array( $this, 'inject_wpforms_lead_event' ), 20 );
+		}
+
+		/**
+		 * Injects browser Lead event in normal (non-AJAX) page flow.
+		 */
+		public function inject_wpforms_lead_event() {
+			if ( is_admin() ) {
+				return;
+			}
+
+			$event = $this->get_latest_tracked_wpforms_lead_event();
+			if ( ! $event ) {
+				return;
+			}
+
+			echo $this->pixel->get_event_script( 'Lead', $this->build_wpforms_lead_pixel_params( $event ) );
+		}
+
+		/**
+		 * Injects WPForms Lead pixel code into AJAX success/redirect response payload.
+		 *
+		 * @param array $response Existing WPForms response.
+		 * @return array
+		 */
+		public function inject_wpforms_lead_event_ajax( $response, $form_id = null, $extra = null ) {
+			if ( is_admin() && ! wp_doing_ajax() ) {
+				return $response;
+			}
+
+			$event = $this->get_latest_tracked_wpforms_lead_event();
+			if ( ! $event ) {
+				return $response;
+			}
+
+			$response['fb_pxl_code'] = $this->pixel->get_event_code( 'Lead', $this->build_wpforms_lead_pixel_params( $event ) );
+			return $response;
+		}
+
+		/**
+		 * Adds a front-end listener to execute fb_pxl_code returned in WPForms AJAX responses.
+		 */
+		public function inject_wpforms_ajax_listener() {
+			if ( is_admin() ) {
+				return;
+			}
+			?>
+			<script type='text/javascript'>
+			(function ( $ ) {
+				if ( ! $ || typeof document === 'undefined' ) {
+					return;
+				}
+				$( document ).on( 'wpformsAjaxSubmitSuccess', function ( event, data ) {
+					if ( data && data.data && data.data.fb_pxl_code ) {
+						try {
+							new Function( data.data.fb_pxl_code )();
+						} catch ( e ) {
+							// no-op
+						}
+					}
+				} );
+			})( window.jQuery );
+			</script>
+			<?php
+		}
+
+		/**
+		 * Gets latest tracked WPForms Lead event from current request.
+		 *
+		 * @return Event|null
+		 */
+		private function get_latest_tracked_wpforms_lead_event() {
+			if ( empty( $this->tracked_events ) ) {
+				return null;
+			}
+
+			$lead_events = array_values(
+				array_filter(
+					$this->tracked_events,
+					function( $event ) {
+						if ( ! $event instanceof Event ) {
+							return false;
+						}
+
+						$event_name = method_exists( $event, 'get_event_name' ) ? $event->get_event_name() : ( method_exists( $event, 'get_name' ) ? $event->get_name() : '' );
+						if ( 'Lead' !== $event_name ) {
+							return false;
+						}
+
+						$custom_data = $event->get_custom_data();
+						return is_array( $custom_data )
+							&& isset( $custom_data['fb_integration_tracking'] )
+							&& 'wpforms-lite' === $custom_data['fb_integration_tracking'];
+					}
+				)
+			);
+
+			if ( empty( $lead_events ) ) {
+				return null;
+			}
+
+			return end( $lead_events );
+		}
+
+		/**
+		 * Builds browser pixel params for WPForms Lead event.
+		 *
+		 * @param Event $event Lead event.
+		 * @return array
+		 */
+		private function build_wpforms_lead_pixel_params( Event $event ) {
+			$params = array(
+				'event_id' => $event->get_id(),
+			);
+
+			$user_data = $event->get_user_data();
+			if ( is_array( $user_data ) && ! empty( $user_data['em'] ) ) {
+				$params['user_data'] = array( 'em' => $user_data['em'] );
+			}
+
+			return $params;
+		}
+
+		/**
+		 * Extracts WPForms user_data payload for Lead tracking.
+		 *
+		 * @param array $entry WPForms entry values.
+		 * @param array $form_data WPForms form config.
+		 * @return array
+		 */
+		private function get_wpforms_user_data( $entry, $form_data ) {
+			$user_data = $this->pixel->get_user_info();
+			$email     = $this->get_wpforms_email( $entry, $form_data );
+			if ( ! empty( $email ) ) {
+				$user_data['em'] = $email;
+			}
+
+			return $user_data;
+		}
+
+		/**
+		 * Tries to resolve submitted WPForms email from form schema and entry values.
+		 *
+		 * @param array $entry WPForms entry values.
+		 * @param array $form_data WPForms form config.
+		 * @return string|null
+		 */
+		private function get_wpforms_email( $entry, $form_data ) {
+			if ( empty( $entry ) || empty( $form_data['fields'] ) ) {
+				return null;
+			}
+
+			foreach ( $form_data['fields'] as $field ) {
+				if ( isset( $field['type'] ) && 'email' === $field['type'] ) {
+					$field_id = isset( $field['id'] ) ? (string) $field['id'] : null;
+					if ( $field_id && isset( $entry[ $field_id ] ) ) {
+						$value = sanitize_email( (string) $entry[ $field_id ] );
+						if ( ! empty( $value ) ) {
+							return $value;
+						}
+					}
+
+					if ( $field_id && isset( $entry['fields'] ) && is_array( $entry['fields'] ) && isset( $entry['fields'][ $field_id ] ) ) {
+						$value = sanitize_email( (string) $entry['fields'][ $field_id ] );
+						if ( ! empty( $value ) ) {
+							return $value;
+						}
+					}
+				}
+			}
+
+			// Fallback for unexpected entry shapes.
+			foreach ( (array) $entry as $value ) {
+				if ( is_array( $value ) ) {
+					continue;
+				}
+				$email = sanitize_email( (string) $value );
+				if ( ! empty( $email ) && is_email( $email ) ) {
+					return $email;
+				}
+			}
+
+			return null;
 		}
 
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -1427,7 +1427,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 							return false;
 						}
 
-						$event_name = method_exists( $event, 'get_event_name' ) ? $event->get_event_name() : ( method_exists( $event, 'get_name' ) ? $event->get_name() : '' );
+						$event_name = $event->get_name();
 						if ( 'Lead' !== $event_name ) {
 							return false;
 						}

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -1396,7 +1396,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				$( document ).on( 'wpformsAjaxSubmitSuccess', function ( event, data ) {
 					if ( data && data.data && data.data.fb_pxl_code ) {
 						try {
-							new Function( data.data.fb_pxl_code )();
+							var s = document.createElement( 'script' );
+							s.textContent = data.data.fb_pxl_code;
+							document.head.appendChild( s );
 						} catch ( e ) {
 							// no-op
 						}

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -272,7 +272,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			// Lead events through Contact Form 7 / WPForms.
 			add_action( 'wp_footer', array( $this, 'inject_lead_event' ), 11 );
-			add_action( 'wpforms_process_complete', array( $this, 'track_wpforms_lead_event' ), 20, 4 );
+			add_action( 'wpforms_process_complete', array( $this, 'track_wpforms_lead_event' ), 20, 3 );
 			add_filter( 'wpforms_ajax_submit_success_response', array( $this, 'inject_wpforms_lead_event_ajax' ), 20, 3 );
 			add_filter( 'wpforms_ajax_submit_redirect', array( $this, 'inject_wpforms_lead_event_ajax' ), 20, 3 );
 			add_action( 'wp_footer', array( $this, 'inject_wpforms_ajax_listener' ), 9 );
@@ -1322,9 +1322,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 * @param array $fields     Sanitised field values.
 		 * @param array $entry      Raw entry values.
 		 * @param array $form_data  WPForms form config.
-		 * @param int   $entry_id   Saved entry ID.
 		 */
-		public function track_wpforms_lead_event( $fields, $entry, $form_data, $entry_id ) {
+		public function track_wpforms_lead_event( $fields, $entry, $form_data ) {
 			if ( ( is_admin() && ! wp_doing_ajax() ) || ! $this->is_pixel_enabled() ) {
 				return;
 			}
@@ -1366,7 +1365,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 * @param array $response Existing WPForms response.
 		 * @return array
 		 */
-		public function inject_wpforms_lead_event_ajax( $response, $form_id = null, $extra = null ) {
+		public function inject_wpforms_lead_event_ajax( $response ) {
 			if ( is_admin() && ! wp_doing_ajax() ) {
 				return $response;
 			}
@@ -1422,7 +1421,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			$lead_events = array_values(
 				array_filter(
 					$this->tracked_events,
-					function( $event ) {
+					function ( $event ) {
 						if ( ! $event instanceof Event ) {
 							return false;
 						}

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -272,7 +272,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			// Lead events through Contact Form 7 / WPForms.
 			add_action( 'wp_footer', array( $this, 'inject_lead_event' ), 11 );
-			add_action( 'wpforms_process_before', array( $this, 'track_wpforms_lead_event' ), 20, 2 );
+			add_action( 'wpforms_process_complete', array( $this, 'track_wpforms_lead_event' ), 20, 4 );
 			add_filter( 'wpforms_ajax_submit_success_response', array( $this, 'inject_wpforms_lead_event_ajax' ), 20, 3 );
 			add_filter( 'wpforms_ajax_submit_redirect', array( $this, 'inject_wpforms_lead_event_ajax' ), 20, 3 );
 			add_action( 'wp_footer', array( $this, 'inject_wpforms_ajax_listener' ), 9 );
@@ -1316,14 +1316,15 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		/**
 		 * Tracks WPForms Lead event for server-side delivery.
 		 *
-		 * - server event tracked on wpforms_process_before
-		 * - browser event injected on normal footer path
-		 * - browser event code attached to AJAX success payload
+		 * Fires only after WPForms completes a successful entry save (wpforms_process_complete),
+		 * so CAPI Lead events are not sent for invalid/rejected form submissions.
 		 *
-		 * @param array $entry WPForms entry values.
-		 * @param array $form_data WPForms form config.
+		 * @param array $fields     Sanitised field values.
+		 * @param array $entry      Raw entry values.
+		 * @param array $form_data  WPForms form config.
+		 * @param int   $entry_id   Saved entry ID.
 		 */
-		public function track_wpforms_lead_event( $entry, $form_data ) {
+		public function track_wpforms_lead_event( $fields, $entry, $form_data, $entry_id ) {
 			if ( ( is_admin() && ! wp_doing_ajax() ) || ! $this->is_pixel_enabled() ) {
 				return;
 			}

--- a/tests/Unit/Events/FacebookCommerceEventsTrackerTest.php
+++ b/tests/Unit/Events/FacebookCommerceEventsTrackerTest.php
@@ -575,18 +575,16 @@ class FacebookCommerceEventsTrackerTest extends AbstractWPUnitTestWithSafeFilter
 	}
 
 	/**
-	 * Test that inject_lead_event_hook adds the footer action.
+	 * Test that the constructor registers inject_lead_event on wp_footer.
 	 *
-	 * @covers WC_Facebookcommerce_EventsTracker::inject_lead_event_hook
+	 * @covers WC_Facebookcommerce_EventsTracker::__construct
 	 */
-	public function test_inject_lead_event_hook_adds_footer_action(): void {
+	public function test_constructor_registers_inject_lead_event_on_footer(): void {
 		$this->instance = $this->create_tracker_with_pixel_enabled();
-
-		$this->instance->inject_lead_event_hook();
 
 		$this->assertTrue(
 			has_action( 'wp_footer', array( $this->instance, 'inject_lead_event' ) ) !== false,
-			'inject_lead_event_hook should add inject_lead_event to wp_footer'
+			'Constructor should register inject_lead_event on wp_footer'
 		);
 	}
 


### PR DESCRIPTION
## Description

This changeset improves Lead event tracking for Contact Form 7 and WPForms plugins.

The plugin tracks successful WPForms submissions as `Lead` events after `wpforms_process_complete`, ensuring events are sent after WPForms validates
and completes the submission. It supports both CAPI Lead and pixel Lead events.

### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Improve Lead event support for WPForms and Contact Form 7


## Test Plan

1. Ensure the website is connected to Facebook.
2. Install and activate WPForms / Contact Form 7.
3. Create a form with an email field.
4. Submit the form using a normal/non-AJAX submission.
  - Confirm a server-side `Lead` event is sent.
  - Confirm a browser `Lead` pixel event is injected with a matching `event_id`.
5. Enable AJAX submission for the same form.
6. Submit the AJAX form.
  - Confirm the WPForms AJAX response includes `fb_pxl_code`.
  - Confirm the frontend listener executes the returned pixel code.
  - Confirm the browser `Lead` event fires only after successful submission.
7. Submit an invalid WPForms form.
  - Confirm no `Lead` event is sent.
8. Verify existing Contact Form 7 Lead tracking still works on pages where the CF7 frontend script is enqueued.