### PR TITLE
Update facebook-commerce-iframe-whatsapp-utility-event.php

### DIFF
--- a/facebook-commerce-iframe-whatsapp-utility-event.php
+++ b/facebook-commerce-iframe-whatsapp-utility-event.php
@@ -63,7 +63,7 @@ class WC_Facebookcommerce_Iframe_Whatsapp_Utility_Event {
 		// Get WhatsApp Phone number from entered Billing and Shipping phone number
 		$billing_phone_number  = $order->get_billing_phone();
 		$shipping_phone_number = $order->get_shipping_phone();
-		$phone_number          = $billing_phone_number ?: $shipping_phone_number;
+		$phone_number          = ! empty( $billing_phone_number ) ? $billing_phone_number : $shipping_phone_number;
 		// Get Country Code from Billing and Shipping Country to override Country Calling Code
 		$should_use_billing_info = ! empty( $billing_phone_number );
 		$country_code            = $should_use_billing_info ? $order->get_billing_country() : $order->get_shipping_country();

--- a/facebook-commerce-iframe-whatsapp-utility-event.php
+++ b/facebook-commerce-iframe-whatsapp-utility-event.php
@@ -63,7 +63,7 @@ class WC_Facebookcommerce_Iframe_Whatsapp_Utility_Event {
 		// Get WhatsApp Phone number from entered Billing and Shipping phone number
 		$billing_phone_number  = $order->get_billing_phone();
 		$shipping_phone_number = $order->get_shipping_phone();
-		$phone_number          = $billing_phone_number ?? $shipping_phone_number;
+		$phone_number          = $billing_phone_number ?: $shipping_phone_number;
 		// Get Country Code from Billing and Shipping Country to override Country Calling Code
 		$should_use_billing_info = ! empty( $billing_phone_number );
 		$country_code            = $should_use_billing_info ? $order->get_billing_country() : $order->get_shipping_country();


### PR DESCRIPTION
## Description                                                                                                                    
                                                                                                                                    
  Fix phone number fallback in WhatsApp utility messaging events.                                                                   
                                                                                                                                    
  The plugin uses `??` (null coalescing) to fall back from billing phone to shipping phone. However, WooCommerce's `get_billing_phone()` returns `""` (empty string) — not `null` — when no billing phone is set. Since `""` is non-null, the `??` operator never falls through to the shipping phone number, causing the event to be silently dropped at the validation check on line 79.                                                                                                                 
                                                                                                                                    
  This change replaces `??` with `?:` (falsy coalescing) so that an empty billing phone correctly falls back to the shipping phone. 
                                                                                                                                    
  ### Type of change                                        
                                                                                                                                    
  - Fix (non-breaking change which fixes an issue)                                                                                  
  
  ## Checklist                                                                                                                      
                                                            
  - [x] I have commented my code, particularly in hard-to-understand areas, if any.                                                 
  - [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
  - [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.                     
  - [x] I followed general Pull Request best practices. Meta employees to follow this                                               
  - [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.                     
  - [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break     
  existing functionality.                                                                                                           
  - [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this                    
  [wiki]([url](https://fburl.com/wiki/nhx73tgs)).                                                                                   
                                                                                                                                    
  ## Changelog entry                                        
                                                                                                                                    
  Fix phone number fallback in WhatsApp utility events to correctly use shipping phone when billing phone is empty.
                                                                                                                                    
  ## Test Plan
                                                                                                                                    
  1. Create a WooCommerce test order with:                  
     - Billing phone: empty                                                                                                         
     - Shipping phone: a valid number (e.g., +1234567890)   
  2. Change order status to "processing"                                                                                            
  3. Verify in WooCommerce logs (`WooCommerce > Status > Logs`) that the WhatsApp utility event fires with the shipping phone — no "missing Order info" skip message                                                                                                       
  4. Create an order with a valid billing phone and empty shipping phone                                                            
  5. Verify the billing phone is used (no regression)                                                                               
  6. Create an order with both phones empty — verify the event is correctly skipped with "missing Order info" log message                            