### PR TITLE
Prevent duplicate AddToCart Pixel fires from repeated AJAX fragment execution

### DIFF
--- a/assets/js/frontend/pixel-events.js
+++ b/assets/js/frontend/pixel-events.js
@@ -18,7 +18,8 @@
     var data = (typeof wc_facebook_pixel_data !== 'undefined' && wc_facebook_pixel_data) ?
         wc_facebook_pixel_data :
         { eventQueue: [] };
-    var firedEvents = {};
+    window.wcFacebookPixelFiredEvents = window.wcFacebookPixelFiredEvents || {};
+    var firedEvents = window.wcFacebookPixelFiredEvents;
 
     /**
      * Build event data object for fbq()

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -958,9 +958,15 @@ JS;
 		if ( ! empty( $event_id ) ) {
 			$event = sprintf(
 				"/* %s Facebook Integration Event Tracking */\n" .
+				"window.wcFacebookPixelFiredEvents = window.wcFacebookPixelFiredEvents || {};\n" .
+				"if (!window.wcFacebookPixelFiredEvents[%s]) {\n" .
+				"window.wcFacebookPixelFiredEvents[%s] = true;\n" .
 				"fbq('set', 'agent', '%s', '%s');\n" .
-				"fbq('%s', '%s', %s, %s);",
+				"fbq('%s', '%s', %s, %s);\n" .
+				'}',
 				WC_Facebookcommerce_Utils::get_integration_name(),
+				wp_json_encode( $event_id ),
+				wp_json_encode( $event_id ),
 				Event::get_platform_identifier(),
 				self::get_pixel_id(),
 				esc_js( $method ),

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -958,17 +958,17 @@ JS;
 		if ( ! empty( $event_id ) ) {
 			$event = sprintf(
 				"/* %s Facebook Integration Event Tracking */\n" .
+				"fbq('set', 'agent', '%s', '%s');\n" .
 				"window.wcFacebookPixelFiredEvents = window.wcFacebookPixelFiredEvents || {};\n" .
 				"if (!window.wcFacebookPixelFiredEvents[%s]) {\n" .
 				"window.wcFacebookPixelFiredEvents[%s] = true;\n" .
-				"fbq('set', 'agent', '%s', '%s');\n" .
 				"fbq('%s', '%s', %s, %s);\n" .
 				'}',
 				WC_Facebookcommerce_Utils::get_integration_name(),
-				wp_json_encode( $event_id ),
-				wp_json_encode( $event_id ),
 				Event::get_platform_identifier(),
 				self::get_pixel_id(),
+				wp_json_encode( $event_id ),
+				wp_json_encode( $event_id ),
 				esc_js( $method ),
 				esc_js( $event_name ),
 				wp_json_encode( $event_params, JSON_PRETTY_PRINT | JSON_FORCE_OBJECT ),

--- a/tests/Unit/FacebookCommercePixelIsolatedExecutionTest.php
+++ b/tests/Unit/FacebookCommercePixelIsolatedExecutionTest.php
@@ -429,6 +429,50 @@ class FacebookCommercePixelIsolatedExecutionTest extends AbstractWPUnitTestWithO
 	// inject_event() with Rollout Switch Tests
 	// =========================================================================
 
+	public function test_build_event_adds_browser_dedup_guard_when_event_id_is_present(): void {
+		$event_id = 'add-to-cart-event-123';
+		$event    = WC_Facebookcommerce_Pixel::build_event(
+			'AddToCart',
+			array(
+				'content_ids' => array( 'PROD123' ),
+				'event_id'    => $event_id,
+			),
+			'track'
+		);
+
+		$this->assertStringContainsString(
+			'window.wcFacebookPixelFiredEvents = window.wcFacebookPixelFiredEvents || {};',
+			$event
+		);
+		$this->assertStringContainsString(
+			'if (!window.wcFacebookPixelFiredEvents["add-to-cart-event-123"]) {',
+			$event
+		);
+		$this->assertStringContainsString(
+			'window.wcFacebookPixelFiredEvents["add-to-cart-event-123"] = true;',
+			$event
+		);
+		$this->assertStringContainsString(
+			'fbq(\'track\', \'AddToCart\'',
+			$event
+		);
+		$this->assertStringContainsString(
+			'"eventID": "add-to-cart-event-123"',
+			$event
+		);
+	}
+
+	public function test_build_event_does_not_add_browser_dedup_guard_without_event_id(): void {
+		$event = WC_Facebookcommerce_Pixel::build_event(
+			'ViewContent',
+			array( 'content_ids' => array( 'PROD123' ) ),
+			'track'
+		);
+
+		$this->assertStringNotContainsString( 'window.wcFacebookPixelFiredEvents', $event );
+		$this->assertStringContainsString( 'fbq(\'track\', \'ViewContent\'', $event );
+	}
+
 	public function test_inject_event_uses_isolated_execution_when_switch_enabled(): void {
 		$this->reset_static_properties();
 		$this->enable_isolated_pixel_execution_switch();

--- a/tests/js/pixel-events.test.js
+++ b/tests/js/pixel-events.test.js
@@ -872,6 +872,7 @@ describe('Integration: pixel-events.js IIFE', function () {
         // Clean up globals
         delete global.fbq;
         delete global.wc_facebook_pixel_data;
+        delete window.wcFacebookPixelFiredEvents;
 
         consoleWarnSpy.mockRestore();
         addEventListenerSpy.mockRestore();
@@ -992,23 +993,47 @@ describe('Integration: pixel-events.js IIFE', function () {
 
         global.wc_facebook_pixel_data = {
             eventQueue: [
-                {
-                    name: 'AddToCart',
-                    params: { content_ids: ['SKU-789'] },
-                    method: 'track',
-                    eventId: 'unique-event-id-123'
-                }
+                { name: 'AddToCart', params: { content_ids: ['123'] }, method: 'track', eventId: 'unique-event-id' }
             ]
         };
 
         require('../../assets/js/frontend/pixel-events.js');
+        jest.runAllTimers();
 
         expect(mockFbq).toHaveBeenCalledWith(
             'track',
             'AddToCart',
-            { content_ids: ['SKU-789'] },
-            { eventID: 'unique-event-id-123' }
+            { content_ids: ['123'] },
+            { eventID: 'unique-event-id' }
         );
+    });
+
+    it('should skip queued events already marked in shared browser dedup map', function () {
+        mockFbq = jest.fn();
+        global.fbq = mockFbq;
+        window.wcFacebookPixelFiredEvents = {
+            'shared-event-id': true,
+        };
+
+        global.wc_facebook_pixel_data = {
+            eventQueue: [
+                { name: 'AddToCart', params: { content_ids: ['123'] }, method: 'track', eventId: 'shared-event-id' },
+                { name: 'ViewContent', params: { content_ids: ['456'] }, method: 'track', eventId: 'new-event-id' },
+            ]
+        };
+
+        require('../../assets/js/frontend/pixel-events.js');
+        jest.runAllTimers();
+
+        expect(mockFbq).toHaveBeenCalledTimes(1);
+        expect(mockFbq).toHaveBeenCalledWith(
+            'track',
+            'ViewContent',
+            { content_ids: ['456'] },
+            { eventID: 'new-event-id' }
+        );
+        expect(window.wcFacebookPixelFiredEvents['shared-event-id']).toBe(true);
+        expect(window.wcFacebookPixelFiredEvents['new-event-id']).toBe(true);
     });
 
     it('should handle empty eventQueue without errors', function () {


### PR DESCRIPTION
## Description

This fixes a duplicate AddToCart Pixel event issue on the add-to-cart flows. Some third-party plugins can cause AJAX fragments or related frontend handlers to execute the same injected Pixel script more than once. When that happened, the same AddToCart event could call fbq() twice in the browser.

### Type of change

Added browser-side deduplication using the event’s eventID. Every AddToCart event already has a unique ID. When the browser is about to send the Pixel event, we now check whether that exact ID has already been sent on the page.

If it has not been sent yet:

mark this eventID as sent
send the Pixel event

If it has already been sent:
do nothing
skip the duplicate Pixel event

This fixes the issue because the duplicate was happening in the browser. WooCommerce AJAX was causing the same AddToCart Pixel script to run twice. Both executions had the same eventID, so the new guard lets the first one fire and blocks the second one.

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

One liner entry to be surfaced in changelog.txt


## Test Plan

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration.

1. Install a few third party plugins (e.g, Side Cart, FunnelCart, etc). Go to the Shop page and click Add To Cart. Verify that only 1 AddToCart pixel gets fired.

### Before

https://github.com/user-attachments/assets/280a5019-80ab-4ef6-a1f7-216640be0310

### After

https://github.com/user-attachments/assets/b7093525-70fd-40f3-93b7-30714f07d441
