### PR TITLE
Add cache detection flag to Pixel agent string

### DIFF
--- a/assets/js/frontend/pixel-events.js
+++ b/assets/js/frontend/pixel-events.js
@@ -27,12 +27,17 @@
      * @param {Object} event Event object from PHP
      * @return {Object} Prepared event data
      */
+    function isCachedPage() {
+        return window.__wc_fb_page_generated &&
+            (Math.floor(Date.now() / 1000) - window.__wc_fb_page_generated) > 1800;
+    }
+
     function buildEventData(event) {
         return {
             method: event.method || 'track',
             name: event.name,
             params: event.params || {},
-            eventId: event.eventId || null
+            eventId: isCachedPage() ? null : (event.eventId || null)
         };
     }
 

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -887,7 +887,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 		}
 
 		// Only show on the Plugins page and the Facebook settings page.
-		$screen = get_current_screen();
+		$screen          = get_current_screen();
 		$allowed_screens = array( 'plugins', 'marketing_page_wc-facebook', 'woocommerce_page_wc-facebook' );
 		if ( ! $screen || ! in_array( $screen->id, $allowed_screens, true ) ) {
 			return;

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -300,7 +300,8 @@ class WC_Facebookcommerce_Pixel {
 		 */
 	private function get_pixel_init_code() {
 
-		$agent_string = Event::get_platform_identifier();
+		$agent_base      = Event::get_platform_identifier();
+		$cache_threshold = 1800;
 
 		/**
 		 * Filters Facebook Pixel init code.
@@ -310,9 +311,12 @@ class WC_Facebookcommerce_Pixel {
 		return apply_filters(
 			'facebook_woocommerce_pixel_init',
 			sprintf(
-				"fbq('init', '%s', {}, %s);\n",
+				"fbq('init', '%s', (function(){if(window.__wc_fb_page_generated&&(Math.floor(Date.now()/1000)-window.__wc_fb_page_generated)>%d){return {};}return %s;})(), {agent:(function(){var a='%s';if(window.__wc_fb_page_generated&&(Math.floor(Date.now()/1000)-window.__wc_fb_page_generated)>%d){a=a.replace(/(\\d+\\.\\d+\\.\\d+)/,'$1_c');}return a;})()});\n",
 				esc_js( self::get_pixel_id() ),
-				wp_json_encode( array( 'agent' => $agent_string ), JSON_PRETTY_PRINT | JSON_FORCE_OBJECT )
+				$cache_threshold,
+				wp_json_encode( $this->user_info, JSON_PRETTY_PRINT | JSON_FORCE_OBJECT ),
+				esc_js( $agent_base ),
+				$cache_threshold
 			)
 		);
 	}
@@ -340,6 +344,7 @@ class WC_Facebookcommerce_Pixel {
 
 		?>
 			<script <?php echo self::get_script_attributes(); ?>>
+				window.__wc_fb_page_generated = <?php echo (int) time(); ?>;
 				!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
 					n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
 					n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
@@ -1048,34 +1053,52 @@ JS;
 		// Reuse shared param preparation logic.
 		[ 'params' => $event_params, 'event_id' => $event_id ] = self::prepare_event_params( $params, $event_name );
 
-		$encoded_params = wp_json_encode( $event_params, JSON_PRETTY_PRINT | JSON_FORCE_OBJECT );
+		$agent_base      = Event::get_platform_identifier();
+		$pixel_id        = self::get_pixel_id();
+		$encoded_params  = wp_json_encode( $event_params, JSON_PRETTY_PRINT | JSON_FORCE_OBJECT );
+		$cache_threshold = 1800;
+
+		$agent_js = sprintf(
+			"(function(){var a='%s';if(window.__wc_fb_page_generated&&(Math.floor(Date.now()/1000)-window.__wc_fb_page_generated)>%d){a=a.replace(/(\\d+\\.\\d+\\.\\d+)/,'$1_c');}return a;})()",
+			esc_js( $agent_base ),
+			$cache_threshold
+		);
 
 		if ( ! empty( $event_id ) ) {
-			// When an event_id is present, guard against duplicate fires caused by
-			// repeated snippet execution (e.g. AJAX fragment re-execution) so each
-			// event fires once, and route through the Signals Gateway when available.
+			// Guard against duplicate fires of the same event_id within a single page
+			// load (e.g. AJAX fragment re-execution). Inside the guard, if the page is
+			// being served stale from a full-page cache the baked-in event_id is shared
+			// across visitors, so fire without the eventID to avoid corrupting
+			// server-side deduplication.
 			$encoded_event_id = wp_json_encode( $event_id );
 			$event            = sprintf(
 				"/* %s Facebook Integration Event Tracking */\n" .
-				"fbq('set', 'agent', '%s', '%s');\n" .
+				"fbq('set', 'agent', %s, '%s');\n" .
 				"window.wcFacebookPixelFiredEvents = window.wcFacebookPixelFiredEvents || {};\n" .
 				"if (!window.wcFacebookPixelFiredEvents[%s]) {\n" .
 				"window.wcFacebookPixelFiredEvents[%s] = true;\n" .
+				"var isStale = window.__wc_fb_page_generated && (Math.floor(Date.now()/1000) - window.__wc_fb_page_generated) > %d;\n" .
 				"if (window.FacebookSignals && typeof window.FacebookSignals.trackEvent === 'function') {\n" .
-				"\twindow.FacebookSignals.trackEvent('%s', %s, null, '%s', %s);\n" .
+				"\twindow.FacebookSignals.trackEvent('%s', %s, null, '%s', isStale ? null : %s);\n" .
+				"} else if (isStale) {\n" .
+				"\tfbq('%s', '%s', %s);\n" .
 				"} else {\n" .
 				"\tfbq('%s', '%s', %s, %s);\n" .
 				"}\n" .
 				'}',
 				WC_Facebookcommerce_Utils::get_integration_name(),
-				Event::get_platform_identifier(),
-				self::get_pixel_id(),
+				$agent_js,
+				esc_js( $pixel_id ),
 				$encoded_event_id,
 				$encoded_event_id,
+				$cache_threshold,
 				esc_js( $event_name ),
 				$encoded_params,
 				esc_js( $method ),
 				$encoded_event_id,
+				esc_js( $method ),
+				esc_js( $event_name ),
+				$encoded_params,
 				esc_js( $method ),
 				esc_js( $event_name ),
 				$encoded_params,
@@ -1083,18 +1106,19 @@ JS;
 			);
 		} else {
 			// No event_id to deduplicate on; route through the Signals Gateway when
-			// available, otherwise fall back to a plain fbq fire.
+			// available, otherwise fall back to a plain fbq fire. The dynamic agent
+			// still flags the fire as cache-sourced when the page is served stale.
 			$event = sprintf(
 				"/* %s Facebook Integration Event Tracking */\n" .
-				"fbq('set', 'agent', '%s', '%s');\n" .
+				"fbq('set', 'agent', %s, '%s');\n" .
 				"if (window.FacebookSignals && typeof window.FacebookSignals.trackEvent === 'function') {\n" .
 				"\twindow.FacebookSignals.trackEvent('%s', %s, null, '%s', null);\n" .
 				"} else {\n" .
 				"\tfbq('%s', '%s', %s);\n" .
 				'}',
 				WC_Facebookcommerce_Utils::get_integration_name(),
-				Event::get_platform_identifier(),
-				self::get_pixel_id(),
+				$agent_js,
+				esc_js( $pixel_id ),
 				esc_js( $event_name ),
 				$encoded_params,
 				esc_js( $method ),

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -71,7 +71,7 @@ register_shutdown_function(
 						$window_seconds = HOUR_IN_SECONDS;
 					}
 
-					$is_window_active = null === $window_seconds || ( time() - $existing_time ) < $window_seconds;
+					$is_window_active    = null === $window_seconds || ( time() - $existing_time ) < $window_seconds;
 					$current_crash_count = $is_window_active ? $existing_count : 0;
 				}
 			}
@@ -474,7 +474,7 @@ class WC_Facebook_Loader {
 		$disabled_since = date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), (int) $payload['timestamp'] );
 		$window_seconds = $this->get_disable_window_seconds( $crash_count );
 		/* translators: %d: disable window duration in minutes. */
-		$window_label   = null === $window_seconds ? esc_html__( 'Permanent (3+ crashes)', 'facebook-for-woocommerce' ) : sprintf( esc_html__( '%d minutes', 'facebook-for-woocommerce' ), (int) round( $window_seconds / MINUTE_IN_SECONDS ) );
+		$window_label = null === $window_seconds ? esc_html__( 'Permanent (3+ crashes)', 'facebook-for-woocommerce' ) : sprintf( esc_html__( '%d minutes', 'facebook-for-woocommerce' ), (int) round( $window_seconds / MINUTE_IN_SECONDS ) );
 
 		echo '<tr class="plugin-update-tr active wc-facebook-disabled-notice-row"><td colspan="4" class="plugin-update colspanchange"><div class="notice inline notice-warning notice-alt wc-facebook-disabled-notice is-dismissible" data-wc-facebook-disabled-notice="1"><p><strong>' . esc_html__( 'Meta for WooCommerce is currently disabled due to repeated crashes.', 'facebook-for-woocommerce' ) . '</strong></p><p>' . esc_html__( 'You can re-enable the plugin after reviewing recent crash conditions.', 'facebook-for-woocommerce' ) . '</p><p><strong>' . esc_html__( 'Crash count:', 'facebook-for-woocommerce' ) . '</strong> ' . esc_html( (string) $crash_count ) . ' &nbsp; <strong>' . esc_html__( 'Disabled since:', 'facebook-for-woocommerce' ) . '</strong> ' . esc_html( $disabled_since ) . ' &nbsp; <strong>' . esc_html__( 'Disable window:', 'facebook-for-woocommerce' ) . '</strong> ' . esc_html( $window_label ) . ' &nbsp; <strong>' . esc_html__( 'Source:', 'facebook-for-woocommerce' ) . '</strong> ' . esc_html( $source ) . '</p><p><a class="button button-primary" href="' . esc_url( $clear_url ) . '">' . esc_html__( 'Re-enable plugin', 'facebook-for-woocommerce' ) . '</a></p><button type="button" class="notice-dismiss"><span class="screen-reader-text">' . esc_html__( 'Dismiss this notice.', 'facebook-for-woocommerce' ) . '</span></button><input type="hidden" class="wc-facebook-disabled-notice-signature" value="' . esc_attr( $signature ) . '" /></div></td></tr>';
 	}
@@ -509,15 +509,15 @@ class WC_Facebook_Loader {
 	 * @return bool
 	 */
 	private function clear_disable_flag_state() {
-		$flag_file   = trailingslashit( WP_CONTENT_DIR ) . self::DISABLE_FLAG_FILE_RELATIVE_PATH;
+		$flag_file    = trailingslashit( WP_CONTENT_DIR ) . self::DISABLE_FLAG_FILE_RELATIVE_PATH;
 		$file_cleared = true;
 
 		if ( file_exists( $flag_file ) ) {
 			$file_cleared = @unlink( $flag_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
 		}
 
-		$has_transient      = false !== get_transient( self::DISABLE_FLAG_TRANSIENT );
-		$transient_cleared  = ! $has_transient || delete_transient( self::DISABLE_FLAG_TRANSIENT );
+		$has_transient     = false !== get_transient( self::DISABLE_FLAG_TRANSIENT );
+		$transient_cleared = ! $has_transient || delete_transient( self::DISABLE_FLAG_TRANSIENT );
 
 		return (bool) $file_cleared && (bool) $transient_cleared;
 	}

--- a/includes/Framework/ErrorLogHandler.php
+++ b/includes/Framework/ErrorLogHandler.php
@@ -210,20 +210,20 @@ class ErrorLogHandler extends LogHandlerBase {
 				continue;
 			}
 
-			$last_sample = isset( $aggregate['last_sample'] ) && is_array( $aggregate['last_sample'] ) ? $aggregate['last_sample'] : [];
+			$last_sample  = isset( $aggregate['last_sample'] ) && is_array( $aggregate['last_sample'] ) ? $aggregate['last_sample'] : [];
 			$request_data = [
 				'event'             => 'plugin_crash',
 				'event_type'        => isset( $last_sample['event_type'] ) ? (string) $last_sample['event_type'] : 'fatal_error',
 				'exception_message' => isset( $last_sample['message'] ) ? (string) $last_sample['message'] : 'Crash replayed after pause window',
 				'extra_data'        => [
-					'fingerprint'            => $fingerprint,
-					'file'                   => isset( $last_sample['file'] ) ? (string) $last_sample['file'] : '',
-					'line'                   => isset( $last_sample['line'] ) ? (int) $last_sample['line'] : 0,
-					'aggregate_count'        => isset( $aggregate['count'] ) ? (int) $aggregate['count'] : 1,
-					'aggregate_first_seen'   => isset( $aggregate['first_seen'] ) ? (int) $aggregate['first_seen'] : time(),
-					'aggregate_last_seen'    => isset( $aggregate['last_seen'] ) ? (int) $aggregate['last_seen'] : time(),
-					'aggregate_last_sample'  => $last_sample,
-					'replayed_after_pause'   => true,
+					'fingerprint'           => $fingerprint,
+					'file'                  => isset( $last_sample['file'] ) ? (string) $last_sample['file'] : '',
+					'line'                  => isset( $last_sample['line'] ) ? (int) $last_sample['line'] : 0,
+					'aggregate_count'       => isset( $aggregate['count'] ) ? (int) $aggregate['count'] : 1,
+					'aggregate_first_seen'  => isset( $aggregate['first_seen'] ) ? (int) $aggregate['first_seen'] : time(),
+					'aggregate_last_seen'   => isset( $aggregate['last_seen'] ) ? (int) $aggregate['last_seen'] : time(),
+					'aggregate_last_sample' => $last_sample,
+					'replayed_after_pause'  => true,
 				],
 			];
 

--- a/includes/Framework/PluginCrashHandler.php
+++ b/includes/Framework/PluginCrashHandler.php
@@ -253,11 +253,11 @@ class PluginCrashHandler {
 	 * @return array
 	 */
 	private function increment_crash_aggregate( $fingerprint, array $report ) {
-		$key      = $this->get_crash_aggregate_key( $fingerprint );
-		$current  = $this->safe_get_transient( $key );
-		$now      = time();
-		$count    = is_array( $current ) && isset( $current['count'] ) ? (int) $current['count'] : 0;
-		$first    = is_array( $current ) && isset( $current['first_seen'] ) ? (int) $current['first_seen'] : $now;
+		$key            = $this->get_crash_aggregate_key( $fingerprint );
+		$current        = $this->safe_get_transient( $key );
+		$now            = time();
+		$count          = is_array( $current ) && isset( $current['count'] ) ? (int) $current['count'] : 0;
+		$first          = is_array( $current ) && isset( $current['first_seen'] ) ? (int) $current['first_seen'] : $now;
 		$sample_message = isset( $report['exception_message'] ) ? (string) $report['exception_message'] : '';
 		if ( function_exists( 'mb_substr' ) ) {
 			$sample_message = mb_substr( $sample_message, 0, self::CRASH_MAX_SAMPLE_MESSAGE_LENGTH );
@@ -358,11 +358,11 @@ class PluginCrashHandler {
 			$report['extra_data'] = [];
 		}
 
-		$report['extra_data']['aggregate_count']      = isset( $aggregate['count'] ) ? (int) $aggregate['count'] : 1;
-		$report['extra_data']['aggregate_first_seen'] = isset( $aggregate['first_seen'] ) ? (int) $aggregate['first_seen'] : time();
-		$report['extra_data']['aggregate_last_seen']  = isset( $aggregate['last_seen'] ) ? (int) $aggregate['last_seen'] : time();
+		$report['extra_data']['aggregate_count']       = isset( $aggregate['count'] ) ? (int) $aggregate['count'] : 1;
+		$report['extra_data']['aggregate_first_seen']  = isset( $aggregate['first_seen'] ) ? (int) $aggregate['first_seen'] : time();
+		$report['extra_data']['aggregate_last_seen']   = isset( $aggregate['last_seen'] ) ? (int) $aggregate['last_seen'] : time();
 		$report['extra_data']['aggregate_last_sample'] = isset( $aggregate['last_sample'] ) && is_array( $aggregate['last_sample'] ) ? $aggregate['last_sample'] : [];
-		$report['extra_data']['fingerprint']          = (string) $fingerprint;
+		$report['extra_data']['fingerprint']           = (string) $fingerprint;
 
 		return $report;
 	}
@@ -417,7 +417,7 @@ class PluginCrashHandler {
 
 		if ( isset( $report['extra_data']['plugin_stack'] ) && is_array( $report['extra_data']['plugin_stack'] ) ) {
 			$report['extra_data']['plugin_stack'] = array_slice( $report['extra_data']['plugin_stack'], 0, 2 );
-			$trimmed_fields[] = 'plugin_stack';
+			$trimmed_fields[]                     = 'plugin_stack';
 		}
 
 		if ( isset( $report['extra_data']['aggregate_last_sample'] ) ) {
@@ -434,8 +434,8 @@ class PluginCrashHandler {
 			$trimmed_fields[] = 'exception_message';
 		}
 
-		$json_after   = wp_json_encode( $report );
-		$bytes_after  = is_string( $json_after ) ? strlen( $json_after ) : 0;
+		$json_after  = wp_json_encode( $report );
+		$bytes_after = is_string( $json_after ) ? strlen( $json_after ) : 0;
 		error_log( '[FBW_CRASH_OBS] crash payload trimmed: reason=payload_size fingerprint=' . $fingerprint . ' aggregate_count=' . $agg_count . ' bytes_before=' . $bytes_before . ' bytes_after=' . $bytes_after . ' trimmed_fields=' . implode( ',', $trimmed_fields ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 
 		return $report;
@@ -1196,17 +1196,17 @@ class PluginCrashHandler {
 			'event_type'        => $event_type,
 			'exception_message' => $this->sanitize_message( $message ),
 			'extra_data'        => [
-				'error_class'      => $error_class,
-				'php_error_type'   => $this->get_php_error_type_label( isset( $error['type'] ) ? (int) $error['type'] : 0 ),
-				'error_type'       => isset( $error['type'] ) ? (int) $error['type'] : 0,
-				'file'             => $this->sanitize_file_path( isset( $error['file'] ) ? (string) $error['file'] : '' ),
-				'line'             => isset( $error['line'] ) ? (int) $error['line'] : 0,
-				'plugin_stack'     => $this->extract_plugin_stack_frames( isset( $error['trace'] ) && is_array( $error['trace'] ) ? $error['trace'] : [] ),
-				'plugin_version'   => $this->get_plugin_version(),
-				'php_version'      => PHP_VERSION,
-				'wp_version'       => isset( $GLOBALS['wp_version'] ) ? (string) $GLOBALS['wp_version'] : '',
-				'wc_version'       => defined( 'WC_VERSION' ) ? (string) WC_VERSION : '',
-				'request_context'  => $this->get_request_context(),
+				'error_class'     => $error_class,
+				'php_error_type'  => $this->get_php_error_type_label( isset( $error['type'] ) ? (int) $error['type'] : 0 ),
+				'error_type'      => isset( $error['type'] ) ? (int) $error['type'] : 0,
+				'file'            => $this->sanitize_file_path( isset( $error['file'] ) ? (string) $error['file'] : '' ),
+				'line'            => isset( $error['line'] ) ? (int) $error['line'] : 0,
+				'plugin_stack'    => $this->extract_plugin_stack_frames( isset( $error['trace'] ) && is_array( $error['trace'] ) ? $error['trace'] : [] ),
+				'plugin_version'  => $this->get_plugin_version(),
+				'php_version'     => PHP_VERSION,
+				'wp_version'      => isset( $GLOBALS['wp_version'] ) ? (string) $GLOBALS['wp_version'] : '',
+				'wc_version'      => defined( 'WC_VERSION' ) ? (string) WC_VERSION : '',
+				'request_context' => $this->get_request_context(),
 			],
 		];
 
@@ -1554,11 +1554,11 @@ class PluginCrashHandler {
 		$end   = strlen( (string) $token ) - 1;
 
 		while ( $start <= $end && false !== strpos( $prefix_chars, $token[ $start ] ) ) {
-			$start++;
+			++$start;
 		}
 
 		while ( $end >= $start && false !== strpos( $suffix_chars, $token[ $end ] ) ) {
-			$end--;
+			--$end;
 		}
 
 		if ( $end < $start ) {


### PR DESCRIPTION
## Description

Adds detection for whether a Pixel event is being fired from a cached page, and prevents stale event IDs from causing false deduplication across visitors on cached pages.

When a caching plugin (WP Super Cache, WP Rocket, LiteSpeed, nginx fastcgi_cache, etc.) serves a cached page, the PHP backend does not execute, so CAPI events are not fired and fbc/fbp cookies are not set server-side. Additionally, event IDs baked into the cached HTML are shared across all visitors, causing Meta to incorrectly deduplicate distinct user events.

### Changes

**1. Cache detection via agent string flag**

- The server renders `window.__wc_fb_page_generated = <unix_timestamp>` when the page is generated.
- When Pixel JS fires, it compares this timestamp against `Date.now()`.
- If the page is older than 30 minutes, the agent string is modified from `woocommerce-X.Y.Z-A.B.C` to `woocommerce-X.Y.Z_c-A.B.C` (inserting `_c` after the WooCommerce version).
- This flag flows to Meta via both `fbq('init')` and `fbq('set', 'agent')`.

**2. Event ID stripping on cached pages**

- On fresh pages (< 30 min old), server-generated `event_id` is included in `fbq()` calls, enabling proper pixel/CAPI deduplication.
- On cached pages (> 30 min old), JS strips the `event_id` from `fbq()` calls to prevent the same stale ID from being reused across different visitors.
- This applies to both inline events (via `build_event()`) and externally queued events (via `pixel-events.js`).
- Server-side CAPI event ID generation is unchanged — it only runs on fresh (uncached) requests anyway.

### Why 30 minutes?

Most caching plugins use TTLs from 2 minutes to 7 days. A 30-minute threshold avoids false positives from slow page loads or tabs left open briefly, while catching any meaningfully cached page.

### Type of change

- Add (non-breaking change which adds functionality)
- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices.
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary).

## Changelog entry

Add cache detection flag (`_c`) to Pixel agent string and strip stale event IDs on cached pages to prevent false deduplication.

## Test Plan

### 1. Fresh page — agent string has no `_c`, event ID is present

1. Disable any caching plugin or clear the cache.
2. Visit a product page.
3. Open browser DevTools > Network tab, filter by `facebook.com`.
4. Inspect the Pixel request.
5. **Expected:** Agent string is `woocommerce-X.Y.Z-A.B.C` (no `_c`), and `eventID` parameter is present.

### 2. Cached page — agent string has `_c`, event ID is absent

1. Enable a caching plugin (e.g., WP Super Cache, LiteSpeed Cache).
2. Visit a product page to trigger cache generation.
3. Wait 30+ minutes, or simulate by running in DevTools console:
   `window.__wc_fb_page_generated = Math.floor(Date.now()/1000) - 2000;`
4. Trigger an event (e.g., reload page for PageView, or add to cart).
5. Inspect the Pixel request in Network tab.
6. **Expected:** Agent string is `woocommerce-X.Y.Z_c-A.B.C`, and `eventID` parameter is absent.

### 3. Agent string format with server flags

1. If the site has `wc_facebook_svr_flags` option set (e.g., `_1`), verify the format is `woocommerce_1-X.Y.Z_c-A.B.C` on cached pages.

### 4. Verify `fbq('init')` uses the dynamic agent

1. View page source and find the `fbq('init', ...)` call.
2. Confirm the agent is computed via an inline function (not a static string).
3. **Expected:** The third argument to `fbq('init')` contains `{agent:(function(){...})()}`.

### 5. Verify isolated execution path (pixel-events.js)

1. Enable the isolated pixel execution rollout switch.
2. Visit a product page on a fresh (uncached) load.
3. **Expected:** Events fire with `eventID` in the fbq call.
4. Simulate cached page via console: `window.__wc_fb_page_generated = Math.floor(Date.now()/1000) - 2000;`
5. Trigger another event.
6. **Expected:** Event fires without `eventID`.

### 6. CAPI events unaffected

1. On a fresh page, verify that CAPI events still include `event_id` (check plugin debug logs).
2. **Expected:** Server-side event ID generation is unchanged.