### PR TITLE
ci(release): grant actions:write so Prepare Release can dispatch the build

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -16,6 +16,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  actions: write # required to dispatch build-plugin-artifact.yml for the new release branch
 
 jobs:
   prepare-release:


### PR DESCRIPTION
## What

Add `actions: write` to the `permissions` block in `prepare-release.yml`.

## Why

The `Trigger build for the new release branch` step dispatches `build-plugin-artifact.yml` via `gh workflow run` using the default `GITHUB_TOKEN`. Creating a `workflow_dispatch` event requires the `actions: write` scope, but the workflow only granted `contents`/`pull-requests`/`issues`. The dispatch failed with:

```
could not create workflow dispatch event: HTTP 403: Resource not accessible by integration
```

## Why it surfaced now

The trigger step was added on 2026-06-24. Every prepare-release run since then was `push`-triggered, which skips the `prepare-release` job (guarded by `if: github.event_name == 'workflow_dispatch'`). The 3.7.5 run (2026-07-14) was the first `workflow_dispatch` invocation after the step landed, so it was the first to actually execute it and hit the 403. Earlier dispatch runs (e.g. 3.7.1, 3.7.2) predated the step entirely and passed.

Failing run: https://github.com/facebook/facebook-for-woocommerce/actions/runs/29332213787/job/87082637447

## Note

Because `workflow_dispatch` always runs the workflow definition from the default branch, this fix only takes effect once merged to `main`.