### PR TITLE
Fix/prepare release changelog fix

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -63,7 +63,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_PUBLISHED_AT: ${{ steps.get_release.outputs.published_at }}
-          CHANGELOG_BASE_REF: ${{ github.ref_name }}
           NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
         run: |
           CHANGELOG=""
@@ -74,7 +73,7 @@ jobs:
             LABEL="$(echo "${LABEL:0:1}" | tr '[:lower:]' '[:upper:]')${LABEL:1}"
             CHANGELOG="${CHANGELOG}* ${LABEL} - ${PR_TITLE} by @${PR_AUTHOR} in #${PR_NUM}\n"
           done < <(
-            gh pr list --state closed --base "$CHANGELOG_BASE_REF" --limit 1000 --json number,title,author,labels,mergedAt,closedAt --jq '
+            gh pr list --state closed --base main --limit 1000 --json number,title,author,labels,mergedAt,closedAt --jq '
               .[]
               | . as $pr
               | ($pr.mergedAt // $pr.closedAt) as $date

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -52,17 +52,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG=$(gh release view --json tagName --jq '.tagName')
-          PUBLISHED_AT=$(gh release view --json publishedAt --jq '.publishedAt')
+          git fetch origin tag "$TAG"
+          TAG_COMMIT_TIMESTAMP=$(git log -1 --format=%ct "$TAG")
           echo "Latest release tag: $TAG"
-          echo "Latest release published at: $PUBLISHED_AT"
+          echo "Latest release tag commit timestamp: $TAG_COMMIT_TIMESTAMP"
           echo "latest_tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "published_at=$PUBLISHED_AT" >> "$GITHUB_OUTPUT"
+          echo "tag_commit_timestamp=$TAG_COMMIT_TIMESTAMP" >> "$GITHUB_OUTPUT"
 
       - name: Build changelog from PRs
         id: changelog
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_PUBLISHED_AT: ${{ steps.get_release.outputs.published_at }}
+          RELEASE_CUTOFF_TIMESTAMP: ${{ steps.get_release.outputs.tag_commit_timestamp }}
           NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
         run: |
           CHANGELOG=""
@@ -81,7 +82,7 @@ jobs:
               | (any(.labels[].name; ascii_downcase | test("^changelog:[[:space:]]*none$"))) as $hasChangelogNone
               | select(($pr.mergedAt != null) or $hasMergedLabel)
               | select($hasChangelogNone | not)
-              | select($date > env.RELEASE_PUBLISHED_AT)
+              | select(($date | fromdateiso8601) > (env.RELEASE_CUTOFF_TIMESTAMP | tonumber))
               | ([.labels[].name | ascii_downcase | select(startswith("changelog:")) | sub("^changelog:[[:space:]]*"; "")][0] // "") as $label
               | select($label != "")
               | select((.title | test("^release\\s+[0-9]+\\.[0-9]+\\.[0-9]+"; "i")) | not)

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -77,9 +77,13 @@ jobs:
             PR_NUM=$(echo "$MSG" | grep -oP '\(#\K\d+' | head -1)
             [ -z "$PR_NUM" ] && continue
 
-            LABEL=$(gh pr view "$PR_NUM" --json labels --jq '[.labels[].name | select(startswith("changelog:"))][0] // empty' | sed 's/^changelog:[[:space:]]*//')
+            PR_LABELS=$(gh pr view "$PR_NUM" --json labels --jq '.labels[].name')
+            if echo "$PR_LABELS" | grep -iqE '^changelog:[[:space:]]*none$'; then
+              continue
+            fi
+
+            LABEL=$(echo "$PR_LABELS" | grep -iE '^changelog:' | head -1 | sed 's/^changelog:[[:space:]]*//I')
             [ -z "$LABEL" ] && continue
-            [ "$(echo "$LABEL" | tr '[:upper:]' '[:lower:]')" = "none" ] && continue
 
             # Capitalize first letter
             LABEL="$(echo "${LABEL:0:1}" | tr '[:lower:]' '[:upper:]')${LABEL:1}"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -52,45 +52,44 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG=$(gh release view --json tagName --jq '.tagName')
+          PUBLISHED_AT=$(gh release view --json publishedAt --jq '.publishedAt')
           echo "Latest release tag: $TAG"
+          echo "Latest release published at: $PUBLISHED_AT"
           echo "latest_tag=$TAG" >> "$GITHUB_OUTPUT"
-
-      - name: Get commits since latest release
-        id: get_commits
-        run: |
-          git fetch origin tag ${{ steps.get_release.outputs.latest_tag }}
-          echo "commits<<EOF" >> $GITHUB_OUTPUT
-          git rev-list ${{ steps.get_release.outputs.latest_tag }}..HEAD >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "published_at=$PUBLISHED_AT" >> "$GITHUB_OUTPUT"
 
       - name: Build changelog from PRs
         id: changelog
         env:
           GH_TOKEN: ${{ github.token }}
-          COMMITS: ${{ steps.get_commits.outputs.commits }}
+          RELEASE_PUBLISHED_AT: ${{ steps.get_release.outputs.published_at }}
+          CHANGELOG_BASE_REF: ${{ github.ref_name }}
           NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
         run: |
           CHANGELOG=""
-          while IFS= read -r SHA; do
-            [ -z "$SHA" ] && continue
-            MSG=$(gh api "repos/${{ github.repository }}/commits/$SHA" --jq '.commit.message')
-            PR_NUM=$(echo "$MSG" | grep -oP '\(#\K\d+' | head -1)
+          while IFS=$'\t' read -r DATE LABEL PR_TITLE PR_AUTHOR PR_NUM; do
             [ -z "$PR_NUM" ] && continue
-
-            PR_LABELS=$(gh pr view "$PR_NUM" --json labels --jq '.labels[].name')
-            if echo "$PR_LABELS" | grep -iqE '^changelog:[[:space:]]*none$'; then
-              continue
-            fi
-
-            LABEL=$(echo "$PR_LABELS" | grep -iE '^changelog:' | head -1 | sed 's/^changelog:[[:space:]]*//I')
-            [ -z "$LABEL" ] && continue
 
             # Capitalize first letter
             LABEL="$(echo "${LABEL:0:1}" | tr '[:lower:]' '[:upper:]')${LABEL:1}"
-            PR_TITLE=$(gh pr view "$PR_NUM" --json title --jq '.title')
-            PR_AUTHOR=$(gh pr view "$PR_NUM" --json author --jq '.author.login')
             CHANGELOG="${CHANGELOG}* ${LABEL} - ${PR_TITLE} by @${PR_AUTHOR} in #${PR_NUM}\n"
-          done <<< "$COMMITS"
+          done < <(
+            gh pr list --state closed --base "$CHANGELOG_BASE_REF" --limit 1000 --json number,title,author,labels,mergedAt,closedAt --jq '
+              .[]
+              | . as $pr
+              | ($pr.mergedAt // $pr.closedAt) as $date
+              | ([.labels[].name | ascii_downcase] | index("merged")) as $hasMergedLabel
+              | (any(.labels[].name; ascii_downcase | test("^changelog:[[:space:]]*none$"))) as $hasChangelogNone
+              | select(($pr.mergedAt != null) or $hasMergedLabel)
+              | select($hasChangelogNone | not)
+              | select($date > env.RELEASE_PUBLISHED_AT)
+              | ([.labels[].name | ascii_downcase | select(startswith("changelog:")) | sub("^changelog:[[:space:]]*"; "")][0] // "") as $label
+              | select($label != "")
+              | select((.title | test("^release\\s+[0-9]+\\.[0-9]+\\.[0-9]+"; "i")) | not)
+              | [$date, $label, .title, .author.login, (.number | tostring)]
+              | @tsv
+            ' | sort
+          )
 
           TODAY=$(date -u +%Y-%m-%d)
           OUTPUT="= ${NEW_VERSION} - ${TODAY} =\n${CHANGELOG}"


### PR DESCRIPTION
## Description

Fixes changelog generation in the `prepare-release` workflow for Meta for WooCommerce.

The workflow previously built changelog entries by looking at commits since the latest release tag and extracting PR numbers from commit messages. After changes to the release/sync process, commit messages no longer reliably include the `(#PR_NUMBER)` pattern, so valid PRs could be skipped and release changelog entries were not populated.

This updates the changelog generation to read closed PRs targeting `main` directly and filter them by the latest release tag commit timestamp and changelog labels.

## Changes included

* Build changelog entries from closed PRs targeting `main`.
* Treat PRs as included if they either:
  * have `mergedAt` set, or
  * have the `Merged` label.
* Use `closedAt` as a fallback PR date when `mergedAt` is unavailable.
* Use the latest release tag commit timestamp as the cutoff for included PRs.
* Skip PRs labeled `changelog: none`.
* Skip PRs that do not have a `changelog:` label.
* Keep the existing title-based release PR exclusion.

## Type of change

Bug fix (non-breaking change that fixes an issue)

## Checklist

* [ ] I followed general Pull Request best practices. Meta employees should also follow the internal PR wiki.
* [x] I have completed dogfooding and QA testing, or otherwise verified that the changes do not break existing functionality.

## Changelog entry

Fix changelog generation in the Meta for WooCommerce release workflow when PRs are closed by the Meta sync flow.

## Test Plan

* Reviewed the changelog generation logic in `.github/workflows/prepare-release.yml`.
* Verified that changelog generation no longer depends on PR numbers being present in commit messages.
* Verified that PRs with the `Merged` label and an empty `mergedAt` value are no longer skipped.
* Verified that `closedAt` is used as the fallback PR date when `mergedAt` is unavailable.
* Verified that the latest release tag commit timestamp is used as the cutoff instead of the GitHub release publish date.
* Verified that PRs labeled `changelog: none` or without a `changelog:` label continue to be excluded.
* Verified that YAML remains valid.