### PR TITLE
test(e2e): assert exact mapped value on Facebook color field

### DIFF
--- a/tests/e2e/plugin-level-tests.spec.js
+++ b/tests/e2e/plugin-level-tests.spec.js
@@ -909,18 +909,25 @@ test.describe('WooCommerce Plugin level tests', () => {
       const colorValue = facebookData[0]['color'];
       console.log(`📊 Facebook color field value: ${colorValue}`);
 
-      // Verify the color value matches one of our attribute options
-      const validColors = attributeOptions.map(opt => opt.toLowerCase());
-      const colorLower = colorValue ? colorValue.toLowerCase() : '';
-      const colorMatches = validColors.some(valid => colorLower.includes(valid.toLowerCase()));
+      // The mapped WooCommerce attribute value must actually propagate to Meta's
+      // "color" field. Assert this unconditionally: a missing or mismatched value
+      // is a real regression in attribute mapping, not something to warn past.
+      // (A prior version fell back to expect(colorValue).toBeTruthy(), which
+      // accepted any non-empty value — even a wrong one — masking mapping bugs.)
+      expect(
+        colorValue,
+        'Facebook "color" field should be populated from the mapped attribute'
+      ).toBeTruthy();
 
-      if (colorMatches) {
-        console.log(`✅ Color field correctly contains attribute value(s): ${colorValue}`);
-      } else {
-        console.log(`⚠️ Color field value "${colorValue}" - verifying it was set from attribute mapping`);
-        // The color might be formatted differently, just ensure it exists
-        expect(colorValue).toBeTruthy();
-      }
+      const validColors = attributeOptions.map(opt => opt.toLowerCase());
+      const colorLower = colorValue.toLowerCase();
+      const colorMatches = validColors.some(valid => colorLower.includes(valid));
+      expect(
+        colorMatches,
+        `Facebook "color" field "${colorValue}" should contain one of the mapped ` +
+        `attribute values [${attributeOptions.join(', ')}]`
+      ).toBe(true);
+      console.log(`✅ Color field correctly contains mapped attribute value(s): ${colorValue}`);
 
       console.log('✅ Attribute mapping test completed successfully');
       logTestEnd(testInfo, true);


### PR DESCRIPTION
## Summary

Follow-up hardening from the "Reducing manual regression scope after the E2E expansion" review (companion to #3984). Targets the Facebook-specific field defect that blocks retiring the guide's field-verification manual step.

### Facebook "color" field: warn-and-continue → real assertion
`tests/e2e/plugin-level-tests.spec.js` — "Create attribute mapping and verify attribute syncs to Facebook catalog" mapped a WooCommerce attribute to Meta's `color` field, then checked whether the synced value matched. But on a mismatch it logged `⚠️` and fell back to `expect(colorValue).toBeTruthy()`, which accepts **any** non-empty value — even a wrong one — so an attribute-mapping regression could pass silently.

Now the test asserts unconditionally:
1. the `color` field is populated, and
2. it contains one of the mapped attribute values,

with descriptive failure messages. This satisfies the reliability gate's requirement that a hardened test go red when the behavior is broken, before the guide's "Facebook-specific product data" step can be reduced.

## Not included (needs your call) — Search/AJAX conditional skips
The review also flagged conditional `test.skip(...)` in `events-test.spec.js` for Search and shop AJAX add-to-cart across the 10 customer-facing browser/theme projects. This is **not** a mechanical fix:
- `chromium-wp-customer-classic-theme` / `-block-theme` are skipped by design (search UI not guaranteed on non-Storefront themes).
- Only `brave-wp-customer` currently hard-fails on a missing search input; every other Storefront fixture (`chromium`, `edge`, `firefox`, `opera`, `android-pixel`, `safari-ios`) silently skips.

Converting those silent skips to hard failures is correct in principle (a skip is not coverage evidence for that config) but risks false failures on mobile fixtures where search may be behind a toggle. Deferring pending a per-fixture decision on which projects must have a search UI.

## Test plan
- Attribute-mapping E2E test passes with correct mapping and fails when the color field is empty or mismatched.