### PR TITLE
Raise Ajax listener priority for WPForms `assets_footer`

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -275,7 +275,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			add_action( 'wpforms_process_complete', array( $this, 'track_wpforms_lead_event' ), 20, 3 );
 			add_filter( 'wpforms_ajax_submit_success_response', array( $this, 'inject_wpforms_lead_event_ajax' ), 20, 3 );
 			add_filter( 'wpforms_ajax_submit_redirect', array( $this, 'inject_wpforms_lead_event_ajax' ), 20, 3 );
-			add_action( 'wp_footer', array( $this, 'inject_wpforms_ajax_listener' ), 9 );
+			add_action( 'wp_footer', array( $this, 'inject_wpforms_ajax_listener' ), 20 );
 
 			// Flush pending events on shutdown
 			add_action( 'shutdown', array( $this, 'send_pending_events' ) );


### PR DESCRIPTION
## Description

This change raises the priority of the WPForms AJAX listener injected in `wp_footer`

WPForms outputs its own footer assets through `assets_footer` at the default priority of `10`. By running our listener after that, we ensure the WPForms AJAX hooks are available before the Facebook for WooCommerce listener script is injected.

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fix WPForms AJAX lead event listener timing


## Test Plan

1. Enable WPForms and configure a form using AJAX submission.
2. Open a page containing the AJAX-enabled WPForms form.
3. Confirm the Facebook for WooCommerce WPForms AJAX listener is injected after WPForms footer assets.
4. Submit the form through AJAX.
5. Confirm the Lead event is tracked successfully.