### PR TITLE
Fix for fbc & fbp priorities on when they are set

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -69,6 +69,12 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		private static $param_builder = null;
 
+		/** @var string|null Cached fbc value from ParamBuilder */
+		private static $cached_fbc = null;
+
+		/** @var string|null Cached fbp value from ParamBuilder */
+		private static $cached_fbp = null;
+
 		/**
 		 * Order meta keys used by the tracker.
 		 */
@@ -131,6 +137,26 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			return self::$param_builder;
 		}
 
+		public static function get_fbc() {
+			if ( null === self::$cached_fbc ) {
+				$param_builder = self::get_param_builder();
+				if ( $param_builder ) {
+					self::$cached_fbc = $param_builder->getFbc();
+				}
+			}
+			return self::$cached_fbc;
+		}
+
+		public static function get_fbp() {
+			if ( null === self::$cached_fbp ) {
+				$param_builder = self::get_param_builder();
+				if ( $param_builder ) {
+					self::$cached_fbp = $param_builder->getFbp();
+				}
+			}
+			return self::$cached_fbp;
+		}
+
 		/**
 		 * Initializes the CAPI server side Parameter Builder and sets cookies as needed.
 		 */
@@ -146,8 +172,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				// When signals are held, still run ParamBuilder so it can generate
 				// attribution IDs, but do not write cookies until signals are released.
 				if ( FacebookSignalsState::is_held() ) {
-					$fbc = $param_builder->getFbc();
-					$fbp = $param_builder->getFbp();
+					$fbc = self::get_fbc();
+					$fbp = self::get_fbp();
 
 					if ( ! empty( $fbc ) ) {
 						FacebookSignalsState::set_attribution_data( 'fbc', $fbc );
@@ -164,22 +190,22 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 						}
 					}
 
-					return;
-				}
+				} else {
+					$cookie_to_set = $param_builder->getCookiesToSet();
 
-				$cookie_to_set = $param_builder->getCookiesToSet();
-
-				if ( ! headers_sent() ) {
-					foreach ( $cookie_to_set as $cookie ) {
-						setcookie(
-							$cookie->name,
-							$cookie->value,
-							time() + $cookie->max_age,
-							'/',
-							$cookie->domain
-						);
+					if ( ! headers_sent() ) {
+						foreach ( $cookie_to_set as $cookie ) {
+							setcookie(
+								$cookie->name,
+								$cookie->value,
+								time() + $cookie->max_age,
+								'/',
+								$cookie->domain
+							);
+						}
 					}
 				}
+
 			} catch ( \Exception $exception ) {
 				Logger::log(
 					'Error setting up server side CAPI Parameter Builder: ' . $exception->getMessage(),

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -189,7 +189,6 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 							FacebookSignalsState::set_attribution_data( 'fbc_domain', $cookie->domain );
 						}
 					}
-
 				} else {
 					$cookie_to_set = $param_builder->getCookiesToSet();
 
@@ -205,7 +204,6 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 						}
 					}
 				}
-
 			} catch ( \Exception $exception ) {
 				Logger::log(
 					'Error setting up server side CAPI Parameter Builder: ' . $exception->getMessage(),

--- a/facebook-commerce-iframe-whatsapp-utility-event.php
+++ b/facebook-commerce-iframe-whatsapp-utility-event.php
@@ -110,8 +110,8 @@ class WC_Facebookcommerce_Iframe_Whatsapp_Utility_Event {
 
 		$items = method_exists( $order, 'get_items' ) ? $order->get_items() : array();
 		foreach ( $items as $item ) {
-			$product_id = method_exists( $item, 'get_product_id' ) ? $item->get_product_id() : ( isset( $item['product_id'] ) ? $item['product_id'] : 0 );
-			$item_total = method_exists( $item, 'get_total' ) ? $item->get_total() : ( isset( $item['line_total'] ) ? $item['line_total'] : 0 );
+			$product_id                = method_exists( $item, 'get_product_id' ) ? $item->get_product_id() : ( isset( $item['product_id'] ) ? $item['product_id'] : 0 );
+			$item_total                = method_exists( $item, 'get_total' ) ? $item->get_total() : ( isset( $item['line_total'] ) ? $item['line_total'] : 0 );
 			$order_metadata['items'][] = array(
 				'product_id' => $product_id,
 				'name'       => method_exists( $item, 'get_name' ) ? $item->get_name() : ( isset( $item['name'] ) ? $item['name'] : '' ),

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -282,6 +282,7 @@ class WC_Facebook_Loader {
 
 		deactivate_plugins( plugin_basename( __FILE__ ) );
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['activate'] ) ) {
 			unset( $_GET['activate'] );
 		}
@@ -297,6 +298,7 @@ class WC_Facebook_Loader {
 	 * @param string $class   The css class for the notice.
 	 * @param string $message The notice message.
 	 */
+	// phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.classFound
 	private function add_admin_notice( $slug, $class, $message ) {
 
 		$this->notices[ $slug ] = array(
@@ -407,8 +409,8 @@ class WC_Facebook_Loader {
 	private static function set_wc_facebook_svr_flags() {
 
 		if ( ! function_exists( 'update_option' ) ||
-			 ! function_exists( 'get_transient' ) ||
-			 ! function_exists( 'set_transient' ) ) {
+			! function_exists( 'get_transient' ) ||
+			! function_exists( 'set_transient' ) ) {
 			return;
 		}
 
@@ -565,7 +567,7 @@ class WC_Facebook_Loader {
 		$existing_version = $existing->new_version ?? '0.0.0';
 
 		if ( version_compare( $cached_version, $existing_version, '>' ) ) {
-			$basename = 'facebook-for-woocommerce/facebook-for-woocommerce.php';
+			$basename                         = 'facebook-for-woocommerce/facebook-for-woocommerce.php';
 			$transient->response[ $basename ] = self::$compat_cached_entry;
 			unset( $transient->no_update[ $basename ] );
 		}

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -374,6 +374,7 @@ class AJAX {
 		$products_query_vars = array(
 			'post_type'  => 'product',
 			'fields'     => 'ids',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			'meta_query' => $sync_enabled_meta_query,
 		);
 
@@ -399,6 +400,7 @@ class AJAX {
 				}
 			}
 
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 			$products_query_vars['tax_query'] = $categories_tax_query;
 		}
 
@@ -425,8 +427,10 @@ class AJAX {
 			}
 
 			if ( empty( $products_query_vars['tax_query'] ) ) {
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 				$products_query_vars['tax_query'] = $tags_tax_query;
 			} else {
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 				$products_query_vars['tax_query'] = array(
 					'relation' => 'OR',
 					$products_query_vars,

--- a/includes/API.php
+++ b/includes/API.php
@@ -153,14 +153,14 @@ class API extends Base {
 			 *
 			 * @link https://developers.facebook.com/docs/graph-api/using-graph-api/error-handling#errorcodes
 			 */
-			if ( ( $code >= 200 && $code < 300 ) || in_array( $code, array( 10, 102, 190 ), false ) ) {
+			if ( ( $code >= 200 && $code < 300 ) || in_array( $code, array( 10, 102, 190 ), true ) ) {
 				set_transient( 'wc_facebook_connection_invalid', time(), DAY_IN_SECONDS );
 			} else {
 				// this was an unrelated error, so the OAuth connection may still be valid
 				delete_transient( 'wc_facebook_connection_invalid' );
 			}
 			// if the code indicates a retry and we've not hit the retry limit, perform the request again
-			if ( in_array( $code, $request->get_retry_codes(), false ) && $request->get_retry_count() < $request->get_retry_limit() ) {
+			if ( in_array( $code, $request->get_retry_codes(), true ) && $request->get_retry_count() < $request->get_retry_limit() ) {
 				$request->mark_retry();
 				$this->response = $this->perform_request( $request );
 				return;
@@ -777,7 +777,7 @@ class API extends Base {
 		$next_response = null;
 		// get the next page if we haven't reached the limit of pages to retrieve and the endpoint for the next page is available
 		if ( ( 0 === $additional_pages || $response->get_pages_retrieved() <= $additional_pages ) && $response->get_next_page_endpoint() ) {
-			$components = parse_url( str_replace( $this->request_uri, '', $response->get_next_page_endpoint() ) );
+			$components = wp_parse_url( str_replace( $this->request_uri, '', $response->get_next_page_endpoint() ) );
 			$request    = $this->get_new_request(
 				[
 					'path'   => $components['path'] ?? '',

--- a/includes/API/FBE/Installation/Read/Response.php
+++ b/includes/API/FBE/Installation/Read/Response.php
@@ -25,7 +25,7 @@ class Response extends API\Response {
 		if ( ! empty( $data['installed_features'] ) && is_array( $data['installed_features'] ) ) {
 			foreach ( $data['installed_features'] as $feature ) {
 				if ( isset( $feature['feature_type'], $feature['connected_assets']['pixel_id'] ) &&
-					 'pixel' === $feature['feature_type'] ) {
+					'pixel' === $feature['feature_type'] ) {
 					return $feature['connected_assets']['pixel_id'];
 				}
 			}

--- a/includes/API/Plugin/InitializeRestAPI.php
+++ b/includes/API/Plugin/InitializeRestAPI.php
@@ -97,6 +97,7 @@ class InitializeRestAPI {
 				}
 			} catch ( \Exception $e ) {
 				// Log error but continue with other requests
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 				error_log( 'Meta for WooCommerce: Error creating request class ' . $request_class . ': ' . $e->getMessage() );
 			}
 		}

--- a/includes/API/Plugin/Request.php
+++ b/includes/API/Plugin/Request.php
@@ -109,6 +109,7 @@ abstract class Request {
 	 * @param mixed  $default Default value if key doesn't exist.
 	 * @return mixed The value or default if not set.
 	 */
+	// phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.defaultFound
 	public function get_param( $key, $default = null ) {
 		return isset( $this->data[ $key ] ) ? $this->data[ $key ] : $default;
 	}

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -641,6 +641,7 @@ class Admin {
 	 * @param string $product_edit the product metadata that is being edited.
 	 */
 	public function handle_products_sync_bulk_actions( $product_edit ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$sync_mode = isset( $_GET['facebook_bulk_sync_options'] ) ? (string) sanitize_text_field( wp_unslash( $_GET['facebook_bulk_sync_options'] ) ) : null;
 
 		if ( $sync_mode ) {
@@ -1357,15 +1358,15 @@ class Admin {
 		}
 
 		// Get variation meta values
-		$description       = $this->get_product_variation_meta( $variation, \WC_Facebookcommerce_Integration::FB_RICH_TEXT_DESCRIPTION, $parent );
-		$price             = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_PRICE, $parent );
-		$image_url         = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_IMAGE, $parent );
-		$image_source      = $variation->get_meta( Products::PRODUCT_IMAGE_SOURCE_META_KEY );
-		$image_urls        = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_IMAGES, $parent );
-		$video_source      = $variation->get_meta( Products::PRODUCT_VIDEO_SOURCE_META_KEY );
-		$video_urls        = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_VIDEO, $parent );
-		$custom_video_url  = $variation->get_meta( \WC_Facebook_Product::FB_PRODUCT_VIDEO . '_custom_url' );
-		$fb_mpn            = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_MPN, $parent );
+		$description      = $this->get_product_variation_meta( $variation, \WC_Facebookcommerce_Integration::FB_RICH_TEXT_DESCRIPTION, $parent );
+		$price            = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_PRICE, $parent );
+		$image_url        = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_IMAGE, $parent );
+		$image_source     = $variation->get_meta( Products::PRODUCT_IMAGE_SOURCE_META_KEY );
+		$image_urls       = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_IMAGES, $parent );
+		$video_source     = $variation->get_meta( Products::PRODUCT_VIDEO_SOURCE_META_KEY );
+		$video_urls       = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_VIDEO, $parent );
+		$custom_video_url = $variation->get_meta( \WC_Facebook_Product::FB_PRODUCT_VIDEO . '_custom_url' );
+		$fb_mpn           = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_MPN, $parent );
 
 		?>
 		<div class="facebook-metabox wc-metabox closed">
@@ -1461,7 +1462,7 @@ class Admin {
 		</p>
 		<div id="fb_product_video_selected_thumbnails_<?php echo esc_attr( $index ); ?>" class="fb-product-video-thumbnails product-video-source-field <?php echo esc_attr( 'show-if-product-video-source-' . Products::PRODUCT_VIDEO_SOURCE_UPLOAD ); ?>" >
 			<?php
-				$attachment_ids = [];
+				$attachment_ids   = [];
 				$video_urls_array = ! empty( $video_urls ) && is_string( $video_urls ) ? explode( ',', $video_urls ) : ( is_array( $video_urls ) ? $video_urls : [] );
 			if ( ! empty( $video_urls_array ) && is_array( $video_urls_array ) ) {
 				foreach ( $video_urls_array as $video_url ) {
@@ -1724,7 +1725,7 @@ class Admin {
 					explode( ',', $video_ids_raw )
 				)
 			);
-			$video_urls = $video_urls_array; // Store as array like simple products do
+			$video_urls       = $video_urls_array; // Store as array like simple products do
 		} else {
 			$video_urls = array();
 		}
@@ -1746,7 +1747,7 @@ class Admin {
 		$image_ids    = isset( $_POST[ $posted_param ] ) ? sanitize_text_field( wp_unslash( $_POST[ $posted_param ] ) ) : '';
 		$posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_PRICE;
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verification is handled in save_product_variation_edit_fields method
-		$price        = isset( $_POST[ $posted_param ][ $index ] ) ? wc_format_decimal( wc_clean( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) ) : '';
+		$price = isset( $_POST[ $posted_param ][ $index ] ) ? wc_format_decimal( wc_clean( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) ) : '';
 
 		return array(
 			'description_plain' => $description_plain,

--- a/includes/Admin/Enhanced_Settings.php
+++ b/includes/Admin/Enhanced_Settings.php
@@ -70,7 +70,7 @@ class Enhanced_Settings {
 		if ( $is_connected ) {
 			if ( $is_woo_all_products_sync_enbaled ) {
 				$screens = array(
-					Settings_Screens\Shops::ID        => new Settings_Screens\Shops(),
+					Settings_Screens\Shops::ID => new Settings_Screens\Shops(),
 					Settings_Screens\Product_Attributes::ID => new Settings_Screens\Product_Attributes(),
 				);
 			} else {
@@ -98,8 +98,8 @@ class Enhanced_Settings {
 	 * @return void
 	 */
 	public function add_extra_screens(): void {
-		$rollout_switches                      = $this->plugin->get_rollout_switches();
-		$is_connected                          = $this->plugin->get_connection_handler()->is_connected();
+		$rollout_switches = $this->plugin->get_rollout_switches();
+		$is_connected     = $this->plugin->get_connection_handler()->is_connected();
 	}
 
 	/**

--- a/includes/Admin/Global_Attributes_Banner.php
+++ b/includes/Admin/Global_Attributes_Banner.php
@@ -51,8 +51,9 @@ class Global_Attributes_Banner {
 	 * Check for URL parameter to trigger test banner.
 	 */
 	public function maybe_trigger_test_banner() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['test_fb_banner'] ) && current_user_can( 'manage_woocommerce' ) ) {
-			$attribute_name = sanitize_text_field( wp_unslash( $_GET['test_fb_banner'] ) );
+			$attribute_name = sanitize_text_field( wp_unslash( $_GET['test_fb_banner'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			if ( empty( $attribute_name ) ) {
 				$attribute_name = 'escobar';
 			}

--- a/includes/Admin/Settings_Screens/Localization_Settings_Trait.php
+++ b/includes/Admin/Settings_Screens/Localization_Settings_Trait.php
@@ -36,9 +36,9 @@ trait Localization_Settings_Trait {
 		}
 
 		// Get active localization integration to determine setting state
-		$integration = IntegrationRegistry::get_active_localization_integration();
+		$integration  = IntegrationRegistry::get_active_localization_integration();
 		$is_available = $integration && $integration->is_available();
-		$is_eligible = $is_available && method_exists( $integration, 'is_eligible_for_language_override_feeds' ) && $integration->is_eligible_for_language_override_feeds();
+		$is_eligible  = $is_available && method_exists( $integration, 'is_eligible_for_language_override_feeds' ) && $integration->is_eligible_for_language_override_feeds();
 
 		// Hide the entire section for ineligible sites (legacy multi-language setups)
 		if ( ! $is_eligible ) {
@@ -53,7 +53,7 @@ trait Localization_Settings_Trait {
 			// First time - set default based on whether we have an available AND eligible integration
 			// and main product sync is enabled
 			$product_sync_enabled = facebook_for_woocommerce()->get_integration()->is_product_sync_enabled();
-			$default_value = ( $is_eligible && $product_sync_enabled ) ? 'yes' : 'no';
+			$default_value        = ( $is_eligible && $product_sync_enabled ) ? 'yes' : 'no';
 			update_option( \WC_Facebookcommerce_Integration::OPTION_LANGUAGE_OVERRIDE_FEED_GENERATION_ENABLED, $default_value );
 			$current_value = $default_value;
 		}
@@ -102,7 +102,7 @@ trait Localization_Settings_Trait {
 		try {
 			// Get the active localization integration (only one detected plugin)
 			$active_integration = IntegrationRegistry::get_active_localization_integration();
-			$feed_data = new LanguageFeedData();
+			$feed_data          = new LanguageFeedData();
 		} catch ( \Exception $e ) {
 			?>
 			<tr valign="top">
@@ -116,6 +116,7 @@ trait Localization_Settings_Trait {
 				</td>
 			</tr>
 			<?php
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			error_log( 'Meta for WooCommerce - Localization Integrations Error: ' . $e->getMessage() );
 			return;
 		}
@@ -126,6 +127,7 @@ trait Localization_Settings_Trait {
 			try {
 				$languages = $feed_data->get_available_languages();
 			} catch ( \Exception $e ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 				error_log( 'Meta for WooCommerce - Error getting available languages: ' . $e->getMessage() );
 			}
 		}
@@ -155,13 +157,14 @@ trait Localization_Settings_Trait {
 						<?php else : ?>
 							<?php
 							try {
-								$status = $this->get_integration_status( $active_integration );
-								$version = $active_integration->get_plugin_version();
+								$status           = $this->get_integration_status( $active_integration );
+								$version          = $active_integration->get_plugin_version();
 								$default_language = $active_integration->get_default_language();
 							} catch ( \Exception $e ) {
-								$status = 'error';
-								$version = '';
+								$status           = 'error';
+								$version          = '';
 								$default_language = '';
+								// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 								error_log( 'Meta for WooCommerce - Error getting integration data: ' . $e->getMessage() );
 							}
 							?>
@@ -279,11 +282,11 @@ trait Localization_Settings_Trait {
 	 */
 	private function render_status_badge( $status ) {
 		$labels = array(
-			'active'               => __( 'Active', 'facebook-for-woocommerce' ),
-			'active-ineligible'    => __( 'Active - Ineligible', 'facebook-for-woocommerce' ),
-			'misconfigured'        => __( 'Misconfigured', 'facebook-for-woocommerce' ),
-			'installed'            => __( 'Installed', 'facebook-for-woocommerce' ),
-			'not-available'        => __( 'Not Available', 'facebook-for-woocommerce' ),
+			'active'            => __( 'Active', 'facebook-for-woocommerce' ),
+			'active-ineligible' => __( 'Active - Ineligible', 'facebook-for-woocommerce' ),
+			'misconfigured'     => __( 'Misconfigured', 'facebook-for-woocommerce' ),
+			'installed'         => __( 'Installed', 'facebook-for-woocommerce' ),
+			'not-available'     => __( 'Not Available', 'facebook-for-woocommerce' ),
 		);
 
 		$label = isset( $labels[ $status ] ) ? $labels[ $status ] : $status;

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -75,18 +75,20 @@ class Product_Sync extends Abstract_Settings_Screen {
 		if ( ! $this->is_current_screen_page() ) {
 			return;
 		}
-		wp_enqueue_script( 'wc-backbone-modal', null, array( 'backbone' ) );
+		wp_enqueue_script( 'wc-backbone-modal', null, array( 'backbone' ), \WC_Facebookcommerce::PLUGIN_VERSION, true );
 		wp_enqueue_script(
 			'facebook-for-woocommerce-modal',
 			facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/modal.js',
 			array( 'jquery', 'wc-backbone-modal', 'jquery-blockui' ),
-			\WC_Facebookcommerce::PLUGIN_VERSION
+			\WC_Facebookcommerce::PLUGIN_VERSION,
+			true
 		);
 		wp_enqueue_script(
 			'facebook-for-woocommerce-settings-sync',
 			facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/settings-sync.js',
 			array( 'jquery', 'wc-backbone-modal', 'jquery-blockui', 'jquery-tiptip', 'facebook-for-woocommerce-modal', 'wc-enhanced-select' ),
-			\WC_Facebookcommerce::PLUGIN_VERSION
+			\WC_Facebookcommerce::PLUGIN_VERSION,
+			true
 		);
 
 		/* translators: Placeholders: {count} number of remaining items */
@@ -272,7 +274,7 @@ class Product_Sync extends Abstract_Settings_Screen {
 			)
 		);
 		$product_tags       = $term_query->get_terms();
-		$settings = array(
+		$settings           = array(
 			array(
 				'type'  => 'product_sync_title',
 				'title' => __( 'Product sync', 'facebook-for-woocommerce' ),

--- a/includes/CollectionPage.php
+++ b/includes/CollectionPage.php
@@ -122,6 +122,7 @@ class CollectionPage {
 
 			// Prevent WooCommerce core and themes from overriding the product order.
 			// Removes itself after first invocation to avoid affecting other queries in the same request.
+			// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 			$ordering_override = function ( $_args ) use ( &$ordering_override ) {
 				remove_filter( 'woocommerce_get_catalog_ordering_args', $ordering_override, PHP_INT_MAX );
 				return array(

--- a/includes/Events/Event.php
+++ b/includes/Events/Event.php
@@ -38,7 +38,7 @@ class Event {
 	 * }
 	 */
 	public static function get_version_info() {
-		$source = 'woocommerce';
+		$source  = 'woocommerce';
 		$source .= self::get_agent_flags();
 		return array(
 			'source'        => $source,
@@ -269,16 +269,16 @@ class Event {
 
 		if ( empty( $fbc ) ) {
 			$cookie_fbc = ! empty( $_COOKIE['_fbc'] )
-                ? sanitize_text_field( wp_unslash( $_COOKIE['_fbc'] ) )
-                : null;
-			
-            $request_fbclid = isset( $_GET['fbclid'] ) // phpcs:ignore WordPress.Security.NonceVerification
-                ? sanitize_text_field( wp_unslash( $_GET['fbclid'] ) ) // phpcs:ignore WordPress.Security.NonceVerification
-                : null;
-			
+				? sanitize_text_field( wp_unslash( $_COOKIE['_fbc'] ) )
+				: null;
+
+			$request_fbclid = isset( $_GET['fbclid'] ) // phpcs:ignore WordPress.Security.NonceVerification
+				? sanitize_text_field( wp_unslash( $_GET['fbclid'] ) ) // phpcs:ignore WordPress.Security.NonceVerification
+				: null;
+
 			if ( $request_fbclid && ( empty( $cookie_fbc ) || self::has_fbclid_changed( $cookie_fbc, $request_fbclid ) ) ) {
-				$creation_time 	= time();
-				$fbc			= "fb.1.{$creation_time}.{$request_fbclid}";
+				$creation_time = time();
+				$fbc           = "fb.1.{$creation_time}.{$request_fbclid}";
 			}
 
 			if ( empty( $fbc ) && ! empty( $cookie_fbc ) ) {
@@ -286,8 +286,8 @@ class Event {
 			}
 
 			if ( empty( $fbc ) && isset( $_SESSION['_fbc'] ) ) {
-                $fbc = sanitize_text_field( $_SESSION['_fbc'] );
-            }
+				$fbc = sanitize_text_field( $_SESSION['_fbc'] );
+			}
 		}
 
 		if ( ! empty( $fbc ) && ! FacebookSignalsState::is_held() ) {
@@ -399,34 +399,34 @@ class Event {
 	private static function get_agent_flags() {
 		$postfix = '';
 		if ( function_exists( 'get_option' ) && false !== get_option( 'wc_facebook_svr_flags' ) ) {
-			$flags = get_option( 'wc_facebook_svr_flags' );
+			$flags   = get_option( 'wc_facebook_svr_flags' );
 			$postfix = "_{$flags}";
 		}
 		return $postfix;
 	}
 
 	/**
-     * Checks whether the fbclid in the current request differs from
-     * the one stored in the existing _fbc cookie.
-     *
-     * @param string      $cookie_fbc The current _fbc cookie value
-     *                                (format: fb.{subdomain}.{timestamp}.{fbclid}).
-     * @param string|null $request_fbclid The fbclid from the current request,
-     *                                    or null if not present.
-     *
-     * @return bool True if fbclid has changed, false otherwise.
-     */
-    private static function has_fbclid_changed( $cookie_fbc, $request_fbclid ) {
-        if ( null === $request_fbclid ) {
-            return false;
-        }
+	 * Checks whether the fbclid in the current request differs from
+	 * the one stored in the existing _fbc cookie.
+	 *
+	 * @param string      $cookie_fbc     The current _fbc cookie value
+	 *                                    (format: fb.{subdomain}.{timestamp}.{fbclid}).
+	 * @param string|null $request_fbclid The fbclid from the current request,
+	 *                                    or null if not present.
+	 *
+	 * @return bool True if fbclid has changed, false otherwise.
+	 */
+	private static function has_fbclid_changed( $cookie_fbc, $request_fbclid ) {
+		if ( null === $request_fbclid ) {
+			return false;
+		}
 
-        $parts = explode( '.', $cookie_fbc );
-        if ( count( $parts ) < 4 ) {
-            return true;
-        }
+		$parts = explode( '.', $cookie_fbc );
+		if ( count( $parts ) < 4 ) {
+			return true;
+		}
 
-        $cookie_fbclid = implode( '.', array_slice( $parts, 3 ) );
-        return $cookie_fbclid !== $request_fbclid;
-    }
+		$cookie_fbclid = implode( '.', array_slice( $parts, 3 ) );
+		return $cookie_fbclid !== $request_fbclid;
+	}
 }

--- a/includes/Events/Event.php
+++ b/includes/Events/Event.php
@@ -265,27 +265,19 @@ class Event {
 	 * @return string
 	 */
 	protected function get_click_id() {
-		$fbc = '';
-		if ( ! empty( $_COOKIE['_fbc'] ) ) {
-			$fbc = wc_clean( wp_unslash( $_COOKIE['_fbc'] ) );
-		}
-
-		if ( empty( $fbc ) && ! empty( $_SESSION['_fbc'] ) ) {
-			$fbc = $_SESSION['_fbc']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		}
-
+		$fbc = \WC_Facebookcommerce_EventsTracker::get_fbc();
 		if ( empty( $fbc ) ) {
-			$param_builder = \WC_Facebookcommerce_EventsTracker::get_param_builder();
-			$fbc = $param_builder->getFbc();
+			if ( ! empty( $_COOKIE['_fbc'] ) ) {
+				$fbc = wc_clean( wp_unslash( $_COOKIE['_fbc'] ) );
+			} else if ( ! empty( $_SESSION['_fbc'] ) ) {
+				$fbc = $_SESSION['_fbc']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			} else if ( ! empty( $_REQUEST['fbclid'] ) ) {
+				$creation_time = time();
+				$fbclid = wc_clean( wp_unslash( $_REQUEST['fbclid'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+				$fbc = "fb.1.{$creation_time}.{$fbclid}";
+			}
 		}
-
-		if ( empty( $fbc ) && ! empty( $_REQUEST['fbclid'] ) ) {
-			$creation_time = time();
-			$fbclid = wc_clean( wp_unslash( $_REQUEST['fbclid'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
-			$fbc = "fb.1.{$creation_time}.{$fbclid}";
-		}
-
-		if ( ! empty( $fbc ) ) {
+		if ( ! empty( $fbc ) && ! FacebookSignalsState::is_held() ) {
 			$_SESSION['_fbc'] = $fbc;
 		}
 		// Return null instead of empty string
@@ -307,18 +299,15 @@ class Event {
 	 * @return string
 	 */
 	protected function get_browser_id() {
-		$fbp = ! empty( $_COOKIE['_fbp'] ) ? wc_clean( wp_unslash( $_COOKIE['_fbp'] ) ) : '';
-
-		if ( empty( $fbp ) && ! empty( $_SESSION['_fbp'] ) ) {
-			$fbp = $_SESSION['_fbp']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		}
-
+		$fbp = \WC_Facebookcommerce_EventsTracker::get_fbp();
 		if ( empty( $fbp ) ) {
-			$param_builder = \WC_Facebookcommerce_EventsTracker::get_param_builder();
-			$fbp = $param_builder->getFbp();
+			if ( ! empty( $_COOKIE['_fbp'] ) ) {
+				$fbp = wc_clean( wp_unslash( $_COOKIE['_fbp'] ) );
+			} else if ( ! empty( $_SESSION['_fbp'] ) ) {
+				$fbp = $_SESSION['_fbp']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			}
 		}
-
-		if ( ! empty( $fbp ) ) {
+		if ( ! empty( $fbp ) && ! FacebookSignalsState::is_held() ) {
 			$_SESSION['_fbp'] = $fbp;
 		}
 		// Return null instead of empty string

--- a/includes/Events/Event.php
+++ b/includes/Events/Event.php
@@ -266,20 +266,34 @@ class Event {
 	 */
 	protected function get_click_id() {
 		$fbc = \WC_Facebookcommerce_EventsTracker::get_fbc();
+
 		if ( empty( $fbc ) ) {
-			if ( ! empty( $_COOKIE['_fbc'] ) ) {
-				$fbc = wc_clean( wp_unslash( $_COOKIE['_fbc'] ) );
-			} else if ( ! empty( $_SESSION['_fbc'] ) ) {
-				$fbc = $_SESSION['_fbc']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			} else if ( ! empty( $_REQUEST['fbclid'] ) ) {
-				$creation_time = time();
-				$fbclid = wc_clean( wp_unslash( $_REQUEST['fbclid'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
-				$fbc = "fb.1.{$creation_time}.{$fbclid}";
+			$cookie_fbc = ! empty( $_COOKIE['_fbc'] )
+                ? sanitize_text_field( wp_unslash( $_COOKIE['_fbc'] ) )
+                : null;
+			
+            $request_fbclid = isset( $_GET['fbclid'] ) // phpcs:ignore WordPress.Security.NonceVerification
+                ? sanitize_text_field( wp_unslash( $_GET['fbclid'] ) ) // phpcs:ignore WordPress.Security.NonceVerification
+                : null;
+			
+			if ( $request_fbclid && ( empty( $cookie_fbc ) || self::has_fbclid_changed( $cookie_fbc, $request_fbclid ) ) ) {
+				$creation_time 	= time();
+				$fbc			= "fb.1.{$creation_time}.{$request_fbclid}";
 			}
+
+			if ( empty( $fbc ) && ! empty( $cookie_fbc ) ) {
+				$fbc = $cookie_fbc;
+			}
+
+			if ( empty( $fbc ) && isset( $_SESSION['_fbc'] ) ) {
+                $fbc = sanitize_text_field( $_SESSION['_fbc'] );
+            }
 		}
+
 		if ( ! empty( $fbc ) && ! FacebookSignalsState::is_held() ) {
 			$_SESSION['_fbc'] = $fbc;
 		}
+
 		// Return null instead of empty string
 		return ! empty( $fbc ) ? $fbc : null;
 	}
@@ -303,7 +317,7 @@ class Event {
 		if ( empty( $fbp ) ) {
 			if ( ! empty( $_COOKIE['_fbp'] ) ) {
 				$fbp = wc_clean( wp_unslash( $_COOKIE['_fbp'] ) );
-			} else if ( ! empty( $_SESSION['_fbp'] ) ) {
+			} elseif ( ! empty( $_SESSION['_fbp'] ) ) {
 				$fbp = $_SESSION['_fbp']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			}
 		}
@@ -390,4 +404,29 @@ class Event {
 		}
 		return $postfix;
 	}
+
+	/**
+     * Checks whether the fbclid in the current request differs from
+     * the one stored in the existing _fbc cookie.
+     *
+     * @param string      $cookie_fbc The current _fbc cookie value
+     *                                (format: fb.{subdomain}.{timestamp}.{fbclid}).
+     * @param string|null $request_fbclid The fbclid from the current request,
+     *                                    or null if not present.
+     *
+     * @return bool True if fbclid has changed, false otherwise.
+     */
+    private static function has_fbclid_changed( $cookie_fbc, $request_fbclid ) {
+        if ( null === $request_fbclid ) {
+            return false;
+        }
+
+        $parts = explode( '.', $cookie_fbc );
+        if ( count( $parts ) < 4 ) {
+            return true;
+        }
+
+        $cookie_fbclid = implode( '.', array_slice( $parts, 3 ) );
+        return $cookie_fbclid !== $request_fbclid;
+    }
 }

--- a/includes/FBSignedData/JWTCodec.php
+++ b/includes/FBSignedData/JWTCodec.php
@@ -176,6 +176,7 @@ class JWTCodec {
 		if ( $remainder ) {
 			$input .= str_repeat( '=', 4 - $remainder );
 		}
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 		return base64_decode( strtr( $input, '-_', '+/' ) );
 	}
 
@@ -186,6 +187,7 @@ class JWTCodec {
 	 * @return string The base64url encoded string.
 	 */
 	private static function urlsafe_b64_encode( string $input ): string {
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 		return str_replace( '=', '', strtr( base64_encode( $input ), '+/', '-_' ) );
 	}
 
@@ -197,7 +199,7 @@ class JWTCodec {
 	 * @return string The DER-encoded signature.
 	 */
 	private static function signature_to_der( string $sig ): string {
-		$length = max( 1, (int) ( strlen( $sig ) / 2 ) );
+		$length        = max( 1, (int) ( strlen( $sig ) / 2 ) );
 		list( $r, $s ) = str_split( $sig, $length );
 
 		$r = ltrim( $r, "\x00" );
@@ -281,7 +283,7 @@ class JWTCodec {
 		}
 
 		if ( self::ASN1_BIT_STRING === $type ) {
-			$pos++;
+			++$pos;
 			$data = substr( $der, $pos, $len - 1 );
 			$pos += $len - 1;
 		} elseif ( ! $constructed ) {

--- a/includes/Feed/Localization/LanguageFeedData.php
+++ b/includes/Feed/Localization/LanguageFeedData.php
@@ -29,17 +29,17 @@ class LanguageFeedData {
 	 */
 	public function get_available_languages(): array {
 		$all_languages = [];
-		$integrations = IntegrationRegistry::get_all_localization_integrations();
+		$integrations  = IntegrationRegistry::get_all_localization_integrations();
 
 		foreach ( $integrations as $integration ) {
 			if ( $integration->is_plugin_active() ) {
-				$languages = $integration->get_available_languages();
+				$languages     = $integration->get_available_languages();
 				$all_languages = array_merge( $all_languages, $languages );
 			}
 		}
 
 		// Remove duplicates and default language
-		$all_languages = array_unique( $all_languages );
+		$all_languages    = array_unique( $all_languages );
 		$default_language = $this->get_default_language();
 
 		if ( $default_language ) {
@@ -88,11 +88,11 @@ class LanguageFeedData {
 
 		// Fallback: get regular products if no localization plugin is active
 		$args = [
-			'post_type' => 'product',
-			'post_status' => 'publish',
+			'post_type'      => 'product',
+			'post_status'    => 'publish',
 			'posts_per_page' => $limit,
-			'offset' => $offset,
-			'fields' => 'ids',
+			'offset'         => $offset,
+			'fields'         => 'ids',
 		];
 
 		return get_posts( $args );
@@ -115,11 +115,11 @@ class LanguageFeedData {
 
 		// Fallback: return basic structure if no localization plugin is active
 		return [
-			'product_id' => $product_id,
-			'default_language' => null,
-			'translations' => [],
+			'product_id'         => $product_id,
+			'default_language'   => null,
+			'translations'       => [],
 			'translation_status' => [],
-			'translated_fields' => [],
+			'translated_fields'  => [],
 		];
 	}
 
@@ -139,14 +139,14 @@ class LanguageFeedData {
 			return [];
 		}
 
-		$product_ids = $this->get_products_from_default_language( $limit, 0 );
+		$product_ids           = $this->get_products_from_default_language( $limit, 0 );
 		$all_translated_fields = [];
 
 		foreach ( $product_ids as $product_id ) {
 			$details = $this->get_product_translation_details( $product_id );
 
 			if ( isset( $details['translated_fields'][ $language_code ] ) ) {
-				$translated_fields = $details['translated_fields'][ $language_code ];
+				$translated_fields     = $details['translated_fields'][ $language_code ];
 				$all_translated_fields = array_merge( $all_translated_fields, $translated_fields );
 			}
 		}
@@ -163,14 +163,14 @@ class LanguageFeedData {
 	private function map_translated_fields_to_csv_columns( array $translated_fields ): array {
 		// Mapping from WPML field names to Facebook CSV column names
 		$field_mapping = [
-			'name' => 'title',
-			'description' => 'description',
-			'short_description' => 'short_description',
+			'name'                  => 'title',
+			'description'           => 'description',
+			'short_description'     => 'short_description',
 			'rich_text_description' => 'rich_text_description',
-			'image_id' => 'image_link',
-			'gallery_image_ids' => 'additional_image_link',
-			'link' => 'link',
-			'video' => 'video',
+			'image_id'              => 'image_link',
+			'gallery_image_ids'     => 'additional_image_link',
+			'link'                  => 'link',
+			'video'                 => 'video',
 		];
 
 		$csv_columns = [];
@@ -209,18 +209,18 @@ class LanguageFeedData {
 	public function get_language_csv_data( string $language_code, int $limit = 100, int $offset = 0 ): array {
 		if ( ! IntegrationRegistry::has_active_localization_plugin() ) {
 			return [
-				'data' => [],
-				'columns' => [ 'id', 'override' ],
+				'data'              => [],
+				'columns'           => [ 'id', 'override' ],
 				'translated_fields' => [],
 			];
 		}
 
 		// First, determine which fields are translated for this language
 		$translated_fields = $this->get_translated_fields_for_language( $language_code, $limit );
-		$csv_columns = $this->map_translated_fields_to_csv_columns( $translated_fields );
+		$csv_columns       = $this->map_translated_fields_to_csv_columns( $translated_fields );
 
 		$product_ids = $this->get_products_from_default_language( $limit, $offset );
-		$csv_data = [];
+		$csv_data    = [];
 
 		foreach ( $product_ids as $product_id ) {
 			// Skip products that don't pass Facebook sync validation
@@ -243,7 +243,7 @@ class LanguageFeedData {
 				continue;
 			}
 
-			$translated_id = $details['translations'][ $language_code ];
+			$translated_id             = $details['translations'][ $language_code ];
 			$product_translated_fields = $details['translated_fields'][ $language_code ] ?? [];
 
 			// Only include products that have actual translated content
@@ -261,7 +261,7 @@ class LanguageFeedData {
 				require_once WC_FACEBOOKCOMMERCE_PLUGIN_DIR . '/includes/fbproduct.php';
 			}
 
-			$original_fb_product = new \WC_Facebook_Product( $original_product );
+			$original_fb_product   = new \WC_Facebook_Product( $original_product );
 			$translated_fb_product = new \WC_Facebook_Product( $translated_product );
 
 			// Determine the ID based on product type (matching catalog backend logic):
@@ -324,7 +324,7 @@ class LanguageFeedData {
 
 				// Start with required columns
 				$csv_row = [
-					'id' => $product_id,
+					'id'       => $product_id,
 					'override' => \WooCommerce\Facebook\Locale::convert_to_facebook_language_code( $language_code ),
 				];
 
@@ -355,8 +355,8 @@ class LanguageFeedData {
 		}
 
 		return [
-			'data' => $csv_data,
-			'columns' => array_merge( [ 'id', 'override' ], $csv_columns ),
+			'data'              => $csv_data,
+			'columns'           => array_merge( [ 'id', 'override' ], $csv_columns ),
 			'translated_fields' => $translated_fields,
 		];
 	}
@@ -371,6 +371,7 @@ class LanguageFeedData {
 	 * @param string               $language_code Target language code for permalink translation
 	 * @return string Field value with proper validation and cleaning
 	 */
+	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 	private function get_translated_field_value(
 		string $column,
 		\WC_Facebook_Product $original_fb_product,
@@ -400,7 +401,7 @@ class LanguageFeedData {
 				if ( in_array( 'description', $product_translated_fields, true ) ) {
 					// Use get_fb_description() to match main feed behavior (strips HTML tags)
 					$description = $translated_fb_product->get_fb_description();
-					$value = \WooCommerce\Facebook\Framework\Helper::str_truncate(
+					$value       = \WooCommerce\Facebook\Framework\Helper::str_truncate(
 						$description,
 						\WC_Facebook_Product::MAX_DESCRIPTION_LENGTH
 					);
@@ -410,7 +411,7 @@ class LanguageFeedData {
 			case 'short_description':
 				if ( in_array( 'short_description', $product_translated_fields, true ) ) {
 					$short_description = $translated_fb_product->get_fb_short_description();
-					$value = \WooCommerce\Facebook\Framework\Helper::str_truncate(
+					$value             = \WooCommerce\Facebook\Framework\Helper::str_truncate(
 						$short_description,
 						\WC_Facebook_Product::MAX_DESCRIPTION_LENGTH
 					);
@@ -420,7 +421,7 @@ class LanguageFeedData {
 			case 'rich_text_description':
 				if ( in_array( 'rich_text_description', $product_translated_fields, true ) ) {
 					$rich_text_description = $translated_fb_product->get_rich_text_description();
-					$value = \WooCommerce\Facebook\Framework\Helper::str_truncate(
+					$value                 = \WooCommerce\Facebook\Framework\Helper::str_truncate(
 						$rich_text_description,
 						\WC_Facebook_Product::MAX_DESCRIPTION_LENGTH
 					);
@@ -430,15 +431,15 @@ class LanguageFeedData {
 			case 'image_link':
 				if ( in_array( 'image_id', $product_translated_fields, true ) ) {
 					$image_urls = $translated_fb_product->get_all_image_urls();
-					$value = $image_urls[0] ?? '';
+					$value      = $image_urls[0] ?? '';
 				}
 				break;
 
 			case 'additional_image_link':
 				if ( in_array( 'gallery_image_ids', $product_translated_fields, true ) ) {
-					$image_urls = $translated_fb_product->get_all_image_urls();
+					$image_urls        = $translated_fb_product->get_all_image_urls();
 					$additional_images = array_slice( $image_urls, 1, 5 ); // Max 5 additional images
-					$value = ! empty( $additional_images ) ? implode( ',', $additional_images ) : '';
+					$value             = ! empty( $additional_images ) ? implode( ',', $additional_images ) : '';
 				}
 				break;
 

--- a/includes/Feed/Localization/LanguageFeedManagementTrait.php
+++ b/includes/Feed/Localization/LanguageFeedManagementTrait.php
@@ -49,7 +49,7 @@ trait LanguageFeedManagementTrait {
 	 * @since 3.6.0
 	 */
 	private function store_language_feed_id( string $language_code, string $feed_id ): void {
-		$stored_feeds = get_option( 'wc_facebook_language_feed_ids', [] );
+		$stored_feeds                   = get_option( 'wc_facebook_language_feed_ids', [] );
 		$stored_feeds[ $language_code ] = $feed_id;
 		update_option( 'wc_facebook_language_feed_ids', $stored_feeds );
 	}
@@ -113,7 +113,7 @@ trait LanguageFeedManagementTrait {
 			return '';
 		}
 
-		$fb_language_code = \WooCommerce\Facebook\Locale::convert_to_facebook_language_code( $language_code );
+		$fb_language_code   = \WooCommerce\Facebook\Locale::convert_to_facebook_language_code( $language_code );
 		$expected_feed_name = sprintf( 'WooCommerce Language Override Feed (%s)', strtoupper( $fb_language_code ) );
 
 		foreach ( $feed_nodes as $feed ) {
@@ -157,12 +157,12 @@ trait LanguageFeedManagementTrait {
 			}
 
 			$fb_language_code = \WooCommerce\Facebook\Locale::convert_to_facebook_language_code( $language_code );
-			$override_value = \WooCommerce\Facebook\Locale::convert_to_facebook_override_value( $fb_language_code );
+			$override_value   = \WooCommerce\Facebook\Locale::convert_to_facebook_override_value( $fb_language_code );
 
 			$feed_data = [
-				'name' => self::generate_language_feed_name( $language_code ),
-				'file_name' => self::generate_language_feed_filename( $language_code, true ), // For Facebook API
-				'override_type' => 'language',
+				'name'           => self::generate_language_feed_name( $language_code ),
+				'file_name'      => self::generate_language_feed_filename( $language_code, true ), // For Facebook API
+				'override_type'  => 'language',
 				'override_value' => $override_value,
 			];
 
@@ -213,11 +213,11 @@ trait LanguageFeedManagementTrait {
 	 */
 	public static function generate_language_feed_filename( string $language_code, bool $for_facebook_api = false, bool $is_temp_file = false ): string {
 		$fb_language_code = \WooCommerce\Facebook\Locale::convert_to_facebook_language_code( $language_code );
-		$feed_secret = \WooCommerce\Facebook\Products\Feed::get_feed_secret();
+		$feed_secret      = \WooCommerce\Facebook\Products\Feed::get_feed_secret();
 
 		// Use the same filename generation logic for both local and Facebook API
 		// This matches the main product feed behavior which reuses the same file
-		$prefix = $is_temp_file ? 'temp_' : '';
+		$prefix      = $is_temp_file ? 'temp_' : '';
 		$hash_suffix = wp_hash( $feed_secret );
 
 		return "facebook_language_feed_{$prefix}{$fb_language_code}_{$hash_suffix}.csv";

--- a/includes/Feed/Localization/LanguageOverrideFeed.php
+++ b/includes/Feed/Localization/LanguageOverrideFeed.php
@@ -38,11 +38,11 @@ class LanguageOverrideFeed {
 	private $language_feed_data = null;
 
 	/** Action constants */
-	const GENERATE_FEED_ACTION = 'wc_facebook_regenerate_feed_';
-	const REQUEST_FEED_ACTION = 'wc_facebook_get_feed_data_language_override';
+	const GENERATE_FEED_ACTION     = 'wc_facebook_regenerate_feed_';
+	const REQUEST_FEED_ACTION      = 'wc_facebook_get_feed_data_language_override';
 	const FEED_GEN_COMPLETE_ACTION = 'wc_facebook_feed_generation_completed_';
-	const LEGACY_API_PREFIX = 'woocommerce_api_';
-	const OPTION_FEED_URL_SECRET = 'wc_facebook_feed_url_secret_';
+	const LEGACY_API_PREFIX        = 'woocommerce_api_';
+	const OPTION_FEED_URL_SECRET   = 'wc_facebook_feed_url_secret_';
 
 	/**
 	 * Constructor
@@ -86,7 +86,7 @@ class LanguageOverrideFeed {
 		}
 		set_transient( $flag_name, 'yes', HOUR_IN_SECONDS );
 
-		$integration   = facebook_for_woocommerce()->get_integration();
+		$integration        = facebook_for_woocommerce()->get_integration();
 		$connection_handler = facebook_for_woocommerce()->get_connection_handler();
 		// Language feeds only require an active connection, not a Facebook Page ID
 		$is_connected = $connection_handler && $connection_handler->is_connected();
@@ -193,18 +193,18 @@ class LanguageOverrideFeed {
 		}
 
 		$successful_languages = [];
-		$failed_languages = [];
-		$language_stats = [];
+		$failed_languages     = [];
+		$language_stats       = [];
 
 		// Generate feed file for each language using the feed handler directly
 		foreach ( $languages as $language_code ) {
 			try {
 				// Generate the feed file for this language
 				$language_feed_writer = new LanguageOverrideFeedWriter( $language_code );
-				$result = $language_feed_writer->write_language_feed_file( $this->get_language_feed_data(), $language_code );
+				$result               = $language_feed_writer->write_language_feed_file( $this->get_language_feed_data(), $language_code );
 
 				if ( $result['success'] ) {
-					$successful_languages[] = $language_code;
+					$successful_languages[]           = $language_code;
 					$language_stats[ $language_code ] = [
 						'translated_products' => $result['count'],
 						'last_generated'      => time(),
@@ -215,9 +215,9 @@ class LanguageOverrideFeed {
 						sprintf( 'Failed to generate language override feed for: %s', $language_code ),
 						[ 'language_code' => $language_code ],
 						array(
-							'should_send_log_to_meta'        => true,
+							'should_send_log_to_meta' => true,
 							'should_save_log_in_woocommerce' => true,
-							'woocommerce_log_level'          => \WC_Log_Levels::ERROR,
+							'woocommerce_log_level'   => \WC_Log_Levels::ERROR,
 						)
 					);
 				}
@@ -226,7 +226,7 @@ class LanguageOverrideFeed {
 				Logger::log(
 					sprintf( 'Exception while generating language override feed for %s: %s', $language_code, $e->getMessage() ),
 					[
-						'language_code' => $language_code,
+						'language_code'     => $language_code,
 						'exception_message' => $e->getMessage(),
 					],
 					array(
@@ -250,7 +250,7 @@ class LanguageOverrideFeed {
 				),
 				[
 					'failed_languages' => $failed_languages,
-					'total_languages' => count( $languages ),
+					'total_languages'  => count( $languages ),
 				],
 				array(
 					'should_send_log_to_meta'        => false,
@@ -375,8 +375,8 @@ class LanguageOverrideFeed {
 
 		// Check connection methods
 		$has_valid_connection = ! empty( $connection_handler->get_commerce_partner_integration_id() ) ||
-							   ! empty( $connection_handler->get_commerce_merchant_settings_id() ) ||
-							   ! empty( $connection_handler->get_access_token() );
+								! empty( $connection_handler->get_commerce_merchant_settings_id() ) ||
+								! empty( $connection_handler->get_access_token() );
 
 		if ( ! $has_valid_connection ) {
 			return true;
@@ -411,7 +411,7 @@ class LanguageOverrideFeed {
 
 			// Create language-specific feed writer to get file path
 			$language_feed_writer = new LanguageOverrideFeedWriter( $language_code );
-			$file_path = $language_feed_writer->get_file_path();
+			$file_path            = $language_feed_writer->get_file_path();
 
 			// Regenerate if the file doesn't exist or if explicitly requested
 			$regenerate = Helper::get_requested_value( 'regenerate' );
@@ -436,13 +436,16 @@ class LanguageOverrideFeed {
 			header( 'Pragma: public' );
 			header( 'Content-Length:' . filesize( $file_path ) );
 
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 			$file = @fopen( $file_path, 'rb' );
 			if ( ! $file ) {
 				throw new PluginException( 'Could not open language feed file', 500 );
 			}
 
 			// fpassthru might be disabled in some hosts (like Flywheel)
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			if ( \WC_Facebookcommerce_Utils::is_fpassthru_disabled() || ! @fpassthru( $file ) ) {
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 				$contents = @stream_get_contents( $file );
 				if ( ! $contents ) {
 					throw new PluginException( 'Could not get language feed file contents', 500 );
@@ -450,6 +453,7 @@ class LanguageOverrideFeed {
 				echo $contents; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 			@fclose( $file );
 
 		} catch ( \Exception $exception ) {
@@ -478,9 +482,9 @@ class LanguageOverrideFeed {
 	 */
 	public function get_language_feed_url( string $language_code ): string {
 		$query_args = array(
-			'wc-api' => static::REQUEST_FEED_ACTION,
+			'wc-api'   => static::REQUEST_FEED_ACTION,
 			'language' => $language_code,
-			'secret' => $this->get_feed_secret(),
+			'secret'   => $this->get_feed_secret(),
 		);
 
 		return add_query_arg( $query_args, home_url( '/' ) );
@@ -517,7 +521,7 @@ class LanguageOverrideFeed {
 		try {
 			// Check if feed file exists and has data before attempting upload
 			$language_feed_writer = new LanguageOverrideFeedWriter( $language_code );
-			$file_path = $language_feed_writer->get_file_path();
+			$file_path            = $language_feed_writer->get_file_path();
 
 			// Skip upload if file doesn't exist
 			if ( ! file_exists( $file_path ) ) {

--- a/includes/Feed/Localization/LanguageOverrideFeedWriter.php
+++ b/includes/Feed/Localization/LanguageOverrideFeedWriter.php
@@ -47,7 +47,7 @@ class LanguageOverrideFeedWriter extends AbstractFeedFileWriter {
 		$this->language_code = $language_code;
 
 		$fb_language_code = \WooCommerce\Facebook\Locale::convert_to_facebook_language_code( $language_code );
-		$feed_name = "language_override_{$fb_language_code}";
+		$feed_name        = "language_override_{$fb_language_code}";
 
 		// Use dummy header - real headers will be generated dynamically in write_language_feed_file
 		$dummy_header = 'id,override'; // Minimal required columns
@@ -106,6 +106,7 @@ class LanguageOverrideFeedWriter extends AbstractFeedFileWriter {
 	 */
 	public function write_temp_feed_file( array $data ): void {
 		$temp_file_path = $this->get_temp_file_path();
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 		$temp_feed_file = @fopen( $temp_file_path, 'a' );
 
 		if ( ! $temp_feed_file ) {
@@ -119,6 +120,7 @@ class LanguageOverrideFeedWriter extends AbstractFeedFileWriter {
 				}
 			}
 		} finally {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 			fclose( $temp_feed_file );
 		}
 	}
@@ -154,7 +156,7 @@ class LanguageOverrideFeedWriter extends AbstractFeedFileWriter {
 			if ( empty( $csv_result['data'] ) ) {
 				// Still create an empty file with headers
 				$csv_result = array(
-					'data' => array(),
+					'data'    => array(),
 					'columns' => array( 'id', 'override' ),
 				);
 			}
@@ -188,9 +190,9 @@ class LanguageOverrideFeedWriter extends AbstractFeedFileWriter {
 				\WooCommerce\Facebook\Framework\Logger::log(
 					sprintf( 'Failed to write language feed file for %s: %s', $language_code, $e->getMessage() ),
 					array(
-						'language_code' => $language_code,
+						'language_code'     => $language_code,
 						'exception_message' => $e->getMessage(),
-						'exception_trace' => $e->getTraceAsString(),
+						'exception_trace'   => $e->getTraceAsString(),
 					),
 					array(
 						'should_send_log_to_meta'        => true,

--- a/includes/Framework/AdminMessageHandler.php
+++ b/includes/Framework/AdminMessageHandler.php
@@ -102,6 +102,7 @@ class AdminMessageHandler {
 	 * @since 1.0.0
 	 */
 	public function load_messages() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$message_id_get_name = isset( $_GET[ self::MESSAGE_ID_GET_NAME ] ) ? wc_clean( wp_unslash( $_GET[ self::MESSAGE_ID_GET_NAME ] ) ) : false;
 		if ( $message_id_get_name && $this->get_message_id() === $message_id_get_name ) {
 			$memo = get_transient( self::MESSAGE_TRANSIENT_PREFIX . $message_id_get_name );

--- a/includes/Framework/AdminNoticeHandler.php
+++ b/includes/Framework/AdminNoticeHandler.php
@@ -379,8 +379,9 @@ class AdminNoticeHandler {
 	 * @since 3.0.0
 	 */
 	public function handle_dismiss_notice() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_REQUEST['messageid'] ) ) {
-			$this->dismiss_notice( wc_clean( wp_unslash( $_REQUEST['messageid'] ) ) );
+			$this->dismiss_notice( wc_clean( wp_unslash( $_REQUEST['messageid'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
 	}
 

--- a/includes/Framework/Plugin.php
+++ b/includes/Framework/Plugin.php
@@ -477,6 +477,7 @@ abstract class Plugin {
 		$messages   = [];
 		$messages[] = isset( $data['uri'] ) && $data['uri'] ? 'Request' : 'Response';
 		foreach ( (array) $data as $key => $value ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 			$messages[] = trim( sprintf( '%s: %s', $key, is_array( $value ) || ( is_object( $value ) && 'stdClass' === get_class( $value ) ) ? print_r( (array) $value, true ) : $value ) );
 		}
 		return implode( "\n", $messages ) . "\n";

--- a/includes/Framework/Plugin/Dependencies.php
+++ b/includes/Framework/Plugin/Dependencies.php
@@ -163,6 +163,7 @@ class Dependencies {
 	 * @since 5.2.0
 	 */
 	public function add_php_settings_notices() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] ) {
 			$bad_settings = $this->get_incompatible_php_settings();
 			if ( count( $bad_settings ) > 0 ) {

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -741,12 +741,12 @@ class Connection {
 			home_url( '/' )
 		);
 		// build the proxy app URL where the user will land after onboarding, to be redirected to the site URL
-		$redirect_url = add_query_arg( 'site_url', urlencode( $site_url ), $this->get_connection_authentication_url() );
+		$redirect_url = add_query_arg( 'site_url', rawurlencode( $site_url ), $this->get_connection_authentication_url() );
 		// build the final connect URL, direct to Facebook
 		$connect_url = add_query_arg(
 			array(
 				'app_id'       => $this->get_client_id(), // this endpoint calls the client ID "app ID"
-				'redirect_url' => urlencode( $redirect_url ),
+				'redirect_url' => rawurlencode( $redirect_url ),
 			),
 			'https://www.facebook.com/commerce_manager/onboarding/'
 		);

--- a/includes/Handlers/PluginRender.php
+++ b/includes/Handlers/PluginRender.php
@@ -51,18 +51,20 @@ class PluginRender {
 	}
 
 	public static function enqueue_assets() {
-		wp_enqueue_script( 'wc-backbone-modal', null, array( 'backbone' ) );
+		wp_enqueue_script( 'wc-backbone-modal', null, array( 'backbone' ), \WC_Facebookcommerce::PLUGIN_VERSION, true );
 		wp_enqueue_script(
 			'facebook-for-woocommerce-modal',
 			facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/modal.js',
 			array( 'jquery', 'wc-backbone-modal', 'jquery-blockui' ),
-			\WC_Facebookcommerce::PLUGIN_VERSION
+			\WC_Facebookcommerce::PLUGIN_VERSION,
+			true
 		);
 		wp_enqueue_script(
 			'facebook-for-woocommerce-plugin-update',
 			facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/plugin-rendering.js',
 			array( 'jquery', 'wc-backbone-modal', 'jquery-blockui', 'jquery-tiptip', 'facebook-for-woocommerce-modal', 'wc-enhanced-select' ),
 			\WC_Facebookcommerce::PLUGIN_VERSION,
+			true
 		);
 		wp_localize_script(
 			'facebook-for-woocommerce-plugin-update',

--- a/includes/Handlers/WhatsAppExtension.php
+++ b/includes/Handlers/WhatsAppExtension.php
@@ -60,16 +60,16 @@ class WhatsAppExtension {
 		);
 
 		$external_client_metadata = array(
-			'client_version'                        => $plugin->get_version(),
+			'client_version' => $plugin->get_version(),
 		);
 
 		return add_query_arg(
 			array(
-				'access_client_token'   => self::CLIENT_TOKEN,
-				'app_id'                => self::APP_ID,
-				'app_owner_business_id' => self::TP_BUSINESS_ID,
-				'external_business_id'  => $external_wa_id,
-				'locale'                => get_user_locale() ?? self::DEFAULT_LANGUAGE,
+				'access_client_token'      => self::CLIENT_TOKEN,
+				'app_id'                   => self::APP_ID,
+				'app_owner_business_id'    => self::TP_BUSINESS_ID,
+				'external_business_id'     => $external_wa_id,
+				'locale'                   => get_user_locale() ?? self::DEFAULT_LANGUAGE,
 				'external_client_metadata' => rawurlencode( wp_json_encode( $external_client_metadata ) ),
 			),
 			self::COMMERCE_HUB_URL . 'whatsapp_utility_integration/splash/'
@@ -247,7 +247,6 @@ class WhatsAppExtension {
 				)
 			);
 		}
-		return;
 	}
 
 	/**
@@ -267,7 +266,7 @@ class WhatsAppExtension {
 
 		if ( ! empty( $order_metadata['items'] ) && is_array( $order_metadata['items'] ) ) {
 			foreach ( $order_metadata['items'] as $order_item ) {
-				$item_arr = array();
+				$item_arr             = array();
 				$item_arr['name']     = $order_item['name'] ?? ( $order_item['product_name'] ?? '' );
 				$item_arr['quantity'] = isset( $order_item['quantity'] ) ? intval( $order_item['quantity'] ) : null;
 
@@ -285,7 +284,7 @@ class WhatsAppExtension {
 						if ( $product ) {
 							$image_id = method_exists( $product, 'get_image_id' ) ? $product->get_image_id() : null;
 							if ( $image_id ) {
-								$img = wp_get_attachment_image_url( $image_id, 'large' );
+								$img       = wp_get_attachment_image_url( $image_id, 'large' );
 								$image_url = $img ? $img : wp_get_attachment_url( $image_id );
 								// Ensure HTTPS protocol for image URLs
 								$image_url = preg_replace( '/^http:/', 'https:', $image_url );
@@ -295,7 +294,7 @@ class WhatsAppExtension {
 						wc_get_logger()->info( 'Error fetching product image: ' . $e->getMessage() );
 					}
 				}
-				$item_arr['image_url'] = $image_url;
+				$item_arr['image_url']         = $image_url;
 				$rich_status_object['items'][] = $item_arr;
 			}
 		}

--- a/includes/Integrations/Abstract_Localization_Integration.php
+++ b/includes/Integrations/Abstract_Localization_Integration.php
@@ -121,14 +121,14 @@ abstract class Abstract_Localization_Integration {
 
 		// Query products
 		$args = [
-			'post_type' => 'product',
-			'post_status' => 'publish',
+			'post_type'      => 'product',
+			'post_status'    => 'publish',
 			'posts_per_page' => $limit,
-			'offset' => $offset,
-			'fields' => 'ids',
+			'offset'         => $offset,
+			'fields'         => 'ids',
 		];
 
-		$all_products = get_posts( $args );
+		$all_products              = get_posts( $args );
 		$default_language_products = [];
 
 		// Filter products using plugin-specific language check
@@ -175,11 +175,11 @@ abstract class Abstract_Localization_Integration {
 		// Default implementation - return basic structure
 		// Specific integrations should override this method
 		return [
-			'product_id' => $product_id,
-			'default_language' => $this->get_default_language(),
-			'translations' => [],
+			'product_id'         => $product_id,
+			'default_language'   => $this->get_default_language(),
+			'translations'       => [],
 			'translation_status' => [],
-			'translated_fields' => [],
+			'translated_fields'  => [],
 		];
 	}
 
@@ -219,10 +219,10 @@ abstract class Abstract_Localization_Integration {
 	 */
 	public function get_availability_data(): array {
 		$data = [
-			'plugin_name' => $this->get_plugin_name(),
-			'plugin_file' => $this->get_plugin_file_name(),
+			'plugin_name'  => $this->get_plugin_name(),
+			'plugin_file'  => $this->get_plugin_file_name(),
 			'is_installed' => $this->is_plugin_installed(),
-			'is_active' => $this->is_plugin_active(),
+			'is_active'    => $this->is_plugin_active(),
 		];
 
 		// Add version if available

--- a/includes/Integrations/CostOfGoods/CostOfGoods.php
+++ b/includes/Integrations/CostOfGoods/CostOfGoods.php
@@ -52,9 +52,9 @@ class CostOfGoods {
 			if ( ! is_array( $tuple ) || ! isset( $tuple['product'], $tuple['qty'] ) ) {
 				throw new IncorrectCogsInputStructure();
 			}
-			$product = $tuple['product'];
+			$product  = $tuple['product'];
 			$quantity = $tuple['qty'];
-			$cogs = $this->get_cogs_for_product( $product );
+			$cogs     = $this->get_cogs_for_product( $product );
 
 			// If cogs was 0 for one product, the value is invalid for the order
 			if ( ! $cogs || $cogs < 0 ) {
@@ -78,7 +78,7 @@ class CostOfGoods {
 		if ( ! $this->already_fetched ) {
 			$this->available_integrations = array();
 			foreach ( $this->supported_integrations as $integration => $class_name ) {
-				$class = 'WooCommerce\\Facebook\\Integrations\\CostOfGoods\\' . $class_name;
+				$class    = 'WooCommerce\\Facebook\\Integrations\\CostOfGoods\\' . $class_name;
 				$instance = new $class();
 				if ( $instance->is_available() ) {
 					$this->available_integrations[] = $instance;

--- a/includes/Integrations/Facebook_Fields_Translation_Trait.php
+++ b/includes/Integrations/Facebook_Fields_Translation_Trait.php
@@ -27,7 +27,7 @@ trait Facebook_Fields_Translation_Trait {
 	 * @return array Array of field names that have different values
 	 */
 	protected function get_translated_fields( int $original_id, int $translated_id, ?string $target_language = null ): array {
-		$original_product = wc_get_product( $original_id );
+		$original_product   = wc_get_product( $original_id );
 		$translated_product = wc_get_product( $translated_id );
 
 		if ( ! $original_product || ! $translated_product ) {
@@ -41,7 +41,7 @@ trait Facebook_Fields_Translation_Trait {
 			require_once WC_FACEBOOKCOMMERCE_PLUGIN_DIR . '/includes/fbproduct.php';
 		}
 
-		$original_fb_product = new \WC_Facebook_Product( $original_product );
+		$original_fb_product   = new \WC_Facebook_Product( $original_product );
 		$translated_fb_product = new \WC_Facebook_Product( $translated_product );
 
 		// Get core Facebook fields mapping
@@ -74,7 +74,7 @@ trait Facebook_Fields_Translation_Trait {
 					}
 				} else {
 					// Convert to string for comparison
-					$original_str = (string) $original_value;
+					$original_str   = (string) $original_value;
 					$translated_str = (string) $translated_value;
 
 					// FIXED: Only require translated value to be non-empty
@@ -100,20 +100,20 @@ trait Facebook_Fields_Translation_Trait {
 	protected function get_facebook_field_mapping(): array {
 		return [
 			// Basic product information
-			'name' => 'get_name',
-			'description' => 'get_fb_description',
-			'short_description' => 'get_fb_short_description',
+			'name'                  => 'get_name',
+			'description'           => 'get_fb_description',
+			'short_description'     => 'get_fb_short_description',
 			'rich_text_description' => 'get_rich_text_description',
 
 			// Images
-			'image_id' => 'get_all_image_urls',
-			'gallery_image_ids' => 'get_all_image_urls',
+			'image_id'              => 'get_all_image_urls',
+			'gallery_image_ids'     => 'get_all_image_urls',
 
 			// Video
-			'video' => 'get_all_video_urls',
+			'video'                 => 'get_all_video_urls',
 
 			// Product link
-			'link' => 'get_permalink',
+			'link'                  => 'get_permalink',
 		];
 	}
 }

--- a/includes/Integrations/IntegrationRegistry.php
+++ b/includes/Integrations/IntegrationRegistry.php
@@ -21,7 +21,7 @@ class IntegrationRegistry {
 	 */
 	private static $localization_integrations = [
 		'polylang' => Polylang::class,
-		'wpml' => WPML::class,
+		'wpml'     => WPML::class,
 	];
 
 	/**
@@ -62,7 +62,7 @@ class IntegrationRegistry {
 		}
 
 		// Create and cache the instance
-		$instance = new $class_name();
+		$instance                                        = new $class_name();
 		self::$integration_instances[ $integration_key ] = $instance;
 
 		return $instance;
@@ -210,12 +210,12 @@ class IntegrationRegistry {
 			}
 
 			$active_plugins_list = get_option( 'active_plugins', [] );
-			$all_plugins = get_plugins();
+			$all_plugins         = get_plugins();
 			$active_plugins_data = [];
 
 			foreach ( $active_plugins_list as $plugin_file ) {
 				if ( isset( $all_plugins[ $plugin_file ] ) ) {
-					$plugin_data = $all_plugins[ $plugin_file ];
+					$plugin_data               = $all_plugins[ $plugin_file ];
 						$active_plugins_data[] = $plugin_data['Name'];
 				}
 			}

--- a/includes/Integrations/Polylang.php
+++ b/includes/Integrations/Polylang.php
@@ -259,6 +259,7 @@ class Polylang extends Abstract_Localization_Integration {
 	 * @param int $offset Offset for pagination
 	 * @return array Array of product IDs from the default language
 	 */
+	// phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
 	public function get_products_from_default_language( int $limit = 10, int $offset = 0 ): array {
 		// Use parent implementation with template method pattern
 		return parent::get_products_from_default_language( $limit, $offset );
@@ -279,9 +280,9 @@ class Polylang extends Abstract_Localization_Integration {
 		}
 
 		$details = [
-			'product_id' => $product_id,
-			'default_language' => $this->get_default_language(),
-			'translations' => [],
+			'product_id'         => $product_id,
+			'default_language'   => $this->get_default_language(),
+			'translations'       => [],
 			'translation_status' => [],
 		];
 
@@ -294,12 +295,12 @@ class Polylang extends Abstract_Localization_Integration {
 		$locale_to_slug_map = [];
 		$slug_to_locale_map = [];
 		foreach ( $polylang_languages as $language ) {
-			$locale = $language->locale ?? $language->slug;
-			$locale_to_slug_map[ $locale ] = $language->slug;
+			$locale                                = $language->locale ?? $language->slug;
+			$locale_to_slug_map[ $locale ]         = $language->slug;
 			$slug_to_locale_map[ $language->slug ] = $locale;
 		}
 
-		$languages = $this->get_available_languages(); // This now returns full locales
+		$languages        = $this->get_available_languages(); // This now returns full locales
 		$default_language = $this->get_default_language(); // This now returns full locale
 
 		foreach ( $languages as $full_locale ) {
@@ -397,7 +398,7 @@ class Polylang extends Abstract_Localization_Integration {
 
 			// Set languages for both products
 			$default_language = $this->get_default_language();
-			$default_slug = $this->get_polylang_slug_for_locale( $default_language );
+			$default_slug     = $this->get_polylang_slug_for_locale( $default_language );
 
 			// Set language assignments
 			if ( $default_slug ) {
@@ -408,7 +409,7 @@ class Polylang extends Abstract_Localization_Integration {
 			// Create translation relationship
 			$translations_array = [
 				$default_slug => $original_product_id,
-				$target_slug => $translated_product_id,
+				$target_slug  => $translated_product_id,
 			];
 
 			pll_save_post_translations( $translations_array );
@@ -491,7 +492,7 @@ class Polylang extends Abstract_Localization_Integration {
 				'is_pro_version' => $this->is_pro_version(),
 			];
 
-			$data['languages'] = $this->get_available_languages();
+			$data['languages']        = $this->get_available_languages();
 			$data['default_language'] = $this->get_default_language();
 		}
 

--- a/includes/Integrations/WPML.php
+++ b/includes/Integrations/WPML.php
@@ -168,7 +168,7 @@ class WPML extends Abstract_Localization_Integration {
 
 		// Fallback: extract language code from locale
 		if ( ! $wpml_lang_code ) {
-			$lang_parts = explode( '_', $locale );
+			$lang_parts     = explode( '_', $locale );
 			$wpml_lang_code = $lang_parts[0];
 		}
 
@@ -269,14 +269,14 @@ class WPML extends Abstract_Localization_Integration {
 
 		// Query products
 		$args = [
-			'post_type' => 'product',
-			'post_status' => 'publish',
+			'post_type'      => 'product',
+			'post_status'    => 'publish',
 			'posts_per_page' => $batch_size,
-			'offset' => $offset,
-			'fields' => 'ids',
+			'offset'         => $offset,
+			'fields'         => 'ids',
 		];
 
-		$all_products = get_posts( $args );
+		$all_products              = get_posts( $args );
 		$default_language_products = [];
 
 		// Filter products using plugin-specific language check
@@ -309,9 +309,9 @@ class WPML extends Abstract_Localization_Integration {
 		}
 
 		$details = [
-			'product_id' => $product_id,
-			'default_language' => $this->get_default_language(),
-			'translations' => [],
+			'product_id'         => $product_id,
+			'default_language'   => $this->get_default_language(),
+			'translations'       => [],
 			'translation_status' => [],
 		];
 
@@ -324,12 +324,12 @@ class WPML extends Abstract_Localization_Integration {
 		$locale_to_code_map = [];
 		$code_to_locale_map = [];
 		foreach ( $wpml_languages as $code => $language_data ) {
-			$locale = $language_data['default_locale'] ?? $code;
+			$locale                        = $language_data['default_locale'] ?? $code;
 			$locale_to_code_map[ $locale ] = $code;
-			$code_to_locale_map[ $code ] = $locale;
+			$code_to_locale_map[ $code ]   = $locale;
 		}
 
-		$languages = $this->get_available_languages(); // This now returns full locales
+		$languages        = $this->get_available_languages(); // This now returns full locales
 		$default_language = $this->get_default_language(); // This now returns full locale
 
 		foreach ( $languages as $full_locale ) {
@@ -349,7 +349,7 @@ class WPML extends Abstract_Localization_Integration {
 				$details['translations'][ $full_locale ] = $translated_id;
 
 				/** Get translation status using WPML's API with the WPML code */
-				$translation_status = apply_filters( 'wpml_translation_status', null, $product_id, $wpml_code );
+				$translation_status                            = apply_filters( 'wpml_translation_status', null, $product_id, $wpml_code );
 				$details['translation_status'][ $full_locale ] = $translation_status;
 
 				// Get which fields are translated
@@ -371,8 +371,8 @@ class WPML extends Abstract_Localization_Integration {
 		$data = parent::get_availability_data();
 
 		if ( $this->is_plugin_active() ) {
-			$data['languages'] = $this->get_available_languages();
-			$data['default_language'] = $this->get_default_language();
+			$data['languages']                       = $this->get_available_languages();
+			$data['default_language']                = $this->get_default_language();
 			$data['has_legacy_multi_language_setup'] = $this->has_legacy_multi_language_setup();
 		}
 

--- a/includes/Jobs/GenerateProductFeed.php
+++ b/includes/Jobs/GenerateProductFeed.php
@@ -99,7 +99,7 @@ class GenerateProductFeed extends AbstractChainedJob {
 		);
 
 		// Add language parameter to prevent Polylang/WPML from filtering by current language context
-		$integration = \WooCommerce\Facebook\Integrations\IntegrationRegistry::get_active_localization_integration();
+		$integration              = \WooCommerce\Facebook\Integrations\IntegrationRegistry::get_active_localization_integration();
 		$is_language_feed_enabled = facebook_for_woocommerce()->get_integration()->is_language_override_feed_generation_enabled();
 
 		if ( $integration && $is_language_feed_enabled ) {
@@ -115,11 +115,13 @@ class GenerateProductFeed extends AbstractChainedJob {
 			$query_args['lang'] = 'all';
 		}
 
-		$products       = wc_get_products( $query_args );
-		$feed_handler   = new \WC_Facebook_Product_Feed();
+		$products     = wc_get_products( $query_args );
+		$feed_handler = new \WC_Facebook_Product_Feed();
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 		$temp_feed_file = fopen( $feed_handler->get_temp_file_path(), 'a' );
 		$feed_handler->write_products_feed_to_temp_file( $products, $temp_feed_file );
 		if ( is_resource( $temp_feed_file ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 			fclose( $temp_feed_file );
 		}
 		facebook_for_woocommerce()->get_tracker()->increment_batch_generation_time( microtime( true ) - $start_time );

--- a/includes/Locale.php
+++ b/includes/Locale.php
@@ -399,7 +399,7 @@ class Locale {
 	public static function convert_to_facebook_language_code( string $locale_code ): string {
 		// Extract the language part (before the underscore)
 		$language_parts = explode( '_', $locale_code );
-		$language = strtolower( $language_parts[0] );
+		$language       = strtolower( $language_parts[0] );
 
 		// Special cases where WordPress/Polylang language codes don't match Facebook's expected codes
 		// These must be handled BEFORE other mappings
@@ -418,10 +418,10 @@ class Locale {
 		// This is critical because we need to distinguish zh_CN from zh_TW
 		if ( 'zh' === $language && isset( $language_parts[1] ) ) {
 			$region = strtoupper( $language_parts[1] );
-			if ( in_array( $region, [ 'TW', 'HK', 'MO' ] ) ) {
+			if ( in_array( $region, [ 'TW', 'HK', 'MO' ], true ) ) {
 				return 'zh_TW'; // Traditional Chinese
 			}
-			return 'zh_CN'; // Simplified Chinese (default)
+			return 'zh_CN'; // Simplified Chinese (default) // phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 		}
 
 		// Check if this language uses the _XX format
@@ -450,16 +450,16 @@ class Locale {
 	public static function convert_to_facebook_override_value( string $language_code ): string {
 		// Extract the language part (before the underscore)
 		$language_parts = explode( '_', $language_code );
-		$language = strtolower( $language_parts[0] );
+		$language       = strtolower( $language_parts[0] );
 
 		// Handle special cases for Chinese FIRST (before generic mappings)
 		// This is critical because we need to distinguish zh_CN from zh_TW
 		if ( 'zh' === $language && isset( $language_parts[1] ) ) {
 			$region = strtoupper( $language_parts[1] );
-			if ( in_array( $region, [ 'TW', 'HK', 'MO' ] ) ) {
+			if ( in_array( $region, [ 'TW', 'HK', 'MO' ], true ) ) {
 				return 'zh_TW'; // Traditional Chinese
 			}
-			return 'zh_CN'; // Simplified Chinese (default)
+			return 'zh_CN'; // Simplified Chinese (default) // phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 		}
 
 		// Check if we have a specific Facebook override value for this language

--- a/includes/OfferManagement/RequestVerification.php
+++ b/includes/OfferManagement/RequestVerification.php
@@ -26,7 +26,7 @@ use WooCommerce\Facebook\FBSignedData\JWTCodec;
  * between signature and key due to key rotation.
  */
 class RequestVerification {
-	const KEY_NAME_FIELD                    = 'key_name';
+	const KEY_NAME_FIELD                      = 'key_name';
 	const PUBLIC_KEY_FETCH_COOLDOWN_TRANSIENT = '_wc_facebook_for_woocommerce_public_key_fetch_cooldown';
 	const PUBLIC_KEY_FETCH_COOLDOWN_SECONDS   = 30;
 

--- a/includes/ProductAttributeMapper.php
+++ b/includes/ProductAttributeMapper.php
@@ -846,6 +846,7 @@ class ProductAttributeMapper {
 			$result            = self::save_mapped_attributes( $product, $mapped_attributes );
 			return $result;
 		} catch ( \Exception $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			error_log( 'ProductAttributeMapper sync error: ' . $e->getMessage() );
 			return array();
 		}

--- a/includes/ProductSets/LegacyProductSetMigration.php
+++ b/includes/ProductSets/LegacyProductSetMigration.php
@@ -24,7 +24,7 @@ class LegacyProductSetMigration {
 		// Query legacy fb product sets
 		global $wpdb;
 		$fb_product_set_taxonomy_name = 'fb_product_set';
-		$results = $wpdb->get_results(
+		$results                      = $wpdb->get_results(
 			$wpdb->prepare(
 				'SELECT t.term_id, t.name, t.slug, tt.description
 				FROM wp_terms t
@@ -36,7 +36,7 @@ class LegacyProductSetMigration {
 
 		// Migrate legacy fb product sets to dynamic product sets filter
 		foreach ( $results as $result ) {
-			$fb_product_set_id = get_term_meta( $result->term_id, 'fb_product_set_id', true );
+			$fb_product_set_id         = get_term_meta( $result->term_id, 'fb_product_set_id', true );
 			$wc_product_categories_ids = get_term_meta( $result->term_id, '_wc_facebook_product_cats', true );
 			if ( is_array( $wc_product_categories_ids ) && ! empty( $wc_product_categories_ids ) ) {
 				$wc_categories = array();
@@ -56,7 +56,7 @@ class LegacyProductSetMigration {
 		$filters = array();
 		foreach ( $wc_categories as $wc_category ) {
 			$wc_category_name = WC_Facebookcommerce_Utils::clean_string( get_term_field( 'name', $wc_category, 'product_cat' ) );
-			$filters[] = array( 'product_type' => array( 'i_contains' => $wc_category_name ) );
+			$filters[]        = array( 'product_type' => array( 'i_contains' => $wc_category_name ) );
 		}
 		$fb_product_set_data = array(
 			'name'     => $fb_set_name,

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -412,7 +412,7 @@ class ProductValidator {
 	protected function validate_product_language() {
 		// Get the product to check (use parent for variations)
 		$product_to_check = $this->product_parent ? $this->product_parent : $this->product;
-		$product_id = $product_to_check->get_id();
+		$product_id       = $product_to_check->get_id();
 
 		// Only validate language if language override feed generation is enabled
 		// Use the integration method instead of get_option() to handle all necessary checks

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -644,7 +644,7 @@ class Products {
 			$gender = $product->get_meta( self::GENDER_META_KEY );
 		}
 
-		if ( ! in_array( $gender, array( 'female', 'male', 'unisex' ) ) ) {
+		if ( ! in_array( $gender, array( 'female', 'male', 'unisex' ), true ) ) {
 			$gender = 'unisex';
 		}
 
@@ -725,7 +725,7 @@ class Products {
 			throw new PluginException( "The provided attribute name $attribute_name does not match any of the available attributes for the product {$product->get_name()}" );
 		}
 
-		if ( self::get_product_color_attribute( $product ) !== $attribute_name && in_array( $attribute_name, self::get_distinct_product_attributes( $product ) ) ) {
+		if ( self::get_product_color_attribute( $product ) !== $attribute_name && in_array( $attribute_name, self::get_distinct_product_attributes( $product ), true ) ) {
 			throw new PluginException( "The provided attribute $attribute_name is already used for the product {$product->get_name()}" );
 		}
 
@@ -821,7 +821,7 @@ class Products {
 			throw new PluginException( "The provided attribute name $attribute_name does not match any of the available attributes for the product {$product->get_name()}" );
 		}
 
-		if ( self::get_product_size_attribute( $product ) !== $attribute_name && in_array( $attribute_name, self::get_distinct_product_attributes( $product ) ) ) {
+		if ( self::get_product_size_attribute( $product ) !== $attribute_name && in_array( $attribute_name, self::get_distinct_product_attributes( $product ), true ) ) {
 			throw new PluginException( "The provided attribute $attribute_name is already used for the product {$product->get_name()}" );
 		}
 
@@ -915,7 +915,7 @@ class Products {
 		if ( ! empty( $attribute_name ) && ! self::product_has_attribute( $product, $attribute_name ) ) {
 			throw new PluginException( "The provided attribute name $attribute_name does not match any of the available attributes for the product {$product->get_name()}" );
 		}
-		if ( self::get_product_pattern_attribute( $product ) !== $attribute_name && in_array( $attribute_name, self::get_distinct_product_attributes( $product ) ) ) {
+		if ( self::get_product_pattern_attribute( $product ) !== $attribute_name && in_array( $attribute_name, self::get_distinct_product_attributes( $product ), true ) ) {
 			throw new PluginException( "The provided attribute $attribute_name is already used for the product {$product->get_name()}" );
 		}
 		$product->update_meta_data( self::PATTERN_ATTRIBUTE_META_KEY, $attribute_name );
@@ -1137,7 +1137,9 @@ class Products {
 		$products = wc_get_products(
 			array(
 				'limit'      => 1,
+				// phpcs:ignore WordPress.DB.SlowDBQuery
 				'meta_key'   => \WC_Facebookcommerce_Integration::FB_PRODUCT_ITEM_ID,
+				// phpcs:ignore WordPress.DB.SlowDBQuery
 				'meta_value' => $fb_product_id,
 			)
 		);
@@ -1151,7 +1153,9 @@ class Products {
 			$products = wc_get_products(
 				array(
 					'limit'      => 1,
+					// phpcs:ignore WordPress.DB.SlowDBQuery
 					'meta_key'   => \WC_Facebookcommerce_Integration::FB_PRODUCT_GROUP_ID,
+					// phpcs:ignore WordPress.DB.SlowDBQuery
 					'meta_value' => $fb_product_id,
 				)
 			);

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -97,6 +97,7 @@ class Feed {
 		$file_path    = $feed_handler->get_file_path();
 
 		// regenerate if the file doesn't exist
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! empty( $_GET['regenerate'] ) || ! file_exists( $file_path ) ) {
 			$feed_handler->generate_feed();
 		}
@@ -121,12 +122,14 @@ class Feed {
 			header( 'Pragma: public' );
 			header( 'Content-Length:' . filesize( $file_path ) );
 
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 			$file = @fopen( $file_path, 'rb' );
 			if ( ! $file ) {
 				throw new PluginException( 'Could not open feed file.', 500 );
 			}
 
 			// fpassthru might be disabled in some hosts (like Flywheel)
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			if ( $this->is_fpassthru_disabled() || ! @fpassthru( $file ) ) {
 				Logger::log(
 					'fpassthru is disabled: getting file contents',
@@ -137,6 +140,7 @@ class Feed {
 						'woocommerce_log_level'          => \WC_Log_Levels::DEBUG,
 					)
 				);
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 				$contents = @stream_get_contents( $file );
 				if ( ! $contents ) {
 					throw new PluginException( 'Could not get feed file contents.', 500 );
@@ -420,8 +424,9 @@ class Feed {
 	private function is_fpassthru_disabled() {
 		$disabled = false;
 		if ( function_exists( 'ini_get' ) ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			$disabled_functions = @ini_get( 'disable_functions' );
-			$disabled           = is_string( $disabled_functions ) && in_array( 'fpassthru', explode( ',', $disabled_functions ), false );
+			$disabled           = is_string( $disabled_functions ) && in_array( 'fpassthru', explode( ',', $disabled_functions ), true );
 		}
 		return $disabled;
 	}

--- a/includes/RolloutSwitches.php
+++ b/includes/RolloutSwitches.php
@@ -24,17 +24,17 @@ class RolloutSwitches {
 	/** @var \WC_Facebookcommerce commerce handler */
 	private \WC_Facebookcommerce $plugin;
 
-	public const SWITCH_ROLLOUT_FEATURES                    = 'rollout_enabled';
-	public const SWITCH_PRODUCT_SETS_SYNC_ENABLED           = 'product_sets_sync_enabled';
-	public const SWITCH_WOO_ALL_PRODUCTS_SYNC_ENABLED       = 'woo_all_products_sync_enabled';
-	public const SWITCH_OFFER_MANAGEMENT_ENABLED            = 'offer_management_enabled';
-	public const SWITCH_MULTIPLE_IMAGES_ENABLED             = 'woo_variant_multiple_images_enabled';
-	public const SWITCH_CONTENT_ID_MIGRATION_ENABLED        = 'enable_woocommerce_content_id_migration';
-	public const SWITCH_LANGUAGE_OVERRIDE_FEED_ENABLED      = 'wooc_language_override_feed';
-	public const SWITCH_ISOLATED_PIXEL_EXECUTION_ENABLED    = 'enable_woocommerce_isolated_pixel_execution';
-	public const SWITCH_COMPAT_CHECK_ENABLED                = 'enable_woocommerce_compat_check';
-	private const SETTINGS_KEY                              = 'wc_facebook_for_woocommerce_rollout_switches';
-	public const CAPI_EVENT_LOGGING_ENABLED                 = 'enable_woocommerce_capi_event_logging';
+	public const SWITCH_ROLLOUT_FEATURES                 = 'rollout_enabled';
+	public const SWITCH_PRODUCT_SETS_SYNC_ENABLED        = 'product_sets_sync_enabled';
+	public const SWITCH_WOO_ALL_PRODUCTS_SYNC_ENABLED    = 'woo_all_products_sync_enabled';
+	public const SWITCH_OFFER_MANAGEMENT_ENABLED         = 'offer_management_enabled';
+	public const SWITCH_MULTIPLE_IMAGES_ENABLED          = 'woo_variant_multiple_images_enabled';
+	public const SWITCH_CONTENT_ID_MIGRATION_ENABLED     = 'enable_woocommerce_content_id_migration';
+	public const SWITCH_LANGUAGE_OVERRIDE_FEED_ENABLED   = 'wooc_language_override_feed';
+	public const SWITCH_ISOLATED_PIXEL_EXECUTION_ENABLED = 'enable_woocommerce_isolated_pixel_execution';
+	public const SWITCH_COMPAT_CHECK_ENABLED             = 'enable_woocommerce_compat_check';
+	private const SETTINGS_KEY                           = 'wc_facebook_for_woocommerce_rollout_switches';
+	public const CAPI_EVENT_LOGGING_ENABLED              = 'enable_woocommerce_capi_event_logging';
 
 	private const ACTIVE_SWITCHES = array(
 		self::SWITCH_ROLLOUT_FEATURES,

--- a/includes/Utilities/Background_Remove_Duplicate_Visibility_Meta.php
+++ b/includes/Utilities/Background_Remove_Duplicate_Visibility_Meta.php
@@ -79,6 +79,7 @@ class Background_Remove_Duplicate_Visibility_Meta extends BackgroundJobHandler {
 			}
 		}
 
+		// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 		// job complete! :)
 		if ( $this->count_remaining_products() === 0 ) {
 

--- a/includes/Utilities/Heartbeat.php
+++ b/includes/Utilities/Heartbeat.php
@@ -64,6 +64,7 @@ class Heartbeat {
 	 * Add hooks.
 	 */
 	public function init() {
+		// phpcs:ignore WordPress.WP.CronInterval.CronSchedulesInterval
 		add_filter( 'cron_schedules', array( $this, 'five_minutes_cron_schedules' ) );
 		add_action( 'init', array( $this, 'schedule_cron_events' ) );
 		add_action( $this->hourly_cron_name, array( $this, 'schedule_hourly_action' ) );

--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -193,7 +193,7 @@ class Tracker {
 
 		// 2. Active localization plugin + version
 		$integration = \WooCommerce\Facebook\Integrations\IntegrationRegistry::get_active_localization_integration();
-		$data['extensions']['facebook-for-woocommerce']['localization-plugin'] = $integration ? $integration->get_plugin_name() : 'none';
+		$data['extensions']['facebook-for-woocommerce']['localization-plugin']         = $integration ? $integration->get_plugin_name() : 'none';
 		$data['extensions']['facebook-for-woocommerce']['localization-plugin-version'] = $integration ? $integration->get_plugin_version() : '';
 
 		// 3. Number of available languages

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1753,6 +1753,7 @@ class WC_Facebook_Product {
 					ProductAttributeMapper::get_and_save_mapped_attributes( $product );
 				}
 			} catch ( Exception $e ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 				error_log( 'WC_Facebook_Product::prepare_product() sync error: ' . $e->getMessage() );
 			}
 		}
@@ -1808,7 +1809,7 @@ class WC_Facebook_Product {
 		$product_data['gender']    = $this->get_fb_gender();
 		$product_data['material']  = Helper::str_truncate( $this->get_fb_material(), 100 );
 		// Generate and add collection URI
-		$collection_uri = site_url( CollectionPage::ENDPOINT_PATH );
+		$collection_uri                                     = site_url( CollectionPage::ENDPOINT_PATH );
 		$product_data[ CollectionPage::PRODUCT_FEED_FIELD ] = $collection_uri;
 		if ( $this->get_type() === 'variation' ) {
 			$parent_id      = $this->woo_product->get_parent_id();
@@ -1947,7 +1948,7 @@ class WC_Facebook_Product {
 						case 'condition':
 							// Only allow specific condition values
 							$normalized_value = strtolower( trim( $attribute_value ) );
-							if ( ! in_array( $normalized_value, array( 'new', 'used', 'refurbished' ) ) ) {
+							if ( ! in_array( $normalized_value, array( 'new', 'used', 'refurbished' ), true ) ) {
 								$normalized_value = 'new'; // Default to new if not valid
 							}
 							break;
@@ -2094,7 +2095,7 @@ class WC_Facebook_Product {
 							break;
 						case 'condition':
 							$clean_value = strtolower( trim( $value ) );
-							if ( in_array( $clean_value, array( 'new', 'used', 'refurbished' ) ) ) {
+							if ( in_array( $clean_value, array( 'new', 'used', 'refurbished' ), true ) ) {
 								$product_data[ $fb_field ] = $clean_value;
 							}
 							break;
@@ -2271,7 +2272,7 @@ class WC_Facebook_Product {
 		$date_modified = $this->woo_product->get_date_modified();
 		if ( $date_modified ) {
 			$external_update_time = (int) $date_modified->getTimestamp();
-			$last_change_time = (int) $this->woo_product->get_meta( '_last_change_time' );
+			$last_change_time     = (int) $this->woo_product->get_meta( '_last_change_time' );
 
 			// Use the newer timestamp if _last_change_time is valid, otherwise use external_update_time
 			if ( $last_change_time > 0 ) {
@@ -2399,7 +2400,7 @@ class WC_Facebook_Product {
 			$all_attributes,
 			function ( $attribute ) use ( $sanitized_keys ) {
 				if ( is_array( $attribute ) && isset( $attribute['key'] ) ) {
-					return in_array( $attribute['key'], $sanitized_keys );
+					return in_array( $attribute['key'], $sanitized_keys, true );
 				}
 				return false; // Return false if $attribute is not valid
 			}
@@ -2571,7 +2572,7 @@ class WC_Facebook_Product {
 
 					$first_option = $product->get_variation_default_attribute( $key );
 
-					$index = array_search( $first_option, $option_values, false );
+					$index = array_search( $first_option, $option_values, true );
 
 					unset( $option_values[ $index ] );
 
@@ -2818,7 +2819,7 @@ class WC_Facebook_Product {
 			// Updated to match Facebook's actual supported values
 			$valid_age_groups = array( 'newborn', 'infant', 'toddler', 'kids', 'teen', 'adult', 'all ages' );
 
-			if ( ! in_array( $age_group, $valid_age_groups ) ) {
+			if ( ! in_array( $age_group, $valid_age_groups, true ) ) {
 				// Try to map to a valid value
 				if ( 'teenager' === $age_group ) {
 					$product_data['age_group'] = 'teen'; // Map teenager to teen
@@ -2839,7 +2840,7 @@ class WC_Facebook_Product {
 			$gender        = strtolower( trim( $product_data['gender'] ) );
 			$valid_genders = array( 'male', 'female', 'unisex' );
 
-			if ( ! in_array( $gender, $valid_genders ) ) {
+			if ( ! in_array( $gender, $valid_genders, true ) ) {
 				// Map to supported values
 				if ( in_array( $gender, array( 'man', 'men', 'boys', 'boy' ), true ) ) {
 					$product_data['gender'] = 'male';
@@ -2854,7 +2855,7 @@ class WC_Facebook_Product {
 			$condition        = strtolower( trim( $product_data['condition'] ) );
 			$valid_conditions = array( 'new', 'used', 'refurbished' );
 
-			if ( ! in_array( $condition, $valid_conditions ) ) {
+			if ( ! in_array( $condition, $valid_conditions, true ) ) {
 				// Default to new for invalid conditions
 				$product_data['condition'] = 'new';
 			}

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -250,9 +250,12 @@ class WC_Facebook_Product_Feed {
 
 		foreach ( $files as $file ) {
 			if ( wp_mkdir_p( $file['base'] ) && ! file_exists( trailingslashit( $file['base'] ) . $file['file'] ) ) {
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 				$file_handle = @fopen( trailingslashit( $file['base'] ) . $file['file'], 'w' );
 				if ( $file_handle ) {
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
 					fwrite( $file_handle, $file['content'] );
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 					fclose( $file_handle );
 				}
 			}
@@ -299,7 +302,7 @@ class WC_Facebook_Product_Feed {
 
 			// close the temporary file
 			if ( ! empty( $temp_feed_file ) && is_resource( $temp_feed_file ) ) {
-
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 				fclose( $temp_feed_file );
 			}
 
@@ -323,9 +326,11 @@ class WC_Facebook_Product_Feed {
 	 */
 	public function prepare_temporary_feed_file() {
 		$temp_file_path = $this->get_temp_file_path();
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 		$temp_feed_file = @fopen( $temp_file_path, 'w' );
 
 		// check if we can open the temporary feed file
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
 		if ( false === $temp_feed_file || ! is_writable( $temp_file_path ) ) {
 			throw new PluginException( __( 'Could not open the product catalog temporary feed file for writing', 'facebook-for-woocommerce' ), 500 );
 		}
@@ -333,10 +338,12 @@ class WC_Facebook_Product_Feed {
 		$file_path = $this->get_file_path();
 
 		// check if we will be able to write to the final feed file
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
 		if ( file_exists( $file_path ) && ! is_writable( $file_path ) ) {
 			throw new PluginException( __( 'Could not open the product catalog feed file for writing', 'facebook-for-woocommerce' ), 500 );
 		}
 
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
 		fwrite( $temp_feed_file, $this->get_product_feed_header_row() );
 		return $temp_feed_file;
 	}
@@ -382,6 +389,7 @@ class WC_Facebook_Product_Feed {
 			);
 
 			if ( ! empty( $temp_feed_file ) ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
 				fwrite( $temp_feed_file, $product_data_as_feed_row );
 			}
 		}
@@ -389,6 +397,7 @@ class WC_Facebook_Product_Feed {
 		wp_reset_postdata();
 
 		if ( ! empty( $temp_feed_file ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 			fclose( $temp_feed_file );
 		}
 	}

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -27,12 +27,12 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 
 		const FB_RETAILER_ID_PREFIX = 'wc_post_id_';
 		// TODO: remove this in v2.0.0 {CW 2020-02-06}
-		const PLUGIN_VERSION     = \WC_Facebookcommerce::VERSION;
-		const FB_VARIANT_SIZE    = 'size';
-		const FB_VARIANT_COLOR   = 'color';
-		const FB_VARIANT_COLOUR  = 'colour';
-		const FB_VARIANT_PATTERN = 'pattern';
-		const FB_VARIANT_GENDER  = 'gender';
+		const PLUGIN_VERSION              = \WC_Facebookcommerce::VERSION;
+		const FB_VARIANT_SIZE             = 'size';
+		const FB_VARIANT_COLOR            = 'color';
+		const FB_VARIANT_COLOUR           = 'colour';
+		const FB_VARIANT_PATTERN          = 'pattern';
+		const FB_VARIANT_GENDER           = 'gender';
 		const WC_EXCERPT_LENGTH_THRESHOLD = 10;
 
 		// TODO: this constant is no longer used and can probably be removed {WV 2020-01-21}
@@ -567,6 +567,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		) {
 			$args = array(
 				'fields'         => 'ids',
+				// phpcs:ignore WordPress.DB.SlowDBQuery
 				'meta_query'     => array(
 					( ( $product_group_id ) ?
 					array(
@@ -613,7 +614,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 			// Fallback to site url
 			$url = get_site_url();
 			if ( $url ) {
-				self::$store_name = parse_url( $url, PHP_URL_HOST );
+				self::$store_name = wp_parse_url( $url, PHP_URL_HOST );
 				return self::$store_name;
 			}
 

--- a/tests/Unit/Api/Pixel/Events/RequestTest.php
+++ b/tests/Unit/Api/Pixel/Events/RequestTest.php
@@ -16,6 +16,53 @@ use WP_UnitTestCase;
 class RequestTest extends WP_UnitTestCase {
 
 	/**
+	 * Clear the static caches on the tracker before each test so that
+	 * param_builder / cached_fbc / cached_fbp from a previous test
+	 * do not leak into the next one.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->clear_tracker_caches();
+	}
+
+	public function tearDown(): void {
+		$this->clear_tracker_caches();
+		parent::tearDown();
+	}
+
+	private function clear_tracker_caches(): void {
+		if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) {
+			return;
+		}
+		$ref = new \ReflectionClass( 'WC_Facebookcommerce_EventsTracker' );
+
+		// Install a stub that returns null — setting param_builder to null
+		// causes get_param_builder() to recreate it from the SDK.
+		$stub = new class() {
+			public function getFbc() {
+				return null;
+			}
+			public function getFbp() {
+				return null;
+			}
+		};
+
+		if ( $ref->hasProperty( 'param_builder' ) ) {
+			$prop = $ref->getProperty( 'param_builder' );
+			$prop->setAccessible( true );
+			$prop->setValue( null, $stub );
+		}
+
+		foreach ( array( 'cached_fbc', 'cached_fbp' ) as $prop_name ) {
+			if ( $ref->hasProperty( $prop_name ) ) {
+				$prop = $ref->getProperty( $prop_name );
+				$prop->setAccessible( true );
+				$prop->setValue( null, null );
+			}
+		}
+	}
+
+	/**
 	 * Test that Request properly formats data with fbc and fbp.
 	 */
 	public function test_request_data_contains_fbc_fbp() {
@@ -357,8 +404,8 @@ class RequestTest extends WP_UnitTestCase {
 	 * Data provider for fbc/fbp from cookie and session tests.
 	 *
 	 * Tests the priority order for fbc/fbp values from multiple sources:
-	 * - For fbc: cookie > session > param_builder > request (fbclid)
-	 * - For fbp: cookie > session > param_builder
+	 * - For fbc: param_builder > fbclid (new click) > cookie > session
+	 * - For fbp: param_builder > cookie > session
 	 *
 	 * @return array Test cases with format: [field_name, cookie_value, session_value, parambuilder_value, request_value, expected_value]
 	 */
@@ -413,7 +460,7 @@ class RequestTest extends WP_UnitTestCase {
 				null,
 				'fb.1.1234567890.ParamBuilderFBP',
 			),
-			// Test priority: cookie > session
+			// Test priority: cookie > session (when no param_builder)
 			'fbc cookie takes priority over session' => array(
 				'fbc',
 				'fb.1.1234567890.CookieFBC',
@@ -430,56 +477,56 @@ class RequestTest extends WP_UnitTestCase {
 				null,
 				'fb.1.1234567890.CookieFBP',
 			),
-			// Test priority: cookie > param_builder
-			'fbc cookie takes priority over param_builder' => array(
+			// Test priority: param_builder > cookie
+			'fbc param_builder takes priority over cookie' => array(
 				'fbc',
 				'fb.1.1234567890.CookieFBC',
 				null,
 				'fb.1.1234567890.ParamBuilderFBC',
 				null,
-				'fb.1.1234567890.CookieFBC',
+				'fb.1.1234567890.ParamBuilderFBC',
 			),
-			'fbp cookie takes priority over param_builder' => array(
+			'fbp param_builder takes priority over cookie' => array(
 				'fbp',
 				'fb.1.1234567890.CookieFBP',
 				null,
 				'fb.1.1234567890.ParamBuilderFBP',
 				null,
-				'fb.1.1234567890.CookieFBP',
+				'fb.1.1234567890.ParamBuilderFBP',
 			),
-			// Test priority: session > param_builder
-			'fbc session takes priority over param_builder' => array(
+			// Test priority: param_builder > session
+			'fbc param_builder takes priority over session' => array(
 				'fbc',
 				null,
 				'fb.1.1234567890.SessionFBC',
 				'fb.1.1234567890.ParamBuilderFBC',
 				null,
-				'fb.1.1234567890.SessionFBC',
+				'fb.1.1234567890.ParamBuilderFBC',
 			),
-			'fbp session takes priority over param_builder' => array(
+			'fbp param_builder takes priority over session' => array(
 				'fbp',
 				null,
 				'fb.1.1234567890.SessionFBP',
 				'fb.1.1234567890.ParamBuilderFBP',
 				null,
-				'fb.1.1234567890.SessionFBP',
+				'fb.1.1234567890.ParamBuilderFBP',
 			),
-			// Test all sources present: cookie should win
-			'fbc cookie takes priority over all other sources' => array(
+			// Test all sources present: param_builder should win
+			'fbc param_builder takes priority over all other sources' => array(
 				'fbc',
 				'fb.1.1234567890.CookieFBC',
 				'fb.1.1234567890.SessionFBC',
 				'fb.1.1234567890.ParamBuilderFBC',
 				null,
-				'fb.1.1234567890.CookieFBC',
+				'fb.1.1234567890.ParamBuilderFBC',
 			),
-			'fbp cookie takes priority over all other sources' => array(
+			'fbp param_builder takes priority over all other sources' => array(
 				'fbp',
 				'fb.1.1234567890.CookieFBP',
 				'fb.1.1234567890.SessionFBP',
 				'fb.1.1234567890.ParamBuilderFBP',
 				null,
-				'fb.1.1234567890.CookieFBP',
+				'fb.1.1234567890.ParamBuilderFBP',
 			),
 		);
 	}
@@ -488,13 +535,16 @@ class RequestTest extends WP_UnitTestCase {
 	 * Test that fbc/fbp values from cookies, sessions, and param_builder are properly handled with correct priority.
 	 *
 	 * This test verifies the priority order for fbc/fbp values:
-	 * - For fbc: cookie > session > param_builder > request (fbclid)
-	 * - For fbp: cookie > session > param_builder
+	 * - For fbc: param_builder > fbclid (new click) > cookie > session
+	 * - For fbp: param_builder > cookie > session
 	 *
 	 * @dataProvider fbc_fbp_sources_provider
 	 */
 	public function test_fbc_fbp_from_cookie_and_session( $field_name, $cookie_value, $session_value, $parambuilder_value, $request_value, $expected_value ) {
 		$pixel_id = 'test_pixel_id_123';
+
+		// Reset caches so previous tests don't leak.
+		$this->clear_tracker_caches();
 
 		// Set up cookie value if provided
 		if ( null !== $cookie_value ) {
@@ -542,9 +592,9 @@ class RequestTest extends WP_UnitTestCase {
 
 		// Set up request value if provided (for fbc from fbclid)
 		if ( null !== $request_value && 'fbc' === $field_name ) {
-			$_REQUEST['fbclid'] = $request_value;
+			$_GET['fbclid'] = $request_value;
 		} else {
-			unset( $_REQUEST['fbclid'] );
+			unset( $_GET['fbclid'] );
 		}
 
 		$event = new Event( array( 'event_name' => 'TestEvent' ) );
@@ -560,11 +610,12 @@ class RequestTest extends WP_UnitTestCase {
 		// Clean up
 		unset( $_COOKIE[ '_' . $field_name ] );
 		unset( $_SESSION[ '_' . $field_name ] );
-		unset( $_REQUEST['fbclid'] );
+		unset( $_GET['fbclid'] );
 
 		if ( isset( $prop ) ) {
 			$prop->setValue( null, $original_param_builder );
 		}
+		$this->clear_tracker_caches();
 	}
 
 	/**
@@ -596,6 +647,8 @@ class RequestTest extends WP_UnitTestCase {
 	 */
 	public function test_param_builder_values( $field_name, $test_value, $getter_method, $additional_methods ) {
 		$pixel_id = 'test_pixel_id_123';
+
+		$this->clear_tracker_caches();
 
 		$mock_param_builder = new class( $test_value, $getter_method, $additional_methods ) {
 			private $value;
@@ -653,46 +706,28 @@ class RequestTest extends WP_UnitTestCase {
 	}
 
 	public function test_fbc_from_fbclid() {
-		$test_fbc = 'fb.1.1234567890.Test';
-		$pixel_id = 'test_pixel_id_123';
+		$test_fbclid = 'AbCdEfGhIjKlMnOp';
+		$pixel_id    = 'test_pixel_id_123';
 
-		// Case: click_id existed in request parameter
-		$_REQUEST['fbclid'] = $test_fbc;
+		$this->clear_tracker_caches();
 
-		// Ensure param_builder doesn't override the fbclid-derived fbc
-		$original_param_builder = null;
-		if ( class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) {
-			$ref = new \ReflectionClass( 'WC_Facebookcommerce_EventsTracker' );
-			if ( $ref->hasProperty( 'param_builder' ) ) {
-				$prop = $ref->getProperty( 'param_builder' );
-				$prop->setAccessible( true );
-				$original_param_builder = $prop->getValue();
-				$prop->setValue( null, null );
-			}
-		}
+		$_GET['fbclid'] = $test_fbclid;
 
-		if ( isset( $_COOKIE['_fbc'] ) ) {
-			unset( $_COOKIE['_fbc'] );
-		}
-		if ( isset( $_SESSION['_fbc'] ) ) {
-			unset( $_SESSION['_fbc'] );
-		}
+		unset( $_COOKIE['_fbc'] );
+		unset( $_SESSION['_fbc'] );
 
-		$event = new Event( array( 'event_name' => 'TestEvent' ) );
-		$request = new Request( $pixel_id, array( $event ) );
-		$data = $request->get_data();
+		$event     = new Event( array( 'event_name' => 'TestEvent' ) );
+		$request   = new Request( $pixel_id, array( $event ) );
+		$data      = $request->get_data();
 
 		$this->assertArrayHasKey( 'user_data', $data['data'][0] );
 		$this->assertArrayHasKey( 'fbc', $data['data'][0]['user_data'] );
 		$fbc_value = $data['data'][0]['user_data']['fbc'];
-		$this->assertMatchesRegularExpression('/^fb\.1\.\d+\.' . preg_quote( $test_fbc, '/' ) . '$/', $fbc_value );
+		$this->assertMatchesRegularExpression( '/^fb\.1\.\d+\.' . preg_quote( $test_fbclid, '/' ) . '$/', $fbc_value );
 		$this->assertArrayNotHasKey( 'click_id', $data['data'][0]['user_data'] );
 		$this->assertArrayNotHasKey( 'browser_id', $data['data'][0]['user_data'] );
 
-		unset( $_REQUEST['fbclid'] );
-		if ( isset( $prop ) ) {
-			$prop->setValue( null, $original_param_builder );
-		}
+		unset( $_GET['fbclid'] );
 	}
 
 }

--- a/tests/Unit/Api/Pixel/Events/RequestTest.php
+++ b/tests/Unit/Api/Pixel/Events/RequestTest.php
@@ -637,6 +637,10 @@ class RequestTest extends WP_UnitTestCase {
 				public function getFbp() {
 					return $this->field === 'fbp' ? $this->value : null;
 				}
+
+				public function getCookiesToSet() {
+					return array();
+				}
 			};
 
 			$ref = new \ReflectionClass( 'WC_Facebookcommerce_EventsTracker' );
@@ -717,6 +721,10 @@ class RequestTest extends WP_UnitTestCase {
 				$this->value = $value;
 				$this->getter = $getter;
 				$this->methods = $methods;
+			}
+
+			public function getCookiesToSet() {
+				return array();
 			}
 
 			public function __call( $name, $arguments ) {

--- a/tests/Unit/Api/Pixel/Events/RequestTest.php
+++ b/tests/Unit/Api/Pixel/Events/RequestTest.php
@@ -20,24 +20,32 @@ class RequestTest extends WP_UnitTestCase {
 	 * param_builder / cached_fbc / cached_fbp from a previous test
 	 * do not leak into the next one.
 	 */
+	/** @var mixed Original param_builder to restore after tests. */
+	private $original_param_builder;
+
 	public function setUp(): void {
 		parent::setUp();
-		$this->clear_tracker_caches();
+		$this->original_param_builder = $this->install_null_param_builder();
 	}
 
 	public function tearDown(): void {
-		$this->clear_tracker_caches();
+		$this->restore_tracker_state( $this->original_param_builder );
 		parent::tearDown();
 	}
 
-	private function clear_tracker_caches(): void {
+	/**
+	 * Replaces the static param_builder with a stub that returns null for
+	 * getFbc/getFbp (and getCookiesToSet) and clears cached values so Event
+	 * falls through to cookie/session/query-string paths.
+	 *
+	 * @return mixed The original param_builder value to restore later.
+	 */
+	private function install_null_param_builder() {
 		if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) {
-			return;
+			return null;
 		}
 		$ref = new \ReflectionClass( 'WC_Facebookcommerce_EventsTracker' );
 
-		// Install a stub that returns null — setting param_builder to null
-		// causes get_param_builder() to recreate it from the SDK.
 		$stub = new class() {
 			public function getFbc() {
 				return null;
@@ -45,14 +53,64 @@ class RequestTest extends WP_UnitTestCase {
 			public function getFbp() {
 				return null;
 			}
+			public function getCookiesToSet() {
+				return array();
+			}
 		};
+
+		$original = null;
+		if ( $ref->hasProperty( 'param_builder' ) ) {
+			$prop = $ref->getProperty( 'param_builder' );
+			$prop->setAccessible( true );
+			$original = $prop->getValue();
+			$prop->setValue( null, $stub );
+		}
+
+		foreach ( array( 'cached_fbc', 'cached_fbp' ) as $prop_name ) {
+			if ( $ref->hasProperty( $prop_name ) ) {
+				$prop = $ref->getProperty( $prop_name );
+				$prop->setAccessible( true );
+				$prop->setValue( null, null );
+			}
+		}
+
+		return $original;
+	}
+
+	/**
+	 * Restores the original param_builder and clears caches so subsequent
+	 * test classes are not affected by the stub.
+	 */
+	private function restore_tracker_state( $original_param_builder ): void {
+		if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) {
+			return;
+		}
+		$ref = new \ReflectionClass( 'WC_Facebookcommerce_EventsTracker' );
 
 		if ( $ref->hasProperty( 'param_builder' ) ) {
 			$prop = $ref->getProperty( 'param_builder' );
 			$prop->setAccessible( true );
-			$prop->setValue( null, $stub );
+			$prop->setValue( null, $original_param_builder );
 		}
 
+		foreach ( array( 'cached_fbc', 'cached_fbp' ) as $prop_name ) {
+			if ( $ref->hasProperty( $prop_name ) ) {
+				$prop = $ref->getProperty( $prop_name );
+				$prop->setAccessible( true );
+				$prop->setValue( null, null );
+			}
+		}
+	}
+
+	/**
+	 * Clears only cached_fbc/cached_fbp so the stub param_builder is
+	 * re-queried on the next Event construction.
+	 */
+	private function reset_cached_values(): void {
+		if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) {
+			return;
+		}
+		$ref = new \ReflectionClass( 'WC_Facebookcommerce_EventsTracker' );
 		foreach ( array( 'cached_fbc', 'cached_fbp' ) as $prop_name ) {
 			if ( $ref->hasProperty( $prop_name ) ) {
 				$prop = $ref->getProperty( $prop_name );
@@ -544,7 +602,7 @@ class RequestTest extends WP_UnitTestCase {
 		$pixel_id = 'test_pixel_id_123';
 
 		// Reset caches so previous tests don't leak.
-		$this->clear_tracker_caches();
+		$this->reset_cached_values();
 
 		// Set up cookie value if provided
 		if ( null !== $cookie_value ) {
@@ -615,7 +673,7 @@ class RequestTest extends WP_UnitTestCase {
 		if ( isset( $prop ) ) {
 			$prop->setValue( null, $original_param_builder );
 		}
-		$this->clear_tracker_caches();
+		$this->reset_cached_values();
 	}
 
 	/**
@@ -648,7 +706,7 @@ class RequestTest extends WP_UnitTestCase {
 	public function test_param_builder_values( $field_name, $test_value, $getter_method, $additional_methods ) {
 		$pixel_id = 'test_pixel_id_123';
 
-		$this->clear_tracker_caches();
+		$this->reset_cached_values();
 
 		$mock_param_builder = new class( $test_value, $getter_method, $additional_methods ) {
 			private $value;
@@ -709,7 +767,7 @@ class RequestTest extends WP_UnitTestCase {
 		$test_fbclid = 'AbCdEfGhIjKlMnOp';
 		$pixel_id    = 'test_pixel_id_123';
 
-		$this->clear_tracker_caches();
+		$this->reset_cached_values();
 
 		$_GET['fbclid'] = $test_fbclid;
 

--- a/tests/Unit/Api/Pixel/Events/RequestTest.php
+++ b/tests/Unit/Api/Pixel/Events/RequestTest.php
@@ -612,6 +612,9 @@ class RequestTest extends WP_UnitTestCase {
 		}
 
 		// Set up session value if provided
+		if ( ! isset( $_SESSION ) ) {
+			$_SESSION = array();
+		}
 		if ( null !== $session_value ) {
 			$_SESSION[ '_' . $field_name ] = $session_value;
 		} else {
@@ -669,9 +672,11 @@ class RequestTest extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'click_id', $data['data'][0]['user_data'] );
 		$this->assertArrayNotHasKey( 'browser_id', $data['data'][0]['user_data'] );
 
-		// Clean up
+		// Clean up.
 		unset( $_COOKIE[ '_' . $field_name ] );
-		unset( $_SESSION[ '_' . $field_name ] );
+		if ( isset( $_SESSION ) ) {
+			unset( $_SESSION[ '_' . $field_name ] );
+		}
 		unset( $_GET['fbclid'] );
 
 		if ( isset( $prop ) ) {

--- a/tests/Unit/Events/EventSignalsStateTest.php
+++ b/tests/Unit/Events/EventSignalsStateTest.php
@@ -74,13 +74,29 @@ class EventSignalsStateTest extends AbstractWPUnitTestWithOptionIsolationAndSafe
 	// ------------------------------------------------------------------
 
 	/**
-	 * Null-out the static param-builder and cached fbc/fbp on the tracker
-	 * so that Event falls through to cookie / session / query-string paths.
+	 * Install a stub param-builder that returns null for getFbc/getFbp, and
+	 * clear the cached values so Event falls through to cookie / session /
+	 * query-string paths.  Setting param_builder to null is not enough
+	 * because get_param_builder() would recreate it from the SDK.
 	 */
 	private function clear_tracker_caches(): void {
 		$ref = new ReflectionClass( \WC_Facebookcommerce_EventsTracker::class );
 
-		foreach ( array( 'param_builder', 'cached_fbc', 'cached_fbp' ) as $prop ) {
+		// Install a stub that always returns null.
+		$stub = new class() {
+			public function getFbc() {
+				return null;
+			}
+			public function getFbp() {
+				return null;
+			}
+		};
+
+		$pb = $ref->getProperty( 'param_builder' );
+		$pb->setAccessible( true );
+		$pb->setValue( null, $stub );
+
+		foreach ( array( 'cached_fbc', 'cached_fbp' ) as $prop ) {
 			$rp = $ref->getProperty( $prop );
 			$rp->setAccessible( true );
 			$rp->setValue( null, null );

--- a/tests/Unit/Events/EventSignalsStateTest.php
+++ b/tests/Unit/Events/EventSignalsStateTest.php
@@ -26,33 +26,30 @@ class EventSignalsStateTest extends AbstractWPUnitTestWithOptionIsolationAndSafe
 	/** @var string|null */
 	private $original_user_agent;
 
+	/** @var mixed Original param_builder to restore after tests. */
+	private $original_param_builder;
+
 	public function setUp(): void {
 		parent::setUp();
 
 		$this->original_user_agent = $_SERVER['HTTP_USER_AGENT'] ?? null;
 		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Test)';
 
-		// Ensure a session array exists.
 		if ( ! isset( $_SESSION ) ) {
 			$_SESSION = array();
 		}
 		$this->original_session = $_SESSION;
 
-		// Clear any residual superglobal state the tests touch.
 		unset( $_COOKIE['_fbc'], $_COOKIE['_fbp'] );
 		unset( $_GET['fbclid'] );
 		unset( $_SESSION['_fbc'], $_SESSION['_fbp'] );
 
-		// Reset FacebookSignalsState to a clean, released state.
 		FacebookSignalsState::release();
 
-		// Ensure the param-builder cache returns null so cookie/session/
-		// query-string paths are exercised without SDK side-effects.
-		$this->clear_tracker_caches();
+		$this->original_param_builder = $this->install_null_param_builder();
 	}
 
 	public function tearDown(): void {
-		// Restore superglobals.
 		$_SESSION = $this->original_session;
 		unset( $_COOKIE['_fbc'], $_COOKIE['_fbp'] );
 		unset( $_GET['fbclid'] );
@@ -64,7 +61,7 @@ class EventSignalsStateTest extends AbstractWPUnitTestWithOptionIsolationAndSafe
 		}
 
 		FacebookSignalsState::release();
-		$this->clear_tracker_caches();
+		$this->restore_tracker_state( $this->original_param_builder );
 
 		parent::tearDown();
 	}
@@ -74,15 +71,15 @@ class EventSignalsStateTest extends AbstractWPUnitTestWithOptionIsolationAndSafe
 	// ------------------------------------------------------------------
 
 	/**
-	 * Install a stub param-builder that returns null for getFbc/getFbp, and
-	 * clear the cached values so Event falls through to cookie / session /
-	 * query-string paths.  Setting param_builder to null is not enough
-	 * because get_param_builder() would recreate it from the SDK.
+	 * Replaces the static param_builder with a stub that returns null and
+	 * clears cached values so Event falls through to cookie/session/query-
+	 * string paths.
+	 *
+	 * @return mixed The original param_builder value to restore later.
 	 */
-	private function clear_tracker_caches(): void {
+	private function install_null_param_builder() {
 		$ref = new ReflectionClass( \WC_Facebookcommerce_EventsTracker::class );
 
-		// Install a stub that always returns null.
 		$stub = new class() {
 			public function getFbc() {
 				return null;
@@ -90,11 +87,34 @@ class EventSignalsStateTest extends AbstractWPUnitTestWithOptionIsolationAndSafe
 			public function getFbp() {
 				return null;
 			}
+			public function getCookiesToSet() {
+				return array();
+			}
 		};
 
 		$pb = $ref->getProperty( 'param_builder' );
 		$pb->setAccessible( true );
+		$original = $pb->getValue();
 		$pb->setValue( null, $stub );
+
+		foreach ( array( 'cached_fbc', 'cached_fbp' ) as $prop ) {
+			$rp = $ref->getProperty( $prop );
+			$rp->setAccessible( true );
+			$rp->setValue( null, null );
+		}
+
+		return $original;
+	}
+
+	/**
+	 * Restores the original param_builder and clears caches.
+	 */
+	private function restore_tracker_state( $original_param_builder ): void {
+		$ref = new ReflectionClass( \WC_Facebookcommerce_EventsTracker::class );
+
+		$pb = $ref->getProperty( 'param_builder' );
+		$pb->setAccessible( true );
+		$pb->setValue( null, $original_param_builder );
 
 		foreach ( array( 'cached_fbc', 'cached_fbp' ) as $prop ) {
 			$rp = $ref->getProperty( $prop );

--- a/tests/Unit/Events/EventSignalsStateTest.php
+++ b/tests/Unit/Events/EventSignalsStateTest.php
@@ -1,0 +1,323 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\Facebook\Tests\Unit\Events;
+
+use ReflectionClass;
+use WooCommerce\Facebook\Events\Event;
+use WooCommerce\Facebook\Events\FacebookSignalsState;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+
+/**
+ * Tests for Event behaviour when FacebookSignalsState is held.
+ *
+ * Covers session-write suppression for _fbc/_fbp, the click-ID priority
+ * chain, the fbclid-change detection helper, and browser-ID fallback logic.
+ */
+class EventSignalsStateTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+	/** @var array|null Original $_SESSION backup. */
+	private $original_session;
+
+	/** @var array Superglobal keys to save/restore. */
+	private $saved_cookie = array();
+	private $saved_get    = array();
+
+	/** @var string|null */
+	private $original_user_agent;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->original_user_agent = $_SERVER['HTTP_USER_AGENT'] ?? null;
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Test)';
+
+		// Ensure a session array exists.
+		if ( ! isset( $_SESSION ) ) {
+			$_SESSION = array();
+		}
+		$this->original_session = $_SESSION;
+
+		// Clear any residual superglobal state the tests touch.
+		unset( $_COOKIE['_fbc'], $_COOKIE['_fbp'] );
+		unset( $_GET['fbclid'] );
+		unset( $_SESSION['_fbc'], $_SESSION['_fbp'] );
+
+		// Reset FacebookSignalsState to a clean, released state.
+		FacebookSignalsState::release();
+
+		// Ensure the param-builder cache returns null so cookie/session/
+		// query-string paths are exercised without SDK side-effects.
+		$this->clear_tracker_caches();
+	}
+
+	public function tearDown(): void {
+		// Restore superglobals.
+		$_SESSION = $this->original_session;
+		unset( $_COOKIE['_fbc'], $_COOKIE['_fbp'] );
+		unset( $_GET['fbclid'] );
+
+		if ( null === $this->original_user_agent ) {
+			unset( $_SERVER['HTTP_USER_AGENT'] );
+		} else {
+			$_SERVER['HTTP_USER_AGENT'] = $this->original_user_agent;
+		}
+
+		FacebookSignalsState::release();
+		$this->clear_tracker_caches();
+
+		parent::tearDown();
+	}
+
+	// ------------------------------------------------------------------
+	// Helpers
+	// ------------------------------------------------------------------
+
+	/**
+	 * Null-out the static param-builder and cached fbc/fbp on the tracker
+	 * so that Event falls through to cookie / session / query-string paths.
+	 */
+	private function clear_tracker_caches(): void {
+		$ref = new ReflectionClass( \WC_Facebookcommerce_EventsTracker::class );
+
+		foreach ( array( 'param_builder', 'cached_fbc', 'cached_fbp' ) as $prop ) {
+			$rp = $ref->getProperty( $prop );
+			$rp->setAccessible( true );
+			$rp->setValue( null, null );
+		}
+	}
+
+	/**
+	 * Call the protected has_fbclid_changed() via reflection.
+	 */
+	private function call_has_fbclid_changed( string $cookie_fbc, ?string $request_fbclid ): bool {
+		$ref    = new ReflectionClass( Event::class );
+		$method = $ref->getMethod( 'has_fbclid_changed' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null, $cookie_fbc, $request_fbclid );
+	}
+
+	// ------------------------------------------------------------------
+	// 1. Session not written when signals are held
+	// ------------------------------------------------------------------
+
+	public function test_session_fbc_not_written_when_held(): void {
+		FacebookSignalsState::hold();
+		$_COOKIE['_fbc'] = 'fb.1.1000000.testclickid';
+
+		new Event( array( 'event_name' => 'PageView' ) );
+
+		$this->assertArrayNotHasKey( '_fbc', $_SESSION );
+	}
+
+	public function test_session_fbp_not_written_when_held(): void {
+		FacebookSignalsState::hold();
+		$_COOKIE['_fbp'] = 'fb.1.1000000.999888777';
+
+		new Event( array( 'event_name' => 'PageView' ) );
+
+		$this->assertArrayNotHasKey( '_fbp', $_SESSION );
+	}
+
+	public function test_session_fbc_not_written_when_held_via_fbclid(): void {
+		FacebookSignalsState::hold();
+		$_GET['fbclid'] = 'newclickid123';
+
+		new Event( array( 'event_name' => 'PageView' ) );
+
+		$this->assertArrayNotHasKey( '_fbc', $_SESSION );
+	}
+
+	// ------------------------------------------------------------------
+	// 2. Session written normally when signals are active
+	// ------------------------------------------------------------------
+
+	public function test_session_fbc_written_when_not_held(): void {
+		$_COOKIE['_fbc'] = 'fb.1.1000000.testclickid';
+
+		new Event( array( 'event_name' => 'PageView' ) );
+
+		$this->assertArrayHasKey( '_fbc', $_SESSION );
+		$this->assertEquals( 'fb.1.1000000.testclickid', $_SESSION['_fbc'] );
+	}
+
+	public function test_session_fbp_written_when_not_held(): void {
+		$_COOKIE['_fbp'] = 'fb.1.1000000.999888777';
+
+		new Event( array( 'event_name' => 'PageView' ) );
+
+		$this->assertArrayHasKey( '_fbp', $_SESSION );
+		$this->assertEquals( 'fb.1.1000000.999888777', $_SESSION['_fbp'] );
+	}
+
+	// ------------------------------------------------------------------
+	// 3. New fbclid overrides stale cookie
+	// ------------------------------------------------------------------
+
+	public function test_new_fbclid_overrides_stale_cookie_fbc(): void {
+		$_COOKIE['_fbc'] = 'fb.1.1000000.oldfbclid';
+		$_GET['fbclid']  = 'newfbclid';
+
+		$event     = new Event( array( 'event_name' => 'PageView' ) );
+		$user_data = $event->get_user_data();
+
+		$this->assertStringContainsString( 'newfbclid', $user_data['click_id'] );
+		$this->assertStringNotContainsString( 'oldfbclid', $user_data['click_id'] );
+	}
+
+	// ------------------------------------------------------------------
+	// 4. Same fbclid preserves existing cookie
+	// ------------------------------------------------------------------
+
+	public function test_same_fbclid_preserves_existing_cookie(): void {
+		$_COOKIE['_fbc'] = 'fb.1.1000000.samefbclid';
+		$_GET['fbclid']  = 'samefbclid';
+
+		$event     = new Event( array( 'event_name' => 'PageView' ) );
+		$user_data = $event->get_user_data();
+
+		$this->assertEquals( 'fb.1.1000000.samefbclid', $user_data['click_id'] );
+	}
+
+	// ------------------------------------------------------------------
+	// 5. Click-ID fallback priority chain
+	// ------------------------------------------------------------------
+
+	public function test_click_id_returns_cookie_when_no_fbclid(): void {
+		$_COOKIE['_fbc'] = 'fb.1.2000000.cookieclickid';
+
+		$event     = new Event( array( 'event_name' => 'PageView' ) );
+		$user_data = $event->get_user_data();
+
+		$this->assertEquals( 'fb.1.2000000.cookieclickid', $user_data['click_id'] );
+	}
+
+	public function test_click_id_falls_back_to_session(): void {
+		$_SESSION['_fbc'] = 'fb.1.3000000.sessionclickid';
+
+		$event     = new Event( array( 'event_name' => 'PageView' ) );
+		$user_data = $event->get_user_data();
+
+		$this->assertEquals( 'fb.1.3000000.sessionclickid', $user_data['click_id'] );
+	}
+
+	public function test_click_id_returns_null_when_nothing_available(): void {
+		$event     = new Event( array( 'event_name' => 'PageView' ) );
+		$user_data = $event->get_user_data();
+
+		$this->assertNull( $user_data['click_id'] );
+	}
+
+	// ------------------------------------------------------------------
+	// 6. Browser-ID fallback priority chain
+	// ------------------------------------------------------------------
+
+	public function test_browser_id_returns_cookie_value(): void {
+		$_COOKIE['_fbp'] = 'fb.1.4000000.cookiebrowserid';
+
+		$event     = new Event( array( 'event_name' => 'PageView' ) );
+		$user_data = $event->get_user_data();
+
+		$this->assertEquals( 'fb.1.4000000.cookiebrowserid', $user_data['browser_id'] );
+	}
+
+	public function test_browser_id_falls_back_to_session(): void {
+		$_SESSION['_fbp'] = 'fb.1.5000000.sessionbrowserid';
+
+		$event     = new Event( array( 'event_name' => 'PageView' ) );
+		$user_data = $event->get_user_data();
+
+		$this->assertEquals( 'fb.1.5000000.sessionbrowserid', $user_data['browser_id'] );
+	}
+
+	public function test_browser_id_returns_null_when_nothing_available(): void {
+		$event     = new Event( array( 'event_name' => 'PageView' ) );
+		$user_data = $event->get_user_data();
+
+		$this->assertNull( $user_data['browser_id'] );
+	}
+
+	// ------------------------------------------------------------------
+	// Event still populates user_data in-memory even when held
+	// ------------------------------------------------------------------
+
+	public function test_event_has_click_id_in_memory_when_held(): void {
+		FacebookSignalsState::hold();
+		$_COOKIE['_fbc'] = 'fb.1.6000000.inmemorytest';
+
+		$event     = new Event( array( 'event_name' => 'PageView' ) );
+		$user_data = $event->get_user_data();
+
+		$this->assertEquals( 'fb.1.6000000.inmemorytest', $user_data['click_id'] );
+	}
+
+	public function test_event_has_browser_id_in_memory_when_held(): void {
+		FacebookSignalsState::hold();
+		$_COOKIE['_fbp'] = 'fb.1.6000000.inmemorytest';
+
+		$event     = new Event( array( 'event_name' => 'PageView' ) );
+		$user_data = $event->get_user_data();
+
+		$this->assertEquals( 'fb.1.6000000.inmemorytest', $user_data['browser_id'] );
+	}
+
+	// ------------------------------------------------------------------
+	// 7. Session suppressed even during admin/cron when held
+	// ------------------------------------------------------------------
+
+	public function test_session_not_written_when_held_during_admin(): void {
+		FacebookSignalsState::hold();
+		$_COOKIE['_fbc'] = 'fb.1.7000000.admintest';
+		$_COOKIE['_fbp'] = 'fb.1.7000000.adminbrowser';
+
+		// Simulate an admin context.
+		set_current_screen( 'edit-post' );
+		$this->assertTrue( is_admin() );
+
+		new Event( array( 'event_name' => 'Purchase' ) );
+
+		$this->assertArrayNotHasKey( '_fbc', $_SESSION );
+		$this->assertArrayNotHasKey( '_fbp', $_SESSION );
+
+		set_current_screen( 'front' );
+	}
+
+	// ------------------------------------------------------------------
+	// 9. has_fbclid_changed() edge cases
+	// ------------------------------------------------------------------
+
+	public function test_has_fbclid_changed_returns_false_for_null_fbclid(): void {
+		$this->assertFalse(
+			$this->call_has_fbclid_changed( 'fb.1.1000000.abc', null )
+		);
+	}
+
+	public function test_has_fbclid_changed_returns_true_for_malformed_cookie(): void {
+		$this->assertTrue(
+			$this->call_has_fbclid_changed( 'malformed', 'anyfbclid' )
+		);
+	}
+
+	public function test_has_fbclid_changed_returns_false_for_same_fbclid(): void {
+		$this->assertFalse(
+			$this->call_has_fbclid_changed( 'fb.1.1000000.sameid', 'sameid' )
+		);
+	}
+
+	public function test_has_fbclid_changed_returns_true_for_different_fbclid(): void {
+		$this->assertTrue(
+			$this->call_has_fbclid_changed( 'fb.1.1000000.oldid', 'newid' )
+		);
+	}
+
+	public function test_has_fbclid_changed_handles_fbclid_with_dots(): void {
+		$this->assertFalse(
+			$this->call_has_fbclid_changed( 'fb.1.1000000.dotted.fbclid.value', 'dotted.fbclid.value' )
+		);
+
+		$this->assertTrue(
+			$this->call_has_fbclid_changed( 'fb.1.1000000.dotted.fbclid.value', 'dotted.fbclid.other' )
+		);
+	}
+}

--- a/tests/Unit/FacebookCommerceTest.php
+++ b/tests/Unit/FacebookCommerceTest.php
@@ -554,7 +554,10 @@ class FacebookCommerceTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTes
 	 */
 	public function test_wp_all_import_compat_displays_message() {
 		if ( ! class_exists( 'PMXI_Import_Record' ) ) {
-			$this->markTestSkipped( 'PMXI_Import_Record class not available' );
+			// Stub the WP All Import class so the method under test can be exercised
+			// without requiring the full plugin.
+			// phpcs:ignore
+			eval( 'class PMXI_Import_Record { public $options = array( "custom_type" => "product" ); private $id = null; public function getById( $id ) { $this->id = $id; return $this; } public function isEmpty() { return false; } }' );
 		}
 
 		$this->facebook_for_woocommerce->expects( $this->once() )

--- a/tests/integration/COGS/CogsIntegrationTestsBase.php
+++ b/tests/integration/COGS/CogsIntegrationTestsBase.php
@@ -69,12 +69,20 @@ abstract class CogsIntegrationTestsBase extends IntegrationTestCase {
 			include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 			require_once ABSPATH . 'wp-admin/includes/class-plugin-upgrader.php';
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-			
+
 			$response = wp_remote_get( $plugin_download_url );
-			$plugin_zip = wp_upload_bits( $plugin_slug . '.zip', null, wp_remote_retrieve_body( $response ) );
-			$upgrader = new \Plugin_Upgrader();
-			$result = $upgrader->install( $plugin_zip['file'] );
-			
+
+			$this->assertFalse( is_wp_error( $response ), 'Plugin download failed: ' . ( is_wp_error( $response ) ? $response->get_error_message() : '' ) );
+
+			$body = wp_remote_retrieve_body( $response );
+			$code = wp_remote_retrieve_response_code( $response );
+
+			$this->assertNotEmpty( $body, "Plugin download returned empty body (HTTP {$code}) from: {$plugin_download_url}" );
+
+			$plugin_zip = wp_upload_bits( $plugin_slug . '.zip', null, $body );
+			$upgrader   = new \Plugin_Upgrader();
+			$result     = $upgrader->install( $plugin_zip['file'] );
+
 			if ( is_wp_error( $result ) ) {
 				throw new \Exception('Cannot install/enable WPFactory plugin');
 			}


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue. 
Please also include relevant motivation and context. 
List any dependencies that are required for this change.

### Type of change

Please delete options that are not relevant

- Fix (non-breaking change which fixes an issue)
- Add (non-breaking change which adds functionality)
- Tweak (non-breaking change which fixes code modularity, linting or phpcs issues)
- Break (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Fix for fbc & fbp priorities on when they are set

## Test Plan
The code is fully covered by automated tests. 
The only manual test that needs to be performed is through:
- visiting the page with &fbclid=lasjdfhkashfaweiufhakjnf added to the url
- holding the signal state,
- After the page loaded, releasing the signals
- Checking that all signals have fbc & fbp after being released