### PR TITLE
test(e2e): harden weak assertions and modernize CI database

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: wordpress_test

--- a/.github/workflows/product-creation-tests.yml
+++ b/.github/workflows/product-creation-tests.yml
@@ -123,12 +123,12 @@ jobs:
     name: E2E Tests - ${{ matrix.version-label }} - ${{ matrix.test-group }}
     needs: [check-secrets, resolve-versions]
     if: ${{ needs.check-secrets.outputs.secrets-configured == 'true' }}
-    # Run every shard on the standard GitHub-hosted x86 runner. We previously
+    # Run every shard on the standard GitHub-hosted runner. We previously
     # pinned plugin-events/product-crud to a `4-core-ubuntu-22.04` larger-runner
     # pool, but that label isn't provisioned for this repo, so those jobs queued
     # indefinitely and were cancelled ~24h later by the next scheduled run —
-    # never actually executing. ubuntu-latest is required anyway because the
-    # mysql:5.7 service container has no arm64 image.
+    # never actually executing. The mysql:8.0 service container is multi-arch,
+    # so this is no longer constrained to x86-only pools.
     runs-on: ubuntu-latest
     # Fail fast instead of letting a stuck step (e.g. a hung browser install) run
     # until GitHub's 6-hour default job timeout. plugin-events runs many browser
@@ -155,7 +155,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_ROOT_PASSWORD: wordpress
           MYSQL_DATABASE: wordpress

--- a/tests/e2e/plugin-level-tests.spec.js
+++ b/tests/e2e/plugin-level-tests.spec.js
@@ -635,23 +635,18 @@ test.describe('WooCommerce Plugin level tests', () => {
       ];
 
       for (const pageInfo of pagesToCheck) {
-        try {
-          console.log(`🔍 Checking ${pageInfo.name} page...`);
-          await page.goto(`${baseURL}${pageInfo.path}`, {
-            waitUntil: 'domcontentloaded',
-            timeout: TIMEOUTS.MAX
-          });
+        console.log(`🔍 Checking ${pageInfo.name} page...`);
+        await page.goto(`${baseURL}${pageInfo.path}`, {
+          waitUntil: 'domcontentloaded',
+          timeout: TIMEOUTS.MAX
+        });
 
-          await checkForPhpErrors(page);
+        await checkForPhpErrors(page);
 
-          // Verify admin content loaded
-          await page.locator('#wpcontent').isVisible({ timeout: TIMEOUTS.LONG });
+        // Verify admin content loaded
+        await expect(page.locator('#wpcontent')).toBeVisible({ timeout: TIMEOUTS.LONG });
 
-          console.log(`✅ ${pageInfo.name} page loaded without errors`);
-
-        } catch (error) {
-          console.log(`⚠️ ${pageInfo.name} page check failed: ${error.message}`);
-        }
+        console.log(`✅ ${pageInfo.name} page loaded without errors`);
       }
 
       logTestEnd(testInfo, true);

--- a/tests/e2e/product-deletion.spec.js
+++ b/tests/e2e/product-deletion.spec.js
@@ -201,7 +201,9 @@ test.describe('Meta for WooCommerce - Product Deletion E2E Tests', () => {
       } catch (e) {
         console.warn(`⚠️ Description still not updated in woo: expected "${newDescription}", got "${syncResultAfter?.raw_data?.woo_data?.[0]?.description}"`);
       }
-      expect(syncResultAfter['raw_data']['facebook_data']['found']).toBe(false);
+      // facebook_data is an array of per-item results ([{ found: bool, ... }]),
+      // mirroring woo_data above. After exclusion the item must report found=false.
+      expect(syncResultAfter['raw_data']['facebook_data'][0]['found']).toBe(false);
       console.log('✅ Product no longer exists on Facebook catalog');
       logTestEnd(testInfo, true);
     } catch (error) {

--- a/tests/e2e/product-deletion.spec.js
+++ b/tests/e2e/product-deletion.spec.js
@@ -201,7 +201,7 @@ test.describe('Meta for WooCommerce - Product Deletion E2E Tests', () => {
       } catch (e) {
         console.warn(`⚠️ Description still not updated in woo: expected "${newDescription}", got "${syncResultAfter?.raw_data?.woo_data?.[0]?.description}"`);
       }
-      expect(syncResultAfter['raw_data']['facebook_data']['found'], false);
+      expect(syncResultAfter['raw_data']['facebook_data']['found']).toBe(false);
       console.log('✅ Product no longer exists on Facebook catalog');
       logTestEnd(testInfo, true);
     } catch (error) {


### PR DESCRIPTION
## Summary

Hardening changes from the "Reducing manual regression scope after the E2E expansion" review. Under the reliability gate — a manual step is retired only when the automated test replacing it *asserts the actual outcome* — two confirmed no-op checks and an EOL DB pin block progress. This fixes them.

### 1. Fix no-op catalog-absence assertion
`tests/e2e/product-deletion.spec.js` — `expect(syncResultAfter['raw_data']['facebook_data']['found'], false)` passed `false` as `expect()`'s *message* argument, so **no matcher ran**. The "product absent from catalog after exclusion" check asserted nothing. Now `.toBe(false)`.

### 2. Make the key-pages PHP check able to fail
`tests/e2e/plugin-level-tests.spec.js` — "Quick PHP error check across key pages" wrapped each page in a `try/catch` that logged `⚠️` and continued, so the test could pass with every page broken. The `#wpcontent` visibility result was also queried but never asserted. Removed the inner swallow; assert visibility with `expect(...).toBeVisible()`. The outer catch still fails + rethrows on genuine errors.

### 3. Modernize CI database: mysql:5.7 → mysql:8.0
`mysql:5.7` is EOL (Oct 2023), has no arm64 image (forcing x86-only pools), and doesn't match "latest WP + latest WC" reality (collation/SQL-mode/reserved-word changes in 8.0). Moved E2E (`product-creation-tests.yml`) and integration (`integration-tests.yml`) DB services to `mysql:8.0` (multi-arch) and refreshed the stale runner comment.

> **Watch on first run:** MySQL 8.0 defaults to `caching_sha2_password` (5.7 used `mysql_native_password`). Connections here go over TCP via the `mysql` CLI and PHP mysqlnd, both of which support it on ubuntu-latest + PHP 7.4/8.4, so this should work. If a connection fails, the fix is `--default-authentication-plugin=mysql_native_password` on the service.

## Not included
E2E PHP 8.1 → version-set matrix pairing is handled separately in #3982.

## Test plan
- CI E2E + integration suites must pass on mysql:8.0.
- The two assertion fixes should be verified to go red when the behavior is broken (per the reliability gate's "hardening PR must show the assertion fails when the behavior is broken").