### PR TITLE
Fix/subscriptions renewal purchase capi

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -1147,6 +1147,19 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		}
 
 		/**
+		 * Determines whether a given order object should be tracked as a Purchase.
+		 *
+		 * We only track Purchases for actual WooCommerce orders (`shop_order`).
+		 * Subscription objects (`shop_subscription`) are handled via Subscribe events.
+		 *
+		 * @param WC_Order $order order object.
+		 * @return bool
+		 */
+		private function is_purchase_trackable_order( $order ) {
+			return is_a( $order, 'WC_Order' ) && 'shop_order' === $order->get_type();
+		}
+
+		/**
 		 * Triggers a Purchase event when checkout is completed.
 		 *
 		 * This may happen either when:
@@ -1174,6 +1187,11 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			$order = wc_get_order( $order_id );
 
 			if ( ! $order ) {
+				return;
+			}
+
+			// Track Purchase only for checkout/renewal orders, not subscription posts.
+			if ( ! $this->is_purchase_trackable_order( $order ) ) {
 				return;
 			}
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -1130,6 +1130,15 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 * @return array
 		 */
 		public function exclude_purchase_tracking_meta_from_renewal_orders( $data, $to_object, $from_object ) {
+			// Guard to only affect subscription -> renewal order copies.
+			if ( ! is_a( $to_object, 'WC_Order' ) || 'shop_order' !== $to_object->get_type() ) {
+				return $data;
+			}
+
+			if ( ! is_a( $from_object, 'WC_Order' ) || 'shop_subscription' !== $from_object->get_type() ) {
+				return $data;
+			}
+
 			unset( $data[ self::META_PURCHASE_TRACKED_SERVER ] );
 			unset( $data[ self::META_PURCHASE_TRACKED_BROWSER ] );
 			unset( $data[ self::META_EVENT_ID ] );

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -302,6 +302,10 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			add_filter( 'wpforms_ajax_submit_redirect', array( $this, 'inject_wpforms_lead_event_ajax' ), 20, 3 );
 			add_action( 'wp_footer', array( $this, 'inject_wpforms_ajax_listener' ), 20 );
 
+			// Prevent stale Purchase tracking flags from being copied from subscriptions
+			// onto renewal orders (which would make inject_purchase_event() skip CAPI).
+			add_filter( 'wc_subscriptions_renewal_order_data', array( $this, 'exclude_purchase_tracking_meta_from_renewal_orders' ), 10, 3 );
+
 			// Flush pending events on shutdown
 			add_action( 'shutdown', array( $this, 'send_pending_events' ) );
 		}
@@ -1112,6 +1116,26 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			$this->pixel->inject_event( $event_name, $event_data );
 		}
 
+
+		/**
+		 * Excludes Meta Purchase tracking keys when Woo Subscriptions copies subscription meta
+		 * to renewal orders.
+		 *
+		 * Without this, renewal orders may inherit `_meta_purchase_tracked_server` and
+		 * `_meta_event_id`, causing inject_purchase_event() to treat them as already sent.
+		 *
+		 * @param array    $data copied data keyed by meta key.
+		 * @param WC_Order $to_object target order (renewal order).
+		 * @param WC_Order $from_object source object (subscription).
+		 * @return array
+		 */
+		public function exclude_purchase_tracking_meta_from_renewal_orders( $data, $to_object, $from_object ) {
+			unset( $data[ self::META_PURCHASE_TRACKED_SERVER ] );
+			unset( $data[ self::META_PURCHASE_TRACKED_BROWSER ] );
+			unset( $data[ self::META_EVENT_ID ] );
+
+			return $data;
+		}
 
 		/**
 		 * Triggers a Purchase event when checkout is completed.

--- a/tests/Unit/Events/FacebookCommerceEventsTrackerTest.php
+++ b/tests/Unit/Events/FacebookCommerceEventsTrackerTest.php
@@ -565,6 +565,72 @@ class FacebookCommerceEventsTrackerTest extends AbstractWPUnitTestWithSafeFilter
 	}
 
 	/**
+	 * Test that renewal-order meta copy excludes Purchase tracking keys.
+	 *
+	 * @covers WC_Facebookcommerce_EventsTracker::exclude_purchase_tracking_meta_from_renewal_orders
+	 */
+	public function test_exclude_purchase_tracking_meta_from_renewal_orders_removes_tracking_keys(): void {
+		$this->instance = $this->create_tracker_with_pixel_enabled();
+
+		$data = array(
+			'_meta_purchase_tracked_server'  => '1',
+			'_meta_purchase_tracked_browser' => '1',
+			'_meta_event_id'                 => 'event-id',
+			'_subscription_renewal'          => '123',
+		);
+
+		$to_order = $this->getMockBuilder( \WC_Order::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_type' ) )
+			->getMock();
+		$to_order->method( 'get_type' )->willReturn( 'shop_order' );
+
+		$from_subscription = $this->getMockBuilder( \WC_Order::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_type' ) )
+			->getMock();
+		$from_subscription->method( 'get_type' )->willReturn( 'shop_subscription' );
+
+		$result = $this->instance->exclude_purchase_tracking_meta_from_renewal_orders( $data, $to_order, $from_subscription );
+
+		$this->assertArrayNotHasKey( '_meta_purchase_tracked_server', $result );
+		$this->assertArrayNotHasKey( '_meta_purchase_tracked_browser', $result );
+		$this->assertArrayNotHasKey( '_meta_event_id', $result );
+		$this->assertArrayHasKey( '_subscription_renewal', $result );
+	}
+
+	/**
+	 * Test that renewal-order meta copy leaves data unchanged for non-subscription sources.
+	 *
+	 * @covers WC_Facebookcommerce_EventsTracker::exclude_purchase_tracking_meta_from_renewal_orders
+	 */
+	public function test_exclude_purchase_tracking_meta_from_renewal_orders_keeps_data_for_non_subscription_source(): void {
+		$this->instance = $this->create_tracker_with_pixel_enabled();
+
+		$data = array(
+			'_meta_purchase_tracked_server'  => '1',
+			'_meta_purchase_tracked_browser' => '1',
+			'_meta_event_id'                 => 'event-id',
+		);
+
+		$to_order = $this->getMockBuilder( \WC_Order::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_type' ) )
+			->getMock();
+		$to_order->method( 'get_type' )->willReturn( 'shop_order' );
+
+		$from_order = $this->getMockBuilder( \WC_Order::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_type' ) )
+			->getMock();
+		$from_order->method( 'get_type' )->willReturn( 'shop_order' );
+
+		$result = $this->instance->exclude_purchase_tracking_meta_from_renewal_orders( $data, $to_order, $from_order );
+
+		$this->assertSame( $data, $result );
+	}
+
+	/**
 	 * Test that inject_subscribe_event does nothing when function not available.
 	 *
 	 * @covers WC_Facebookcommerce_EventsTracker::inject_subscribe_event

--- a/tests/Unit/Events/FacebookCommerceEventsTrackerTest.php
+++ b/tests/Unit/Events/FacebookCommerceEventsTrackerTest.php
@@ -446,6 +446,34 @@ class FacebookCommerceEventsTrackerTest extends AbstractWPUnitTestWithSafeFilter
 	}
 
 	/**
+	 * Test that is_purchase_trackable_order returns true only for shop_order.
+	 *
+	 * @covers WC_Facebookcommerce_EventsTracker::is_purchase_trackable_order
+	 */
+	public function test_is_purchase_trackable_order_only_allows_shop_order(): void {
+		$this->instance = $this->create_tracker_with_pixel_enabled();
+
+		$shop_order = $this->getMockBuilder( \WC_Order::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_type' ) )
+			->getMock();
+		$shop_order->method( 'get_type' )->willReturn( 'shop_order' );
+
+		$shop_subscription = $this->getMockBuilder( \WC_Order::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_type' ) )
+			->getMock();
+		$shop_subscription->method( 'get_type' )->willReturn( 'shop_subscription' );
+
+		$reflection = new ReflectionClass( $this->instance );
+		$method     = $reflection->getMethod( 'is_purchase_trackable_order' );
+		$method->setAccessible( true );
+
+		$this->assertTrue( $method->invoke( $this->instance, $shop_order ) );
+		$this->assertFalse( $method->invoke( $this->instance, $shop_subscription ) );
+	}
+
+	/**
 	 * Test that inject_purchase_event sends CAPI event for server context.
 	 *
 	 * When triggered by a server-side hook (e.g., woocommerce_new_order),


### PR DESCRIPTION
## Description

Fix renewal-order Purchase CAPI not being sent when Woo Subscriptions copies Meta tracking keys from subscription meta to the renewal order.

### Summary
- Added a filter on `wc_subscriptions_renewal_order_data`.
- Excluded copied keys:
  - `_meta_purchase_tracked_server`
  - `_meta_purchase_tracked_browser`
  - `_meta_event_id`
- This ensures renewal orders are not treated as already tracked before `inject_purchase_event()` runs.

### Type of change
- Fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have commented my code, particularly in hard-to-understand areas, if any.
- [X] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
- [X] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [X] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [X] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [X] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Changelog entry

Ensure Purchase CAPI events are sent for subscription renewal orders

## Test Plan

1. Create or use an active subscription.
2. Force a renewal order via WP-CLI (`wcs_create_renewal_order`) and mark it paid (`payment_complete`).
3. Confirm renewal order has `_subscription_renewal` meta.
4. Check Woo logs for that renewal order:
   - `Purchase event fired for order <renewal_id>`
   - Graph API POST body includes `"event_name":"Purchase"` and `"order_id":<renewal_id>`
   - Response `code: 200` and `events_received: 1`