### PR TITLE
Prevent orphan variation sync-field fatal during trash flows

### DIFF
--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -340,10 +340,15 @@ class ProductValidator {
 			throw $invalid_exception;
 		} elseif ( $this->product->get_type() === 'variation' ) {
 			/**
-			 * This check will run for background jobs like sync all and feeds
+			 * This check will run for background jobs like sync all and feeds.
+			 * Parent product can be unavailable during trash/delete cascades
+			 * (for example when translation plugins process variations after parent removal).
 			 */
-			// Check if product_parent exists before calling get_meta() to prevent "Call to a member function get_meta() on null" error
-			$parent_sync = $this->product_parent ? $this->product_parent->get_meta( Products::get_product_sync_meta_key() ) : null;
+			if ( ! $this->product_parent instanceof WC_Product ) {
+				throw $invalid_exception;
+			}
+
+			$parent_sync = $this->product_parent->get_meta( Products::get_product_sync_meta_key() );
 
 			if ( 'yes' === $parent_sync ) {
 				return;

--- a/tests/integration/ProductValidation/ProductValidatorTest.php
+++ b/tests/integration/ProductValidation/ProductValidatorTest.php
@@ -372,4 +372,55 @@ class ProductValidatorTest extends IntegrationTestCase {
 		// Out of stock products should still be synced
 		$this->assertProductShouldSync( $product, 'Out of stock products should be synced' );
 	}
-} 
+
+	/**
+	 * Test orphan variation does not fatally error when checking sync field.
+	 */
+	public function test_orphan_variation_sync_field_check_does_not_fatal(): void {
+		$this->enable_facebook_sync();
+
+		$variable_product = $this->create_variable_product();
+		$variation_ids    = $variable_product->get_children();
+
+		$this->assertNotEmpty( $variation_ids, 'Variable product should have at least one variation.' );
+
+		$variation_id = (int) $variation_ids[0];
+
+		// Remove parent permanently so the variation has no resolvable WC parent object.
+		wp_delete_post( $variable_product->get_id(), true );
+
+		$orphan_variation = wc_get_product( $variation_id );
+		$this->assertInstanceOf( WC_Product::class, $orphan_variation );
+		$this->assertSame( 'variation', $orphan_variation->get_type() );
+
+		$validator = facebook_for_woocommerce()->get_product_sync_validator( $orphan_variation );
+
+		$this->assertFalse(
+			$validator->passes_product_sync_field_check(),
+			'Orphan variation should be treated as non-syncable and must not fatal.'
+		);
+	}
+
+	/**
+	 * Test orphan variation is considered not sync-enabled through Products helper.
+	 */
+	public function test_orphan_variation_is_not_sync_enabled(): void {
+		$this->enable_facebook_sync();
+
+		$variable_product = $this->create_variable_product();
+		$variation_ids    = $variable_product->get_children();
+
+		$this->assertNotEmpty( $variation_ids, 'Variable product should have at least one variation.' );
+
+		$variation_id = (int) $variation_ids[0];
+		wp_delete_post( $variable_product->get_id(), true );
+
+		$orphan_variation = wc_get_product( $variation_id );
+		$this->assertInstanceOf( WC_Product::class, $orphan_variation );
+
+		$this->assertFalse(
+			Products::is_sync_enabled_for_product( $orphan_variation ),
+			'Orphan variation should not be considered sync-enabled.'
+		);
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes a fatal error that can occur when validating variation sync eligibility after the parent variable product has already been removed (for example during trash/delete cascades, including WPML-related flows).

### Summary of changes
- Updated `includes/ProductSync/ProductValidator.php` to explicitly treat missing/non-resolvable variation parent products as invalid for sync checks.
- Added a defensive `WC_Product` parent type check before reading parent sync metadata.
- Preserved existing behavior for valid variation-parent relationships.
- Added integration coverage in `tests/integration/ProductValidation/ProductValidatorTest.php` for:
  - orphan variation sync-field validation not fatalling,
  - orphan variation being treated as not sync-enabled.

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have commented my code, particularly in hard-to-understand areas, if any.
- [X] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [X] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [X] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [X] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [X] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).


## Changelog entry

Prevent fatal error when validating orphaned product variations during trash/delete sync flows.


## Test Plan

1. Enable product sync.
2. Create a variable product with at least one variation.
3. Permanently delete the parent variable product.
4. Trigger product sync validation path for the remaining variation (or run the relevant integration tests).
5. Confirm:
   - no PHP fatal occurs,
   - variation is treated as non-syncable.