### PR TITLE
test(e2e): cover Search event on classic + block theme projects

### DIFF
--- a/tests/e2e/events-test.spec.js
+++ b/tests/e2e/events-test.spec.js
@@ -13,6 +13,8 @@ const {
   removeJsErrorSimulatorMuPlugin,
   installSingleSearchRedirectBlockerMuPlugin,
   removeSingleSearchRedirectBlockerMuPlugin,
+  installBlockThemeHeaderSearchMuPlugin,
+  removeBlockThemeHeaderSearchMuPlugin,
   getVisibleSearchInput,
   createVariableProductEventFixture,
   createGroupedProductEventFixture,
@@ -40,10 +42,30 @@ const {
 } = require('./helpers/js');
 
 const STOREFRONT_THEME_SLUG = 'storefront';
+// Classic project uses Twenty Thirteen because it ships a persistent, load-visible
+// search form in its header (get_search_form() in header.php) — unlike Twenty
+// Twenty-One, which has no header search. This lets the Search event run natively on
+// the classic architecture. The block project keeps Twenty Twenty-Five (no FSE theme
+// ships a header search) and gets a search block injected via the header-search
+// mu-plugin (see PROJECTS_NEEDING_HEADER_SEARCH_INJECTION below).
 const THEME_PROJECT_TO_SLUG = {
-  'chromium-wp-customer-classic-theme': 'twentytwentyone',
+  'chromium-wp-customer-classic-theme': 'twentythirteen',
   'chromium-wp-customer-block-theme': 'twentytwentyfive',
 };
+
+// Block-theme projects that need a search block injected into the header so the
+// Search event can be exercised (no stock FSE theme ships a header search).
+const PROJECTS_NEEDING_HEADER_SEARCH_INJECTION = ['chromium-wp-customer-block-theme'];
+
+// Projects where a search UI is guaranteed and its absence is a real failure, not a
+// skippable fixture limitation: Storefront-based brave, the classic theme (native
+// header search) and the block theme (injected header search). A skip here would be
+// false coverage evidence for that configuration.
+const PROJECTS_REQUIRING_SEARCH = [
+  'brave-wp-customer',
+  'chromium-wp-customer-classic-theme',
+  'chromium-wp-customer-block-theme',
+];
 
 let themeLockToken = null;
 let originalThemeSlug = null;
@@ -199,15 +221,23 @@ test.beforeAll(async ({}, workerInfo) => {
     }
   }
 
+  if (PROJECTS_NEEDING_HEADER_SEARCH_INJECTION.includes(workerInfo.project.name)) {
+    await installBlockThemeHeaderSearchMuPlugin();
+  }
+
   activeThemeProjectSlug = targetThemeSlug;
 });
 
-test.afterAll(async () => {
+test.afterAll(async ({}, workerInfo) => {
   if (!themeLockToken) {
     return;
   }
 
   try {
+    if (PROJECTS_NEEDING_HEADER_SEARCH_INJECTION.includes(workerInfo.project.name)) {
+      await removeBlockThemeHeaderSearchMuPlugin();
+    }
+
     const restoreTarget = originalThemeSlug || STOREFRONT_THEME_SLUG;
     const restoreResult = await switchThemeBySlug(restoreTarget);
     if (!restoreResult.success) {
@@ -804,11 +834,6 @@ test('Purchase - Multiple Place Order Clicks', async ({ page }, testInfo) => {
 });
 
 test('Search', async ({ page }, testInfo) => {
-    test.skip(
-      ['chromium-wp-customer-classic-theme', 'chromium-wp-customer-block-theme'].includes(testInfo.project.name),
-      'Search is not validated on non-Storefront theme projects because search UI is not guaranteed.'
-    );
-
     await installSingleSearchRedirectBlockerMuPlugin();
 
     try {
@@ -820,8 +845,8 @@ test('Search', async ({ page }, testInfo) => {
 
       console.log(`   🔍 Typing search query in search box`);
       const searchInput = await getVisibleSearchInput(page);
-      if (!searchInput && testInfo.project.name.includes('brave')) {
-        throw new Error('Search UI was not found for brave-wp-customer on Storefront; this should be present and must not be skipped.');
+      if (!searchInput && PROJECTS_REQUIRING_SEARCH.includes(testInfo.project.name)) {
+        throw new Error(`Search UI was not found for ${testInfo.project.name}; a search UI is expected here and this must not be skipped.`);
       }
       test.skip(!searchInput, 'Search UI is not available in this browser/theme fixture.');
       await searchInput.fill('test');
@@ -858,11 +883,6 @@ test('Search', async ({ page }, testInfo) => {
 });
 
 test('Search - No Results', async ({ page }, testInfo) => {
-    test.skip(
-      ['chromium-wp-customer-classic-theme', 'chromium-wp-customer-block-theme'].includes(testInfo.project.name),
-      'Search is not validated on non-Storefront theme projects because search UI is not guaranteed.'
-    );
-
     const { testId, pixelCapture } = await TestSetup.init(page, 'Search', testInfo, true); // expectZeroEvents=true
 
     console.log(`   🏠 Navigating to homepage`);
@@ -874,8 +894,8 @@ test('Search - No Results', async ({ page }, testInfo) => {
     console.log(`   🔍 Typing random search query: ${randomString}`);
 
     const searchInput = await getVisibleSearchInput(page);
-    if (!searchInput && testInfo.project.name.includes('brave')) {
-      throw new Error('Search UI was not found for brave-wp-customer on Storefront; this should be present and must not be skipped.');
+    if (!searchInput && PROJECTS_REQUIRING_SEARCH.includes(testInfo.project.name)) {
+      throw new Error(`Search UI was not found for ${testInfo.project.name}; a search UI is expected here and this must not be skipped.`);
     }
     test.skip(!searchInput, 'Search UI is not available in this browser/theme fixture.');
     await searchInput.fill(randomString);

--- a/tests/e2e/helpers/js/index.js
+++ b/tests/e2e/helpers/js/index.js
@@ -99,7 +99,9 @@ const {
   installJsErrorSimulatorMuPlugin,
   removeJsErrorSimulatorMuPlugin,
   installSingleSearchRedirectBlockerMuPlugin,
-  removeSingleSearchRedirectBlockerMuPlugin
+  removeSingleSearchRedirectBlockerMuPlugin,
+  installBlockThemeHeaderSearchMuPlugin,
+  removeBlockThemeHeaderSearchMuPlugin
 } = require('./wordpress/plugins');
 
 const {
@@ -254,6 +256,8 @@ const wordpress = {
   removeJsErrorSimulatorMuPlugin,
   installSingleSearchRedirectBlockerMuPlugin,
   removeSingleSearchRedirectBlockerMuPlugin,
+  installBlockThemeHeaderSearchMuPlugin,
+  removeBlockThemeHeaderSearchMuPlugin,
   runWpCli,
   getActiveThemeStatus,
   switchThemeBySlug,
@@ -385,6 +389,8 @@ module.exports = {
   removeJsErrorSimulatorMuPlugin,
   installSingleSearchRedirectBlockerMuPlugin,
   removeSingleSearchRedirectBlockerMuPlugin,
+  installBlockThemeHeaderSearchMuPlugin,
+  removeBlockThemeHeaderSearchMuPlugin,
 
   // WordPress - Themes
   runWpCli,

--- a/tests/e2e/helpers/js/wordpress/plugins.js
+++ b/tests/e2e/helpers/js/wordpress/plugins.js
@@ -205,6 +205,74 @@ async function removeSingleSearchRedirectBlockerMuPlugin() {
   console.log('✅ Single-search redirect blocker mu-plugin removed');
 }
 
+/**
+ * Install mu-plugin that injects a core/search block into block-theme header
+ * template parts.
+ *
+ * No stock or common third-party FSE (block) theme ships a search UI in its
+ * default header, so the Search event cannot be exercised on the block-theme
+ * project out of the box. This injects a visible search form into the header
+ * template part (via the get_block_template filters, which fire for both DB- and
+ * file-based parts) so Search validates on the block architecture too. The
+ * classic-theme project uses a theme with a native header search instead, so it
+ * does not need this. Harmless on classic themes — they have no block template
+ * parts for the filter to match.
+ */
+async function installBlockThemeHeaderSearchMuPlugin() {
+  console.log('🔧 Installing block-theme header search injector mu-plugin...');
+  const muPluginDir = `${wpSitePath}/wp-content/mu-plugins`;
+  const muPluginFile = `${muPluginDir}/e2e-block-theme-header-search.php`;
+  const code = `<?php
+/**
+ * Plugin Name: E2E Block Theme Header Search Injector
+ * Description: Injects a core/search block into block-theme header template parts so the
+ *   WooCommerce Search event can be exercised on FSE themes that ship no header search.
+ * Version: 1.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$e2e_inject_header_search = function ( $block_template, $id, $template_type ) {
+    if (
+        'wp_template_part' === $template_type
+        && $block_template instanceof WP_Block_Template
+        && isset( $block_template->slug )
+        && 'header' === $block_template->slug
+        && false === strpos( (string) $block_template->content, 'e2e-injected-search' )
+    ) {
+        $block_template->content .= ' <!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","buttonPosition":"button-outside","className":"e2e-injected-search"} /-->';
+    }
+
+    return $block_template;
+};
+
+// Register on both filters: get_block_file_template covers file-based parts (the
+// default for stock themes), get_block_template covers DB-backed/customized parts.
+add_filter( 'get_block_file_template', $e2e_inject_header_search, 10, 3 );
+add_filter( 'get_block_template', $e2e_inject_header_search, 10, 3 );
+`;
+
+  fs.mkdirSync(muPluginDir, { recursive: true });
+  fs.writeFileSync(muPluginFile, code);
+
+  console.log('✅ Block-theme header search injector mu-plugin installed');
+}
+
+/**
+ * Remove the block-theme header search injector mu-plugin.
+ */
+async function removeBlockThemeHeaderSearchMuPlugin() {
+  console.log('🧹 Removing block-theme header search injector mu-plugin...');
+  const muPluginFile = `${wpSitePath}/wp-content/mu-plugins/e2e-block-theme-header-search.php`;
+
+  if (fs.existsSync(muPluginFile)) {
+    fs.unlinkSync(muPluginFile);
+  }
+  console.log('✅ Block-theme header search injector mu-plugin removed');
+}
+
 module.exports = {
   installPlugin,
   uninstallPlugin,
@@ -215,5 +283,7 @@ module.exports = {
   installJsErrorSimulatorMuPlugin,
   removeJsErrorSimulatorMuPlugin,
   installSingleSearchRedirectBlockerMuPlugin,
-  removeSingleSearchRedirectBlockerMuPlugin
+  removeSingleSearchRedirectBlockerMuPlugin,
+  installBlockThemeHeaderSearchMuPlugin,
+  removeBlockThemeHeaderSearchMuPlugin
 };


### PR DESCRIPTION
## Summary

Closes gap #6 from the "Reducing manual regression scope after the E2E expansion" review. The Search and *Search - No Results* event tests were **skipped** on the `chromium-wp-customer-classic-theme` and `chromium-wp-customer-block-theme` projects because those themes render no header search UI. Per the reliability gate, **a skipped configuration is not coverage evidence** — so the manual Search step couldn't be retired for the classic/block architectures.

This enables real Search coverage on both theme architectures.

### Investigation (why not just "pick a theme with search")
I inspected the default header of every stock WP theme and the popular third-party FSE themes:
- **Classic:** Twenty Thirteen and Twenty Eleven ship a persistent, load-visible `get_search_form()` in `header.php`. Twenty Twenty hides search behind a toggle; Twenty Fifteen/Sixteen/Seventeen/Twenty-One have none.
- **Block/FSE:** *none* — stock (Twenty Twenty-Two → Five) **and** popular third-party (Ollie, Frost, Tove, Aino, Wabi, Pendant, Blockbase, Raft) all ship header = title + nav, no search.

So the classic half is a clean theme swap; the block half genuinely needs injection.

### Changes
- **Classic** → switch project theme `twentytwentyone` → **`twentythirteen`** (native header search, no injection).
- **Block** → keep `twentytwentyfive`; a mu-plugin (installed **only** for the block-theme project, removed in `afterAll`) injects a `core/search` block into the header template part via the `get_block_template` / `get_block_file_template` filters (covers file- and DB-based parts). Harmless on classic themes (no block template parts to match).
- Remove the classic/block project-name skips; generalize the brave-only hard-fail to `PROJECTS_REQUIRING_SEARCH` (brave + classic + block) so a missing search UI on these configs **fails loudly instead of silently skipping**.
- The responsive/mobile skip (search behind a hamburger on `android-pixel` / `safari-ios`) is intentionally left unchanged — a genuinely different fixture limitation.

`submitSearch` already forces `post_type=product`, so both the native and injected core search forms fire the plugin's WooCommerce Search event the same way the Storefront product-search form does.

### Test plan / verification
Because the tests now **hard-fail** (not skip) on classic + block, CI is the verification: if Twenty Thirteen's native search or the injected block search doesn't render/fire the Search event, the `Search` and `Search - No Results` tests on those two projects will go red. Watching the first run on:
- `E2E Tests - * - plugin-events` (classic-theme + block-theme projects).

Local checks: `node --check` on all changed JS, `php -l` on the generated mu-plugin, and a runtime `require()` of the helper barrel all pass.