### PR TITLE
Improve escaping and WordPress Plugin Check compliance

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -8,6 +8,8 @@
  * @package MetaCommerce
  */
 
+defined( 'ABSPATH' ) || exit;
+
 require_once __DIR__ . '/includes/fbutils.php';
 
 use Automattic\WooCommerce\Admin\Features\Features as WooAdminFeatures;

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -15,6 +15,8 @@ use WooCommerce\Facebook\Framework\Helper;
 use WooCommerce\Facebook\Framework\Logger;
 use WooCommerce\Facebook\Integrations\CostOfGoods\CostOfGoods;
 
+defined( 'ABSPATH' ) || exit;
+
 if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 	if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) {

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -18,6 +18,8 @@
  * Tested up to: 7.0.1
  * WC requires at least: 6.4
  * WC tested up to: 10.9.4
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  *
  * @package MetaCommerce
  */

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -228,9 +228,9 @@ class AJAX {
 		check_ajax_referer( 'set-product-sync-bulk-action-prompt', 'security' );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$product_ids = isset( $_POST['products'] ) ? (array) wc_clean( wp_unslash( $_POST['products'] ) ) : array();
+		$product_ids = isset( $_POST['products'] ) ? array_map( 'absint', (array) wp_unslash( $_POST['products'] ) ) : array();
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$toggle = isset( $_POST['toggle'] ) ? (string) wc_clean( wp_unslash( $_POST['toggle'] ) ) : '';
+		$toggle = isset( $_POST['toggle'] ) ? (string) sanitize_text_field( wp_unslash( $_POST['toggle'] ) ) : '';
 
 		if ( ! empty( $product_ids ) && ! empty( $toggle ) && 'facebook_include' === $toggle ) {
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -371,7 +371,7 @@ class Admin {
 		} else {
 			esc_html_e( 'Not synced', 'facebook-for-woocommerce' );
 			if ( ! empty( $no_sync_reason ) ) {
-				echo wc_help_tip( $no_sync_reason );
+				echo wp_kses_post( wc_help_tip( $no_sync_reason ) );
 			}
 		}
 	}
@@ -452,7 +452,7 @@ class Admin {
 			// store original meta query
 			$original_meta_query = ! empty( $query_vars['meta_query'] ) ? $query_vars['meta_query'] : [];
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$filter_value = wc_clean( wp_unslash( $_REQUEST['fb_sync_enabled'] ) );
+			$filter_value = sanitize_text_field( wp_unslash( $_REQUEST['fb_sync_enabled'] ) );
 			// by default use an "AND" clause if multiple conditions exist for a meta query
 			if ( ! empty( $query_vars['meta_query'] ) ) {
 				$query_vars['meta_query']['relation'] = 'AND';
@@ -480,8 +480,10 @@ class Admin {
 
 				if ( ! empty( $exclude_products ) ) {
 					if ( ! empty( $query_vars['post__not_in'] ) ) {
+						// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_post__not_in -- Excluding products that fail sync validation from the admin product list filter; the exclusion set is bounded by the current page of results.
 						$query_vars['post__not_in'] = array_merge( $query_vars['post__not_in'], $exclude_products );
 					} else {
+						// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_post__not_in -- Excluding products that fail sync validation from the admin product list filter; the exclusion set is bounded by the current page of results.
 						$query_vars['post__not_in'] = $exclude_products;
 					}
 				}
@@ -1646,7 +1648,7 @@ class Admin {
 	 */
 	private function determine_variation_sync_mode( $variation ) {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verification is handled in save_product_variation_edit_fields method
-		$sync_mode = isset( $_POST['wc_facebook_sync_mode'] ) ? wc_clean( wp_unslash( $_POST['wc_facebook_sync_mode'] ) ) : self::SYNC_MODE_SYNC_DISABLED;
+		$sync_mode = isset( $_POST['wc_facebook_sync_mode'] ) ? sanitize_text_field( wp_unslash( $_POST['wc_facebook_sync_mode'] ) ) : self::SYNC_MODE_SYNC_DISABLED;
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verification is handled in save_product_variation_edit_fields method
 		if ( ! isset( $_POST['wc_facebook_sync_mode'] ) ) {
@@ -1747,7 +1749,7 @@ class Admin {
 		$image_ids    = isset( $_POST[ $posted_param ] ) ? sanitize_text_field( wp_unslash( $_POST[ $posted_param ] ) ) : '';
 		$posted_param = 'variable_' . \WC_Facebook_Product::FB_PRODUCT_PRICE;
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verification is handled in save_product_variation_edit_fields method
-		$price = isset( $_POST[ $posted_param ][ $index ] ) ? wc_format_decimal( wc_clean( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) ) : '';
+		$price = isset( $_POST[ $posted_param ][ $index ] ) ? wc_format_decimal( sanitize_text_field( wp_unslash( $_POST[ $posted_param ][ $index ] ) ) ) : '';
 
 		return array(
 			'description_plain' => $description_plain,
@@ -2626,8 +2628,13 @@ class Admin {
 	/**
 	 * Displays a notice about WordPress.com automatic updates ending.
 	 *
-	 * Uses an onClick dismiss button that triggers a page reload with a GET parameter,
-	 * ensuring the dismissal is saved server-side before the notice re-renders.
+	 * The dismiss control is a plain link that triggers a page reload with a GET parameter,
+	 * ensuring the dismissal is saved server-side before the notice re-renders. It is rendered
+	 * as an anchor so the dismiss URL lives in an href attribute, which is the correct output
+	 * context for esc_url().
+	 *
+	 * The .notice-dismiss class is preserved so WordPress core does not inject a second,
+	 * client-only dismiss button onto the notice.
 	 *
 	 * @since 3.5.3
 	 *
@@ -2637,13 +2644,13 @@ class Admin {
 		printf(
 			'
 <div class="notice notice-warning is-dismissible">
-	<p>%s</p>
-	<button
-		type="button"
+	<p>%1$s</p>
+	<a
+		href="%2$s"
 		class="notice-dismiss"
-		onClick="location.href=\'%s\'">
-		<span class="screen-reader-text">%s</span>
-	</button>
+		style="text-decoration: none;">
+		<span class="screen-reader-text">%3$s</span>
+	</a>
 </div>
 			',
 			wp_kses_post( $this->get_wpcom_update_notice_message() ),

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -97,7 +97,7 @@ class Products {
 		<p class="form-field">
 			<label for="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>">
 				<?php esc_html_e( 'Google Product Category', 'facebook-for-woocommerce' ); ?>
-				<?php echo wc_help_tip( __( 'Choose the Google product category and (optionally) sub-categories associated with this product.', 'facebook-for-woocommerce' ) ); ?>
+				<?php echo wp_kses_post( wc_help_tip( __( 'Choose the Google product category and (optionally) sub-categories associated with this product.', 'facebook-for-woocommerce' ) ) ); ?>
 			</label>
 			<input
 				id="<?php echo esc_attr( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ); ?>"

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -427,7 +427,7 @@ class Shops extends Abstract_Settings_Screen {
 		// Generate a fresh nonce for this request
 		$nonce = wp_json_encode( wp_create_nonce( 'wp_rest' ) );
 
-		return <<<JAVASCRIPT
+		return "
 			const fbAPI = GeneratePluginAPIClient({$nonce});
 			const ALLOWED_ORIGINS = [
 				'https://www.commercepartnerhub.com',
@@ -497,6 +497,6 @@ class Shops extends Abstract_Settings_Screen {
 						});
 				}
 			});
-		JAVASCRIPT;
+		";
 	}
 }

--- a/includes/Admin/WhatsApp_Integration_Settings.php
+++ b/includes/Admin/WhatsApp_Integration_Settings.php
@@ -285,7 +285,7 @@ class WhatsApp_Integration_Settings {
 		// Generate a fresh nonce for this request
 		$nonce = wp_json_encode( wp_create_nonce( 'wp_rest' ) );
 
-		return <<<JAVASCRIPT
+		return "
 			const whatsAppAPI = GeneratePluginAPIClient({$nonce});
 			const ALLOWED_ORIGINS = [
 				'https://www.commercepartnerhub.com',
@@ -362,6 +362,6 @@ class WhatsApp_Integration_Settings {
 						});
 				}
 			});
-		JAVASCRIPT;
+		";
 	}
 }

--- a/includes/Events/Event.php
+++ b/includes/Events/Event.php
@@ -97,7 +97,7 @@ class Event {
 		);
 
 		if ( isset( $_SERVER['HTTP_REFERER'] ) ) {
-			$this->data['referrer_url'] = wc_clean( wp_unslash( $_SERVER['HTTP_REFERER'] ) );
+			$this->data['referrer_url'] = esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) );
 		}
 
 		$this->prepare_user_data( $this->data['user_data'] );
@@ -217,7 +217,7 @@ class Event {
 			 */
 			$url = home_url();
 			if ( isset( $_SERVER['REQUEST_URI'] ) ) {
-				$url .= wc_clean( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+				$url .= esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
 			}
 		}
 		return $url;
@@ -244,7 +244,7 @@ class Event {
 	 * @return string
 	 */
 	public function get_client_user_agent() {
-		return ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? wc_clean( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
+		return ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
 	}
 
 
@@ -316,7 +316,7 @@ class Event {
 		$fbp = \WC_Facebookcommerce_EventsTracker::get_fbp();
 		if ( empty( $fbp ) ) {
 			if ( ! empty( $_COOKIE['_fbp'] ) ) {
-				$fbp = wc_clean( wp_unslash( $_COOKIE['_fbp'] ) );
+				$fbp = sanitize_text_field( wp_unslash( $_COOKIE['_fbp'] ) );
 			} elseif ( ! empty( $_SESSION['_fbp'] ) ) {
 				$fbp = $_SESSION['_fbp']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			}

--- a/includes/ExternalVersionUpdate/Update.php
+++ b/includes/ExternalVersionUpdate/Update.php
@@ -231,7 +231,8 @@ class Update {
 		}
 
 		// Block/FSE themes bypass the PHP archive template and woocommerce_product_query hook.
-		if ( wp_is_block_theme() ) {
+		// wp_is_block_theme() was introduced in WordPress 5.9; older versions cannot be block themes.
+		if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
 			return false;
 		}
 
@@ -246,8 +247,8 @@ class Update {
 			foreach ( $conditions as $template_conditions ) {
 				foreach ( (array) $template_conditions as $condition ) {
 					if ( is_string( $condition )
-						&& str_contains( $condition, 'product' )
-						&& str_contains( $condition, 'archive' ) ) {
+						&& false !== strpos( $condition, 'product' )
+						&& false !== strpos( $condition, 'archive' ) ) {
 						return false;
 					}
 				}

--- a/includes/Feed/ShippingProfiles/ShippingProfilesFeed.php
+++ b/includes/Feed/ShippingProfiles/ShippingProfilesFeed.php
@@ -262,7 +262,7 @@ class ShippingProfilesFeed extends AbstractFeed {
 		$prefix_length               = strlen( $class_cost_prefix );
 
 		foreach ( $shipping_settings as $key => $value ) {
-			if ( str_starts_with( $key, $class_cost_prefix ) ) {
+			if ( 0 === strpos( $key, $class_cost_prefix ) ) {
 				$shipping_class_id                                 = substr( $key, $prefix_length );
 				$shipping_class_ids_to_costs[ $shipping_class_id ] = $value;
 			}

--- a/includes/Framework/AdminMessageHandler.php
+++ b/includes/Framework/AdminMessageHandler.php
@@ -103,7 +103,7 @@ class AdminMessageHandler {
 	 */
 	public function load_messages() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$message_id_get_name = isset( $_GET[ self::MESSAGE_ID_GET_NAME ] ) ? wc_clean( wp_unslash( $_GET[ self::MESSAGE_ID_GET_NAME ] ) ) : false;
+		$message_id_get_name = isset( $_GET[ self::MESSAGE_ID_GET_NAME ] ) ? sanitize_text_field( wp_unslash( $_GET[ self::MESSAGE_ID_GET_NAME ] ) ) : false;
 		if ( $message_id_get_name && $this->get_message_id() === $message_id_get_name ) {
 			$memo = get_transient( self::MESSAGE_TRANSIENT_PREFIX . $message_id_get_name );
 			if ( isset( $memo['errors'] ) ) {

--- a/includes/Framework/AdminNoticeHandler.php
+++ b/includes/Framework/AdminNoticeHandler.php
@@ -385,7 +385,7 @@ class AdminNoticeHandler {
 	public function handle_dismiss_notice() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_REQUEST['messageid'] ) ) {
-			$this->dismiss_notice( wc_clean( wp_unslash( $_REQUEST['messageid'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$this->dismiss_notice( sanitize_text_field( wp_unslash( $_REQUEST['messageid'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
 	}
 

--- a/includes/Framework/Helper.php
+++ b/includes/Framework/Helper.php
@@ -240,7 +240,7 @@ class Helper {
 		//phpcs:ignore WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST[ $key ] ) ) {
 			//phpcs:ignore WordPress.Security.NonceVerification.Missing
-			$sanitized_value = wc_clean( wp_unslash( $_POST[ $key ] ) );
+			$sanitized_value = map_deep( wp_unslash( $_POST[ $key ] ), 'sanitize_text_field' );
 			$value           = is_string( $sanitized_value ) ? trim( $sanitized_value ) : $sanitized_value;
 		}
 
@@ -265,7 +265,7 @@ class Helper {
 		//phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_REQUEST[ $key ] ) ) {
 			//phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$sanitized_value = wc_clean( wp_unslash( $_REQUEST[ $key ] ) );
+			$sanitized_value = map_deep( wp_unslash( $_REQUEST[ $key ] ), 'sanitize_text_field' );
 			$value           = is_string( $sanitized_value ) ? trim( $sanitized_value ) : $sanitized_value;
 		}
 
@@ -400,7 +400,7 @@ class Helper {
 		}
 
 		$rest_prefix         = trailingslashit( rest_get_url_prefix() );
-		$is_rest_api_request = false !== strpos( wc_clean( wp_unslash( $_SERVER['REQUEST_URI'] ) ), $rest_prefix );
+		$is_rest_api_request = false !== strpos( esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ), $rest_prefix );
 
 		/** Applies WooCommerce core filter */
 		return (bool) apply_filters( 'woocommerce_is_rest_api_request', $is_rest_api_request );

--- a/includes/Framework/Lifecycle.php
+++ b/includes/Framework/Lifecycle.php
@@ -378,6 +378,7 @@ class Lifecycle {
 		array_unshift( $history, $event );
 		// limit to the last 30 events
 		$history = array_slice( $history, 0, 29 );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- one-off upsert of the plugin lifecycle event history option; caching not applicable
 		return $wpdb->replace(
 			$wpdb->options,
 			array(
@@ -405,6 +406,7 @@ class Lifecycle {
 	public function get_event_history() {
 		global $wpdb;
 		$history = [];
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- reads the lifecycle event history option; value is mutated within the request by store_event(), caching not applicable
 		$results = $wpdb->get_var(
 			$wpdb->prepare(
 				"

--- a/includes/Framework/Plugin.php
+++ b/includes/Framework/Plugin.php
@@ -319,6 +319,7 @@ abstract class Plugin {
 
 		load_textdomain( $textdomain, WP_LANG_DIR . '/' . $textdomain . '/' . $textdomain . '-' . $locale . '.mo' );
 
+		// phpcs:ignore PluginCheck.CodeAnalysis.DiscouragedFunctions.load_plugin_textdomainFound -- Loads translations bundled in the plugin's own /i18n/languages directory; required for non-WordPress.org distributions (e.g. woocommerce.com) that don't receive automatic language packs.
 		load_plugin_textdomain( $textdomain, false, untrailingslashit( $path ) . '/i18n/languages' );
 	}
 

--- a/includes/Framework/PluginCrashHandler.php
+++ b/includes/Framework/PluginCrashHandler.php
@@ -1167,7 +1167,10 @@ class PluginCrashHandler {
 			return ErrorLogHandler::enqueue_meta_log_request( $report, true );
 		}
 
-		$delay = function_exists( 'wp_rand' ) ? wp_rand( 60, self::CRASH_REPORT_MAX_JITTER_SECONDS ) : mt_rand( 60, self::CRASH_REPORT_MAX_JITTER_SECONDS );
+		$delay = function_exists( 'wp_rand' )
+			? wp_rand( 60, self::CRASH_REPORT_MAX_JITTER_SECONDS )
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.rand_mt_rand -- Fallback for the early crash-handler path (shutdown function) where the pluggable wp_rand() may not be loaded yet.
+			: mt_rand( 60, self::CRASH_REPORT_MAX_JITTER_SECONDS );
 
 		try {
 			$action_id = as_schedule_single_action( time() + $delay, ErrorLogHandler::META_LOG_API, [ $report ], ErrorLogHandler::META_LOG_API_GROUP, true );

--- a/includes/Framework/Utilities/BackgroundJobHandler.php
+++ b/includes/Framework/Utilities/BackgroundJobHandler.php
@@ -201,6 +201,7 @@ abstract class BackgroundJobHandler extends AsyncRequest {
 		$queued     = '%"status":"queued"%';
 		$processing = '%"status":"processing"%';
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Counts queued/processing background jobs stored as options; reflects live queue state, caching not applicable.
 		$count = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT COUNT(*)
@@ -445,6 +446,7 @@ abstract class BackgroundJobHandler extends AsyncRequest {
 			$attrs
 		);
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Persists a new background job to the options table; write operation, caching not applicable.
 		$wpdb->insert(
 			$wpdb->options,
 			[
@@ -494,6 +496,7 @@ abstract class BackgroundJobHandler extends AsyncRequest {
 			$queued     = '%"status":"queued"%';
 			$processing = '%"status":"processing"%';
 
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reads the next queued/processing background job from the options table; reflects live queue state, caching not applicable.
 			$results = $wpdb->get_var(
 				$wpdb->prepare(
 					"SELECT option_value
@@ -508,6 +511,7 @@ abstract class BackgroundJobHandler extends AsyncRequest {
 				)
 			);
 		} else {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reads a single background job by id from the options table; reflects live queue state, caching not applicable.
 			$results = $wpdb->get_var(
 				$wpdb->prepare(
 					"SELECT option_value
@@ -599,7 +603,7 @@ abstract class BackgroundJobHandler extends AsyncRequest {
 			$replacements
 		);
 
-		/* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared */
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Query is built via $wpdb->prepare(); the interpolated ORDER BY identifiers are sanitized with sanitize_key(); reflects live queue state, caching not applicable.
 		$results = $wpdb->get_col( $query );
 
 		if ( empty( $results ) ) {
@@ -884,6 +888,7 @@ abstract class BackgroundJobHandler extends AsyncRequest {
 		if ( ! $job ) {
 			return false;
 		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Deletes a completed background job from the options table; write operation, caching not applicable.
 		$wpdb->delete( $wpdb->options, [ 'option_name' => "{$this->identifier}_job_{$job->id}" ] );
 
 		// Invalidate cache since a job was deleted
@@ -1032,6 +1037,7 @@ abstract class BackgroundJobHandler extends AsyncRequest {
 	private function update_job_option( $job ) {
 		global $wpdb;
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Updates a background job's stored state in the options table; write operation, caching not applicable.
 		return $wpdb->update(
 			$wpdb->options,
 			[ 'option_value' => wp_json_encode( $job ) ],

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -396,7 +396,7 @@ class Connection {
 			}
 
 			$is_error   = ! empty( $_GET['err'] );
-			$error_code = ! empty( $_GET['err_code'] ) ? stripslashes( wc_clean( wp_unslash( $_GET['err_code'] ) ) ) : '';
+			$error_code = ! empty( $_GET['err_code'] ) ? stripslashes( sanitize_text_field( wp_unslash( $_GET['err_code'] ) ) ) : '';
 			if ( $is_error && $error_code ) {
 				throw new ConnectApiException( $error_code );
 			}

--- a/includes/Jobs/GenerateProductFeed.php
+++ b/includes/Jobs/GenerateProductFeed.php
@@ -52,6 +52,7 @@ class GenerateProductFeed extends AbstractChainedJob {
 	protected function get_items_for_batch( int $batch_number, array $args ): array {
 		global $wpdb;
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- batch job query paging product IDs for feed generation; caching not applicable
 		$product_ids = $wpdb->get_col(
 			$wpdb->prepare(
 				"SELECT post.ID

--- a/includes/ProductSets/LegacyProductSetMigration.php
+++ b/includes/ProductSets/LegacyProductSetMigration.php
@@ -24,12 +24,14 @@ class LegacyProductSetMigration {
 		// Query legacy fb product sets
 		global $wpdb;
 		$fb_product_set_taxonomy_name = 'fb_product_set';
-		$results                      = $wpdb->get_results(
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- one-off migration query over legacy taxonomy terms; caching not applicable
+		$results = $wpdb->get_results(
 			$wpdb->prepare(
-				'SELECT t.term_id, t.name, t.slug, tt.description
-				FROM wp_terms t
-				INNER JOIN wp_term_taxonomy tt ON t.term_id = tt.term_id
-				WHERE tt.taxonomy = %s',
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names come from $wpdb and are trusted; identifiers cannot be bound as placeholders.
+				"SELECT t.term_id, t.name, t.slug, tt.description
+				FROM {$wpdb->terms} t
+				INNER JOIN {$wpdb->term_taxonomy} tt ON t.term_id = tt.term_id
+				WHERE tt.taxonomy = %s",
 				$fb_product_set_taxonomy_name
 			)
 		);

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -8,6 +8,8 @@ use WC_Facebookcommerce_Integration;
 use WC_Product;
 use WooCommerce\Facebook\Products;
 
+defined( 'ABSPATH' ) || exit;
+
 if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) {
 	include_once '../fbutils.php';
 }

--- a/includes/Utilities/Background_Remove_Duplicate_Visibility_Meta.php
+++ b/includes/Utilities/Background_Remove_Duplicate_Visibility_Meta.php
@@ -113,7 +113,7 @@ class Background_Remove_Duplicate_Visibility_Meta extends BackgroundJobHandler {
 			) AS duplicate_entries
 		";
 
-		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- one-off background maintenance count over postmeta; caching not applicable
 	}
 
 
@@ -140,7 +140,7 @@ class Background_Remove_Duplicate_Visibility_Meta extends BackgroundJobHandler {
 
 			$sql = "DELETE FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = 'fb_visibility' AND meta_id != %d";
 
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- one-off background cleanup deleting duplicate postmeta; caching not applicable
 			if ( false === $wpdb->query( $wpdb->prepare( $sql, $result->post_id, $result->last_meta_id ) ) ) {
 
 				facebook_for_woocommerce()->log(
@@ -180,7 +180,7 @@ class Background_Remove_Duplicate_Visibility_Meta extends BackgroundJobHandler {
 			HAVING entries > 1
 		";
 
-		return $wpdb->get_results( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		return $wpdb->get_results( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- one-off background maintenance query over postmeta; caching not applicable
 	}
 
 

--- a/includes/Utilities/DebugTools.php
+++ b/includes/Utilities/DebugTools.php
@@ -69,6 +69,7 @@ class DebugTools {
 		global $wpdb;
 
 		// Delete job entries (but not cache transients which use different pattern)
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- one-off maintenance cleanup of stale option rows; caching not applicable
 		$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE 'wc_facebook_background_product_sync_job_%'" );
 
 		// Invalidate all sync-related caches since we deleted jobs directly from the database

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -620,7 +620,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 
 			// If site url doesn't exist, fall back to http host.
 			if ( isset( $_SERVER['HTTP_HOST'] ) ) {
-				self::$store_name = wc_clean( wp_unslash( $_SERVER['HTTP_HOST'] ) );
+				self::$store_name = sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) );
 				return self::$store_name;
 			}
 

--- a/tests/Unit/AdminTest.php
+++ b/tests/Unit/AdminTest.php
@@ -175,6 +175,203 @@ class AdminTest extends \WP_UnitTestCase {
     }
 
     /**
+     * Tests that the WordPress.com update notice dismiss control renders its URL in an
+     * href attribute rather than an inline JavaScript event handler.
+     *
+     * The dismiss URL is derived from the current request URI, so it must be output in a
+     * context where esc_url() is the correct escaping. An href attribute satisfies this;
+     * an inline event handler does not, because the browser HTML-decodes handler attributes
+     * before executing them.
+     */
+    public function test_wpcom_update_notice_dismiss_uses_href_not_inline_js(): void {
+        update_option( 'is_wordpress_com_hosted', 1 );
+
+        // Exercise the rendering with a request URI containing quote characters.
+        $original_request_uri   = $_SERVER['REQUEST_URI'] ?? null;
+        $_SERVER['REQUEST_URI'] = "/wp-admin/index.php/',token(),'";
+
+        $admin = $this->createAdminInstance();
+
+        ob_start();
+        $admin->wpcom_update_notice();
+        $output = ob_get_clean();
+
+        if ( null === $original_request_uri ) {
+            unset( $_SERVER['REQUEST_URI'] );
+        } else {
+            $_SERVER['REQUEST_URI'] = $original_request_uri;
+        }
+
+        // The dismiss control must not rely on an inline JS event handler.
+        $this->assertStringNotContainsStringIgnoringCase(
+            'onclick',
+            $output,
+            'Dismiss control must not use an inline onClick handler.'
+        );
+        $this->assertStringNotContainsString(
+            'location.href',
+            $output,
+            'Dismiss control must not navigate via inline JavaScript.'
+        );
+
+        // The request-derived value must not be reflected as an unescaped JS string literal.
+        $this->assertStringNotContainsString(
+            "token(),'",
+            $output,
+            'Request-derived value must not be reflected into an inline JS string.'
+        );
+
+        // The dismiss URL must be rendered in an href attribute context.
+        $this->assertStringContainsString(
+            'href=',
+            $output,
+            'Dismiss URL must be rendered in an href attribute.'
+        );
+        $this->assertStringContainsString(
+            Admin::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE,
+            $output,
+            'Dismiss URL must carry the dismiss query argument.'
+        );
+    }
+
+    /**
+     * Renders the WordPress.com update notice with a given request URI and returns the markup.
+     *
+     * Restores the original REQUEST_URI afterwards so tests remain isolated.
+     *
+     * @param string $request_uri the request URI to expose while rendering.
+     * @return string the rendered notice markup.
+     */
+    private function render_wpcom_update_notice_with_request_uri( string $request_uri ): string {
+        update_option( 'is_wordpress_com_hosted', 1 );
+
+        $original_request_uri   = $_SERVER['REQUEST_URI'] ?? null;
+        $_SERVER['REQUEST_URI'] = $request_uri;
+
+        $admin = $this->createAdminInstance();
+
+        ob_start();
+        $admin->wpcom_update_notice();
+        $output = ob_get_clean();
+
+        if ( null === $original_request_uri ) {
+            unset( $_SERVER['REQUEST_URI'] );
+        } else {
+            $_SERVER['REQUEST_URI'] = $original_request_uri;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Request URIs that contain characters which are significant in HTML-attribute,
+     * HTML-tag and JS-string contexts. Each must be neutralised in the rendered dismiss URL.
+     *
+     * @return array<string, array{0:string}>
+     */
+    public function provider_dismiss_control_crafted_request_uris(): array {
+        return [
+            'single quote / JS-string chars' => [ "/wp-admin/index.php/',token(),'" ],
+            'double quote + tag chars'       => [ '/wp-admin/index.php/"><span>x</span>' ],
+            'attribute-injection chars'      => [ '/wp-admin/index.php/"onmouseover="x' ],
+            'angle brackets in query'        => [ '/wp-admin/edit.php?foo=<b>bar</b>' ],
+            'script-tag chars'               => [ '/wp-admin/index.php/"><script>x=1</script>' ],
+            'backslash and quotes'           => [ '/wp-admin/index.php/\\\'"' ],
+        ];
+    }
+
+    /**
+     * Tests that a request-derived dismiss URL is always emitted in a safe output context,
+     * regardless of the characters present in the request URI.
+     *
+     * @dataProvider provider_dismiss_control_crafted_request_uris
+     *
+     * @param string $request_uri the crafted request URI.
+     */
+    public function test_wpcom_update_notice_dismiss_output_is_escaped_for_crafted_request_uris( string $request_uri ): void {
+        $output = $this->render_wpcom_update_notice_with_request_uri( $request_uri );
+
+        // No real HTML event-handler attribute may be emitted. This is a structural check:
+        // it matches an ` on...="` attribute (whitespace-delimited, opening double quote) and
+        // deliberately does NOT match an event-handler name that survives only as encoded URL
+        // text inside the href value (e.g. ".../onmouseover=%22x"), which is harmless.
+        $this->assertDoesNotMatchRegularExpression(
+            '#\son[a-z]+\s*=\s*"#i',
+            $output,
+            'No inline HTML event-handler attribute may be emitted.'
+        );
+        $this->assertStringNotContainsString( 'location.href', $output, 'No inline JS navigation may be emitted.' );
+
+        // The dismiss anchor must be well-formed: its href attribute is delimited by double
+        // quotes with no embedded double quote, which proves the attribute context was not broken.
+        $this->assertMatchesRegularExpression(
+            '#href="([^"]*)"\s+class="notice-dismiss"#',
+            $output,
+            'Dismiss control must render a well-formed, double-quoted href attribute.'
+        );
+
+        // Extract the dismiss href and assert no raw markup-significant characters leaked into it.
+        preg_match( '#href="([^"]*)"\s+class="notice-dismiss"#', $output, $matches );
+        $dismiss_href = $matches[1] ?? '';
+
+        $this->assertNotSame( '', $dismiss_href, 'Dismiss href must be present.' );
+        $this->assertStringNotContainsString( '<', $dismiss_href, 'Dismiss href must not contain a raw "<".' );
+        $this->assertStringNotContainsString( '>', $dismiss_href, 'Dismiss href must not contain a raw ">".' );
+        $this->assertStringContainsString(
+            Admin::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE,
+            $dismiss_href,
+            'Dismiss href must carry the dismiss query argument.'
+        );
+
+        // No unescaped tag from the request URI may appear anywhere in the output.
+        $this->assertStringNotContainsStringIgnoringCase( '<script', $output, 'No unescaped <script> may appear.' );
+        $this->assertStringNotContainsStringIgnoringCase( '<span>x</span>', $output, 'No unescaped injected tag may appear.' );
+    }
+
+    /**
+     * Tests that the rendered dismiss href is exactly the escaped value produced by
+     * esc_url( add_query_arg( ... ) ) for the current request URI.
+     */
+    public function test_wpcom_update_notice_dismiss_href_uses_escaped_dismiss_url(): void {
+        $request_uri = "/wp-admin/index.php/',token(),'";
+
+        $original_request_uri   = $_SERVER['REQUEST_URI'] ?? null;
+        $_SERVER['REQUEST_URI'] = $request_uri;
+
+        // Compute the expected, escaped dismiss URL exactly as production code does.
+        $expected_href = esc_url( add_query_arg( Admin::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE, '1' ) );
+
+        if ( null === $original_request_uri ) {
+            unset( $_SERVER['REQUEST_URI'] );
+        } else {
+            $_SERVER['REQUEST_URI'] = $original_request_uri;
+        }
+
+        $output = $this->render_wpcom_update_notice_with_request_uri( $request_uri );
+
+        preg_match( '#href="([^"]*)"\s+class="notice-dismiss"#', $output, $matches );
+        $dismiss_href = $matches[1] ?? '';
+
+        $this->assertSame(
+            $expected_href,
+            $dismiss_href,
+            'Dismiss href must equal the esc_url()-escaped dismiss URL.'
+        );
+    }
+
+    /**
+     * Tests that the notice message link (a static WordPress.org URL) is rendered alongside
+     * the dismiss control, confirming the notice body itself is output as expected.
+     */
+    public function test_wpcom_update_notice_renders_message_link(): void {
+        $output = $this->render_wpcom_update_notice_with_request_uri( '/wp-admin/index.php' );
+
+        $this->assertStringContainsString( 'notice notice-warning is-dismissible', $output );
+        $this->assertStringContainsString( 'wordpress.org/plugins/facebook-for-woocommerce/', $output );
+        $this->assertStringContainsString( 'class="notice-dismiss"', $output );
+    }
+
+    /**
      * Tests that the WordPress.com update notice is shown only for
      * WordPress.com-hosted sites when it has not been dismissed.
      */


### PR DESCRIPTION
## Summary

A pass of WordPress Plugin Check fixes and general hardening across the plugin.

## Changes

- Add the plugin **License** header and **ABSPATH** direct-access guards.
- Replace WP-version-incompatible function calls (`wp_is_block_theme`, `str_contains`, `str_starts_with`) with equivalents compatible with the declared minimum WordPress version.
- Convert disallowed **heredoc** syntax to double-quoted strings in the onboarding inline-script generators.
- **Sanitize** superglobal reads with WordPress-recognized sanitizers and **escape** rendered output (including rendering the WordPress.com notice dismiss URL in an `href` attribute — the correct output context for `esc_url()`).
- Annotate direct `$wpdb` queue/maintenance/migration operations with justified `phpcs:ignore` comments, and use `$wpdb` table properties instead of a hard-coded table prefix in the legacy product-set migration.
- Add unit coverage for the notice dismiss rendering.

## Notes

- Exception messages flagged by `ExceptionNotEscaped` are intentionally left as-is to match the project's own `phpcs.xml.dist` (which excludes that rule).
- `readme.txt` metadata (Tested up to / Stable tag) is managed by the release workflow.

## Verification

- All changed files pass `php -l`.
- Repo phpcs (`WooCommerce-Core`) reports 0 errors; remaining warnings are pre-existing.