### PR TITLE
Gate WhatsApp customer_events on onboarding completion (gate + rollout switch + onboarding-complete writers)

### DIFF
--- a/includes/API/Plugin/Controller.php
+++ b/includes/API/Plugin/Controller.php
@@ -37,6 +37,7 @@ class Controller {
 		'WooCommerce\Facebook\API\Plugin\Settings\Uninstall\Request',
 		'WooCommerce\Facebook\API\Plugin\WhatsAppSettings\Update\Request',
 		'WooCommerce\Facebook\API\Plugin\WhatsAppSettings\Uninstall\Request',
+		'WooCommerce\Facebook\API\Plugin\WhatsAppSettings\OnboardingComplete\Request',
 		// Add other JS-enabled request classes here
 	];
 

--- a/includes/API/Plugin/WhatsAppSettings/Handler.php
+++ b/includes/API/Plugin/WhatsAppSettings/Handler.php
@@ -14,6 +14,7 @@ use WooCommerce\Facebook\API\Plugin\AbstractRESTEndpoint;
 use WooCommerce\Facebook\API\Plugin\WhatsAppSettings\Update\Request as UpdateRequest;
 use WooCommerce\Facebook\API\Plugin\WhatsAppSettings\UpdateIntegrationConfig\Request as UpdateIntegrationConfigRequest;
 use WooCommerce\Facebook\API\Plugin\WhatsAppSettings\Uninstall\Request as UninstallRequest;
+use WooCommerce\Facebook\API\Plugin\WhatsAppSettings\OnboardingComplete\Request as OnboardingCompleteRequest;
 use WooCommerce\Facebook\Handlers\WhatsAppConnection;
 
 defined( 'ABSPATH' ) || exit;
@@ -62,6 +63,68 @@ class Handler extends AbstractRESTEndpoint {
 				'permission_callback' => [ $this, 'permission_callback' ],
 			]
 		);
+
+		register_rest_route(
+			$this->get_namespace(),
+			'whatsapp_settings/onboarding_complete',
+			[
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'handle_onboarding_complete' ],
+				'permission_callback' => [ $this, 'permission_callback' ],
+			]
+		);
+	}
+
+	/**
+	 * Handle the onboarding-complete push signal (WA_CONNECT).
+	 *
+	 * Persists that WhatsApp onboarding finished so the customer_events gate
+	 * stops treating this install as pre-onboarding. Reaching this endpoint is
+	 * itself the signal, so it carries no payload.
+	 *
+	 * @since 3.7.5
+	 * @http_method POST
+	 * @description Mark WhatsApp onboarding as complete
+	 *
+	 * @param \WP_REST_Request $wp_request The WordPress request object.
+	 * @return \WP_REST_Response
+	 */
+	public function handle_onboarding_complete( \WP_REST_Request $wp_request ): \WP_REST_Response {
+		try {
+			$request           = new OnboardingCompleteRequest( $wp_request );
+			$validation_result = $request->validate();
+
+			if ( is_wp_error( $validation_result ) ) {
+				return $this->error_response(
+					$validation_result->get_error_message(),
+					400
+				);
+			}
+
+			facebook_for_woocommerce()->get_whatsapp_connection_handler()->set_onboarding_complete( true );
+
+			wc_get_logger()->info(
+				__( 'WhatsApp onboarding marked complete via WA_CONNECT push signal.', 'facebook-for-woocommerce' ),
+			);
+
+			return $this->success_response(
+				[
+					'message' => __( 'WhatsApp onboarding marked complete', 'facebook-for-woocommerce' ),
+				]
+			);
+		} catch ( \Exception $e ) {
+			wc_get_logger()->info(
+				sprintf(
+					/* translators: %s $error_message */
+					__( 'Failed to handle_onboarding_complete for WhatsApp Utility Messages Integration. Exception: %s', 'facebook-for-woocommerce' ),
+					$e->getMessage(),
+				)
+			);
+			return $this->error_response(
+				$e->getMessage(),
+				500
+			);
+		}
 	}
 
 	/**

--- a/includes/API/Plugin/WhatsAppSettings/Handler.php
+++ b/includes/API/Plugin/WhatsAppSettings/Handler.php
@@ -235,6 +235,7 @@ class Handler extends AbstractRESTEndpoint {
 			WhatsAppConnection::OPTION_WA_WABA_ID,
 			WhatsAppConnection::OPTION_WA_PHONE_NUMBER_ID,
 			WhatsAppConnection::OPTION_WA_INTEGRATION_CONFIG_ID,
+			WhatsAppConnection::OPTION_WA_ONBOARDING_COMPLETE,
 		];
 
 		foreach ( $options as $option ) {

--- a/includes/API/Plugin/WhatsAppSettings/OnboardingComplete/Request.php
+++ b/includes/API/Plugin/WhatsAppSettings/OnboardingComplete/Request.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package MetaCommerce
+ */
+
+namespace WooCommerce\Facebook\API\Plugin\WhatsAppSettings\OnboardingComplete;
+
+use WooCommerce\Facebook\API\Plugin\Request as RESTRequest;
+use WooCommerce\Facebook\API\Plugin\Traits\JS_Exposable;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WhatsApp Settings Onboarding-Complete REST API Request.
+ *
+ * Backs the WA_CONNECT push signal: the onboarding iframe posts a
+ * "connection complete" message to the parent, whose JS handler calls this
+ * endpoint so the plugin can persist that onboarding finished (the write side
+ * of the customer_events gate's onboarding flag). The signal carries no
+ * payload — reaching this endpoint means "onboarding complete" — so there are
+ * no parameters.
+ *
+ * @since 3.7.5
+ */
+class Request extends RESTRequest {
+
+	use JS_Exposable;
+
+	/**
+	 * Gets the API endpoint for this request.
+	 *
+	 * @since 3.7.5
+	 *
+	 * @return string
+	 */
+	public function get_endpoint() {
+		return 'whatsapp_settings/onboarding_complete';
+	}
+
+	/**
+	 * Gets the HTTP method for this request.
+	 *
+	 * @since 3.7.5
+	 *
+	 * @return string
+	 */
+	public function get_method() {
+		return 'POST';
+	}
+
+	/**
+	 * Gets the parameter schema for this request.
+	 *
+	 * @since 3.7.5
+	 *
+	 * @return array Array of parameters with their types and whether they're required
+	 */
+	public function get_param_schema() {
+		return [
+			// No parameters: reaching this endpoint means onboarding is complete.
+		];
+	}
+
+	/**
+	 * Gets the JavaScript function name for this request.
+	 *
+	 * @since 3.7.5
+	 *
+	 * @return string
+	 */
+	public function get_js_function_name() {
+		return 'notifyWhatsAppOnboardingComplete';
+	}
+
+	/**
+	 * Validate the request.
+	 *
+	 * @since 3.7.5
+	 *
+	 * @return true|\WP_Error True if valid, WP_Error otherwise.
+	 */
+	public function validate() {
+		// No parameters to validate.
+		return true;
+	}
+}

--- a/includes/Admin/WhatsApp_Integration_Settings.php
+++ b/includes/Admin/WhatsApp_Integration_Settings.php
@@ -325,6 +325,18 @@ class WhatsApp_Integration_Settings {
 						});
 				}
 
+				if (messageEvent === 'CommerceExtension::WA_CONNECT' && message.success) {
+					whatsAppAPI.notifyWhatsAppOnboardingComplete()
+						.then(function(response) {
+							if (!response.success) {
+								console.error('Error marking WhatsApp onboarding complete:', response);
+							}
+						})
+						.catch(function(error) {
+							console.error('Error during onboarding-complete notify:', error);
+						});
+				}
+
 				if (messageEvent === 'CommerceExtension::WA_RESIZE') {
 					const iframe = document.getElementById('facebook-whatsapp-iframe-enhanced');
 					if ( iframe ) {

--- a/includes/Handlers/WhatsAppConnection.php
+++ b/includes/Handlers/WhatsAppConnection.php
@@ -132,6 +132,41 @@ class WhatsAppConnection {
 	}
 
 	/**
+	 * Stores the WhatsApp onboarding completion state.
+	 *
+	 * Written by the onboarding signal handlers: the WA_CONNECT postMessage
+	 * listener (push, new connects) and the upgrade-hook HEAD backfill (pull,
+	 * existing installs). Maps the boolean to the tri-state option the
+	 * customer_events gate reads via get_onboarding_state():
+	 *  - true  → COMPLETE   ('yes')
+	 *  - false → INCOMPLETE  ('no')
+	 *
+	 * @since 3.7.5
+	 *
+	 * @param bool $complete whether Meta has confirmed onboarding is complete
+	 */
+	public function set_onboarding_complete( bool $complete ): void {
+		update_option(
+			self::OPTION_WA_ONBOARDING_COMPLETE,
+			$complete ? self::ONBOARDING_STATE_COMPLETE : self::ONBOARDING_STATE_INCOMPLETE
+		);
+	}
+
+	/**
+	 * Determines whether WhatsApp onboarding is known to be complete.
+	 *
+	 * Only COMPLETE counts as complete; UNKNOWN returns false so callers do not
+	 * treat a not-yet-determined install as onboarded.
+	 *
+	 * @since 3.7.5
+	 *
+	 * @return bool
+	 */
+	public function is_onboarding_complete(): bool {
+		return self::ONBOARDING_STATE_COMPLETE === $this->get_onboarding_state();
+	}
+
+	/**
 	 * Gets the stored whatsapp external ID.
 	 *
 	 * @since 2.0.0

--- a/includes/Handlers/WhatsAppConnection.php
+++ b/includes/Handlers/WhatsAppConnection.php
@@ -35,6 +35,15 @@ class WhatsAppConnection {
 	const OPTION_WA_INSTALLATION_ID = 'wc_facebook_wa_installation_id';
 	/** @var string the whatsapp integration config id option name */
 	const OPTION_WA_INTEGRATION_CONFIG_ID = 'wc_facebook_wa_integration_config_id';
+	/** @var string the whatsapp onboarding completion flag option name */
+	const OPTION_WA_ONBOARDING_COMPLETE = 'wc_facebook_wa_onboarding_complete';
+
+	/** @var string onboarding state: onboarding finished (integration config exists) */
+	const ONBOARDING_STATE_COMPLETE = 'yes';
+	/** @var string onboarding state: known not finished (no integration config) */
+	const ONBOARDING_STATE_INCOMPLETE = 'no';
+	/** @var string onboarding state: not yet determined */
+	const ONBOARDING_STATE_UNKNOWN = 'unknown';
 
 
 
@@ -94,6 +103,32 @@ class WhatsAppConnection {
 	 */
 	public function is_connected() {
 		return (bool) $this->get_access_token();
+	}
+
+	/**
+	 * Gets the stored WhatsApp onboarding completion state.
+	 *
+	 * Onboarding is "complete" once an integration config exists on the Meta
+	 * side. The state is tri-valued so the customer_events gate can fail open
+	 * while it is still unknown (see WhatsAppExtension):
+	 *  - COMPLETE   : a Meta integration config exists for this installation
+	 *  - INCOMPLETE : Meta confirmed no integration config exists
+	 *  - UNKNOWN    : not yet determined (never signalled / backfilled)
+	 *
+	 * The state is written by the onboarding signal handlers (push listener and
+	 * upgrade backfill) added in a follow-up change; until then it is UNKNOWN
+	 * for every install, so the gate fails open and behavior is unchanged.
+	 *
+	 * @since 3.7.5
+	 *
+	 * @return string one of the ONBOARDING_STATE_* constants
+	 */
+	public function get_onboarding_state(): string {
+		$state = get_option( self::OPTION_WA_ONBOARDING_COMPLETE, self::ONBOARDING_STATE_UNKNOWN );
+		if ( self::ONBOARDING_STATE_COMPLETE === $state || self::ONBOARDING_STATE_INCOMPLETE === $state ) {
+			return $state;
+		}
+		return self::ONBOARDING_STATE_UNKNOWN;
 	}
 
 	/**

--- a/includes/Handlers/WhatsAppExtension.php
+++ b/includes/Handlers/WhatsAppExtension.php
@@ -178,6 +178,30 @@ class WhatsAppExtension {
 			);
 			return;
 		}
+
+		// Suppress customer_events calls for installs Meta has confirmed are not
+		// onboarded (no integration config). These calls are dropped server-side
+		// anyway, but only after they have counted against the shared per-app
+		// rate-limit quota, so suppressing them here is what actually reduces
+		// throttling. Fail open while the onboarding state is UNKNOWN so a
+		// legitimately onboarded store is never blocked; the Meta server-side
+		// validator stays as the correctness backstop. Gated by a rollout switch
+		// so Meta can pause the behavior remotely.
+		$rollout_switches = facebook_for_woocommerce()->get_rollout_switches();
+		if (
+			$rollout_switches->is_switch_enabled( RolloutSwitches::SWITCH_WA_CUSTOMER_EVENTS_GATING_ENABLED )
+			&& WhatsAppConnection::ONBOARDING_STATE_INCOMPLETE === $whatsapp_connection->get_onboarding_state()
+		) {
+			wc_get_logger()->info(
+				sprintf(
+				/* translators: %s $order_id */
+					__( 'Customer Events Post API call for Order id %1$s skipped: WhatsApp onboarding not complete.', 'facebook-for-woocommerce' ),
+					$order_id,
+				)
+			);
+			return;
+		}
+
 		$wa_installation_id = $whatsapp_connection->get_wa_installation_id();
 		$base_url           = array( self::BASE_STEFI_ENDPOINT_URL, 'whatsapp/business', $wa_installation_id, 'customer_events' );
 		$base_url           = esc_url( implode( '/', $base_url ) );

--- a/includes/Handlers/WhatsAppExtension.php
+++ b/includes/Handlers/WhatsAppExtension.php
@@ -274,6 +274,77 @@ class WhatsAppExtension {
 	}
 
 	/**
+	 * Backfills the onboarding-complete flag for installs that connected before
+	 * the WA_CONNECT push signal existed (the pull path, run from the upgrade hook).
+	 *
+	 * Asks Meta's HEAD existence endpoint whether an integration config exists
+	 * for this installation and persists the answer once:
+	 *  - 200 → onboarding complete
+	 *  - 404 → onboarding incomplete
+	 *
+	 * Skips when the state is already known (completion is monotonic, so this
+	 * never re-polls) or the store is not connected. Fails open on any
+	 * transport/HTTP error, leaving the state UNKNOWN so the customer_events
+	 * gate keeps sending and Meta's server-side validator remains the backstop.
+	 *
+	 * @since 3.7.5
+	 *
+	 * @param \WC_Facebookcommerce $plugin The plugin instance.
+	 * @return void
+	 */
+	public static function maybe_backfill_onboarding_state( $plugin ): void {
+		$whatsapp_connection = $plugin->get_whatsapp_connection_handler();
+
+		// Completion is monotonic — once known, never re-poll.
+		if ( WhatsAppConnection::ONBOARDING_STATE_UNKNOWN !== $whatsapp_connection->get_onboarding_state() ) {
+			return;
+		}
+
+		if ( ! $whatsapp_connection->is_connected() ) {
+			return;
+		}
+
+		$wa_installation_id = $whatsapp_connection->get_wa_installation_id();
+		if ( empty( $wa_installation_id ) ) {
+			return;
+		}
+
+		$url = array( self::BASE_STEFI_ENDPOINT_URL, 'whatsapp/business/message_integrations/installations', $wa_installation_id, 'integration_config' );
+		$url = esc_url_raw( implode( '/', $url ) );
+
+		$response = wp_remote_request(
+			$url,
+			array(
+				'method'  => 'HEAD',
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $whatsapp_connection->get_access_token(),
+				),
+				'timeout' => 30,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			// Fail open: leave state UNKNOWN so the gate keeps sending.
+			wc_get_logger()->info(
+				sprintf(
+					/* translators: %s error message */
+					__( 'WhatsApp onboarding backfill HEAD request failed: %s', 'facebook-for-woocommerce' ),
+					$response->get_error_message(),
+				)
+			);
+			return;
+		}
+
+		$status_code = wp_remote_retrieve_response_code( $response );
+		if ( 200 === $status_code ) {
+			$whatsapp_connection->set_onboarding_complete( true );
+		} elseif ( 404 === $status_code ) {
+			$whatsapp_connection->set_onboarding_complete( false );
+		}
+		// Any other status: fail open, leave UNKNOWN.
+	}
+
+	/**
 	 * Build the rich_order_status array from order metadata.
 	 *
 	 * @param array $order_metadata The order metadata containing order details.

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -13,6 +13,7 @@ namespace WooCommerce\Facebook;
 defined( 'ABSPATH' ) || exit;
 
 use WooCommerce\Facebook\ProductSets\LegacyProductSetMigration;
+use WooCommerce\Facebook\Handlers\WhatsAppExtension;
 
 /**
  * The Meta for WooCommerce plugin lifecycle handler.
@@ -59,6 +60,7 @@ class Lifecycle extends Framework\Lifecycle {
 			'3.5.3',
 			'3.5.4',
 			'3.5.6',
+			'3.7.5',
 		);
 	}
 
@@ -388,5 +390,16 @@ class Lifecycle extends Framework\Lifecycle {
 	 */
 	protected function upgrade_to_3_5_6() {
 		LegacyProductSetMigration::migrate_legacy_fb_product_sets();
+	}
+
+	/**
+	 * Backfill the WhatsApp onboarding-complete flag for installs that connected
+	 * before the WA_CONNECT push signal existed (the pull path). One-time HEAD
+	 * existence check; fails open on error.
+	 *
+	 * @since 3.7.5
+	 */
+	protected function upgrade_to_3_7_5() {
+		WhatsAppExtension::maybe_backfill_onboarding_state( facebook_for_woocommerce() );
 	}
 }

--- a/includes/RolloutSwitches.php
+++ b/includes/RolloutSwitches.php
@@ -36,6 +36,7 @@ class RolloutSwitches {
 	public const SWITCH_BLOCK_CAPI_ON_INVALID_TOKEN      = 'enable_woocommerce_block_capi_on_invalid_token';
 	private const SETTINGS_KEY                           = 'wc_facebook_for_woocommerce_rollout_switches';
 	public const CAPI_EVENT_LOGGING_ENABLED              = 'enable_woocommerce_capi_event_logging';
+	public const SWITCH_WA_CUSTOMER_EVENTS_GATING_ENABLED = 'enable_woocommerce_wa_customer_events_gating';
 
 	private const ACTIVE_SWITCHES = array(
 		self::SWITCH_ROLLOUT_FEATURES,
@@ -48,6 +49,7 @@ class RolloutSwitches {
 		self::SWITCH_ISOLATED_PIXEL_EXECUTION_ENABLED,
 		self::SWITCH_COMPAT_CHECK_ENABLED,
 		self::SWITCH_BLOCK_CAPI_ON_INVALID_TOKEN,
+		self::SWITCH_WA_CUSTOMER_EVENTS_GATING_ENABLED,
 	);
 
 	public function __construct( \WC_Facebookcommerce $plugin ) {

--- a/tests/Unit/Admin/WhatsApp_Integration_SettingsTest.php
+++ b/tests/Unit/Admin/WhatsApp_Integration_SettingsTest.php
@@ -28,6 +28,13 @@ class WhatsApp_Integration_SettingsTest extends AbstractWPUnitTestWithOptionIsol
         $this->assertStringContainsString( 'whatsAppAPI.uninstallWhatsAppSettings', $output );
     }
 
+    public function test_render_message_handler_handles_wa_connect_onboarding_complete() {
+        $output = $this->build_settings()->generate_inline_enhanced_onboarding_script();
+
+        $this->assertStringContainsString( 'CommerceExtension::WA_CONNECT', $output );
+        $this->assertStringContainsString( 'whatsAppAPI.notifyWhatsAppOnboardingComplete', $output );
+    }
+
     public function test_render_message_handler_enforces_origin_allowlist() {
         $output = $this->build_settings()->generate_inline_enhanced_onboarding_script();
 

--- a/tests/Unit/Api/Plugin/WhatsAppSettings/HandlerTest.php
+++ b/tests/Unit/Api/Plugin/WhatsAppSettings/HandlerTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Unit tests for the WhatsApp Settings REST handler onboarding-complete push endpoint.
+ */
+
+namespace WooCommerce\Facebook\Tests\API\Plugin\WhatsAppSettings;
+
+use WooCommerce\Facebook\API\Plugin\WhatsAppSettings\Handler;
+use WooCommerce\Facebook\API\Plugin\WhatsAppSettings\OnboardingComplete\Request as OnboardingCompleteRequest;
+use WooCommerce\Facebook\Handlers\WhatsAppConnection;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+
+/**
+ * Covers the WA_CONNECT push endpoint that marks onboarding complete.
+ *
+ * @package WooCommerce\Facebook\Tests\Unit\API\Plugin\WhatsAppSettings
+ */
+class HandlerTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+	public function test_handle_onboarding_complete_marks_onboarding_complete() {
+		// Precondition: not yet onboarded.
+		$connection = facebook_for_woocommerce()->get_whatsapp_connection_handler();
+		$this->assertFalse( $connection->is_onboarding_complete() );
+
+		$response = ( new Handler() )->handle_onboarding_complete( new \WP_REST_Request( 'POST' ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertTrue( $connection->is_onboarding_complete() );
+	}
+
+	public function test_onboarding_complete_request_js_definition() {
+		$request = new OnboardingCompleteRequest( new \WP_REST_Request( 'POST' ) );
+
+		$this->assertSame( 'whatsapp_settings/onboarding_complete', $request->get_endpoint() );
+		$this->assertSame( 'POST', $request->get_method() );
+		$this->assertSame( 'notifyWhatsAppOnboardingComplete', $request->get_js_function_name() );
+		$this->assertTrue( OnboardingCompleteRequest::is_js_exposable() );
+	}
+}

--- a/tests/Unit/Handlers/WhatsAppConnectionTest.php
+++ b/tests/Unit/Handlers/WhatsAppConnectionTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Unit tests for WhatsAppConnection onboarding-state reader.
+ */
+
+namespace WooCommerce\Facebook\Tests\Handlers;
+
+use WooCommerce\Facebook\Handlers\WhatsAppConnection;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+
+/**
+ * Covers WhatsAppConnection::get_onboarding_state() — the tri-state reader the
+ * customer_events gate relies on.
+ *
+ * @package WooCommerce\Facebook\Tests\Unit\Handlers
+ */
+class WhatsAppConnectionTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+	private function build_connection(): WhatsAppConnection {
+		return new WhatsAppConnection( $this->createMock( \WC_Facebookcommerce::class ) );
+	}
+
+	public function test_onboarding_state_is_unknown_when_option_unset() {
+		$this->assertSame(
+			WhatsAppConnection::ONBOARDING_STATE_UNKNOWN,
+			$this->build_connection()->get_onboarding_state()
+		);
+	}
+
+	public function test_onboarding_state_complete_when_option_yes() {
+		$this->mock_set_option(
+			WhatsAppConnection::OPTION_WA_ONBOARDING_COMPLETE,
+			WhatsAppConnection::ONBOARDING_STATE_COMPLETE
+		);
+		$this->assertSame(
+			WhatsAppConnection::ONBOARDING_STATE_COMPLETE,
+			$this->build_connection()->get_onboarding_state()
+		);
+	}
+
+	public function test_onboarding_state_incomplete_when_option_no() {
+		$this->mock_set_option(
+			WhatsAppConnection::OPTION_WA_ONBOARDING_COMPLETE,
+			WhatsAppConnection::ONBOARDING_STATE_INCOMPLETE
+		);
+		$this->assertSame(
+			WhatsAppConnection::ONBOARDING_STATE_INCOMPLETE,
+			$this->build_connection()->get_onboarding_state()
+		);
+	}
+
+	/**
+	 * Any value that is not exactly 'yes' or 'no' must normalize to UNKNOWN so the
+	 * gate fails open rather than acting on a corrupt/legacy value.
+	 *
+	 * @dataProvider provider_garbage_values
+	 *
+	 * @param mixed $stored_value the raw stored option value
+	 */
+	public function test_onboarding_state_is_unknown_for_unexpected_values( $stored_value ) {
+		$this->mock_set_option( WhatsAppConnection::OPTION_WA_ONBOARDING_COMPLETE, $stored_value );
+		$this->assertSame(
+			WhatsAppConnection::ONBOARDING_STATE_UNKNOWN,
+			$this->build_connection()->get_onboarding_state()
+		);
+	}
+
+	public function provider_garbage_values(): array {
+		return array(
+			'empty string'  => array( '' ),
+			'numeric one'   => array( '1' ),
+			'arbitrary str' => array( 'maybe' ),
+			'boolean true'  => array( true ),
+		);
+	}
+}

--- a/tests/Unit/Handlers/WhatsAppConnectionTest.php
+++ b/tests/Unit/Handlers/WhatsAppConnectionTest.php
@@ -73,4 +73,23 @@ class WhatsAppConnectionTest extends AbstractWPUnitTestWithOptionIsolationAndSaf
 			'boolean true'  => array( true ),
 		);
 	}
+
+	public function test_set_onboarding_complete_true_marks_state_complete() {
+		$connection = $this->build_connection();
+		$connection->set_onboarding_complete( true );
+		$this->assertSame( WhatsAppConnection::ONBOARDING_STATE_COMPLETE, $connection->get_onboarding_state() );
+		$this->assertTrue( $connection->is_onboarding_complete() );
+	}
+
+	public function test_set_onboarding_complete_false_marks_state_incomplete() {
+		$connection = $this->build_connection();
+		$connection->set_onboarding_complete( false );
+		$this->assertSame( WhatsAppConnection::ONBOARDING_STATE_INCOMPLETE, $connection->get_onboarding_state() );
+		$this->assertFalse( $connection->is_onboarding_complete() );
+	}
+
+	public function test_is_onboarding_complete_is_false_when_state_unknown() {
+		// Unset option → state UNKNOWN → not complete (the gate fails open elsewhere).
+		$this->assertFalse( $this->build_connection()->is_onboarding_complete() );
+	}
 }

--- a/tests/Unit/Handlers/WhatsAppExtensionBackfillTest.php
+++ b/tests/Unit/Handlers/WhatsAppExtensionBackfillTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Unit tests for the WhatsApp onboarding-state HEAD backfill (pull path).
+ */
+
+namespace WooCommerce\Facebook\Tests\Handlers;
+
+use WooCommerce\Facebook\Handlers\WhatsAppConnection;
+use WooCommerce\Facebook\Handlers\WhatsAppExtension;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+
+/**
+ * Covers WhatsAppExtension::maybe_backfill_onboarding_state() — the upgrade-hook
+ * pull path that asks Meta's HEAD existence endpoint whether onboarding is
+ * complete for installs that connected before the push signal existed.
+ *
+ * @package WooCommerce\Facebook\Tests\Unit\Handlers
+ */
+class WhatsAppExtensionBackfillTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+	/** @var int HTTP status the stubbed HEAD endpoint returns. */
+	private $head_status = 200;
+
+	/** @var array recorded [url, method] of intercepted requests. */
+	private $requests = [];
+
+	/** @var bool whether to short-circuit HTTP with a WP_Error. */
+	private $return_wp_error = false;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->requests        = [];
+		$this->return_wp_error = false;
+
+		$this->add_filter_with_safe_teardown(
+			'pre_http_request',
+			function ( $pre, $args, $url ) {
+				$this->requests[] = [
+					'url'    => $url,
+					'method' => $args['method'] ?? 'GET',
+				];
+				if ( $this->return_wp_error ) {
+					return new \WP_Error( 'http_request_failed', 'boom' );
+				}
+				return array(
+					'response' => array( 'code' => $this->head_status ),
+					'body'     => '',
+				);
+			},
+			10,
+			3
+		);
+	}
+
+	private function connection(): WhatsAppConnection {
+		return facebook_for_woocommerce()->get_whatsapp_connection_handler();
+	}
+
+	private function connect(): void {
+		$this->mock_set_option( WhatsAppConnection::OPTION_WA_UTILITY_ACCESS_TOKEN, 'test-token' );
+		$this->mock_set_option( WhatsAppConnection::OPTION_WA_INSTALLATION_ID, '123456789' );
+	}
+
+	public function test_backfill_sets_complete_on_head_200() {
+		$this->connect();
+		$this->head_status = 200;
+
+		WhatsAppExtension::maybe_backfill_onboarding_state( facebook_for_woocommerce() );
+
+		$this->assertSame( WhatsAppConnection::ONBOARDING_STATE_COMPLETE, $this->connection()->get_onboarding_state() );
+		$this->assertCount( 1, $this->requests );
+		$this->assertSame( 'HEAD', $this->requests[0]['method'] );
+		$this->assertStringContainsString( 'message_integrations/installations/123456789/integration_config', $this->requests[0]['url'] );
+	}
+
+	public function test_backfill_sets_incomplete_on_head_404() {
+		$this->connect();
+		$this->head_status = 404;
+
+		WhatsAppExtension::maybe_backfill_onboarding_state( facebook_for_woocommerce() );
+
+		$this->assertSame( WhatsAppConnection::ONBOARDING_STATE_INCOMPLETE, $this->connection()->get_onboarding_state() );
+	}
+
+	public function test_backfill_leaves_unknown_on_error_fail_open() {
+		$this->connect();
+		$this->return_wp_error = true;
+
+		WhatsAppExtension::maybe_backfill_onboarding_state( facebook_for_woocommerce() );
+
+		$this->assertSame( WhatsAppConnection::ONBOARDING_STATE_UNKNOWN, $this->connection()->get_onboarding_state() );
+	}
+
+	public function test_backfill_skips_when_not_connected() {
+		// No token → not connected.
+		WhatsAppExtension::maybe_backfill_onboarding_state( facebook_for_woocommerce() );
+
+		$this->assertSame( WhatsAppConnection::ONBOARDING_STATE_UNKNOWN, $this->connection()->get_onboarding_state() );
+		$this->assertCount( 0, $this->requests, 'No HEAD request when not connected.' );
+	}
+
+	public function test_backfill_skips_when_state_already_known() {
+		$this->connect();
+		$this->mock_set_option( WhatsAppConnection::OPTION_WA_ONBOARDING_COMPLETE, WhatsAppConnection::ONBOARDING_STATE_COMPLETE );
+
+		WhatsAppExtension::maybe_backfill_onboarding_state( facebook_for_woocommerce() );
+
+		$this->assertCount( 0, $this->requests, 'No HEAD request when state already known (monotonic cache).' );
+		$this->assertSame( WhatsAppConnection::ONBOARDING_STATE_COMPLETE, $this->connection()->get_onboarding_state() );
+	}
+}

--- a/tests/Unit/Handlers/WhatsAppExtensionTest.php
+++ b/tests/Unit/Handlers/WhatsAppExtensionTest.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Unit tests for the WhatsApp customer_events onboarding gate.
+ */
+
+namespace WooCommerce\Facebook\Tests\Handlers;
+
+use WooCommerce\Facebook\Handlers\WhatsAppConnection;
+use WooCommerce\Facebook\Handlers\WhatsAppExtension;
+use WooCommerce\Facebook\RolloutSwitches;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+
+/**
+ * Covers WhatsAppExtension::process_whatsapp_utility_message_event() — specifically
+ * the gate that suppresses customer_events POSTs for stores Meta has confirmed are
+ * not onboarded, behind the SWITCH_WA_CUSTOMER_EVENTS_GATING_ENABLED rollout switch.
+ *
+ * @package WooCommerce\Facebook\Tests\Unit\Handlers
+ */
+class WhatsAppExtensionTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+	/**
+	 * URLs an outbound HTTP request was attempted against during the test.
+	 *
+	 * @var string[]
+	 */
+	private $http_requests = [];
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->http_requests = [];
+
+		// Intercept all outbound HTTP: record the URL and short-circuit with a fake 200
+		// so we can assert whether a customer_events POST was attempted.
+		$this->add_filter_with_safe_teardown(
+			'pre_http_request',
+			function ( $pre, $args, $url ) {
+				$this->http_requests[] = $url;
+				return array(
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'body'     => '{}',
+				);
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Sets the rollout switch state by writing the option RolloutSwitches reads.
+	 * The switch is active (in ACTIVE_SWITCHES), so the stored value decides on/off.
+	 */
+	private function set_gating_switch( bool $enabled ): void {
+		$this->mock_set_option(
+			'wc_facebook_for_woocommerce_rollout_switches',
+			array( RolloutSwitches::SWITCH_WA_CUSTOMER_EVENTS_GATING_ENABLED => $enabled ? 'yes' : 'no' )
+		);
+	}
+
+	/**
+	 * Builds a plugin mock whose connection handler reports the given connection
+	 * and onboarding state.
+	 */
+	private function build_plugin( bool $is_connected, string $onboarding_state ): \WC_Facebookcommerce {
+		$connection = $this->getMockBuilder( WhatsAppConnection::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'is_connected', 'get_onboarding_state', 'get_wa_installation_id', 'get_access_token' ) )
+			->getMock();
+		$connection->method( 'is_connected' )->willReturn( $is_connected );
+		$connection->method( 'get_onboarding_state' )->willReturn( $onboarding_state );
+		$connection->method( 'get_wa_installation_id' )->willReturn( '123456789' );
+		$connection->method( 'get_access_token' )->willReturn( 'test-token' );
+
+		$plugin = $this->getMockBuilder( \WC_Facebookcommerce::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_whatsapp_connection_handler' ) )
+			->getMock();
+		$plugin->method( 'get_whatsapp_connection_handler' )->willReturn( $connection );
+
+		return $plugin;
+	}
+
+	private function fire_order_placed_event( \WC_Facebookcommerce $plugin ): void {
+		WhatsAppExtension::process_whatsapp_utility_message_event(
+			$plugin,
+			'ORDER_PLACED',
+			'123',
+			'https://example.com/order/123',
+			'15551234567',
+			'Jane',
+			0,
+			'USD',
+			'US'
+		);
+	}
+
+	/**
+	 * @return string[] recorded request URLs that targeted the customer_events endpoint
+	 */
+	private function customer_events_requests(): array {
+		return array_values(
+			array_filter(
+				$this->http_requests,
+				static function ( $url ) {
+					return false !== strpos( (string) $url, 'customer_events' );
+				}
+			)
+		);
+	}
+
+	/** Switch OFF + INCOMPLETE: gate is inert, the event still POSTs. */
+	public function test_gate_disabled_sends_even_when_onboarding_incomplete() {
+		$this->set_gating_switch( false );
+		$this->fire_order_placed_event(
+			$this->build_plugin( true, WhatsAppConnection::ONBOARDING_STATE_INCOMPLETE )
+		);
+		$this->assertCount( 1, $this->customer_events_requests(), 'Switch off: customer_events should still be sent.' );
+	}
+
+	/** Switch ON + INCOMPLETE: the event is suppressed. */
+	public function test_gate_enabled_suppresses_when_onboarding_incomplete() {
+		$this->set_gating_switch( true );
+		$this->fire_order_placed_event(
+			$this->build_plugin( true, WhatsAppConnection::ONBOARDING_STATE_INCOMPLETE )
+		);
+		$this->assertCount( 0, $this->customer_events_requests(), 'Switch on + INCOMPLETE: customer_events should be suppressed.' );
+	}
+
+	/** Switch ON + COMPLETE: the event POSTs. */
+	public function test_gate_enabled_sends_when_onboarding_complete() {
+		$this->set_gating_switch( true );
+		$this->fire_order_placed_event(
+			$this->build_plugin( true, WhatsAppConnection::ONBOARDING_STATE_COMPLETE )
+		);
+		$this->assertCount( 1, $this->customer_events_requests(), 'Switch on + COMPLETE: customer_events should be sent.' );
+	}
+
+	/** Switch ON + UNKNOWN: fail open, the event POSTs. */
+	public function test_gate_enabled_fails_open_when_onboarding_unknown() {
+		$this->set_gating_switch( true );
+		$this->fire_order_placed_event(
+			$this->build_plugin( true, WhatsAppConnection::ONBOARDING_STATE_UNKNOWN )
+		);
+		$this->assertCount( 1, $this->customer_events_requests(), 'Switch on + UNKNOWN: should fail open and send.' );
+	}
+
+	/** Not connected: nothing is sent (pre-existing behavior, regression guard). */
+	public function test_not_connected_sends_nothing() {
+		$this->set_gating_switch( true );
+		$this->fire_order_placed_event(
+			$this->build_plugin( false, WhatsAppConnection::ONBOARDING_STATE_COMPLETE )
+		);
+		$this->assertCount( 0, $this->customer_events_requests(), 'Not connected: no customer_events request.' );
+	}
+}

--- a/tests/Unit/RolloutSwitchesTest.php
+++ b/tests/Unit/RolloutSwitchesTest.php
@@ -141,6 +141,63 @@ class RolloutSwitchesTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTest
 		$this->assertContains(RolloutSwitches::SWITCH_MULTIPLE_IMAGES_ENABLED, $active_switches);
 	}
 
+	public function test_wa_customer_events_gating_switch_constant_exists() {
+		$this->assertTrue(defined('WooCommerce\Facebook\RolloutSwitches::SWITCH_WA_CUSTOMER_EVENTS_GATING_ENABLED'));
+		$this->assertEquals('enable_woocommerce_wa_customer_events_gating', RolloutSwitches::SWITCH_WA_CUSTOMER_EVENTS_GATING_ENABLED);
+	}
+
+	public function test_wa_customer_events_gating_switch_in_active_switches() {
+		$plugin = facebook_for_woocommerce();
+		$rollout_switches = new RolloutSwitches($plugin);
+
+		// Test that the WA customer_events gating switch is in the active switches list
+		$active_switches = $rollout_switches->get_active_switches();
+		$this->assertContains(RolloutSwitches::SWITCH_WA_CUSTOMER_EVENTS_GATING_ENABLED, $active_switches);
+	}
+
+	public function test_wa_customer_events_gating_switch_behavior() {
+		// mock the active filters to test the WA customer_events gating switch behavior
+		$plugin = facebook_for_woocommerce();
+		$plugin_ref_obj = new ReflectionObject($plugin);
+
+		// setup connection handler
+		$prop_connection_handler = $plugin_ref_obj->getProperty('connection_handler');
+		$prop_connection_handler->setAccessible(true);
+		$mock_connection_handler = $this->getMockBuilder('stdClass')
+			->addMethods(array('get_external_business_id', 'is_connected', 'get_access_token'))
+			->getMock();
+		$mock_connection_handler->expects($this->any())->method('get_external_business_id')->willReturn($this->external_business_id);
+		$mock_connection_handler->expects($this->any())->method('get_access_token')->willReturn($this->access_token);
+		$mock_connection_handler->expects($this->any())->method('is_connected')->willReturn(true);
+		$prop_connection_handler->setValue($plugin, $mock_connection_handler);
+
+		// setup API to return the switch as enabled
+		$prop_api = $plugin_ref_obj->getProperty('api');
+		$prop_api->setAccessible(true);
+		$mock_api = $this->getMockBuilder(API::class)->disableOriginalConstructor()->setMethods(array('do_remote_request'))->getMock();
+		$mock_api->expects($this->any())->method('do_remote_request')->willReturn(
+			array('body' => wp_json_encode(array(
+				'data' => array(
+					array('switch' => RolloutSwitches::SWITCH_WA_CUSTOMER_EVENTS_GATING_ENABLED, 'enabled' => '1'),
+				)
+			)))
+		);
+		$prop_api->setValue($plugin, $mock_api);
+
+		$switch_mock = $this->getMockBuilder(RolloutSwitches::class)
+			->setConstructorArgs(array($plugin))
+			->onlyMethods(['is_switch_active'])
+			->getMock();
+		$switch_mock->expects($this->any())->method('is_switch_active')
+			->willReturnCallback(function($switch_name) {
+				return $switch_name === RolloutSwitches::SWITCH_WA_CUSTOMER_EVENTS_GATING_ENABLED;
+			});
+		$switch_mock->init();
+
+		// Enabled in the response -> enabled.
+		$this->assertTrue($switch_mock->is_switch_enabled(RolloutSwitches::SWITCH_WA_CUSTOMER_EVENTS_GATING_ENABLED));
+	}
+
 	public function test_multiple_images_switch_behavior() {
 		// mock the active filters to test multiple images switch behavior
 		$plugin = facebook_for_woocommerce();


### PR DESCRIPTION
## Description

The plugin POSTs `customer_events` to Meta on every mapped order-status change, gated only on `is_connected()` ("an access token exists"). But a store can hold a token *before* onboarding is complete (before Meta has an integration config for it). In that pre-onboarding window the plugin keeps sending; Meta drops those requests server-side, but the shared per-app Stefi rate-limit counter has already ticked (it keys on `(endpoint, app_id)` and counts at request receipt). That wasted, pre-onboarding traffic is **~47% of WooCommerce `customer_events` volume** and burns shared throttle quota for all WooCommerce stores.

This PR adds a **client-side gate** that skips the POST when Meta has confirmed the store is not onboarded, plus the machinery to know that state — behind a remotely-controlled rollout switch so Meta can ramp/pause it.

"Onboarding complete" = a Meta integration config exists for the installation. WooCommerce can't see Meta's state, so Meta hands the plugin the signal two ways, and the plugin stores and gates on it:

- **Push (new connects):** A `CommerceExtension::WA_CONNECT` postMessage from the onboarding iframe → a listener calls a REST route → flag set. Zero polling.
- **Pull (existing installs):** A one-time upgrade-hook HEAD to Meta's installations `integration_config` existence endpoint → `200` = complete, `404` = incomplete. Backfills stores that connected before the push signal existed.

### What's in this PR (7 commits)

#### Gate + read path + switch

1. **Read path** — `WhatsAppConnection::get_onboarding_state()`, a tri-state (`yes`/`no`/`unknown`) reader over a new `wc_facebook_wa_onboarding_complete` option; unexpected/legacy values normalize to `unknown`.
2. **Rollout switch** — `SWITCH_WA_CUSTOMER_EVENTS_GATING_ENABLED` (`enable_woocommerce_wa_customer_events_gating`) registered in `ACTIVE_SWITCHES`.
3. **Gate** — In `WhatsAppExtension::process_whatsapp_utility_message_event()`, skip the POST only when the switch is **ON** and onboarding state is `no`. States `yes`/`unknown` still send (fail open), so onboarded stores are never blocked and Meta's server-side validator stays the correctness backstop.

#### Onboarding-complete writers

4. **W1 — Writers + clear-on-uninstall:** `set_onboarding_complete(bool)` / `is_onboarding_complete()`; the flag is cleared on integration uninstall.
5. **W2 — Push path:** A JS-exposable `OnboardingComplete` REST request (`POST whatsapp_settings/onboarding_complete`, no payload) + handler that sets the flag, registered so the plugin's JS client exposes `notifyWhatsAppOnboardingComplete()`; a `CommerceExtension::WA_CONNECT` branch in the iframe message handler (behind the existing `ALLOWED_ORIGINS` check) that calls it.
6. **W3 — Pull path:** `WhatsAppExtension::maybe_backfill_onboarding_state()` (HEAD `200`→complete / `404`→incomplete; monotonic — never re-polls once known; fails open on error), wired into `Lifecycle::upgrade_to_3_7_5()`.

### Dependencies / Rollout notes

- Requires the Meta-side changes (HEAD existence endpoint + `WA_CONNECT` postMessage + server-side switch registration, defaulted off) — deployed.
- The W3 backfill only runs once `PLUGIN_VERSION` is bumped to `3.7.5` at release.
- **No behavior change on merge:** fully fail-open, and inert until the switch is ramped (served explicitly `false` until then).
- Related: T239535773

### Type of change

- **Add** (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow [this wiki](https://fburl.com/wiki/2cgfduwc).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentation (if necessary). Meta employees to follow [this wiki](https://fburl.com/wiki/nhx73tgs).
  > N/A — no user-facing docs; behavior is remote-config-gated and inert until ramp.

## Changelog entry

**Add** – Gate WhatsApp `customer_events` API calls on onboarding completion (behind a rollout switch), with `WA_CONNECT` push + upgrade-hook backfill to persist onboarding state, to cut pre-onboarding request volume.

## Test Plan

### Automated (unit)

`composer test-unit` (or CI `php-unit-tests.yml`, PHP 7.4 + 8.4). Full suite green: **2019 tests.** Key coverage:

| Test file | Coverage |
|-----------|----------|
| `WhatsAppConnectionTest` | Read path (`get_onboarding_state` yes/no/unknown normalization) + writers (`set_onboarding_complete` → COMPLETE/INCOMPLETE, `is_onboarding_complete`) |
| `WhatsAppExtensionTest` | Gate matrix via `pre_http_request`: OFF+no→sent, ON+no→suppressed, ON+yes→sent, ON+unknown→sent (fail open), not-connected→no send |
| `RolloutSwitchesTest` | Switch constant, `ACTIVE_SWITCHES`, enabled-from-response |
| `Api/Plugin/WhatsAppSettings/HandlerTest` | `handle_onboarding_complete()` sets flag + 200; `OnboardingComplete` request JS definition |
| `Admin/WhatsApp_Integration_SettingsTest` | `WA_CONNECT` branch + `notifyWhatsAppOnboardingComplete` in the message handler |
| `Handlers/WhatsAppExtensionBackfillTest` | HEAD 200→complete, 404→incomplete, error→fail-open, not-connected/already-known→skip |

### Manual (Local by Flywheel)

Simulated state via `wp option` / `wp eval` and triggered real order-status changes, verifying via `plugin-facebook-for-woocommerce-*.log`:

- **Gate matrix:** OFF→sent; ON+no→*skipped: WhatsApp onboarding not complete.*; ON+yes→sent; ON+unknown→sent (fail open); not connected→*Failed due to failed connection.*
- **Writers → gate integration** (same order, only the flag changed): `set_onboarding_complete(false)` → skipped; `set_onboarding_complete(true)` → attempted.
- **REST route** (`rest_do_request`) → 200 + flag set; non-admin → 401/403.
- **W3 backfill** via `wp eval` → state set from the real HEAD call; fail-open on error; monotonic skip.

**Config:** WP + WooCommerce (latest), PHP 8.5 CLI locally (unit run uses `convertDeprecationsToExceptions=false` to avoid the PHP 8.5 `setAccessible` deprecation; CI runs PHP 8.4).

## Screenshots

Log-based (no UI). Same order #26, only the onboarding flag changed:

**Gate blocks — switch ON + state `no`:**

```
INFO Processing Order id 26 to send Whatsapp Utility messages
INFO Customer Events Post API call for Order id 26 skipped: WhatsApp onboarding not complete.
```

**Gate sends — switch ON + state `yes`:**

```
INFO Processing Order id 26 to send Whatsapp Utility messages
INFO Customer Events Post API call for Order id 26 Failed Authentication Error
```

> *`Failed Authentication Error` = sent with the local test token; a genuinely onboarded store logs `Succeeded.`*