### PR TITLE
ci(release): fix readme Tested-up-to minor version + propagate Stable tag to git

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -188,18 +188,24 @@ jobs:
           LATEST_WP=$(curl -s 'https://api.wordpress.org/core/version-check/1.7/' | jq -r '.offers[0].version')
           echo "Latest WordPress version: $LATEST_WP"
 
+          # WordPress.org's readme "Tested up to" must be a major.minor version only
+          # (e.g. 7.0, not 7.0.1); the patch component trips the Plugin Check
+          # invalid_tested_upto_minor error. Truncate to major.minor.
+          LATEST_WP_MM=$(echo "$LATEST_WP" | cut -d. -f1,2)
+          echo "Latest WordPress major.minor: $LATEST_WP_MM"
+
           # Fetch latest WooCommerce version (X.Y.Z)
           LATEST_WC=$(curl -s 'https://api.wordpress.org/plugins/info/1.0/woocommerce.json' | jq -r '.version')
           echo "Latest WooCommerce version: $LATEST_WC"
 
           # Update Tested up to (WordPress) in facebook-for-woocommerce.php
-          sed -i -E "s/^ \* Tested up to:.*/ \* Tested up to: $LATEST_WP/" "facebook-for-woocommerce.php"
+          sed -i -E "s/^ \* Tested up to:.*/ \* Tested up to: $LATEST_WP_MM/" "facebook-for-woocommerce.php"
 
           # Update WC tested up to in facebook-for-woocommerce.php
           sed -i -E "s/^ \* WC tested up to:.*/ \* WC tested up to: $LATEST_WC/" "facebook-for-woocommerce.php"
 
           # Update Tested up to in readme.txt
-          sed -i -E "s/^Tested up to:.*$/Tested up to: $LATEST_WP/" "readme.txt"
+          sed -i -E "s/^Tested up to:.*$/Tested up to: $LATEST_WP_MM/" "readme.txt"
 
           git diff
 

--- a/.github/workflows/set-stable-tag.yml
+++ b/.github/workflows/set-stable-tag.yml
@@ -233,6 +233,37 @@ jobs:
         with:
           ref: release/${{ needs.set-stable-tag.outputs.version }}
 
+      - name: Set Stable tag on the release branch
+        run: |
+          # set-stable-tag updates the Stable tag in WordPress.org SVN, but the git
+          # release branch (which merges to main) still carries the previous live
+          # version that prepare-release wrote — leaving main's readme.txt Stable tag
+          # perpetually behind. Now that the release is live on wp.org, bump the Stable
+          # tag on this existing release/$VERSION branch so the open "Release $VERSION"
+          # PR carries it to main. No new branch is created.
+          if [ -z "$VERSION" ]; then
+            echo "::error::VERSION is empty; refusing to update the Stable tag."
+            exit 1
+          fi
+          sed -i -E "s/^(Stable tag:)[[:space:]]*[0-9.]+/\1 $VERSION/" readme.txt
+          # WordPress.org's readme parser fails on CRLF; keep LF.
+          sed -i 's/\r$//' readme.txt
+          if ! grep -qx "Stable tag: $VERSION" readme.txt; then
+            echo "::error::Stable tag was not set to $VERSION in readme.txt."
+            grep -i '^stable tag:' readme.txt || true
+            exit 1
+          fi
+          if git diff --quiet -- readme.txt; then
+            echo "ℹ️ Stable tag already $VERSION on release/$VERSION; nothing to commit."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add readme.txt
+            git commit -m "Set Stable tag to $VERSION"
+            git push origin "HEAD:release/$VERSION"
+            echo "✅ Stable tag set to $VERSION on release/$VERSION"
+          fi
+
       - name: Update GitHub release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

Two release-workflow fixes for WordPress Plugin Check `readme.txt` findings.

### 1. `Tested up to` → major.minor only (`prepare-release.yml`)
The workflow wrote the full `X.Y.Z` WordPress version (e.g. `7.0.1`) to `Tested up to`. WP.org requires major.minor (`7.0`), so Plugin Check raised `invalid_tested_upto_minor`. Now truncates the fetched WP version to major.minor before writing it to `readme.txt` and the plugin header. (WC "tested up to" left as full version — not subject to this rule.)

### 2. Propagate the Stable tag to the git release branch (`set-stable-tag.yml`)
`set-stable-tag` bumped the Stable tag in **WordPress.org SVN** but never in git, so the release branch (and `main`) kept the previous live version `prepare-release` wrote — e.g. `main` stayed at `3.7.4` after `3.7.5` shipped (the `stable_tag_mismatch` finding).

Added a step in the existing `create-release-pr` job — which is **already checked out on the existing `release/$VERSION` branch** — to bump `readme.txt`'s Stable tag to `$VERSION`, commit only if changed, and push back to that **same branch**. The already-open "Release $VERSION → main" PR then carries it to `main`.
- **No new branch is created.**
- Runs after the wp.org deploy (in the `create-release-pr` job that follows `set-stable-tag`), so the git Stable tag only advances once the version is actually live — preserving the "never point Stable tag at an undeployed version" safety property.

## Notes
- Both changes affect future releases; the currently-committed values update on the next release run.