### PR TITLE
[2/2] Add WhatsApp onboarding-complete writers

### DIFF
--- a/includes/API/Plugin/Controller.php
+++ b/includes/API/Plugin/Controller.php
@@ -37,6 +37,7 @@ class Controller {
 		'WooCommerce\Facebook\API\Plugin\Settings\Uninstall\Request',
 		'WooCommerce\Facebook\API\Plugin\WhatsAppSettings\Update\Request',
 		'WooCommerce\Facebook\API\Plugin\WhatsAppSettings\Uninstall\Request',
+		'WooCommerce\Facebook\API\Plugin\WhatsAppSettings\OnboardingComplete\Request',
 		// Add other JS-enabled request classes here
 	];
 

--- a/includes/API/Plugin/WhatsAppSettings/Handler.php
+++ b/includes/API/Plugin/WhatsAppSettings/Handler.php
@@ -14,6 +14,7 @@ use WooCommerce\Facebook\API\Plugin\AbstractRESTEndpoint;
 use WooCommerce\Facebook\API\Plugin\WhatsAppSettings\Update\Request as UpdateRequest;
 use WooCommerce\Facebook\API\Plugin\WhatsAppSettings\UpdateIntegrationConfig\Request as UpdateIntegrationConfigRequest;
 use WooCommerce\Facebook\API\Plugin\WhatsAppSettings\Uninstall\Request as UninstallRequest;
+use WooCommerce\Facebook\API\Plugin\WhatsAppSettings\OnboardingComplete\Request as OnboardingCompleteRequest;
 use WooCommerce\Facebook\Handlers\WhatsAppConnection;
 
 defined( 'ABSPATH' ) || exit;
@@ -62,6 +63,68 @@ class Handler extends AbstractRESTEndpoint {
 				'permission_callback' => [ $this, 'permission_callback' ],
 			]
 		);
+
+		register_rest_route(
+			$this->get_namespace(),
+			'whatsapp_settings/onboarding_complete',
+			[
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'handle_onboarding_complete' ],
+				'permission_callback' => [ $this, 'permission_callback' ],
+			]
+		);
+	}
+
+	/**
+	 * Handle the onboarding-complete push signal (WA_CONNECT).
+	 *
+	 * Persists that WhatsApp onboarding finished so the customer_events gate
+	 * stops treating this install as pre-onboarding. Reaching this endpoint is
+	 * itself the signal, so it carries no payload.
+	 *
+	 * @since 3.7.5
+	 * @http_method POST
+	 * @description Mark WhatsApp onboarding as complete
+	 *
+	 * @param \WP_REST_Request $wp_request The WordPress request object.
+	 * @return \WP_REST_Response
+	 */
+	public function handle_onboarding_complete( \WP_REST_Request $wp_request ): \WP_REST_Response {
+		try {
+			$request           = new OnboardingCompleteRequest( $wp_request );
+			$validation_result = $request->validate();
+
+			if ( is_wp_error( $validation_result ) ) {
+				return $this->error_response(
+					$validation_result->get_error_message(),
+					400
+				);
+			}
+
+			facebook_for_woocommerce()->get_whatsapp_connection_handler()->set_onboarding_complete( true );
+
+			wc_get_logger()->info(
+				__( 'WhatsApp onboarding marked complete via WA_CONNECT push signal.', 'facebook-for-woocommerce' ),
+			);
+
+			return $this->success_response(
+				[
+					'message' => __( 'WhatsApp onboarding marked complete', 'facebook-for-woocommerce' ),
+				]
+			);
+		} catch ( \Exception $e ) {
+			wc_get_logger()->info(
+				sprintf(
+					/* translators: %s $error_message */
+					__( 'Failed to handle_onboarding_complete for WhatsApp Utility Messages Integration. Exception: %s', 'facebook-for-woocommerce' ),
+					$e->getMessage(),
+				)
+			);
+			return $this->error_response(
+				$e->getMessage(),
+				500
+			);
+		}
 	}
 
 	/**

--- a/includes/API/Plugin/WhatsAppSettings/Handler.php
+++ b/includes/API/Plugin/WhatsAppSettings/Handler.php
@@ -235,6 +235,7 @@ class Handler extends AbstractRESTEndpoint {
 			WhatsAppConnection::OPTION_WA_WABA_ID,
 			WhatsAppConnection::OPTION_WA_PHONE_NUMBER_ID,
 			WhatsAppConnection::OPTION_WA_INTEGRATION_CONFIG_ID,
+			WhatsAppConnection::OPTION_WA_ONBOARDING_COMPLETE,
 		];
 
 		foreach ( $options as $option ) {

--- a/includes/API/Plugin/WhatsAppSettings/OnboardingComplete/Request.php
+++ b/includes/API/Plugin/WhatsAppSettings/OnboardingComplete/Request.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package MetaCommerce
+ */
+
+namespace WooCommerce\Facebook\API\Plugin\WhatsAppSettings\OnboardingComplete;
+
+use WooCommerce\Facebook\API\Plugin\Request as RESTRequest;
+use WooCommerce\Facebook\API\Plugin\Traits\JS_Exposable;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WhatsApp Settings Onboarding-Complete REST API Request.
+ *
+ * Backs the WA_CONNECT push signal: the onboarding iframe posts a
+ * "connection complete" message to the parent, whose JS handler calls this
+ * endpoint so the plugin can persist that onboarding finished (the write side
+ * of the customer_events gate's onboarding flag). The signal carries no
+ * payload — reaching this endpoint means "onboarding complete" — so there are
+ * no parameters.
+ *
+ * @since 3.7.5
+ */
+class Request extends RESTRequest {
+
+	use JS_Exposable;
+
+	/**
+	 * Gets the API endpoint for this request.
+	 *
+	 * @since 3.7.5
+	 *
+	 * @return string
+	 */
+	public function get_endpoint() {
+		return 'whatsapp_settings/onboarding_complete';
+	}
+
+	/**
+	 * Gets the HTTP method for this request.
+	 *
+	 * @since 3.7.5
+	 *
+	 * @return string
+	 */
+	public function get_method() {
+		return 'POST';
+	}
+
+	/**
+	 * Gets the parameter schema for this request.
+	 *
+	 * @since 3.7.5
+	 *
+	 * @return array Array of parameters with their types and whether they're required
+	 */
+	public function get_param_schema() {
+		return [
+			// No parameters: reaching this endpoint means onboarding is complete.
+		];
+	}
+
+	/**
+	 * Gets the JavaScript function name for this request.
+	 *
+	 * @since 3.7.5
+	 *
+	 * @return string
+	 */
+	public function get_js_function_name() {
+		return 'notifyWhatsAppOnboardingComplete';
+	}
+
+	/**
+	 * Validate the request.
+	 *
+	 * @since 3.7.5
+	 *
+	 * @return true|\WP_Error True if valid, WP_Error otherwise.
+	 */
+	public function validate() {
+		// No parameters to validate.
+		return true;
+	}
+}

--- a/includes/Admin/WhatsApp_Integration_Settings.php
+++ b/includes/Admin/WhatsApp_Integration_Settings.php
@@ -325,6 +325,18 @@ class WhatsApp_Integration_Settings {
 						});
 				}
 
+				if (messageEvent === 'CommerceExtension::WA_CONNECT' && message.success) {
+					whatsAppAPI.notifyWhatsAppOnboardingComplete()
+						.then(function(response) {
+							if (!response.success) {
+								console.error('Error marking WhatsApp onboarding complete:', response);
+							}
+						})
+						.catch(function(error) {
+							console.error('Error during onboarding-complete notify:', error);
+						});
+				}
+
 				if (messageEvent === 'CommerceExtension::WA_RESIZE') {
 					const iframe = document.getElementById('facebook-whatsapp-iframe-enhanced');
 					if ( iframe ) {

--- a/includes/Handlers/WhatsAppConnection.php
+++ b/includes/Handlers/WhatsAppConnection.php
@@ -132,6 +132,41 @@ class WhatsAppConnection {
 	}
 
 	/**
+	 * Stores the WhatsApp onboarding completion state.
+	 *
+	 * Written by the onboarding signal handlers: the WA_CONNECT postMessage
+	 * listener (push, new connects) and the upgrade-hook HEAD backfill (pull,
+	 * existing installs). Maps the boolean to the tri-state option the
+	 * customer_events gate reads via get_onboarding_state():
+	 *  - true  → COMPLETE   ('yes')
+	 *  - false → INCOMPLETE  ('no')
+	 *
+	 * @since 3.7.5
+	 *
+	 * @param bool $complete whether Meta has confirmed onboarding is complete
+	 */
+	public function set_onboarding_complete( bool $complete ): void {
+		update_option(
+			self::OPTION_WA_ONBOARDING_COMPLETE,
+			$complete ? self::ONBOARDING_STATE_COMPLETE : self::ONBOARDING_STATE_INCOMPLETE
+		);
+	}
+
+	/**
+	 * Determines whether WhatsApp onboarding is known to be complete.
+	 *
+	 * Only COMPLETE counts as complete; UNKNOWN returns false so callers do not
+	 * treat a not-yet-determined install as onboarded.
+	 *
+	 * @since 3.7.5
+	 *
+	 * @return bool
+	 */
+	public function is_onboarding_complete(): bool {
+		return self::ONBOARDING_STATE_COMPLETE === $this->get_onboarding_state();
+	}
+
+	/**
 	 * Gets the stored whatsapp external ID.
 	 *
 	 * @since 2.0.0

--- a/includes/Handlers/WhatsAppExtension.php
+++ b/includes/Handlers/WhatsAppExtension.php
@@ -274,6 +274,77 @@ class WhatsAppExtension {
 	}
 
 	/**
+	 * Backfills the onboarding-complete flag for installs that connected before
+	 * the WA_CONNECT push signal existed (the pull path, run from the upgrade hook).
+	 *
+	 * Asks Meta's HEAD existence endpoint whether an integration config exists
+	 * for this installation and persists the answer once:
+	 *  - 200 → onboarding complete
+	 *  - 404 → onboarding incomplete
+	 *
+	 * Skips when the state is already known (completion is monotonic, so this
+	 * never re-polls) or the store is not connected. Fails open on any
+	 * transport/HTTP error, leaving the state UNKNOWN so the customer_events
+	 * gate keeps sending and Meta's server-side validator remains the backstop.
+	 *
+	 * @since 3.7.5
+	 *
+	 * @param \WC_Facebookcommerce $plugin The plugin instance.
+	 * @return void
+	 */
+	public static function maybe_backfill_onboarding_state( $plugin ): void {
+		$whatsapp_connection = $plugin->get_whatsapp_connection_handler();
+
+		// Completion is monotonic — once known, never re-poll.
+		if ( WhatsAppConnection::ONBOARDING_STATE_UNKNOWN !== $whatsapp_connection->get_onboarding_state() ) {
+			return;
+		}
+
+		if ( ! $whatsapp_connection->is_connected() ) {
+			return;
+		}
+
+		$wa_installation_id = $whatsapp_connection->get_wa_installation_id();
+		if ( empty( $wa_installation_id ) ) {
+			return;
+		}
+
+		$url = array( self::BASE_STEFI_ENDPOINT_URL, 'whatsapp/business/message_integrations/installations', $wa_installation_id, 'integration_config' );
+		$url = esc_url_raw( implode( '/', $url ) );
+
+		$response = wp_remote_request(
+			$url,
+			array(
+				'method'  => 'HEAD',
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $whatsapp_connection->get_access_token(),
+				),
+				'timeout' => 30,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			// Fail open: leave state UNKNOWN so the gate keeps sending.
+			wc_get_logger()->info(
+				sprintf(
+					/* translators: %s error message */
+					__( 'WhatsApp onboarding backfill HEAD request failed: %s', 'facebook-for-woocommerce' ),
+					$response->get_error_message(),
+				)
+			);
+			return;
+		}
+
+		$status_code = wp_remote_retrieve_response_code( $response );
+		if ( 200 === $status_code ) {
+			$whatsapp_connection->set_onboarding_complete( true );
+		} elseif ( 404 === $status_code ) {
+			$whatsapp_connection->set_onboarding_complete( false );
+		}
+		// Any other status: fail open, leave UNKNOWN.
+	}
+
+	/**
 	 * Build the rich_order_status array from order metadata.
 	 *
 	 * @param array $order_metadata The order metadata containing order details.

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -13,6 +13,7 @@ namespace WooCommerce\Facebook;
 defined( 'ABSPATH' ) || exit;
 
 use WooCommerce\Facebook\ProductSets\LegacyProductSetMigration;
+use WooCommerce\Facebook\Handlers\WhatsAppExtension;
 
 /**
  * The Meta for WooCommerce plugin lifecycle handler.
@@ -59,6 +60,7 @@ class Lifecycle extends Framework\Lifecycle {
 			'3.5.3',
 			'3.5.4',
 			'3.5.6',
+			'3.7.5',
 		);
 	}
 
@@ -388,5 +390,16 @@ class Lifecycle extends Framework\Lifecycle {
 	 */
 	protected function upgrade_to_3_5_6() {
 		LegacyProductSetMigration::migrate_legacy_fb_product_sets();
+	}
+
+	/**
+	 * Backfill the WhatsApp onboarding-complete flag for installs that connected
+	 * before the WA_CONNECT push signal existed (the pull path). One-time HEAD
+	 * existence check; fails open on error.
+	 *
+	 * @since 3.7.5
+	 */
+	protected function upgrade_to_3_7_5() {
+		WhatsAppExtension::maybe_backfill_onboarding_state( facebook_for_woocommerce() );
 	}
 }

--- a/tests/Unit/Admin/WhatsApp_Integration_SettingsTest.php
+++ b/tests/Unit/Admin/WhatsApp_Integration_SettingsTest.php
@@ -28,6 +28,13 @@ class WhatsApp_Integration_SettingsTest extends AbstractWPUnitTestWithOptionIsol
         $this->assertStringContainsString( 'whatsAppAPI.uninstallWhatsAppSettings', $output );
     }
 
+    public function test_render_message_handler_handles_wa_connect_onboarding_complete() {
+        $output = $this->build_settings()->generate_inline_enhanced_onboarding_script();
+
+        $this->assertStringContainsString( 'CommerceExtension::WA_CONNECT', $output );
+        $this->assertStringContainsString( 'whatsAppAPI.notifyWhatsAppOnboardingComplete', $output );
+    }
+
     public function test_render_message_handler_enforces_origin_allowlist() {
         $output = $this->build_settings()->generate_inline_enhanced_onboarding_script();
 

--- a/tests/Unit/Api/Plugin/WhatsAppSettings/HandlerTest.php
+++ b/tests/Unit/Api/Plugin/WhatsAppSettings/HandlerTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Unit tests for the WhatsApp Settings REST handler onboarding-complete push endpoint.
+ */
+
+namespace WooCommerce\Facebook\Tests\API\Plugin\WhatsAppSettings;
+
+use WooCommerce\Facebook\API\Plugin\WhatsAppSettings\Handler;
+use WooCommerce\Facebook\API\Plugin\WhatsAppSettings\OnboardingComplete\Request as OnboardingCompleteRequest;
+use WooCommerce\Facebook\Handlers\WhatsAppConnection;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+
+/**
+ * Covers the WA_CONNECT push endpoint that marks onboarding complete.
+ *
+ * @package WooCommerce\Facebook\Tests\Unit\API\Plugin\WhatsAppSettings
+ */
+class HandlerTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+	public function test_handle_onboarding_complete_marks_onboarding_complete() {
+		// Precondition: not yet onboarded.
+		$connection = facebook_for_woocommerce()->get_whatsapp_connection_handler();
+		$this->assertFalse( $connection->is_onboarding_complete() );
+
+		$response = ( new Handler() )->handle_onboarding_complete( new \WP_REST_Request( 'POST' ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertTrue( $connection->is_onboarding_complete() );
+	}
+
+	public function test_onboarding_complete_request_js_definition() {
+		$request = new OnboardingCompleteRequest( new \WP_REST_Request( 'POST' ) );
+
+		$this->assertSame( 'whatsapp_settings/onboarding_complete', $request->get_endpoint() );
+		$this->assertSame( 'POST', $request->get_method() );
+		$this->assertSame( 'notifyWhatsAppOnboardingComplete', $request->get_js_function_name() );
+		$this->assertTrue( OnboardingCompleteRequest::is_js_exposable() );
+	}
+}

--- a/tests/Unit/Handlers/WhatsAppConnectionTest.php
+++ b/tests/Unit/Handlers/WhatsAppConnectionTest.php
@@ -73,4 +73,23 @@ class WhatsAppConnectionTest extends AbstractWPUnitTestWithOptionIsolationAndSaf
 			'boolean true'  => array( true ),
 		);
 	}
+
+	public function test_set_onboarding_complete_true_marks_state_complete() {
+		$connection = $this->build_connection();
+		$connection->set_onboarding_complete( true );
+		$this->assertSame( WhatsAppConnection::ONBOARDING_STATE_COMPLETE, $connection->get_onboarding_state() );
+		$this->assertTrue( $connection->is_onboarding_complete() );
+	}
+
+	public function test_set_onboarding_complete_false_marks_state_incomplete() {
+		$connection = $this->build_connection();
+		$connection->set_onboarding_complete( false );
+		$this->assertSame( WhatsAppConnection::ONBOARDING_STATE_INCOMPLETE, $connection->get_onboarding_state() );
+		$this->assertFalse( $connection->is_onboarding_complete() );
+	}
+
+	public function test_is_onboarding_complete_is_false_when_state_unknown() {
+		// Unset option → state UNKNOWN → not complete (the gate fails open elsewhere).
+		$this->assertFalse( $this->build_connection()->is_onboarding_complete() );
+	}
 }

--- a/tests/Unit/Handlers/WhatsAppExtensionBackfillTest.php
+++ b/tests/Unit/Handlers/WhatsAppExtensionBackfillTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Unit tests for the WhatsApp onboarding-state HEAD backfill (pull path).
+ */
+
+namespace WooCommerce\Facebook\Tests\Handlers;
+
+use WooCommerce\Facebook\Handlers\WhatsAppConnection;
+use WooCommerce\Facebook\Handlers\WhatsAppExtension;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+
+/**
+ * Covers WhatsAppExtension::maybe_backfill_onboarding_state() — the upgrade-hook
+ * pull path that asks Meta's HEAD existence endpoint whether onboarding is
+ * complete for installs that connected before the push signal existed.
+ *
+ * @package WooCommerce\Facebook\Tests\Unit\Handlers
+ */
+class WhatsAppExtensionBackfillTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+	/** @var int HTTP status the stubbed HEAD endpoint returns. */
+	private $head_status = 200;
+
+	/** @var array recorded [url, method] of intercepted requests. */
+	private $requests = [];
+
+	/** @var bool whether to short-circuit HTTP with a WP_Error. */
+	private $return_wp_error = false;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->requests        = [];
+		$this->return_wp_error = false;
+
+		$this->add_filter_with_safe_teardown(
+			'pre_http_request',
+			function ( $pre, $args, $url ) {
+				$this->requests[] = [
+					'url'    => $url,
+					'method' => $args['method'] ?? 'GET',
+				];
+				if ( $this->return_wp_error ) {
+					return new \WP_Error( 'http_request_failed', 'boom' );
+				}
+				return array(
+					'response' => array( 'code' => $this->head_status ),
+					'body'     => '',
+				);
+			},
+			10,
+			3
+		);
+	}
+
+	private function connection(): WhatsAppConnection {
+		return facebook_for_woocommerce()->get_whatsapp_connection_handler();
+	}
+
+	private function connect(): void {
+		$this->mock_set_option( WhatsAppConnection::OPTION_WA_UTILITY_ACCESS_TOKEN, 'test-token' );
+		$this->mock_set_option( WhatsAppConnection::OPTION_WA_INSTALLATION_ID, '123456789' );
+	}
+
+	public function test_backfill_sets_complete_on_head_200() {
+		$this->connect();
+		$this->head_status = 200;
+
+		WhatsAppExtension::maybe_backfill_onboarding_state( facebook_for_woocommerce() );
+
+		$this->assertSame( WhatsAppConnection::ONBOARDING_STATE_COMPLETE, $this->connection()->get_onboarding_state() );
+		$this->assertCount( 1, $this->requests );
+		$this->assertSame( 'HEAD', $this->requests[0]['method'] );
+		$this->assertStringContainsString( 'message_integrations/installations/123456789/integration_config', $this->requests[0]['url'] );
+	}
+
+	public function test_backfill_sets_incomplete_on_head_404() {
+		$this->connect();
+		$this->head_status = 404;
+
+		WhatsAppExtension::maybe_backfill_onboarding_state( facebook_for_woocommerce() );
+
+		$this->assertSame( WhatsAppConnection::ONBOARDING_STATE_INCOMPLETE, $this->connection()->get_onboarding_state() );
+	}
+
+	public function test_backfill_leaves_unknown_on_error_fail_open() {
+		$this->connect();
+		$this->return_wp_error = true;
+
+		WhatsAppExtension::maybe_backfill_onboarding_state( facebook_for_woocommerce() );
+
+		$this->assertSame( WhatsAppConnection::ONBOARDING_STATE_UNKNOWN, $this->connection()->get_onboarding_state() );
+	}
+
+	public function test_backfill_skips_when_not_connected() {
+		// No token → not connected.
+		WhatsAppExtension::maybe_backfill_onboarding_state( facebook_for_woocommerce() );
+
+		$this->assertSame( WhatsAppConnection::ONBOARDING_STATE_UNKNOWN, $this->connection()->get_onboarding_state() );
+		$this->assertCount( 0, $this->requests, 'No HEAD request when not connected.' );
+	}
+
+	public function test_backfill_skips_when_state_already_known() {
+		$this->connect();
+		$this->mock_set_option( WhatsAppConnection::OPTION_WA_ONBOARDING_COMPLETE, WhatsAppConnection::ONBOARDING_STATE_COMPLETE );
+
+		WhatsAppExtension::maybe_backfill_onboarding_state( facebook_for_woocommerce() );
+
+		$this->assertCount( 0, $this->requests, 'No HEAD request when state already known (monotonic cache).' );
+		$this->assertSame( WhatsAppConnection::ONBOARDING_STATE_COMPLETE, $this->connection()->get_onboarding_state() );
+	}
+}


### PR DESCRIPTION
## Description

Part 2 of 2. Stacked on #3969 — please review/merge after it; base will retarget to `main` once #3969 lands.

PR #3969 (Part 1) added the read path + gate + rollout switch that skips `customer_events` when onboarding is known-incomplete, but it's inert on its own because nothing yet writes the onboarding flag (state is always `unknown` → gate fails open). **This PR adds the writers that set the flag**, so the gate can actually suppress pre-onboarding traffic.

"Onboarding complete" = a Meta integration config exists for the installation. WooCommerce can't see Meta's state, so Meta hands the plugin a signal two ways, and this PR stores it:

- **Push (new connects):** A `CommerceExtension::WA_CONNECT` postMessage from the onboarding iframe → a listener calls a new REST route → flag set to complete. Zero polling.
- **Pull (existing installs):** A one-time upgrade-hook HEAD to Meta's installations `integration_config` existence endpoint → `200` sets complete, `404` sets incomplete. Backfills stores that connected before the push signal existed.

### What's in this PR (3 commits)

1. **W1 — Writers + clear-on-uninstall:** `WhatsAppConnection::set_onboarding_complete(bool)` and `is_onboarding_complete()`; the flag is also cleared on integration uninstall.
2. **W2 — Push path:** A JS-exposable `OnboardingComplete` REST request (`POST whatsapp_settings/onboarding_complete`, no payload) + handler that sets the flag, registered so the plugin's JS client exposes `notifyWhatsAppOnboardingComplete()`; a `CommerceExtension::WA_CONNECT` branch in the iframe message handler (behind the existing `ALLOWED_ORIGINS` check) that calls it.
3. **W3 — Pull path:** `WhatsAppExtension::maybe_backfill_onboarding_state()` (HEAD `200`→complete / `404`→incomplete; monotonic, never re-polls once known; fails open on error), wired into `Lifecycle::upgrade_to_3_7_5()`.

### Dependencies / Rollout notes

- Requires the Meta-side changes (HEAD existence endpoint + `WA_CONNECT` postMessage) to be deployed — confirmed live.
- The W3 backfill only runs once `PLUGIN_VERSION` is bumped to `3.7.5` at release.
- Fully fail-open: any unset/error state leaves onboarding `unknown` → the gate keeps sending and Meta's server-side validator stays the correctness backstop. **No behavior change until the switch (from #3969) is ramped.**
- Related: T239535773

### Type of change

- **Add** (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow [this wiki](https://fburl.com/wiki/2cgfduwc).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentation (if necessary). Meta employees to follow [this wiki](https://fburl.com/wiki/nhx73tgs).
  > N/A — no user-facing docs; behavior is remote-config-gated and inert until ramp.

## Changelog entry

**Add** – Persist WhatsApp onboarding-complete state (`WA_CONNECT` push + upgrade-hook backfill) so pre-onboarding `customer_events` calls can be gated.

## Test Plan

### Automated (unit)

`composer test-unit` (or CI `php-unit-tests.yml`, PHP 7.4 + 8.4). New/updated: **21 tests green** across —

| Test file | Coverage | Pass |
|-----------|----------|------|
| `WhatsAppConnectionTest` | `set_onboarding_complete(true/false)` → COMPLETE/INCOMPLETE; `is_onboarding_complete()` treats only COMPLETE as complete | ✓ |
| `Api/Plugin/WhatsAppSettings/HandlerTest` | `handle_onboarding_complete()` sets the flag + returns 200; `OnboardingComplete` request JS definition | ✓ |
| `Admin/WhatsApp_Integration_SettingsTest` | `WA_CONNECT` branch + `notifyWhatsAppOnboardingComplete` present in the message handler | ✓ |
| `Handlers/WhatsAppExtensionBackfillTest` | HEAD 200→complete, 404→incomplete, error→fail-open (unknown), not-connected & already-known → skip (no request) | ✓ |

Full suite green: **2019 tests.**

### Manual (Local by Flywheel)

- **W1:** `set_onboarding_complete(true/false)` via `wp eval` → state `yes`/`no`; uninstall clears the flag.
- **W2:** REST route dispatched via `rest_do_request` → 200 + flag `yes`; non-admin → 401/403; `WA_CONNECT` branch verified in page JS.
- **W3:** `maybe_backfill_onboarding_state()` → sets state from the real HEAD call (200→yes) on a connected store; fail-open (`unknown`) on error; monotonic skip when already known.
- **Writer → gate integration** (same order, only the flag changed): `set_onboarding_complete(false)` → *skipped: WhatsApp onboarding not complete*; `set_onboarding_complete(true)` → *call attempted* (Succeeded. / Failed `<error>`).

**Config:** WP + WooCommerce (latest), PHP 8.5 CLI locally (unit run uses `convertDeprecationsToExceptions=false` to avoid the PHP 8.5 `setAccessible` deprecation; CI runs PHP 8.4).

## Screenshots

Log-based (no UI). Writer flips the gate outcome for the same order:

**state = `no` (writer set incomplete) — gate blocks:**

```
INFO Processing Order id 26 to send Whatsapp Utility messages
INFO Customer Events Post API call for Order id 26 skipped: WhatsApp onboarding not complete.
```

**state = `yes` (writer set complete) — gate lets it through:**

```
INFO Processing Order id 26 to send Whatsapp Utility messages
INFO Customer Events Post API call for Order id 26 Failed Authentication Error
```

> *`Failed Authentication Error` = call was sent with the local test token; a genuinely onboarded store logs `Succeeded.`*