### PR TITLE
Refactoring of the hold_release func

### DIFF
--- a/assets/js/frontend/pixel-events.js
+++ b/assets/js/frontend/pixel-events.js
@@ -82,20 +82,22 @@
             return;
         }
 
-        // Skip if fbq not available
-        if (typeof fbq !== 'function') {
-            logWarning('fbq not available, skipping event:', eventData.name);
-            return;
-        }
-
         try {
             var params = eventData.params;
 
-            // Fire the event with eventID as 4th argument for deduplication
-            if (eventData.eventId) {
-                fbq(eventData.method, eventData.name, params, {eventID: eventData.eventId});
+            if (window.FacebookSignals && typeof window.FacebookSignals.trackEvent === 'function') {
+                window.FacebookSignals.trackEvent(eventData.name, params, null, eventData.method, eventData.eventId);
             } else {
-                fbq(eventData.method, eventData.name, params);
+                if (typeof fbq !== 'function') {
+                    logWarning('fbq not available, skipping event:', eventData.name);
+                    return;
+                }
+
+                if (eventData.eventId) {
+                    fbq(eventData.method, eventData.name, params, {eventID: eventData.eventId});
+                } else {
+                    fbq(eventData.method, eventData.name, params);
+                }
             }
 
             markEventFired(eventData.eventId);

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -352,7 +352,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			// Add inline script that executes after the external script has loaded
 			wp_add_inline_script(
 				'facebook-capi-param-builder',
-				'if (typeof clientParamBuilder !== "undefined") {
+				'if (typeof clientParamBuilder !== "undefined" && !/(?:^|;\s*)wc_facebook_signals_state=held(?:;|$)/.test(document.cookie)) {
 					clientParamBuilder.processAndCollectAllParams(window.location.href);
 				}'
 			);

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -1335,8 +1335,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				echo $this->pixel->inject_conditional_event(
 					'Lead',
 					array(),
-					'wpcf7submit',
-					'{ em: event.detail.inputs.filter(ele => ele.name.includes("email"))[0].value }'
+					'wpcf7submit'
 				);
 			}
 		}

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -706,6 +706,7 @@ JS;
 	 *
 	 * @param string $event_name The event name.
 	 * @param array  $params     Event parameters including custom_data, user_data, event_id.
+	 * @param string $method     Signals method name (e.g. track, trackCustom).
 	 * @return string JavaScript code.
 	 */
 	public function get_queued_event_code( $event_name, $params, $method = 'track' ) {

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -290,33 +290,6 @@ class WC_Facebookcommerce_Pixel {
 	}
 
 
-		/**
-		 * Gets Facebook Pixel init code.
-		 *
-		 * Init code might contain additional information to help matching website users with facebook users.
-		 * Information is hashed in JS side using SHA256 before sending to Facebook.
-		 *
-		 * @return string
-		 */
-	private function get_pixel_init_code() {
-
-		$agent_string = Event::get_platform_identifier();
-
-		/**
-		 * Filters Facebook Pixel init code.
-		 *
-		 * @param string $js_code
-		 */
-		return apply_filters(
-			'facebook_woocommerce_pixel_init',
-			sprintf(
-				"fbq('init', '%s', {}, %s);\n",
-				esc_js( self::get_pixel_id() ),
-				wp_json_encode( array( 'agent' => $agent_string ), JSON_PRETTY_PRINT | JSON_FORCE_OBJECT )
-			)
-		);
-	}
-
 
 		/**
 		 * Gets the Facebook Pixel code scripts.
@@ -900,15 +873,14 @@ JS;
 		 *
 		 * @since 1.10.2
 		 *
-		 * @param string $event_name    The name of the event to track.
-		 * @param array  $params        Custom event parameters.
-		 * @param string $listener      Name of the JavaScript event to listen for.
-		 * @param string $jsonified_pii JavaScript code representing an object of data for Advanced Matching.
+		 * @param string $event_name The name of the event to track.
+		 * @param array  $params     Custom event parameters.
+		 * @param string $listener   Name of the JavaScript event to listen for.
 		 * @return string
 		 *
 		 * phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 		 */
-	public function get_conditional_event_script( $event_name, $params, $listener, $jsonified_pii ) {
+	public function get_conditional_event_script( $event_name, $params, $listener ) {
 
 		$this->last_event = $event_name;
 
@@ -932,18 +904,6 @@ JS;
 
 		$code = self::build_event( $event_name, $params, 'track' );
 
-		/**
-		 * TODO: use the settings stored by {@see \WC_Facebookcommerce_Integration}.
-		 * The use_pii setting here is currently always disabled regardless of
-		 * the value configured in the plugin settings page {WV-2020-01-02}.
-		 */
-
-		// Prepends fbq(...) with pii information to the injected code.
-		if ( $jsonified_pii && get_option( self::SETTINGS_KEY )[ self::USE_PII_KEY ] ) {
-			$this->user_info = '%s';
-			$code            = sprintf( $this->get_pixel_init_code(), '" || ' . $jsonified_pii . ' || "' ) . $code;
-		}
-
 		ob_start();
 
 		?>
@@ -965,16 +925,15 @@ JS;
 		 *
 		 * The tracking code will be executed when the given JavaScript event is triggered.
 		 *
-		 * @param string $event_name    Name of the event.
-		 * @param array  $params        Custom event parameters.
-		 * @param string $listener      Name of the JavaScript event to listen for.
-		 * @param string $jsonified_pii JavaScript code representing an object of data for Advanced Matching.
+		 * @param string $event_name Name of the event.
+		 * @param array  $params     Custom event parameters.
+		 * @param string $listener   Name of the JavaScript event to listen for.
 		 * @return string
 		 */
-	public function inject_conditional_event( $event_name, $params, $listener, $jsonified_pii = '' ) {
+	public function inject_conditional_event( $event_name, $params, $listener ) {
 
 		// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
-		return $this->get_conditional_event_script( $event_name, self::build_params( $params, $event_name ), $listener, $jsonified_pii );
+		return $this->get_conditional_event_script( $event_name, self::build_params( $params, $event_name ), $listener );
 	}
 
 

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -243,6 +243,9 @@ class WC_Facebookcommerce_Pixel {
 			$params = $params['custom_data'];
 		}
 
+		// user_data is for CAPI only and must not appear in cacheable pixel output.
+		unset( $params['user_data'] );
+
 		// Apply build_params() to add version info and apply filters.
 		$params = self::build_params( $params, $event_name );
 
@@ -307,9 +310,8 @@ class WC_Facebookcommerce_Pixel {
 		return apply_filters(
 			'facebook_woocommerce_pixel_init',
 			sprintf(
-				"fbq('init', '%s', %s, %s);\n",
+				"fbq('init', '%s', {}, %s);\n",
 				esc_js( self::get_pixel_id() ),
-				wp_json_encode( $this->user_info, JSON_PRETTY_PRINT | JSON_FORCE_OBJECT ),
 				wp_json_encode( array( 'agent' => $agent_string ), JSON_PRETTY_PRINT | JSON_FORCE_OBJECT )
 			)
 		);
@@ -336,8 +338,6 @@ class WC_Facebookcommerce_Pixel {
 
 		ob_start();
 
-		$is_held = FacebookSignalsState::is_held();
-
 		?>
 			<script <?php echo self::get_script_attributes(); ?>>
 				!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
@@ -351,32 +351,20 @@ class WC_Facebookcommerce_Pixel {
 
 				<?php echo self::get_facebook_signals_js(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 
-				<?php if ( $is_held ) : ?>
-				fbq('consent', 'revoke');
-				<?php endif; ?>
-
-				<?php echo $this->get_pixel_init_code(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-
-				<?php if ( $is_held ) : ?>
 				FacebookSignals.init({
-					held: true,
+					held: false,
 					ajaxUrl: <?php echo wp_json_encode( admin_url( 'admin-ajax.php' ) ); ?>,
-					nonce: <?php echo wp_json_encode( wp_create_nonce( 'facebook_release_signals' ) ); ?>,
 					action: 'facebook_release_signals',
 					pixelId: <?php echo wp_json_encode( self::get_pixel_id() ); ?>,
-					attribution: {
-						fbp: <?php echo wp_json_encode( FacebookSignalsState::get_attribution_data( 'fbp' ) ); ?>,
-						fbc: <?php echo wp_json_encode( FacebookSignalsState::get_attribution_data( 'fbc' ) ); ?>,
-						fbpDomain: <?php echo wp_json_encode( FacebookSignalsState::get_attribution_data( 'fbp_domain' ) ); ?>,
-						fbcDomain: <?php echo wp_json_encode( FacebookSignalsState::get_attribution_data( 'fbc_domain' ) ); ?>
-					}
+					attribution: {}
 				});
-				<?php else : ?>
-				FacebookSignals.init({ held: false });
-				<?php endif; ?>
+				FacebookSignals.initPixel(
+					<?php echo wp_json_encode( self::get_pixel_id() ); ?>,
+					<?php echo wp_json_encode( $this->user_info, JSON_FORCE_OBJECT ); ?>,
+					<?php echo wp_json_encode( array( 'agent' => Event::get_platform_identifier() ), JSON_FORCE_OBJECT ); ?>
+				);
 
 				document.addEventListener( 'DOMContentLoaded', function() {
-					// Insert placeholder for events injected when a product is added to the cart through AJAX.
 					document.body.insertAdjacentHTML( 'beforeend', '<div class=\"wc-facebook-pixel-event-placeholder\"></div>' );
 				}, false );
 
@@ -435,6 +423,12 @@ class WC_Facebookcommerce_Pixel {
 		return <<<'JS'
 window.FacebookSignals = window.FacebookSignals || {
 	_held: false,
+	_releasing: false,
+	_pixelInitialized: false,
+	_pixelId: null,
+	_pixelUserInfo: {},
+	_pixelOptions: {},
+	_pendingPixelEvents: [],
 	_queue: [],
 	_config: {},
 	_attribution: {},
@@ -450,8 +444,15 @@ window.FacebookSignals = window.FacebookSignals || {
 		config = config || {};
 		this._config = config;
 		this._attribution = config.attribution || {};
-		this._held = !!config.held;
+
+		var cookieState = this._getCookie('wc_facebook_signals_state');
+		this._held = cookieState ? cookieState === 'held' : !!config.held;
+
 		this._fbclid = this._fbclid || null;
+
+		if (typeof fbq === 'function') {
+			fbq('consent', this._held ? 'revoke' : 'grant');
+		}
 
 		try {
 			var raw = window.sessionStorage.getItem('wc_facebook_signals_seen_event_ids');
@@ -461,15 +462,69 @@ window.FacebookSignals = window.FacebookSignals || {
 		}
 	},
 
+	initPixel: function(pixelId, userInfo, options) {
+		this._pixelId = pixelId;
+		this._pixelUserInfo = userInfo && typeof userInfo === 'object' && !Array.isArray(userInfo) ? userInfo : {};
+		this._pixelOptions = options || {};
+		if (!this._held) {
+			this._runPixelInit();
+		}
+	},
+
+	_runPixelInit: function() {
+		if (this._pixelInitialized || !this._pixelId || typeof fbq !== 'function') return;
+		fbq('init', this._pixelId, this._pixelUserInfo, this._pixelOptions);
+		this._pixelInitialized = true;
+		this._flushPendingPixelEvents();
+	},
+
+	_flushPendingPixelEvents: function() {
+		var pending = this._pendingPixelEvents;
+		this._pendingPixelEvents = [];
+		for (var i = 0; i < pending.length; i++) {
+			var ev = pending[i];
+			this._firePixelEvent(ev.name, ev.params, ev.method, ev.eventId);
+		}
+	},
+
+	_fireOrQueuePixelEvent: function(name, params, method, eventId) {
+		if (!this._pixelInitialized) {
+			this._pendingPixelEvents.push({
+				name: name, params: params || {}, method: method || 'track', eventId: eventId || null
+			});
+			return;
+		}
+		this._firePixelEvent(name, params || {}, method || 'track', eventId || null);
+	},
+
+	_firePixelEvent: function(name, params, method, eventId) {
+		method = method || 'track';
+		if (eventId) {
+			fbq(method, name, params || {}, { eventID: eventId });
+		} else {
+			fbq(method, name, params || {});
+		}
+	},
+
 	queueEvent: function(eventData) {
 		if (!eventData || !eventData.event_name) return;
-		if (eventData.event_id && this._seenEventIds[eventData.event_id]) return;
 
+		var originalId = eventData.event_id || null;
+		if (originalId && this._seenEventIds[originalId]) return;
+
+		if (!this._held) {
+			this._fireOrQueuePixelEvent(eventData.event_name, eventData.custom_data || {}, eventData.method || 'track', originalId);
+			return;
+		}
+
+		eventData = this._cloneEventData(eventData);
+		eventData.event_id = this._generateEventId();
 		eventData.event_time = eventData.event_time || Math.floor(Date.now() / 1000);
 		this._queue.push(eventData);
 
-		if (eventData.event_id) {
-			this._seenEventIds[eventData.event_id] = 1;
+		var idToMark = originalId || eventData.event_id;
+		if (idToMark) {
+			this._seenEventIds[idToMark] = 1;
 			try {
 				window.sessionStorage.setItem(
 					'wc_facebook_signals_seen_event_ids',
@@ -479,40 +534,41 @@ window.FacebookSignals = window.FacebookSignals || {
 		}
 	},
 
-	trackEvent: function(name, params, userData) {
+	trackEvent: function(name, params, userData, method, eventId) {
+		method = method || 'track';
+		eventId = eventId || (params && params.eventID) || null;
+
 		if (this._held) {
 			this.queueEvent({
 				event_name: name,
 				custom_data: params || {},
-				user_data: userData || {},
-				event_id: (params && params.eventID) || null,
-				event_time: Math.floor(Date.now() / 1000)
+				event_id: eventId,
+				event_time: Math.floor(Date.now() / 1000),
+				method: method
 			});
 		} else {
-			if (params && params.eventID) {
-				fbq('track', name, params, { eventID: params.eventID });
-			} else {
-				fbq('track', name, params);
-			}
+			this._fireOrQueuePixelEvent(name, params || {}, method, eventId);
 		}
 	},
 
 	release: function() {
 		var self = this;
-		if (!self._held || !self._config.ajaxUrl) {
+		if (!self._held || self._releasing || !self._config.ajaxUrl) {
 			return Promise.resolve({ success: true, data: { sent_count: 0 } });
 		}
 
+		self._releasing = true;
+		var attribution = self._collectAttribution();
+
 		var payload = JSON.stringify({
-			security: self._config.nonce,
 			events: self._queue,
 			attribution: {
-				fbp: self._attribution.fbp || null,
-				fbc: self._attribution.fbc || null
-			}
+				fbp: attribution.fbp || null,
+				fbc: attribution.fbc || null
+			},
+			fbclid: self._fbclid || null
 		});
 
-		// Pass action as a query parameter so WordPress can route the request.
 		var url = self._config.ajaxUrl +
 			(self._config.ajaxUrl.indexOf('?') === -1 ? '?' : '&') +
 			'action=' + encodeURIComponent(self._config.action);
@@ -523,78 +579,108 @@ window.FacebookSignals = window.FacebookSignals || {
 			xhr.setRequestHeader('Content-Type', 'application/json');
 			xhr.onload = function() {
 				if (xhr.status >= 200 && xhr.status < 300) {
-						try {
-							var resp = JSON.parse(xhr.responseText);
-							self._handleReleaseResponse(resp.data || {});
-							resolve(resp);
-						} catch(e) { reject(e); }
-					} else {
-						reject(new Error('Signal release AJAX failed: ' + xhr.status));
-					}
-				};
-			xhr.onerror = function() { reject(new Error('Network error')); };
+					try {
+						var resp = JSON.parse(xhr.responseText);
+						self._handleReleaseResponse(resp.data || {}, attribution);
+						resolve(resp);
+					} catch(e) { self._releasing = false; reject(e); }
+				} else {
+					self._releasing = false;
+					reject(new Error('Signal release AJAX failed: ' + xhr.status));
+				}
+			};
+			xhr.onerror = function() { self._releasing = false; reject(new Error('Network error')); };
 			xhr.send(payload);
 		});
 	},
 
-	_handleReleaseResponse: function(data) {
-		this._syncAttributionCookies(data || {});
+	_handleReleaseResponse: function(data, attribution) {
+		this._syncAttributionCookies(data || {}, attribution);
 
-		// Re-enable the browser signal path so fbevents.js starts firing.
+		// Override cached user_info with fresh data from the release response.
+		if (data.user_info && typeof data.user_info === 'object' && !Array.isArray(data.user_info)) {
+			this._pixelUserInfo = data.user_info;
+		}
+
+		this._held = false;
+		this._releasing = false;
+
 		fbq('consent', 'grant');
+		this._runPixelInit();
 
-		// Replay queued events via the pixel.
 		var queue = this._queue;
 		for (var i = 0; i < queue.length; i++) {
 			var ev = queue[i];
-			if (ev.event_id) {
-				fbq('track', ev.event_name, ev.custom_data || {}, { eventID: ev.event_id });
-			} else {
-				fbq('track', ev.event_name, ev.custom_data || {});
-			}
+			this._fireOrQueuePixelEvent(ev.event_name, ev.custom_data || {}, ev.method || 'track', ev.event_id || null);
 		}
 
-		// Clear the queue and mark signals as active again.
 		this._queue = [];
-		this._held = false;
 	},
 
-	_syncAttributionCookies: function(data) {
+	_collectAttribution: function() {
 		var clientParams = {};
-
 		if (typeof clientParamBuilder !== 'undefined') {
 			try {
-				// Let the client-side ParamBuilder generate/set missing attribution
-				// cookies using its normal domain-scoping logic.
 				clientParams = clientParamBuilder.processAndCollectParams(this._getAttributionUrl()) || {};
 			} catch (e) {}
 		}
 
-		var fbp = data.fbp || clientParams._fbp || (typeof clientParamBuilder !== 'undefined' ? clientParamBuilder.getFbp() : null);
-		var fbc = data.fbc || clientParams._fbc || (typeof clientParamBuilder !== 'undefined' ? clientParamBuilder.getFbc() : null);
+		var fbp = this._getCookie('_fbp') || clientParams._fbp || (typeof clientParamBuilder !== 'undefined' ? clientParamBuilder.getFbp() : null);
+		var fbc = this._getCookie('_fbc') || clientParams._fbc || (typeof clientParamBuilder !== 'undefined' ? clientParamBuilder.getFbc() : null);
 
-		// If the backend supplied exact values used for CAPI, write them so Pixel
-		// replay and CAPI use matching attribution.
-		if (data.fbp) {
-			this._setAttributionCookie('_fbp', fbp, data.fbp_domain || data.cookie_domain || this._attribution.fbpDomain);
+		if (!fbc && this._fbclid) {
+			fbc = 'fb.1.' + Date.now() + '.' + this._fbclid;
 		}
-		if (data.fbc) {
-			this._setAttributionCookie('_fbc', fbc, data.fbc_domain || data.cookie_domain || this._attribution.fbcDomain || this._attribution.fbpDomain);
+
+		return { fbp: fbp || null, fbc: fbc || null };
+	},
+
+	_syncAttributionCookies: function(data, attribution) {
+		var fbp = data.fbp || (attribution && attribution.fbp) || null;
+		var fbc = data.fbc || (attribution && attribution.fbc) || null;
+
+		if (fbp) {
+			this._setAttributionCookie('_fbp', fbp, data.fbp_domain || null);
+		}
+		if (fbc) {
+			this._setAttributionCookie('_fbc', fbc, data.fbc_domain || null);
 		}
 	},
 
 	_setAttributionCookie: function(name, value, domain) {
 		if (!value) return;
-
 		var domainAttr = domain ? ';domain=' + domain : '';
 		document.cookie = name + '=' + encodeURIComponent(value) + ';path=/;max-age=7776000' + domainAttr + ';SameSite=Lax';
 	},
 
-	_getAttributionUrl: function() {
-		if (!this._fbclid) {
-			return window.location.href;
-		}
+	_getCookie: function(name) {
+		var match = document.cookie.match(new RegExp('(?:^|;\\s*)' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([^;]*)'));
+		if (!match) return null;
+		try { return decodeURIComponent(match[1]); } catch(e) { return null; }
+	},
 
+	_cloneEventData: function(eventData) {
+		var clone = {};
+		for (var key in eventData) {
+			if (Object.prototype.hasOwnProperty.call(eventData, key)) {
+				clone[key] = eventData[key];
+			}
+		}
+		return clone;
+	},
+
+	_generateEventId: function() {
+		if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+			return window.crypto.randomUUID();
+		}
+		return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+			var r = Math.random() * 16 | 0;
+			return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16);
+		});
+	},
+
+	_getAttributionUrl: function() {
+		if (!this._fbclid) return window.location.href;
 		try {
 			var url = new URL(window.location.href);
 			if (!url.searchParams.get('fbclid')) {
@@ -622,27 +708,35 @@ JS;
 	 * @param array  $params     Event parameters including custom_data, user_data, event_id.
 	 * @return string JavaScript code.
 	 */
-	public function get_queued_event_code( $event_name, $params ) {
+	public function get_queued_event_code( $event_name, $params, $method = 'track' ) {
 		$this->last_event = $event_name;
 
 		$event_id   = isset( $params['event_id'] ) ? $params['event_id'] : null;
 		$queue_data = ! empty( $event_id ) ? FacebookSignalsState::get_queued_event( $event_id ) : null;
 
 		if ( ! is_array( $queue_data ) ) {
+			$custom_data = isset( $params['custom_data'] ) ? $params['custom_data'] : $params;
+			unset( $custom_data['user_data'], $custom_data['event_name'], $custom_data['event_id'] );
+
 			$queue_data = array(
 				'event_name'  => $event_name,
-				'custom_data' => isset( $params['custom_data'] ) ? $params['custom_data'] : $params,
+				'custom_data' => $custom_data,
 				'event_id'    => $event_id,
 				'event_time'  => time(),
 			);
-
-			if ( isset( $params['user_data'] ) ) {
-				$queue_data['user_data'] = $params['user_data'];
-			}
 		}
 
 		if ( empty( $queue_data['event_name'] ) ) {
 			$queue_data['event_name'] = $event_name;
+		}
+
+		$queue_data['method'] = $method;
+
+		// Do not render per-visitor user_data into cacheable HTML.
+		// The release endpoint resolves attribution from the releasing request.
+		unset( $queue_data['user_data'] );
+		if ( isset( $queue_data['custom_data'] ) && is_array( $queue_data['custom_data'] ) ) {
+			unset( $queue_data['custom_data']['user_data'] );
 		}
 
 		return sprintf(
@@ -712,7 +806,7 @@ JS;
 			<script <?php echo self::get_script_attributes(); ?>>
 			<?php
 			if ( FacebookSignalsState::is_held() ) {
-				echo $this->get_queued_event_code( $event_name, $params ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo $this->get_queued_event_code( $event_name, $params, $method ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			} else {
 				echo $this->get_event_code( $event_name, $params, $method ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
@@ -744,7 +838,7 @@ JS;
 	public function inject_event( $event_name, $params, $method = 'track' ) {
 		// When signals are held, queue events in the browser instead of firing them.
 		if ( FacebookSignalsState::is_held() ) {
-			$code = $this->get_queued_event_code( $event_name, $params );
+			$code = $this->get_queued_event_code( $event_name, $params, $method );
 			if ( WC_Facebookcommerce_Utils::is_woocommerce_integration() ) {
 				WC_Facebookcommerce_Utils::enqueue_inline_js( $code );
 			} else {
@@ -819,7 +913,6 @@ JS;
 
 		// When signals are held, use FacebookSignals.trackEvent() to queue the event.
 		if ( FacebookSignalsState::is_held() ) {
-			$user_data_js = $jsonified_pii ? $jsonified_pii : '{}';
 			ob_start();
 			?>
 			<!-- Facebook Pixel Event Code -->
@@ -827,8 +920,7 @@ JS;
 				document.addEventListener( '<?php echo esc_js( $listener ); ?>', function (event) {
 					FacebookSignals.trackEvent(
 						<?php echo wp_json_encode( $event_name ); ?>,
-						<?php echo wp_json_encode( $params ); ?>,
-						<?php echo $user_data_js; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<?php echo wp_json_encode( $params ); ?>
 					);
 				}, false );
 			</script>
@@ -955,40 +1047,35 @@ JS;
 		// Reuse shared param preparation logic.
 		[ 'params' => $event_params, 'event_id' => $event_id ] = self::prepare_event_params( $params, $event_name );
 
-		if ( ! empty( $event_id ) ) {
-			$event = sprintf(
-				"/* %s Facebook Integration Event Tracking */\n" .
-				"fbq('set', 'agent', '%s', '%s');\n" .
-				"window.wcFacebookPixelFiredEvents = window.wcFacebookPixelFiredEvents || {};\n" .
-				"if (!window.wcFacebookPixelFiredEvents[%s]) {\n" .
-				"window.wcFacebookPixelFiredEvents[%s] = true;\n" .
-				"fbq('%s', '%s', %s, %s);\n" .
-				'}',
-				WC_Facebookcommerce_Utils::get_integration_name(),
-				Event::get_platform_identifier(),
-				self::get_pixel_id(),
-				wp_json_encode( $event_id ),
-				wp_json_encode( $event_id ),
-				esc_js( $method ),
-				esc_js( $event_name ),
-				wp_json_encode( $event_params, JSON_PRETTY_PRINT | JSON_FORCE_OBJECT ),
-				wp_json_encode( array( 'eventID' => $event_id ), JSON_PRETTY_PRINT | JSON_FORCE_OBJECT )
-			);
+		$encoded_params   = wp_json_encode( $event_params, JSON_PRETTY_PRINT | JSON_FORCE_OBJECT );
+		$encoded_event_id = ! empty( $event_id ) ? wp_json_encode( $event_id ) : 'null';
 
-		} else {
-
-				$event = sprintf(
-					"/* %s Facebook Integration Event Tracking */\n" .
-					"fbq('set', 'agent', '%s', '%s');\n" .
-					"fbq('%s', '%s', %s);",
-					WC_Facebookcommerce_Utils::get_integration_name(),
-					Event::get_platform_identifier(),
-					self::get_pixel_id(),
-					esc_js( $method ),
-					esc_js( $event_name ),
-					wp_json_encode( $event_params, JSON_PRETTY_PRINT | JSON_FORCE_OBJECT )
-				);
-		}
+		$event = sprintf(
+			"/* %s Facebook Integration Event Tracking */\n" .
+			"fbq('set', 'agent', '%s', '%s');\n" .
+			"if (window.FacebookSignals && typeof window.FacebookSignals.trackEvent === 'function') {\n" .
+			"\twindow.FacebookSignals.trackEvent('%s', %s, null, '%s', %s);\n" .
+			"} else if (%s) {\n" .
+			"\tfbq('%s', '%s', %s, { eventID: %s });\n" .
+			"} else {\n" .
+			"\tfbq('%s', '%s', %s);\n" .
+			'}',
+			WC_Facebookcommerce_Utils::get_integration_name(),
+			Event::get_platform_identifier(),
+			self::get_pixel_id(),
+			esc_js( $event_name ),
+			$encoded_params,
+			esc_js( $method ),
+			$encoded_event_id,
+			$encoded_event_id,
+			esc_js( $method ),
+			esc_js( $event_name ),
+			$encoded_params,
+			$encoded_event_id,
+			esc_js( $method ),
+			esc_js( $event_name ),
+			$encoded_params
+		);
 
 		return $event;
 	}

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -488,6 +488,21 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	}
 
 	/**
+	 * Returns user_info for the currently installed pixel using AAM settings.
+	 *
+	 * Public wrapper for external callers (e.g. AJAX handlers) that should not
+	 * access internal AAM loading methods directly.
+	 *
+	 * @return array
+	 * @since 3.7.0
+	 */
+	public function get_pixel_user_info_for_release() {
+		$aam_settings = $this->load_aam_settings_of_pixel();
+
+		return WC_Facebookcommerce_Utils::get_user_info( $aam_settings );
+	}
+
+	/**
 	 * Returns the Automatic advanced matching of this pixel
 	 *
 	 * @return AAMSettings

--- a/includes/Events/FacebookSignalsState.php
+++ b/includes/Events/FacebookSignalsState.php
@@ -31,18 +31,47 @@ class FacebookSignalsState {
 	/** @var array Attribution data captured while signals are held (e.g. fbclid). */
 	private static $attribution_data = array();
 
+	/** @var string Cookie name for signal state. */
+	const COOKIE_NAME = 'wc_facebook_signals_state';
+
 	/**
-	 * Hold signals for the current request.
+	 * Hold signals for the current request and set the browser cookie
+	 * so client-side JS knows the state on cached pages.
 	 */
 	public static function hold() {
 		self::$held = true;
+		self::set_state_cookie( 'held' );
 	}
 
 	/**
-	 * Release signals for the current request.
+	 * Release signals for the current request and update the browser cookie.
 	 */
 	public static function release() {
 		self::$held = false;
+		self::set_state_cookie( 'active' );
+	}
+
+	/**
+	 * Sets the signal-state cookie in the HTTP response headers.
+	 *
+	 * @param string $state 'held' or 'active'.
+	 */
+	private static function set_state_cookie( $state ) {
+		if ( headers_sent() ) {
+			return;
+		}
+
+		setcookie(
+			self::COOKIE_NAME,
+			$state,
+			time() + YEAR_IN_SECONDS,
+			COOKIEPATH,
+			COOKIE_DOMAIN,
+			is_ssl(),
+			false
+		);
+
+		$_COOKIE[ self::COOKIE_NAME ] = $state;
 	}
 
 	/**

--- a/includes/Events/ReleaseSignalsAjax.php
+++ b/includes/Events/ReleaseSignalsAjax.php
@@ -152,8 +152,7 @@ class ReleaseSignalsAjax {
 		try {
 			$integration = facebook_for_woocommerce()->get_integration();
 			if ( $integration ) {
-				$aam_settings = $integration->load_aam_settings_of_pixel();
-				$user_info    = \WC_Facebookcommerce_Utils::get_user_info( $aam_settings );
+				$user_info = $integration->get_pixel_user_info_for_release();
 			}
 		// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 		} catch ( \Exception $e ) {

--- a/includes/Events/ReleaseSignalsAjax.php
+++ b/includes/Events/ReleaseSignalsAjax.php
@@ -27,8 +27,6 @@ class ReleaseSignalsAjax {
 	/** @var string AJAX action name. */
 	const ACTION = 'facebook_release_signals';
 
-	/** @var string Nonce action. */
-	const NONCE_ACTION = 'facebook_release_signals';
 
 	/** @var int Maximum number of events per request. */
 	const MAX_EVENTS = 20;
@@ -36,11 +34,6 @@ class ReleaseSignalsAjax {
 	/** @var int Maximum age of an event in seconds (30 minutes). */
 	const MAX_EVENT_AGE = 1800;
 
-	/** @var int Default rate-limit window in seconds (5 minutes). */
-	const RATE_LIMIT_WINDOW = 300;
-
-	/** @var int Default maximum accepted events per IP per window. */
-	const RATE_LIMIT_MAX_EVENTS = 80;
 
 	/** @var array Allowed event names. */
 	const ALLOWED_EVENTS = array(
@@ -60,8 +53,6 @@ class ReleaseSignalsAjax {
 	 */
 	public function __construct() {
 		add_action( 'wp_ajax_' . self::ACTION, array( $this, 'handle' ) );
-
-		// Signal release must work for guest shoppers as well as logged-in users.
 		add_action( 'wp_ajax_nopriv_' . self::ACTION, array( $this, 'handle' ) );
 	}
 
@@ -76,19 +67,38 @@ class ReleaseSignalsAjax {
 			wp_send_json_error( array( 'message' => 'Invalid request body.' ), 400 );
 		}
 
-		$nonce = isset( $body['security'] ) ? sanitize_text_field( $body['security'] ) : '';
-		if ( ! wp_verify_nonce( $nonce, self::NONCE_ACTION ) ) {
-			wp_send_json_error( array( 'message' => 'Invalid nonce.' ), 403 );
-		}
+		// Reject requests that don't carry the signal-state cookie.
+		// Only browsers that have been through the hold/release flow will
+		// have this cookie, which filters out blind POST abuse.
+		$signal_state = isset( $_COOKIE[ FacebookSignalsState::COOKIE_NAME ] )
+			? sanitize_text_field( wp_unslash( $_COOKIE[ FacebookSignalsState::COOKIE_NAME ] ) )
+			: '';
 
-		if ( $this->is_rate_limited() ) {
-			wp_send_json_error( array( 'message' => 'Rate limit exceeded.' ), 429 );
+		if ( empty( $signal_state ) ) {
+			wp_send_json_error( array( 'message' => 'Missing signal state.' ), 403 );
 		}
 
 		$events      = isset( $body['events'] ) && is_array( $body['events'] ) ? $body['events'] : array();
 		$attribution = isset( $body['attribution'] ) && is_array( $body['attribution'] ) ? $body['attribution'] : array();
 		$fbc         = $this->sanitize_attribution_value( $attribution, 'fbc' );
 		$fbp         = $this->sanitize_attribution_value( $attribution, 'fbp' );
+
+		// If JS sent an fbclid, inject it into $_GET so ParamBuilder can
+		// generate fbc through its standard path.
+		$restore_fbclid = null;
+		if ( empty( $fbc ) && ! empty( $body['fbclid'] ) ) {
+			$fbclid         = sanitize_text_field( $body['fbclid'] );
+			$restore_fbclid = $this->temporarily_set_superglobal_value( '_GET', 'fbclid', $fbclid );
+		}
+
+		// Run ParamBuilder to generate fbc/fbp if not provided by the client.
+		if ( empty( $fbc ) || empty( $fbp ) ) {
+			$this->resolve_attribution_via_param_builder( $fbc, $fbp );
+		}
+
+		if ( null !== $restore_fbclid ) {
+			$this->restore_superglobal_value( '_GET', 'fbclid', $restore_fbclid );
+		}
 
 		$events = array_slice( $events, 0, self::MAX_EVENTS );
 
@@ -104,8 +114,6 @@ class ReleaseSignalsAjax {
 
 		$cookie_domains = $this->get_attribution_cookie_domains();
 
-		// Expose held attribution to Event::get_click_id()/get_browser_id(), so
-		// released events use the same attribution path as normal CAPI events.
 		$restore_cookie_fbc = $this->temporarily_set_superglobal_value( '_COOKIE', '_fbc', $fbc );
 		$restore_cookie_fbp = $this->temporarily_set_superglobal_value( '_COOKIE', '_fbp', $fbp );
 
@@ -130,14 +138,26 @@ class ReleaseSignalsAjax {
 		$this->restore_superglobal_value( '_COOKIE', '_fbp', $restore_cookie_fbp );
 
 		if ( ! empty( $valid_events ) ) {
-			$this->record_rate_limit_usage( count( $valid_events ) );
-
 			try {
 				$api->send_pixel_events( $pixel_id, $valid_events );
 				$sent_count = count( $valid_events );
 			} catch ( ApiException $e ) {
 				facebook_for_woocommerce()->log( 'Release signals: could not send events: ' . $e->getMessage() );
 			}
+		}
+
+		// Provide fresh user_info so JS can call fbq('init') with correct
+		// AAM data instead of potentially stale cached values.
+		$user_info = array();
+		try {
+			$integration = facebook_for_woocommerce()->get_integration();
+			if ( $integration ) {
+				$aam_settings = $integration->load_aam_settings_of_pixel();
+				$user_info    = \WC_Facebookcommerce_Utils::get_user_info( $aam_settings );
+			}
+		// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+		} catch ( \Exception $e ) {
+			// Best-effort: pixel init will use empty user_info.
 		}
 
 		wp_send_json_success(
@@ -147,6 +167,7 @@ class ReleaseSignalsAjax {
 				'fbp_domain' => $cookie_domains['fbp'],
 				'fbc_domain' => $cookie_domains['fbc'],
 				'sent_count' => $sent_count,
+				'user_info'  => $user_info,
 			)
 		);
 	}
@@ -344,6 +365,32 @@ class ReleaseSignalsAjax {
 	}
 
 	/**
+	 * Uses ParamBuilder to generate fbc/fbp from the current request context.
+	 *
+	 * @param string $fbc Attribution click ID reference (populated if empty).
+	 * @param string $fbp Attribution browser ID reference (populated if empty).
+	 */
+	private function resolve_attribution_via_param_builder( &$fbc, &$fbp ) {
+		try {
+			$param_builder = \WC_Facebookcommerce_EventsTracker::get_param_builder();
+			if ( ! $param_builder ) {
+				return;
+			}
+
+			if ( empty( $fbc ) ) {
+				$fbc = $param_builder->getFbc();
+			}
+
+			if ( empty( $fbp ) ) {
+				$fbp = $param_builder->getFbp();
+			}
+		// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+		} catch ( \Exception $e ) {
+			// ParamBuilder is best-effort.
+		}
+	}
+
+	/**
 	 * Builds a sanitized Event object for CAPI delivery.
 	 *
 	 * @param array $event_data Raw event data from the queue.
@@ -382,61 +429,4 @@ class ReleaseSignalsAjax {
 		return new Event( $server_event_data );
 	}
 
-	/**
-	 * Whether the current client is over its release-events rate limit.
-	 *
-	 * Counts accepted events (not requests) per IP per window. Both the
-	 * window length and the cap are filterable.
-	 *
-	 * @since 3.6.0
-	 *
-	 * @return bool
-	 */
-	private function is_rate_limited() {
-		$max = (int) apply_filters( 'wc_facebook_release_signals_rate_limit_max', self::RATE_LIMIT_MAX_EVENTS );
-
-		if ( $max <= 0 ) {
-			return false;
-		}
-
-		$key   = $this->get_rate_limit_key();
-		$count = (int) get_transient( $key );
-
-		return $count >= $max;
-	}
-
-	/**
-	 * Records that the current client just had N events accepted, for rate-limit accounting.
-	 *
-	 * @since 3.6.0
-	 *
-	 * @param int $accepted_event_count Number of events accepted in this request.
-	 */
-	private function record_rate_limit_usage( $accepted_event_count ) {
-		if ( $accepted_event_count <= 0 ) {
-			return;
-		}
-
-		$window = (int) apply_filters( 'wc_facebook_release_signals_rate_limit_window', self::RATE_LIMIT_WINDOW );
-		if ( $window <= 0 ) {
-			return;
-		}
-
-		$key   = $this->get_rate_limit_key();
-		$count = (int) get_transient( $key );
-
-		set_transient( $key, $count + (int) $accepted_event_count, $window );
-	}
-
-	/**
-	 * Builds a transient key scoped to the requesting client IP.
-	 *
-	 * @since 3.6.0
-	 *
-	 * @return string
-	 */
-	private function get_rate_limit_key() {
-		$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
-		return 'wc_fb_release_signals_rl_' . md5( $ip );
-	}
 }

--- a/includes/Events/ReleaseSignalsAjax.php
+++ b/includes/Events/ReleaseSignalsAjax.php
@@ -428,5 +428,4 @@ class ReleaseSignalsAjax {
 
 		return new Event( $server_event_data );
 	}
-
 }

--- a/includes/Signals.php
+++ b/includes/Signals.php
@@ -10,6 +10,8 @@
 
 namespace WooCommerce\Facebook;
 
+use WooCommerce\Facebook\Events\FacebookSignalsState;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -87,34 +89,16 @@ class Signals {
 		$state = isset( $_POST['state'] ) ? sanitize_text_field( wp_unslash( $_POST['state'] ) ) : self::STATE_HELD;
 		$state = $this->normalize_state( $state );
 
-		$this->set_cookie( $state );
-
-		// Populate $_COOKIE so any downstream code in this same request can read it.
-		$_COOKIE[ self::COOKIE_NAME ] = $state;
+		if ( self::STATE_HELD === $state ) {
+			FacebookSignalsState::hold();
+		} else {
+			FacebookSignalsState::release();
+		}
 
 		wp_send_json_success(
 			array(
 				'state' => $state,
 			)
-		);
-	}
-
-	/**
-	 * Sets the signal-state cookie.
-	 *
-	 * @param string $state Signal state.
-	 */
-	private function set_cookie( string $state ) {
-		$expires = time() + YEAR_IN_SECONDS;
-
-		setcookie(
-			self::COOKIE_NAME,
-			$state,
-			$expires,
-			COOKIEPATH,
-			COOKIE_DOMAIN,
-			is_ssl(),
-			false // httponly=false so JS can read it
 		);
 	}
 

--- a/tests/Unit/FacebookCommercePixelIsolatedExecutionTest.php
+++ b/tests/Unit/FacebookCommercePixelIsolatedExecutionTest.php
@@ -429,7 +429,7 @@ class FacebookCommercePixelIsolatedExecutionTest extends AbstractWPUnitTestWithO
 	// inject_event() with Rollout Switch Tests
 	// =========================================================================
 
-	public function test_build_event_adds_browser_dedup_guard_when_event_id_is_present(): void {
+	public function test_build_event_adds_event_id_paths_when_event_id_is_present(): void {
 		$event_id = 'add-to-cart-event-123';
 		$event    = WC_Facebookcommerce_Pixel::build_event(
 			'AddToCart',
@@ -441,15 +441,11 @@ class FacebookCommercePixelIsolatedExecutionTest extends AbstractWPUnitTestWithO
 		);
 
 		$this->assertStringContainsString(
-			'window.wcFacebookPixelFiredEvents = window.wcFacebookPixelFiredEvents || {};',
+			'window.FacebookSignals.trackEvent(\'AddToCart\'',
 			$event
 		);
 		$this->assertStringContainsString(
-			'if (!window.wcFacebookPixelFiredEvents["add-to-cart-event-123"]) {',
-			$event
-		);
-		$this->assertStringContainsString(
-			'window.wcFacebookPixelFiredEvents["add-to-cart-event-123"] = true;',
+			'null, \'track\', "add-to-cart-event-123"',
 			$event
 		);
 		$this->assertStringContainsString(
@@ -457,9 +453,10 @@ class FacebookCommercePixelIsolatedExecutionTest extends AbstractWPUnitTestWithO
 			$event
 		);
 		$this->assertStringContainsString(
-			'"eventID": "add-to-cart-event-123"',
+			'{ eventID: "add-to-cart-event-123" }',
 			$event
 		);
+		$this->assertStringNotContainsString( 'window.wcFacebookPixelFiredEvents', $event );
 	}
 
 	public function test_build_event_does_not_add_browser_dedup_guard_without_event_id(): void {


### PR DESCRIPTION
## Description

This PR improves the pause/resume signals flow on full-page-cached sites.

On full-page-cached pages, render-time PHP state can be stale. That caused inconsistent pause/resume behavior for Pixel/CAPI signals. This change aligns runtime behavior to cookie-driven client-side state resolution so held/released status is evaluated at execution time.

### Summary of changes

- Cookie-driven signal-state resolution for cached pages:
  - Introduced/used `wc_facebook_signals_state` as the runtime source of held/active state.
  - `FacebookSignalsState::hold()` / `FacebookSignalsState::release()` now persist state in cookie for client-side reads.

- Updated frontend signal bootstrap/integration flow:
  - Added `FacebookSignals.init(...)` + `FacebookSignals.initPixel(...)` sequence.
  - JS now determines held state from cookie and applies signal state accordingly.
  - Added release guard (`_releasing`) and pending pixel-event buffering/flush.

- Aligned release flow with upstream behavior:
  - Release endpoint uses signal-state cookie gate.
  - Added attribution recovery fallback (`fbc`/`fbp`) and returns `user_info` for post-release pixel re-init.

- Aligned Signals state endpoint behavior:
  - `Signals::handle_update_state()` now delegates to `FacebookSignalsState::hold()` / `release()`.

- Added/updated tests for signal state + pixel injection paths.

- Cleanup:
  - Removed stale/unused nonce/dead code paths introduced during migration.
  - Fixed class constant references in localized script config.

### Type of change

- Fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change which fixes code modularity, linting or phpcs issues)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki](https://fburl.com/wiki/2cgfduwc).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [ ] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki](https://fburl.com/wiki/nhx73tgs).

## Changelog entry

Refactor pause/resume signals flow for cached-page compatibility.

## Test Plan

1. Use/write a small MU plugin that can hold/release signals and explicitly enable initial held state on first page load.
2. Enter the page and verify the default state is held.
3. Verify no Pixel events are sent while held.
4. Go to `/shop` and trigger multiple AddToCart events, then update signal state to `held: false`.
5. Verify queued events are released and sent with expected parameters.
6. In released state, validate additional events fire correctly.
