### PR TITLE
Add Purchase CAPI diagnostic logging through meta-diagnosis pipeline

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -1159,6 +1159,23 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			// Get the status of the order to ensure we track the actual purchases and not the ones that have a failed payment.
 			$order_state = $order->get_status();
 			if ( ! in_array( $order_state, $valid_purchase_order_states, true ) ) {
+				Logger::log(
+					'Purchase event skipped: order status not in valid purchase states.',
+					array(
+						'event'      => 'purchase_event_skipped',
+						'flow_name'  => 'purchase_capi',
+						'flow_step'  => 'invalid_order_state',
+						'extra_data' => array(
+							'order_id'    => (string) $order_id,
+							'order_state' => (string) $order_state,
+						),
+					),
+					array(
+						'should_send_log_to_meta'        => true,
+						'should_save_log_in_woocommerce' => true,
+						'woocommerce_log_level'          => \WC_Log_Levels::INFO,
+					)
+				);
 				return;
 			}
 
@@ -1198,9 +1215,20 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			Logger::log(
 				'Purchase event fired for order ' . $order_id . ' by hook ' . $hook_name . ' (context: ' . ( $is_browser ? 'browser' : 'server' ) . ').',
-				array(),
 				array(
-					'should_send_log_to_meta'        => false,
+					'event'      => 'purchase_event_fired',
+					'flow_name'  => 'purchase_capi',
+					'flow_step'  => 'purchase_event_fired',
+					'extra_data' => array(
+						'order_id'          => (string) $order_id,
+						'hook'              => (string) $hook_name,
+						'context'           => $is_browser ? 'browser' : 'server',
+						'order_state'       => (string) $order_state,
+						'capi_already_sent' => $capi_already_sent ? 'true' : 'false',
+					),
+				),
+				array(
+					'should_send_log_to_meta'        => true,
 					'should_save_log_in_woocommerce' => true,
 					'woocommerce_log_level'          => \WC_Log_Levels::INFO,
 				)
@@ -1567,6 +1595,14 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		protected function send_api_event( Event $event, bool $send_now = true ) {
 			if ( $this->is_crawler_request( $event ) ) {
 				facebook_for_woocommerce()->log( 'Blocked CAPI event for crawler: ' . $event->get_client_user_agent() );
+				$this->log_purchase_capi_step(
+					$event,
+					'capi_event_blocked',
+					'crawler_blocked',
+					'CAPI event blocked: crawler request.',
+					\WC_Log_Levels::INFO,
+					array( 'user_agent' => (string) $event->get_client_user_agent() )
+				);
 				return;
 			}
 
@@ -1577,6 +1613,13 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 					RolloutSwitches::SWITCH_BLOCK_CAPI_ON_INVALID_TOKEN
 				)
 			) {
+				$this->log_purchase_capi_step(
+					$event,
+					'capi_event_blocked',
+					'connection_invalid',
+					'CAPI event blocked: connection marked invalid (auth error).',
+					\WC_Log_Levels::WARNING
+				);
 				return;
 			}
 
@@ -1585,6 +1628,13 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			// Skip CAPI sends for frontend requests while signals are held.
 			// Backend/cron events (e.g. admin order status changes) still fire.
 			if ( FacebookSignalsState::is_held() && ! is_admin() && ! wp_doing_cron() ) {
+				$this->log_purchase_capi_step(
+					$event,
+					'capi_event_deferred',
+					'signals_held',
+					'CAPI event deferred: signals held for frontend request.',
+					\WC_Log_Levels::INFO
+				);
 				FacebookSignalsState::queue_event( $event );
 				return;
 			}
@@ -1592,12 +1642,70 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			if ( $send_now ) {
 				try {
 					facebook_for_woocommerce()->get_api()->send_pixel_events( facebook_for_woocommerce()->get_integration()->get_facebook_pixel_id(), array( $event ) );
+					$this->log_purchase_capi_step(
+						$event,
+						'capi_event_sent',
+						'capi_event_sent',
+						'CAPI event sent to Meta.',
+						\WC_Log_Levels::INFO
+					);
 				} catch ( ApiException $exception ) {
 					facebook_for_woocommerce()->log( 'Could not send Pixel event: ' . $exception->getMessage() );
+					$this->log_purchase_capi_step(
+						$event,
+						'capi_event_send_failed',
+						'capi_send_exception',
+						'CAPI event send failed.',
+						\WC_Log_Levels::ERROR,
+						array(),
+						$exception
+					);
 				}
 			} else {
 				$this->pending_events[] = $event;
 			}
+		}
+
+
+		/**
+		 * Sends a CAPI-pipeline diagnostic log to Meta, scoped to Purchase events.
+		 *
+		 * Centralises the per-outcome logging added to send_api_event(). The log is
+		 * only queued for Purchase events (to limit volume) and is still gated behind
+		 * the merchant's "meta diagnosis" setting inside Logger::log(). The event name
+		 * and event ID are always attached to extra_data for correlation.
+		 *
+		 * @param Event           $event      the CAPI event being processed
+		 * @param string          $event_key  value for the log 'event' field (e.g. capi_event_sent)
+		 * @param string          $flow_step  the pipeline step reached (e.g. crawler_blocked)
+		 * @param string          $message    human-readable log message
+		 * @param string          $log_level  a \WC_Log_Levels::* constant
+		 * @param array           $extra_data optional additional extra_data fields
+		 * @param \Throwable|null $exception  optional exception to attach
+		 */
+		private function log_purchase_capi_step( Event $event, string $event_key, string $flow_step, string $message, string $log_level, array $extra_data = array(), ?\Throwable $exception = null ) {
+			if ( 'Purchase' !== $event->get_name() ) {
+				return;
+			}
+
+			$extra_data['event_name'] = (string) $event->get_name();
+			$extra_data['event_id']   = (string) $event->get_id();
+
+			Logger::log(
+				$message,
+				array(
+					'event'      => $event_key,
+					'flow_name'  => 'purchase_capi',
+					'flow_step'  => $flow_step,
+					'extra_data' => $extra_data,
+				),
+				array(
+					'should_send_log_to_meta'        => true,
+					'should_save_log_in_woocommerce' => true,
+					'woocommerce_log_level'          => $log_level,
+				),
+				$exception
+			);
 		}
 
 

--- a/tests/Unit/Events/FacebookCommerceEventsTrackerTest.php
+++ b/tests/Unit/Events/FacebookCommerceEventsTrackerTest.php
@@ -1376,4 +1376,138 @@ class FacebookCommerceEventsTrackerTest extends AbstractWPUnitTestWithSafeFilter
 
 		unset( $_SERVER['HTTP_USER_AGENT'] );
 	}
+
+	/**
+	 * Invoke the private log_purchase_capi_step() helper via reflection.
+	 *
+	 * @param \WooCommerce\Facebook\Events\Event $event      the CAPI event.
+	 * @param string                             $event_key  value for the log 'event' field.
+	 * @param string                             $flow_step  the pipeline step reached.
+	 * @param string                             $message    log message.
+	 * @param string                             $log_level  a \WC_Log_Levels::* constant.
+	 * @param array                              $extra_data optional extra_data fields.
+	 * @param \Throwable|null                    $exception  optional exception to attach.
+	 */
+	private function invoke_log_purchase_capi_step(
+		\WooCommerce\Facebook\Events\Event $event,
+		string $event_key,
+		string $flow_step,
+		string $message,
+		string $log_level,
+		array $extra_data = array(),
+		?\Throwable $exception = null
+	): void {
+		$reflection = new ReflectionClass( $this->instance );
+		$method     = $reflection->getMethod( 'log_purchase_capi_step' );
+		$method->setAccessible( true );
+		$method->invoke( $this->instance, $event, $event_key, $flow_step, $message, $log_level, $extra_data, $exception );
+	}
+
+	/**
+	 * Test that log_purchase_capi_step queues a log for Meta when the event is a
+	 * Purchase and meta diagnosis is enabled.
+	 *
+	 * @covers WC_Facebookcommerce_EventsTracker::log_purchase_capi_step
+	 */
+	public function test_log_purchase_capi_step_queues_log_for_purchase_when_meta_diagnosis_enabled(): void {
+		$this->instance = $this->create_tracker_with_pixel_enabled();
+
+		update_option( 'wc_facebook_enable_meta_diagnosis', 'yes' );
+		delete_transient( 'global_logging_message_queue' );
+
+		$event = new \WooCommerce\Facebook\Events\Event(
+			array(
+				'event_name' => 'Purchase',
+				'event_id'   => 'evt_test_purchase_1',
+			)
+		);
+
+		$this->invoke_log_purchase_capi_step(
+			$event,
+			'capi_event_sent',
+			'capi_event_sent',
+			'CAPI event sent to Meta.',
+			\WC_Log_Levels::INFO
+		);
+
+		$logs = get_transient( 'global_logging_message_queue' );
+
+		$this->assertIsArray( $logs, 'A log entry should be queued for Meta.' );
+		$this->assertCount( 1, $logs, 'Exactly one log entry should be queued.' );
+
+		$entry = $logs[0];
+		$this->assertSame( 'capi_event_sent', $entry['event'] );
+		$this->assertSame( 'purchase_capi', $entry['flow_name'] );
+		$this->assertSame( 'capi_event_sent', $entry['flow_step'] );
+		$this->assertSame( 'Purchase', $entry['extra_data']['event_name'] );
+		$this->assertSame( 'evt_test_purchase_1', $entry['extra_data']['event_id'] );
+	}
+
+	/**
+	 * Test that log_purchase_capi_step does NOT queue a log for non-Purchase events,
+	 * even when meta diagnosis is enabled (Purchase-only volume guard).
+	 *
+	 * @covers WC_Facebookcommerce_EventsTracker::log_purchase_capi_step
+	 */
+	public function test_log_purchase_capi_step_skips_non_purchase_events(): void {
+		$this->instance = $this->create_tracker_with_pixel_enabled();
+
+		update_option( 'wc_facebook_enable_meta_diagnosis', 'yes' );
+		delete_transient( 'global_logging_message_queue' );
+
+		$event = new \WooCommerce\Facebook\Events\Event(
+			array(
+				'event_name' => 'AddToCart',
+				'event_id'   => 'evt_test_atc_1',
+			)
+		);
+
+		$this->invoke_log_purchase_capi_step(
+			$event,
+			'capi_event_sent',
+			'capi_event_sent',
+			'CAPI event sent to Meta.',
+			\WC_Log_Levels::INFO
+		);
+
+		$this->assertFalse(
+			get_transient( 'global_logging_message_queue' ),
+			'Non-Purchase events should not queue a Meta log.'
+		);
+	}
+
+	/**
+	 * Test that log_purchase_capi_step does NOT queue a log when meta diagnosis is
+	 * disabled, even for a Purchase event.
+	 *
+	 * @covers WC_Facebookcommerce_EventsTracker::log_purchase_capi_step
+	 */
+	public function test_log_purchase_capi_step_does_not_queue_when_meta_diagnosis_disabled(): void {
+		$this->instance = $this->create_tracker_with_pixel_enabled();
+
+		update_option( 'wc_facebook_enable_meta_diagnosis', 'no' );
+		delete_transient( 'global_logging_message_queue' );
+
+		$event = new \WooCommerce\Facebook\Events\Event(
+			array(
+				'event_name' => 'Purchase',
+				'event_id'   => 'evt_test_purchase_2',
+			)
+		);
+
+		$this->invoke_log_purchase_capi_step(
+			$event,
+			'capi_event_send_failed',
+			'capi_send_exception',
+			'CAPI event send failed.',
+			\WC_Log_Levels::ERROR,
+			array(),
+			new \Exception( 'boom' )
+		);
+
+		$this->assertFalse(
+			get_transient( 'global_logging_message_queue' ),
+			'No Meta log should be queued when meta diagnosis is disabled.'
+		);
+	}
 }


### PR DESCRIPTION
## Description

The plugin sends Purchase signals to Meta via CAPI (`send_api_event()` → `send_pixel_events` → `/{pixel_id}/events`), but when a Purchase fails to reach Meta there is no visibility on our side: the "purchase fired" log was local-only (`should_send_log_to_meta => false`) and every drop/skip branch in `send_api_event()` was either local-only or a silent `return`. This makes it impossible to debug merchants who have purchases but no downstream events on Meta's side.

This adds diagnostic logging on the Purchase → CAPI path that reaches Meta through the existing meta-diagnosis pipeline (`Logger::log(..., should_send_log_to_meta => true)` → `global_logging_message_queue` transient → `BatchLogHandler` → `POST /commerce_seller_logs` → `commerce_3p_platform_event`).

**Changes in `facebook-commerce-events-tracker.php`:**

- **`inject_purchase_event()`**: log when a Purchase is skipped for an invalid order status (`flow_step = invalid_order_state`), and promote the existing "Purchase event fired" log to reach Meta with structured `event`, `flow_name`, `flow_step`, `extra_data` context.
- **`send_api_event()`**: emit a log on each previously-silent or local-only outcome — `crawler_blocked`, `connection_invalid`, `signals_held`, `capi_event_sent`, `capi_send_exception`.
- **New private helper `log_purchase_capi_step()`**: centralises the logging, scopes it to Purchase events only (to limit volume across all diagnosis-enabled merchants), and attaches `event_name` / `event_id` for correlation.

All logs use `flow_name = purchase_capi` so they can be filtered in `commerce_3p_platform_event` per business via `external_business_id` / `cms_id` / `page_id` / `pixel_id`.

**No new infra or permissions:** logging reuses the merchant's existing "Enable meta diagnosis" setting. Each call passes `should_send_log_to_meta => true` only as a per-log *eligibility* marker; the actual send is gated centrally in `Logger::log()` behind `is_meta_diagnosis_enabled()`, so no per-call-site opt-in check is added.

**Dependencies:** none.

### Type of change

- Add (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [ ] I followed general Pull Request best practices. Meta employees to follow this [wiki](https://fburl.com/wiki/2cgfduwc).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [ ] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentation (if necessary). Meta employees to follow this [wiki](https://fburl.com/wiki/nhx73tgs).

## Changelog entry

Add — Purchase → CAPI diagnostic logging surfaced to Meta via the existing meta-diagnosis pipeline.

## Test Plan

`php -l` clean and `composer lint` (PHPCS/WPCS) clean on both changed files.

Added unit tests in `FacebookCommerceEventsTrackerTest.php` covering `log_purchase_capi_step()`:

- Queues a Meta log for a Purchase event when meta diagnosis is enabled (asserts `flow_name`, `flow_step`, `event`, `extra_data`).
- Skips non-Purchase events (Purchase-only volume guard).
- Does not queue when meta diagnosis is disabled.

**Run** (requires the WordPress test DB via `bin/install-wp-tests.sh`):

```bash
./vendor/bin/phpunit --testsuite=unit --filter FacebookCommerceEventsTrackerTest