### PR TITLE
Fix Store API batch AddToCart Pixel tracking

### DIFF
--- a/assets/js/frontend/pixel-events.js
+++ b/assets/js/frontend/pixel-events.js
@@ -13,12 +13,11 @@
 (function() {
     'use strict';
 
-    // Early exit if no data from PHP
-    if (typeof wc_facebook_pixel_data === 'undefined') {
-        return;
-    }
-
-    var data = wc_facebook_pixel_data;
+    // Data from PHP (may be missing if no events were queued for initial render).
+    // Keep Store API interception active even when eventQueue is empty/undefined.
+    var data = (typeof wc_facebook_pixel_data !== 'undefined' && wc_facebook_pixel_data) ?
+        wc_facebook_pixel_data :
+        { eventQueue: [] };
     var firedEvents = {};
 
     /**
@@ -154,8 +153,79 @@
     }
 
     /**
+     * Returns the request URL from a fetch() input.
+     *
+     * @param {*} input fetch() input argument
+     * @return {string}
+     */
+    function getRequestUrl(input) {
+        if (typeof input === 'string') {
+            return input;
+        }
+
+        if (input && typeof input.url === 'string') {
+            return input.url;
+        }
+
+        return '';
+    }
+
+    /**
+     * Checks whether a URL targets the Store API add-item endpoint.
+     *
+     * @param {string} url Request URL
+     * @return {boolean}
+     */
+    function isStoreApiAddItemRequest(url) {
+        return typeof url === 'string' &&
+            (url.indexOf('/wc/store/v1/cart/add-item') !== -1 ||
+             url.indexOf('/wc/store/cart/add-item') !== -1);
+    }
+
+    /**
+     * Checks whether a URL targets the Store API batch endpoint.
+     *
+     * @param {string} url Request URL
+     * @return {boolean}
+     */
+    function isStoreApiBatchRequest(url) {
+        return typeof url === 'string' &&
+            (url.indexOf('/wc/store/v1/batch') !== -1 ||
+             url.indexOf('/wc/store/batch') !== -1);
+    }
+
+    /**
+     * Process Store API response payload and extract plugin extension data.
+     * Handles both direct cart responses and batch responses.
+     *
+     * @param {Object} responseData Parsed Store API response payload
+     */
+    function processStoreApiResponseData(responseData) {
+        if (!responseData || typeof responseData !== 'object') {
+            return;
+        }
+
+        // Direct response shape: { extensions: { 'facebook-for-woocommerce': ... } }
+        if (responseData.extensions && responseData.extensions['facebook-for-woocommerce']) {
+            processStoreApiEvent(responseData.extensions['facebook-for-woocommerce']);
+        }
+
+        // Batch response shape: { responses: [ { body: { extensions: ... } } ] }
+        if (!Array.isArray(responseData.responses)) {
+            return;
+        }
+
+        for (var i = 0; i < responseData.responses.length; i++) {
+            var item = responseData.responses[i];
+            if (item && item.body && item.body.extensions && item.body.extensions['facebook-for-woocommerce']) {
+                processStoreApiEvent(item.body.extensions['facebook-for-woocommerce']);
+            }
+        }
+    }
+
+    /**
      * Set up fetch interceptor to capture Store API responses.
-     * Only intercepts cart/add-item requests to fire AddToCart pixel events.
+     * Intercepts cart/add-item and batch requests to fire AddToCart pixel events.
      */
     function setupFetchInterceptor() {
         var originalFetch = window.fetch;
@@ -165,20 +235,16 @@
 
         window.fetch = function() {
             var args = arguments;
-            var url = args[0];
+            var url = getRequestUrl(args[0]);
 
-            // Only intercept add-item requests (not general cart requests)
-            var isAddToCartRequest = typeof url === 'string' &&
-                (url.indexOf('/wc/store/v1/cart/add-item') !== -1 ||
-                 url.indexOf('/wc/store/cart/add-item') !== -1);
+            var isAddToCartRequest = isStoreApiAddItemRequest(url);
+            var isBatchRequest = isStoreApiBatchRequest(url);
 
             return originalFetch.apply(this, args).then(function(response) {
-                if (isAddToCartRequest && response.ok) {
+                if ((isAddToCartRequest || isBatchRequest) && response.ok) {
                     // Clone response so we can read it without consuming
                     response.clone().json().then(function(responseData) {
-                        if (responseData && responseData.extensions && responseData.extensions['facebook-for-woocommerce']) {
-                            processStoreApiEvent(responseData.extensions['facebook-for-woocommerce']);
-                        }
+                        processStoreApiResponseData(responseData);
                     }).catch(function(e) {
                         logWarning('Store API JSON parse error:', e);
                     });

--- a/assets/js/frontend/pixel-events.js
+++ b/assets/js/frontend/pixel-events.js
@@ -208,17 +208,14 @@
         // Direct response shape: { extensions: { 'facebook-for-woocommerce': ... } }
         if (responseData.extensions && responseData.extensions['facebook-for-woocommerce']) {
             processStoreApiEvent(responseData.extensions['facebook-for-woocommerce']);
-        }
-
-        // Batch response shape: { responses: [ { body: { extensions: ... } } ] }
-        if (!Array.isArray(responseData.responses)) {
-            return;
-        }
-
-        for (var i = 0; i < responseData.responses.length; i++) {
-            var item = responseData.responses[i];
-            if (item && item.body && item.body.extensions && item.body.extensions['facebook-for-woocommerce']) {
-                processStoreApiEvent(item.body.extensions['facebook-for-woocommerce']);
+        } else if (Array.isArray(responseData.responses)) {
+            // Batch response shape: { responses: [ { body: { extensions: ... } } ] }
+            for (var i = 0; i < responseData.responses.length; i++) {
+                var item = responseData.responses[i];
+                if (item && item.body && item.body.extensions && item.body.extensions['facebook-for-woocommerce'] &&
+                    item.status >= 200 && item.status < 300) {
+                    processStoreApiEvent(item.body.extensions['facebook-for-woocommerce']);
+                }
             }
         }
     }

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -816,8 +816,11 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			// store the ID in the session to be sent in AJAX JS event tracking as well
 			WC()->session->set( 'facebook_for_woocommerce_add_to_cart_event_id', $event->get_id() );
 
-			// Store pending pixel event for WooCommerce Blocks Store API
-			// Reuse custom_data and add event_id for deduplication
+			// Store pending pixel event for WooCommerce Blocks Store API.
+			// Reuse custom_data and add event_id for deduplication.
+			// NOTE: single-slot — if a batch request adds multiple products this gets
+			// overwritten for each one and get_store_api_pixel_event_data() will only
+			// return the last product's event. Fix: convert to an array and flush all.
 			$pending_pixel_params                = array_merge( $custom_data, array( 'event_id' => $event->get_id() ) );
 			$this->pending_store_api_pixel_event = array(
 				'event'  => 'AddToCart',

--- a/tests/js/pixel-events.test.js
+++ b/tests/js/pixel-events.test.js
@@ -1542,6 +1542,7 @@ describe('Pixel Events - WooCommerce Blocks Store API', function () {
                     json: () => Promise.resolve({
                         responses: [
                             {
+                                status: 200,
                                 body: {
                                     extensions: {
                                         'facebook-for-woocommerce': {
@@ -1579,6 +1580,7 @@ describe('Pixel Events - WooCommerce Blocks Store API', function () {
                     json: () => Promise.resolve({
                         responses: [
                             {
+                                status: 200,
                                 body: {
                                     extensions: {
                                         'other-plugin': { test: true }
@@ -1599,6 +1601,156 @@ describe('Pixel Events - WooCommerce Blocks Store API', function () {
             await new Promise(resolve => setTimeout(resolve, 0));
 
             expect(mockFbq).not.toHaveBeenCalled();
+        });
+
+        it('should not fire when batch response item status is not 2xx', async function () {
+            const mockResponse = {
+                ok: true,
+                clone: () => ({
+                    json: () => Promise.resolve({
+                        responses: [
+                            {
+                                status: 422,
+                                body: {
+                                    extensions: {
+                                        'facebook-for-woocommerce': {
+                                            event: 'AddToCart',
+                                            params: { event_id: 'failed-1' }
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    })
+                })
+            };
+
+            const mockOriginalFetch = jest.fn().mockResolvedValue(mockResponse);
+            global.fetch = mockOriginalFetch;
+
+            require('../../assets/js/frontend/pixel-events.js');
+
+            await global.fetch('/wc/store/v1/batch', { method: 'POST' });
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(mockFbq).not.toHaveBeenCalled();
+        });
+
+        it('should not fire for empty responses array', async function () {
+            const mockResponse = {
+                ok: true,
+                clone: () => ({
+                    json: () => Promise.resolve({ responses: [] })
+                })
+            };
+
+            const mockOriginalFetch = jest.fn().mockResolvedValue(mockResponse);
+            global.fetch = mockOriginalFetch;
+
+            require('../../assets/js/frontend/pixel-events.js');
+
+            await global.fetch('/wc/store/v1/batch', { method: 'POST' });
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(mockFbq).not.toHaveBeenCalled();
+        });
+
+        it('should fire once per valid item in multi-item batch', async function () {
+            const mkItem = (id) => ({
+                status: 200,
+                body: {
+                    extensions: {
+                        'facebook-for-woocommerce': {
+                            event: 'AddToCart',
+                            params: { event_id: id }
+                        }
+                    }
+                }
+            });
+            const mockResponse = {
+                ok: true,
+                clone: () => ({
+                    json: () => Promise.resolve({
+                        responses: [
+                            mkItem('id-1'),
+                            { status: 200, body: { extensions: {} } },
+                            mkItem('id-2')
+                        ]
+                    })
+                })
+            };
+
+            const mockOriginalFetch = jest.fn().mockResolvedValue(mockResponse);
+            global.fetch = mockOriginalFetch;
+
+            require('../../assets/js/frontend/pixel-events.js');
+
+            await global.fetch('/wc/store/v1/batch', { method: 'POST' });
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(mockFbq).toHaveBeenCalledTimes(2);
+        });
+
+        it('should skip batch items with null body', async function () {
+            const mockResponse = {
+                ok: true,
+                clone: () => ({
+                    json: () => Promise.resolve({
+                        responses: [null, { status: 200, body: null }]
+                    })
+                })
+            };
+
+            const mockOriginalFetch = jest.fn().mockResolvedValue(mockResponse);
+            global.fetch = mockOriginalFetch;
+
+            require('../../assets/js/frontend/pixel-events.js');
+
+            await global.fetch('/wc/store/v1/batch', { method: 'POST' });
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(mockFbq).not.toHaveBeenCalled();
+        });
+
+        it('should fire only once for direct extension, not again for batch responses', async function () {
+            // A response with both top-level extensions AND responses[] should fire
+            // only for the top-level extension (else-if prevents double-fire).
+            const mockResponse = {
+                ok: true,
+                clone: () => ({
+                    json: () => Promise.resolve({
+                        extensions: {
+                            'facebook-for-woocommerce': {
+                                event: 'AddToCart',
+                                params: { event_id: 'direct-1' }
+                            }
+                        },
+                        responses: [
+                            {
+                                status: 200,
+                                body: {
+                                    extensions: {
+                                        'facebook-for-woocommerce': {
+                                            event: 'AddToCart',
+                                            params: { event_id: 'batch-1' }
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    })
+                })
+            };
+
+            const mockOriginalFetch = jest.fn().mockResolvedValue(mockResponse);
+            global.fetch = mockOriginalFetch;
+
+            require('../../assets/js/frontend/pixel-events.js');
+
+            await global.fetch('/wc/store/v1/batch', { method: 'POST' });
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(mockFbq).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/tests/js/pixel-events.test.js
+++ b/tests/js/pixel-events.test.js
@@ -1534,6 +1534,74 @@ describe('Pixel Events - WooCommerce Blocks Store API', function () {
         });
     });
 
+    describe('Batch endpoint support', function () {
+        it('should process AddToCart event from /wc/store/v1/batch response', async function () {
+            const mockResponse = {
+                ok: true,
+                clone: () => ({
+                    json: () => Promise.resolve({
+                        responses: [
+                            {
+                                body: {
+                                    extensions: {
+                                        'facebook-for-woocommerce': {
+                                            event: 'AddToCart',
+                                            params: { value: 29.99, currency: 'USD', event_id: 'batch-1' }
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    })
+                })
+            };
+
+            const mockOriginalFetch = jest.fn().mockResolvedValue(mockResponse);
+            global.fetch = mockOriginalFetch;
+
+            require('../../assets/js/frontend/pixel-events.js');
+
+            await global.fetch('/wc/store/v1/batch', { method: 'POST' });
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(mockFbq).toHaveBeenCalledWith(
+                'track',
+                'AddToCart',
+                { value: 29.99, currency: 'USD', event_id: 'batch-1' },
+                { eventID: 'batch-1' }
+            );
+        });
+
+        it('should not fire for /wc/store/v1/batch when no fb extension exists', async function () {
+            const mockResponse = {
+                ok: true,
+                clone: () => ({
+                    json: () => Promise.resolve({
+                        responses: [
+                            {
+                                body: {
+                                    extensions: {
+                                        'other-plugin': { test: true }
+                                    }
+                                }
+                            }
+                        ]
+                    })
+                })
+            };
+
+            const mockOriginalFetch = jest.fn().mockResolvedValue(mockResponse);
+            global.fetch = mockOriginalFetch;
+
+            require('../../assets/js/frontend/pixel-events.js');
+
+            await global.fetch('/wc/store/v1/batch', { method: 'POST' });
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(mockFbq).not.toHaveBeenCalled();
+        });
+    });
+
     describe('URL matching', function () {
         it('should match /wc/store/v1/cart/add-item', async function () {
             const mockResponse = {


### PR DESCRIPTION
## Description

This changeset fixes AddToCart Pixel tracking for WooCommerce Blocks Store API batch Ajax requests.

The status quo was that the frontend Pixel event interceptor only handled direct Store API `cart/add-item` responses. Some WooCommerce Blocks flows (like on the Shop page) send add-to-cart requests through the Store API batch endpoint instead, so the AddToCart Pixel event could be skipped.

With this PR we keep the frontend Store API fetch interceptor active even when no initial PHP event queue is present.

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fix AddToCart Pixel tracking for WooCommerce Blocks Store API batch requests.


## Test Plan

1. Enable WooCommerce Blocks cart & shop functionality.
2. Trigger an add-to-cart flow that uses the Store API batch endpoint.
3. Confirm the browser request goes to `/wc/store/v1/batch` or `/wc/store/batch`.
4. Confirm the AddToCart Pixel event fires with the expected event ID.

## Screenshots

N/A