### PR TITLE
ci(release): release-workflow guardrails — block overlapping releases + clearer Set Stable Tag errors

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -51,16 +51,28 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
         run: |
+          set -euo pipefail
+
           # Each release opens a PR ("Release X.Y.Z", head release/X.Y.Z -> main) that
           # is merged once the release is published. Don't start a new release while a
           # previous release PR is still open, otherwise releases overlap and the
           # changelog/version bookkeeping drifts. Fail fast if any unmerged release PR
           # (other than this version's) is still open.
-          OPEN_RELEASE_PRS=$(gh pr list \
+          if ! OPEN_RELEASE_PRS=$(gh pr list \
             --repo "${{ github.repository }}" \
             --base main \
             --state open \
-            --json number,headRefName,title,url)
+            --json number,headRefName,title,url); then
+            echo "::error::Failed to query open PRs via the GitHub API; cannot verify previous release PRs are merged."
+            exit 1
+          fi
+
+          # An empty/non-JSON response would make the filter below silently pass and
+          # bypass the guard, so validate we got a JSON array back before relying on it.
+          if ! echo "$OPEN_RELEASE_PRS" | jq -e 'type == "array"' >/dev/null 2>&1; then
+            echo "::error::Unexpected response when listing open PRs; cannot verify previous release PRs are merged."
+            exit 1
+          fi
 
           UNMERGED=$(echo "$OPEN_RELEASE_PRS" | jq -r --arg cur "release/$NEW_VERSION" '
             [ .[]

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -46,38 +46,34 @@ jobs:
           fi
           echo "✅ Branch \"release/$NEW_VERSION\" does not exist."
 
-      - name: Check for open PR for current stable version
+      - name: Ensure previous release PR is merged
         env:
           GH_TOKEN: ${{ github.token }}
+          NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
         run: |
-          set -euo pipefail
-
-          echo "Getting the current stable version"
-          if ! API_RESPONSE=$(curl -sf 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request%5Bslug%5D=facebook-for-woocommerce'); then
-            echo "::error::Failed to fetch plugin information from the WordPress.org API."
-            exit 1
-          fi
-
-          CURRENT_STABLE=$(echo "$API_RESPONSE" | jq -r '.version')
-          echo "Current stable version: $CURRENT_STABLE"
-
-          if [ -z "$CURRENT_STABLE" ] || [ "$CURRENT_STABLE" = "null" ]; then
-            echo "::error::Could not determine the current stable version from the WordPress.org API response."
-            exit 1
-          fi
-
-          OPEN_PR=$(gh pr list \
+          # Each release opens a PR ("Release X.Y.Z", head release/X.Y.Z -> main) that
+          # is merged once the release is published. Don't start a new release while a
+          # previous release PR is still open, otherwise releases overlap and the
+          # changelog/version bookkeeping drifts. Fail fast if any unmerged release PR
+          # (other than this version's) is still open.
+          OPEN_RELEASE_PRS=$(gh pr list \
             --repo "${{ github.repository }}" \
-            --head "release/$CURRENT_STABLE" \
+            --base main \
             --state open \
-            --json url \
-            --jq '.[0].url // ""')
+            --json number,headRefName,title,url)
 
-          if [ -n "$OPEN_PR" ]; then
-            echo "::error::An open PR for the current stable version \"release/$CURRENT_STABLE\" already exists: $OPEN_PR. Merge or close it before preparing a new release."
+          UNMERGED=$(echo "$OPEN_RELEASE_PRS" | jq -r --arg cur "release/$NEW_VERSION" '
+            [ .[]
+              | select(.headRefName | test("^release/[0-9]+[.][0-9]+[.][0-9]+$"))
+              | select(.headRefName != $cur) ]
+            | .[] | "  - #\(.number) \(.title) (\(.headRefName)) — \(.url)"')
+
+          if [ -n "$UNMERGED" ]; then
+            echo "::error::Cannot prepare release $NEW_VERSION — a previous release PR is still open and must be merged first:"
+            echo "$UNMERGED"
             exit 1
           fi
-          echo "✅ No open PR found for the current stable version \"release/$CURRENT_STABLE\"."
+          echo "✅ No unmerged previous release PRs found."
 
       - name: Get latest release tag
         id: get_release

--- a/.github/workflows/set-stable-tag.yml
+++ b/.github/workflows/set-stable-tag.yml
@@ -140,7 +140,26 @@ jobs:
               echo "❌ The WordPress.org marketplace build does NOT match the latest release/$VERSION build (commit $BRANCH_SHA)."
               echo "   Refusing to set the stable tag until they match. Differing files:"
               echo "$REAL_DIFFS"
-              echo "   Resolve the discrepancy (re-deploy via the Release Plugin workflow if the marketplace is out of date), then re-run this workflow."
+
+              # Determine which version WordPress.org is actually serving. If it is not
+              # $VERSION, the "Release Plugin" deploy almost certainly has not run yet,
+              # which is the most common reason this step fails — call that out explicitly
+              # instead of leaving the operator to interpret a list of differing files.
+              WP_VERSION=$(grep -oiP '^\s*\*\s*Version:\s*\K[0-9][0-9.]*' "$TEMP_DIR/wp/facebook-for-woocommerce/facebook-for-woocommerce.php" 2>/dev/null | head -1)
+              echo ""
+              if [ -n "$WP_VERSION" ] && [ "$WP_VERSION" != "$VERSION" ]; then
+                  echo "::error::WordPress.org is still serving v${WP_VERSION}, not v${VERSION} — the Release Plugin deploy for this release has not been published yet."
+                  echo "   This workflow only sets the stable tag; it does NOT deploy the plugin. The deploy is a prior step."
+                  echo "   The 'Release Plugin' deploy is most likely still pending approval on the 'Deployment' environment (or it failed)."
+                  echo "   To fix:"
+                  echo "     1. Open the 'Release Plugin' workflow run for branch release/p${VERSION}/publish and approve/complete the Deployment."
+                  echo "     2. Wait for WordPress.org to serve v${VERSION} (it updates after the deploy commits to SVN)."
+                  echo "     3. Re-run this 'Set Stable Tag' workflow."
+                  echo "   Re-running this workflow before the deploy finishes will keep failing here."
+              else
+                  echo "::error::WordPress.org is serving v${WP_VERSION:-$VERSION} but its contents differ from the release/$VERSION build (commit $BRANCH_SHA)."
+                  echo "   The deployed artifact is out of date for this commit. Re-run the 'Release Plugin' deploy for release/p${VERSION}/publish, wait for WordPress.org to update, then re-run this workflow."
+              fi
               exit 1
           fi
 
@@ -153,11 +172,16 @@ jobs:
         run: svn co https://plugins.svn.wordpress.org/facebook-for-woocommerce/ woocommerce_svn --quiet --non-interactive
 
       - name: Validate SVN tag
+        env:
+          VERSION: ${{ steps.package-version.outputs.current-version }}
         run: |
-          if [ ! -d "woocommerce_svn/tags/${{ steps.package-version.outputs.current-version}}" ]; then
-            echo "❌ SVN tag directory does not exist" 1>&2
+          if [ ! -d "woocommerce_svn/tags/$VERSION" ]; then
+            echo "::error::SVN tag tags/$VERSION does not exist on WordPress.org." 1>&2
+            echo "   The 'Release Plugin' deploy creates this tag, so this means the deploy has not run for v$VERSION." 1>&2
+            echo "   Run/approve the 'Release Plugin' workflow for branch release/p$VERSION/publish and wait for it to finish, then re-run this workflow." 1>&2
             exit 1
           fi
+          echo "✅ SVN tag tags/$VERSION exists."
 
       - name: Update readme.txt
         env:


### PR DESCRIPTION
## Summary

Hardens the release automation so that a new release can't be started while a previous one is still in flight, and makes the **Set Stable Tag** workflow explain *why* it failed instead of leaving the operator to interpret raw diffs.

> Note: #3965 (a narrow "fail if an open PR exists for the *current stable* version" check) was already merged to `main`. This PR **replaces that merged step** with a broader guard — the current-stable case is just one instance of "any open release PR", so the broader check fully covers it without the extra WordPress.org API call. The review-driven hardening from #3965 is folded into the broader check.

## Changes

### `prepare-release.yml` — block overlapping releases
- **Removes** the narrow `Check for open PR for current stable version` step that landed via #3965 (`cbd4a56a`).
- Adds a broader **"Ensure previous release PR is merged"** step (runs right after the branch-exists check, so it fails fast before any work is done).
- Lists open PRs targeting `main` and fails if **any** previous release PR (head matching `release/X.Y.Z`, other than the version being prepared) is still open. Each release opens a PR that's merged once published; starting a new release while one is open causes overlapping branches and changelog/version drift.
- **Hardened against silent bypass** (carried over from #3965's review): the step runs `set -euo pipefail`, fails explicitly if the `gh pr list` API call fails, and validates the response is a JSON array before filtering — so a failed/garbled lookup can no longer make the guard pass with a false ✅.

### `set-stable-tag.yml` — clearer, actionable errors
- When the WordPress.org marketplace build doesn't match the release build, the workflow now detects which version WP.org is actually serving and, if it isn't this release, explains the most common root cause — the **Release Plugin** deploy hasn't published yet (often still pending Deployment-environment approval) — with step-by-step remediation instead of just a list of differing files.
- The **"Validate SVN tag"** step now gives an actionable message when `tags/$VERSION` is missing (the deploy hasn't run), refactors the version into an `env:` var, and logs a ✅ on success.

## Test plan

- [ ] Run **Prepare New Release** while a previous `release/X.Y.Z` PR is open → fails listing the unmerged PR(s).
- [ ] Run with no open release PRs → logs ✅ and proceeds.
- [ ] Simulate a `gh pr list` failure → step errors out instead of falsely passing.
- [ ] Run **Set Stable Tag** before the Release Plugin deploy has published → fails with the "WP.org still serving vX" guidance.
- [ ] Run **Set Stable Tag** with a missing SVN tag → fails with the actionable SVN-tag message.