### PR TITLE
Block CAPI unconditionally on invalid token; remove rollout switch

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -14,7 +14,6 @@ use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
 use WooCommerce\Facebook\Framework\Helper;
 use WooCommerce\Facebook\Framework\Logger;
 use WooCommerce\Facebook\Integrations\CostOfGoods\CostOfGoods;
-use WooCommerce\Facebook\RolloutSwitches;
 
 if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
@@ -1621,13 +1620,10 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				return;
 			}
 
-			// Skip CAPI events when the connection is known-invalid (auth error detected),
-			// gated on the server-side rollout switch. Events resume after the merchant reconnects.
-			if ( get_transient( 'wc_facebook_connection_invalid' )
-				&& facebook_for_woocommerce()->get_rollout_switches()->is_switch_enabled(
-					RolloutSwitches::SWITCH_BLOCK_CAPI_ON_INVALID_TOKEN
-				)
-			) {
+			// Skip CAPI events when the connection is known-invalid (auth error detected).
+			// Sending events with an invalid token generates Graph API errors with no chance
+			// of success, so we suppress them until the merchant reconnects.
+			if ( get_transient( 'wc_facebook_connection_invalid' ) ) {
 				return;
 			}
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -185,11 +185,7 @@ class API extends Base {
 					facebook_for_woocommerce()->log( $message );
 				}
 
-				// Subcode 452 (session mismatch) may be transient and self-resolving,
-				// so we don't flag the connection as invalid for that case.
-				if ( ! ( 190 === $code && 452 === $subcode ) ) {
-					set_transient( 'wc_facebook_connection_invalid', time(), DAY_IN_SECONDS );
-				}
+				set_transient( 'wc_facebook_connection_invalid', time(), DAY_IN_SECONDS );
 			} else {
 				// this was an unrelated error, so the OAuth connection may still be valid
 				delete_transient( 'wc_facebook_connection_invalid' );

--- a/includes/RolloutSwitches.php
+++ b/includes/RolloutSwitches.php
@@ -33,7 +33,6 @@ class RolloutSwitches {
 	public const SWITCH_LANGUAGE_OVERRIDE_FEED_ENABLED   = 'wooc_language_override_feed';
 	public const SWITCH_ISOLATED_PIXEL_EXECUTION_ENABLED = 'enable_woocommerce_isolated_pixel_execution';
 	public const SWITCH_COMPAT_CHECK_ENABLED             = 'enable_woocommerce_compat_check';
-	public const SWITCH_BLOCK_CAPI_ON_INVALID_TOKEN      = 'enable_woocommerce_block_capi_on_invalid_token';
 	private const SETTINGS_KEY                           = 'wc_facebook_for_woocommerce_rollout_switches';
 	public const CAPI_EVENT_LOGGING_ENABLED              = 'enable_woocommerce_capi_event_logging';
 	public const SWITCH_WA_CUSTOMER_EVENTS_GATING_ENABLED = 'enable_woocommerce_wa_customer_events_gating';
@@ -48,7 +47,6 @@ class RolloutSwitches {
 		self::SWITCH_LANGUAGE_OVERRIDE_FEED_ENABLED,
 		self::SWITCH_ISOLATED_PIXEL_EXECUTION_ENABLED,
 		self::SWITCH_COMPAT_CHECK_ENABLED,
-		self::SWITCH_BLOCK_CAPI_ON_INVALID_TOKEN,
 		self::SWITCH_WA_CUSTOMER_EVENTS_GATING_ENABLED,
 	);
 

--- a/tests/Unit/Api/PostParseResponseValidationTest.php
+++ b/tests/Unit/Api/PostParseResponseValidationTest.php
@@ -135,17 +135,18 @@ class PostParseResponseValidationTest extends AbstractWPUnitTestWithOptionIsolat
 	}
 
 	/**
-	 * Test that error code 190 with subcode 452 does NOT set the connection invalid transient.
-	 * Subcode 452 (session mismatch) may be transient and self-resolving.
+	 * Test that error code 190 with subcode 452 sets the connection invalid transient.
+	 * Session mismatch (452) leaves the stored token unusable, so we flag it and
+	 * block CAPI until the merchant reconnects.
 	 */
-	public function test_token_error_452_does_not_set_connection_invalid_transient(): void {
+	public function test_token_error_452_sets_connection_invalid_transient(): void {
 		$api = $this->make_api_with_response(
 			$this->make_error_response( 190, 452, 'Session does not match' )
 		);
 
 		$api->call_do_post_parse_response_validation();
 
-		$this->assertFalse( get_transient( 'wc_facebook_connection_invalid' ) );
+		$this->assertNotFalse( get_transient( 'wc_facebook_connection_invalid' ) );
 	}
 
 	/**

--- a/tests/Unit/Events/FacebookCommerceEventsTrackerTest.php
+++ b/tests/Unit/Events/FacebookCommerceEventsTrackerTest.php
@@ -1389,6 +1389,34 @@ class FacebookCommerceEventsTrackerTest extends AbstractWPUnitTestWithSafeFilter
 	}
 
 	/**
+	 * Test that send_api_event skips CAPI events when the connection is flagged invalid.
+	 *
+	 * @covers WC_Facebookcommerce_EventsTracker::send_api_event
+	 */
+	public function test_send_api_event_skips_when_connection_invalid(): void {
+		$this->instance = $this->create_tracker_with_pixel_enabled();
+
+		set_transient( 'wc_facebook_connection_invalid', time(), DAY_IN_SECONDS );
+
+		$event      = new \WooCommerce\Facebook\Events\Event( array( 'event_name' => 'PageView' ) );
+		$reflection = new ReflectionClass( $this->instance );
+		$method     = $reflection->getMethod( 'send_api_event' );
+		$method->setAccessible( true );
+		$method->invoke( $this->instance, $event, false );
+
+		$this->assertEmpty(
+			$this->instance->get_tracked_events(),
+			'Events should not be tracked while the connection is invalid'
+		);
+		$this->assertEmpty(
+			$this->instance->get_pending_events(),
+			'Events should not be pending while the connection is invalid'
+		);
+
+		delete_transient( 'wc_facebook_connection_invalid' );
+	}
+
+	/**
 	 * Test that send_api_event proceeds for real browser requests.
 	 *
 	 * @covers WC_Facebookcommerce_EventsTracker::send_api_event

--- a/tests/Unit/RolloutSwitchesTest.php
+++ b/tests/Unit/RolloutSwitchesTest.php
@@ -389,21 +389,6 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 		$this->assertFalse($switch_mock->is_switch_enabled(RolloutSwitches::SWITCH_ISOLATED_PIXEL_EXECUTION_ENABLED));
 	}
 
-	// =========================================================================
-	// Block CAPI On Invalid Token Switch Tests
-	// =========================================================================
-
-	public function test_block_capi_on_invalid_token_switch_constant_exists() {
-		$this->assertTrue( defined( 'WooCommerce\Facebook\RolloutSwitches::SWITCH_BLOCK_CAPI_ON_INVALID_TOKEN' ) );
-		$this->assertEquals( 'enable_woocommerce_block_capi_on_invalid_token', RolloutSwitches::SWITCH_BLOCK_CAPI_ON_INVALID_TOKEN );
-	}
-
-	public function test_block_capi_on_invalid_token_switch_in_active_switches() {
-		$plugin           = facebook_for_woocommerce();
-		$rollout_switches = new RolloutSwitches( $plugin );
-		$this->assertContains( RolloutSwitches::SWITCH_BLOCK_CAPI_ON_INVALID_TOKEN, $rollout_switches->get_active_switches() );
-	}
-
 	/**
 	 * Test that version updates bypass transient check and continue execution.
 	 */


### PR DESCRIPTION
## Summary

Removes the `block_capi_on_invalid_token` rollout switch and blocks CAPI events **unconditionally** whenever an invalid access token has been detected. Also brings subcode **452** into the set of auth errors that flag the connection invalid.

## Why the rollout switch didn't work

The switch gated CAPI blocking on `RolloutSwitches::is_switch_enabled( SWITCH_BLOCK_CAPI_ON_INVALID_TOKEN )`. The runtime check reads a local WP option (no token needed), but the switch **value** is fetched from Meta via a Graph API call that uses the store's access token:

```php
$switches = $this->plugin->get_api()->get_rollout_switches( $external_business_id, $catalog_id, $pixel_id );
```

For a store whose token is already invalid — exactly the cohort generating the auth errors — that fetch fails, and the failure fallback defaults any never-cached switch to `no`:

```php
} catch ( Exception $e ) {
    ...
    if ( ! isset( $fb_options[ $switch_name ] ) ) {
        $fb_options[ $switch_name ] = 'no'; // never-cached -> OFF
    }
}
```

So the switch reliably latches ON only for stores that pulled it at least once with a working token. Combined with the lazy, hourly-throttled refresh (`init()` bails on `! is_connected()` and re-fetches at most once/hour), the block never reached the dangling-token population it was meant to protect. This is consistent with the flat error volume observed after the switch was rolled to 100%.

## Changes

| File | Change |
|------|--------|
| `facebook-commerce-events-tracker.php` | `send_api_event()` skips CAPI purely on the `wc_facebook_connection_invalid` transient; removed the rollout-switch gate and the now-unused `RolloutSwitches` import |
| `includes/API.php` | Removed the subcode-452 exemption — 452 now sets the connection-invalid transient like 458/460/464/465 |
| `includes/RolloutSwitches.php` | Removed the `SWITCH_BLOCK_CAPI_ON_INVALID_TOKEN` constant and its `ACTIVE_SWITCHES` entry |
| `tests/Unit/Api/PostParseResponseValidationTest.php` | 452 test now asserts the transient **is** set |
| `tests/Unit/Events/FacebookCommerceEventsTrackerTest.php` | Added `test_send_api_event_skips_when_connection_invalid` |
| `tests/Unit/RolloutSwitchesTest.php` | Removed the two switch-constant tests |

## Behavior

Any detected OAuth error (code 190 subcodes 452/458/460/464/465, plus the broader 10/102/200–299 auth range) sets the 24h `wc_facebook_connection_invalid` transient at detection time. CAPI events are then suppressed for all requests with no rollout gate and no token dependency. The transient still clears on the next successful response and on reconnect via `Settings/Handler.php`.

## Testing

- Full unit suite: **1921 tests, 0 failures, 1 skipped** (pre-existing).
- Affected suites re-run on the `main` base: 84 tests green.
- PHPCS on changed files: 0 errors.