### PR TITLE
Add copyright headers and surface license/legal info

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,9 @@ the [wiki for details of how to build and release the plugin](https://github.com
 
 We currently do not support PHPCS on PHP 8.1+ versions. Please run PHPCS checks on PHP 8.0 or lower versions.
 Refer [#2624 PR](https://github.com/woocommerce/facebook-for-woocommerce/pull/2624/) for additional context.
+
+## License
+
+Meta for WooCommerce is licensed under the [GNU General Public License v2.0 (or later)](https://www.gnu.org/licenses/gpl-2.0.html).
+
+See the [LICENSE](LICENSE) file for the full license text.

--- a/assets/css/admin/facebook-for-woocommerce-advertise.css
+++ b/assets/css/admin/facebook-for-woocommerce-advertise.css
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 /** FB LWI Ads widget iframe */
 .fb-lwi-ads-creation.fb_iframe_widget,
 .fb-lwi-ads-insights.fb_iframe_widget {

--- a/assets/css/admin/facebook-for-woocommerce-connection.css
+++ b/assets/css/admin/facebook-for-woocommerce-connection.css
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #wc-facebook-connection-box {
 	width: 50%;
 	min-width: 720px;

--- a/assets/css/admin/facebook-for-woocommerce-product-attributes.css
+++ b/assets/css/admin/facebook-for-woocommerce-product-attributes.css
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 /* Facebook Product Attributes Styles */
 .facebook-woo-attributes-screen {
     background-color: #f0f0f1;

--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #woocommerce-product-data .fb-product-image-source-field .wc-radios {
 	width: auto;
 }

--- a/assets/css/admin/facebook-for-woocommerce-shops.css
+++ b/assets/css/admin/facebook-for-woocommerce-shops.css
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #facebook-commerce-iframe-enhanced {
 	width: 100%;
 	max-width: 1100px;

--- a/assets/css/admin/facebook-for-woocommerce-whatsapp-banner.css
+++ b/assets/css/admin/facebook-for-woocommerce-whatsapp-banner.css
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 .fb-wa-banner {
 	display: block;
 	position: relative;

--- a/assets/css/admin/facebook-for-woocommerce-whatsapp-enhanced.css
+++ b/assets/css/admin/facebook-for-woocommerce-whatsapp-enhanced.css
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 .facebook-whatsapp-iframe-container {
     justify-content: center;
     margin: 0 auto;

--- a/assets/css/admin/products-categories.css
+++ b/assets/css/admin/products-categories.css
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 .term-wc_facebook_google_product_category_id-wrap #wc-facebook-google-product-category-fields {
 	width: 50%;
 }

--- a/assets/js/admin/index.js
+++ b/assets/js/admin/index.js
@@ -1,1 +1,8 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 // Add new any JS here

--- a/assets/js/admin/plugin-api-client.js
+++ b/assets/js/admin/plugin-api-client.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Meta for WooCommerce API
  *
  * @package MetaCommerce

--- a/assets/js/admin/product-attributes.js
+++ b/assets/js/admin/product-attributes.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Product Attributes Settings Page Scripts
  *
  * @package facebook-for-woocommerce

--- a/assets/js/admin/whatsapp-admin-banner.js
+++ b/assets/js/admin/whatsapp-admin-banner.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 jQuery(function ($) {
 	$(document).on('click', '.fb-wa-banner .wa-close-button', function (e) {
 		e.preventDefault();

--- a/assets/js/admin/whatsapp-admin-notice.js
+++ b/assets/js/admin/whatsapp-admin-notice.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 jQuery(function ($) {
 	$(document).on('click', '.wc-facebook-global-notice.is-dismissible .notice-dismiss', function () {
 		$.post(WCFBAdminNotice.ajax_url, {

--- a/assets/js/frontend/pixel-events.js
+++ b/assets/js/frontend/pixel-events.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Facebook Pixel Events - External JavaScript Handler
  *
  * This script fires pixel events in an isolated execution context,

--- a/bin/GenerateCategoryAttributeMapping.php
+++ b/bin/GenerateCategoryAttributeMapping.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 /**
  * Class GenerateCategoryAttributeMapping

--- a/bin/GenerateCategoryAttributeMapping.php
+++ b/bin/GenerateCategoryAttributeMapping.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 /**
  * Class GenerateCategoryAttributeMapping
  *

--- a/bin/lint-branch.sh
+++ b/bin/lint-branch.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+#
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
 
 # Lint branch
 #

--- a/includes/API/Catalog/Response.php
+++ b/includes/API/Catalog/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\Catalog;

--- a/includes/API/CommerceIntegration/Configuration/Request.php
+++ b/includes/API/CommerceIntegration/Configuration/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\CommerceIntegration\Configuration;

--- a/includes/API/CommerceIntegration/Configuration/Update/Response.php
+++ b/includes/API/CommerceIntegration/Configuration/Update/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 namespace WooCommerce\Facebook\API\CommerceIntegration\Configuration\Update;
 

--- a/includes/API/CommerceIntegration/Configuration/Update/Response.php
+++ b/includes/API/CommerceIntegration/Configuration/Update/Response.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 namespace WooCommerce\Facebook\API\CommerceIntegration\Configuration\Update;
 
 use WooCommerce\Facebook\API\Response as ApiResponse;

--- a/includes/API/CommerceIntegration/Configuration/Update/UpdateRequest.php
+++ b/includes/API/CommerceIntegration/Configuration/Update/UpdateRequest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\CommerceIntegration\Configuration\Update;

--- a/includes/API/CommerceIntegration/Repair/RepairRequest.php
+++ b/includes/API/CommerceIntegration/Repair/RepairRequest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\CommerceIntegration\Repair;

--- a/includes/API/CommerceIntegration/Repair/Response.php
+++ b/includes/API/CommerceIntegration/Repair/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\CommerceIntegration\Repair;

--- a/includes/API/Exceptions/ConnectApiException.php
+++ b/includes/API/Exceptions/ConnectApiException.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 namespace WooCommerce\Facebook\API\Exceptions;
 

--- a/includes/API/Exceptions/ConnectApiException.php
+++ b/includes/API/Exceptions/ConnectApiException.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 namespace WooCommerce\Facebook\API\Exceptions;
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/API/FBE/Configuration/Read/Response.php
+++ b/includes/API/FBE/Configuration/Read/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\FBE\Configuration\Read;

--- a/includes/API/FBE/Configuration/Request.php
+++ b/includes/API/FBE/Configuration/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\FBE\Configuration;

--- a/includes/API/FBE/Configuration/Update/Response.php
+++ b/includes/API/FBE/Configuration/Update/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\FBE\Configuration\Update;

--- a/includes/API/FBE/Installation/Delete/Response.php
+++ b/includes/API/FBE/Installation/Delete/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\FBE\Installation\Delete;

--- a/includes/API/FBE/Installation/Read/Response.php
+++ b/includes/API/FBE/Installation/Read/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\FBE\Installation\Read;

--- a/includes/API/FBE/RolloutSwitches/Request.php
+++ b/includes/API/FBE/RolloutSwitches/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\FBE\RolloutSwitches;

--- a/includes/API/FBE/RolloutSwitches/Response.php
+++ b/includes/API/FBE/RolloutSwitches/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\FBE\RolloutSwitches;

--- a/includes/API/MetaLog/Request.php
+++ b/includes/API/MetaLog/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\MetaLog;

--- a/includes/API/MetaLog/Response.php
+++ b/includes/API/MetaLog/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\MetaLog;

--- a/includes/API/Pages/Read/Request.php
+++ b/includes/API/Pages/Read/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\Pages\Read;

--- a/includes/API/Pages/Read/Response.php
+++ b/includes/API/Pages/Read/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\Pages\Read;

--- a/includes/API/Plugin/InitializeRestAPI.php
+++ b/includes/API/Plugin/InitializeRestAPI.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * REST API Initialization
  *
  * @package MetaCommerce

--- a/includes/API/ProductCatalog/ItemsBatch/Create/Request.php
+++ b/includes/API/ProductCatalog/ItemsBatch/Create/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ItemsBatch\Create;

--- a/includes/API/ProductCatalog/ItemsBatch/Create/Response.php
+++ b/includes/API/ProductCatalog/ItemsBatch/Create/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ItemsBatch\Create;

--- a/includes/API/ProductCatalog/ProductFeedUploads/Create/Request.php
+++ b/includes/API/ProductCatalog/ProductFeedUploads/Create/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductFeedUploads\Create;

--- a/includes/API/ProductCatalog/ProductFeedUploads/Create/Response.php
+++ b/includes/API/ProductCatalog/ProductFeedUploads/Create/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductFeedUploads\Create;

--- a/includes/API/ProductCatalog/ProductFeedUploads/Read/Request.php
+++ b/includes/API/ProductCatalog/ProductFeedUploads/Read/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductFeedUploads\Read;

--- a/includes/API/ProductCatalog/ProductFeedUploads/Read/Response.php
+++ b/includes/API/ProductCatalog/ProductFeedUploads/Read/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductFeedUploads\Read;

--- a/includes/API/ProductCatalog/ProductFeeds/Create/Request.php
+++ b/includes/API/ProductCatalog/ProductFeeds/Create/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductFeeds\Create;

--- a/includes/API/ProductCatalog/ProductFeeds/Create/Response.php
+++ b/includes/API/ProductCatalog/ProductFeeds/Create/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductFeeds\Create;

--- a/includes/API/ProductCatalog/ProductFeeds/Read/Request.php
+++ b/includes/API/ProductCatalog/ProductFeeds/Read/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductFeeds\Read;

--- a/includes/API/ProductCatalog/ProductFeeds/Read/Response.php
+++ b/includes/API/ProductCatalog/ProductFeeds/Read/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductFeeds\Read;

--- a/includes/API/ProductCatalog/ProductFeeds/ReadAll/Request.php
+++ b/includes/API/ProductCatalog/ProductFeeds/ReadAll/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductFeeds\ReadAll;

--- a/includes/API/ProductCatalog/ProductFeeds/ReadAll/Response.php
+++ b/includes/API/ProductCatalog/ProductFeeds/ReadAll/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductFeeds\ReadAll;

--- a/includes/API/ProductCatalog/ProductGroups/Create/Request.php
+++ b/includes/API/ProductCatalog/ProductGroups/Create/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductGroups\Create;

--- a/includes/API/ProductCatalog/ProductGroups/Create/Response.php
+++ b/includes/API/ProductCatalog/ProductGroups/Create/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductGroups\Create;

--- a/includes/API/ProductCatalog/ProductGroups/Read/Request.php
+++ b/includes/API/ProductCatalog/ProductGroups/Read/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductGroups\Read;

--- a/includes/API/ProductCatalog/ProductGroups/Read/Response.php
+++ b/includes/API/ProductCatalog/ProductGroups/Read/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductGroups\Read;

--- a/includes/API/ProductCatalog/ProductGroups/Update/Request.php
+++ b/includes/API/ProductCatalog/ProductGroups/Update/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductGroups\Update;

--- a/includes/API/ProductCatalog/ProductGroups/Update/Response.php
+++ b/includes/API/ProductCatalog/ProductGroups/Update/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductGroups\Update;

--- a/includes/API/ProductCatalog/ProductSets/Create/Request.php
+++ b/includes/API/ProductCatalog/ProductSets/Create/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductSets\Create;

--- a/includes/API/ProductCatalog/ProductSets/Create/Response.php
+++ b/includes/API/ProductCatalog/ProductSets/Create/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductSets\Create;

--- a/includes/API/ProductCatalog/ProductSets/Delete/Request.php
+++ b/includes/API/ProductCatalog/ProductSets/Delete/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductSets\Delete;

--- a/includes/API/ProductCatalog/ProductSets/Delete/Response.php
+++ b/includes/API/ProductCatalog/ProductSets/Delete/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductSets\Delete;

--- a/includes/API/ProductCatalog/ProductSets/Read/Request.php
+++ b/includes/API/ProductCatalog/ProductSets/Read/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 declare(strict_types=1);
 

--- a/includes/API/ProductCatalog/ProductSets/Read/Request.php
+++ b/includes/API/ProductCatalog/ProductSets/Read/Request.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 declare(strict_types=1);
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductSets\Read;

--- a/includes/API/ProductCatalog/ProductSets/Read/Response.php
+++ b/includes/API/ProductCatalog/ProductSets/Read/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductSets\Read;

--- a/includes/API/ProductCatalog/ProductSets/Update/Request.php
+++ b/includes/API/ProductCatalog/ProductSets/Update/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductSets\Update;

--- a/includes/API/ProductCatalog/ProductSets/Update/Response.php
+++ b/includes/API/ProductCatalog/ProductSets/Update/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\ProductSets\Update;

--- a/includes/API/ProductCatalog/Products/Create/Request.php
+++ b/includes/API/ProductCatalog/Products/Create/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\Products\Create;

--- a/includes/API/ProductCatalog/Products/Create/Response.php
+++ b/includes/API/ProductCatalog/Products/Create/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\Products\Create;

--- a/includes/API/ProductCatalog/Products/Delete/Request.php
+++ b/includes/API/ProductCatalog/Products/Delete/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\Products\Delete;

--- a/includes/API/ProductCatalog/Products/Delete/Response.php
+++ b/includes/API/ProductCatalog/Products/Delete/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\Products\Delete;

--- a/includes/API/ProductCatalog/Products/Id/Request.php
+++ b/includes/API/ProductCatalog/Products/Id/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\Products\Id;

--- a/includes/API/ProductCatalog/Products/Id/Response.php
+++ b/includes/API/ProductCatalog/Products/Id/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\Products\Id;

--- a/includes/API/ProductCatalog/Products/Update/Request.php
+++ b/includes/API/ProductCatalog/Products/Update/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\Products\Update;

--- a/includes/API/ProductCatalog/Products/Update/Response.php
+++ b/includes/API/ProductCatalog/Products/Update/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\ProductCatalog\Products\Update;

--- a/includes/API/PublicKeyGet/Request.php
+++ b/includes/API/PublicKeyGet/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\PublicKeyGet;

--- a/includes/API/Request.php
+++ b/includes/API/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API;

--- a/includes/API/User/Permissions/Delete/Request.php
+++ b/includes/API/User/Permissions/Delete/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\User\Permissions\Delete;

--- a/includes/API/User/Permissions/Delete/Response.php
+++ b/includes/API/User/Permissions/Delete/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\User\Permissions\Delete;

--- a/includes/API/User/Request.php
+++ b/includes/API/User/Request.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\User;

--- a/includes/API/User/Response.php
+++ b/includes/API/User/Response.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\API\User;

--- a/includes/Admin/Notes/SettingsMoved.php
+++ b/includes/Admin/Notes/SettingsMoved.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Facebook Menu Settings moved note.
  *
  * Adds a note to merchant's inbox about Facebook Menu being moved to Marketing menu.

--- a/includes/Admin/Tasks/Setup.php
+++ b/includes/Admin/Tasks/Setup.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Set up Facebook task.
  *
  * Adds a set up facebook task to the task list.

--- a/includes/Debug/ProfilingLogger.php
+++ b/includes/Debug/ProfilingLogger.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 namespace WooCommerce\Facebook\Debug;
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/Debug/ProfilingLoggerProcess.php
+++ b/includes/Debug/ProfilingLoggerProcess.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 namespace WooCommerce\Facebook\Debug;
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/Debug/ProfilingLoggerProcess.php
+++ b/includes/Debug/ProfilingLoggerProcess.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 namespace WooCommerce\Facebook\Debug;
 

--- a/includes/Feed/FeedConfigurationDetection.php
+++ b/includes/Feed/FeedConfigurationDetection.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 namespace WooCommerce\Facebook\Feed;
 

--- a/includes/Feed/FeedConfigurationDetection.php
+++ b/includes/Feed/FeedConfigurationDetection.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 namespace WooCommerce\Facebook\Feed;
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/Feed/Localization/LanguageFeedData.php
+++ b/includes/Feed/Localization/LanguageFeedData.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Feed\Localization;

--- a/includes/Framework/AdminMessageHandler.php
+++ b/includes/Framework/AdminMessageHandler.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Meta for WooCommerce.
  */
 

--- a/includes/Framework/AdminNoticeHandler.php
+++ b/includes/Framework/AdminNoticeHandler.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Meta for WooCommerce.
  */
 

--- a/includes/Framework/Api/Base.php
+++ b/includes/Framework/Api/Base.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Meta for WooCommerce.
  */
 

--- a/includes/Framework/Api/Exception.php
+++ b/includes/Framework/Api/Exception.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Meta for WooCommerce.
  */
 

--- a/includes/Framework/Api/JSONRequest.php
+++ b/includes/Framework/Api/JSONRequest.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Meta for WooCommerce.
  */
 

--- a/includes/Framework/Api/JSONResponse.php
+++ b/includes/Framework/Api/JSONResponse.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Meta for WooCommerce.
  */
 

--- a/includes/Framework/Api/Request.php
+++ b/includes/Framework/Api/Request.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Meta for WooCommerce.
  */
 

--- a/includes/Framework/Api/Response.php
+++ b/includes/Framework/Api/Response.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Meta for WooCommerce.
  */
 

--- a/includes/Framework/Helper.php
+++ b/includes/Framework/Helper.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Meta for WooCommerce.
  */
 

--- a/includes/Framework/Lifecycle.php
+++ b/includes/Framework/Lifecycle.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Meta for WooCommerce.
  */
 

--- a/includes/Framework/Plugin.php
+++ b/includes/Framework/Plugin.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Meta for WooCommerce.
  */
 

--- a/includes/Framework/Plugin/Compatibility.php
+++ b/includes/Framework/Plugin/Compatibility.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Meta for WooCommerce.
  */
 

--- a/includes/Framework/Plugin/Dependencies.php
+++ b/includes/Framework/Plugin/Dependencies.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Meta for WooCommerce.
  */
 

--- a/includes/Framework/Plugin/Exception.php
+++ b/includes/Framework/Plugin/Exception.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Meta for WooCommerce.
  */
 

--- a/includes/Framework/Utilities/AsyncRequest.php
+++ b/includes/Framework/Utilities/AsyncRequest.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Meta for WooCommerce.
  */
 

--- a/includes/Framework/Utilities/BackgroundJobHandler.php
+++ b/includes/Framework/Utilities/BackgroundJobHandler.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Meta for WooCommerce.
  */
 

--- a/includes/Integrations/Abstract_Localization_Integration.php
+++ b/includes/Integrations/Abstract_Localization_Integration.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Integrations;

--- a/includes/Integrations/Facebook_Fields_Translation_Trait.php
+++ b/includes/Integrations/Facebook_Fields_Translation_Trait.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Integrations;

--- a/includes/Integrations/IntegrationRegistry.php
+++ b/includes/Integrations/IntegrationRegistry.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Integrations;

--- a/includes/Integrations/Polylang.php
+++ b/includes/Integrations/Polylang.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Integrations;

--- a/includes/Integrations/WPML.php
+++ b/includes/Integrations/WPML.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Integrations;

--- a/includes/Jobs/AbstractChainedJob.php
+++ b/includes/Jobs/AbstractChainedJob.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 namespace WooCommerce\Facebook\Jobs;
 

--- a/includes/Jobs/AbstractChainedJob.php
+++ b/includes/Jobs/AbstractChainedJob.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 namespace WooCommerce\Facebook\Jobs;
 
 use Automattic\WooCommerce\ActionSchedulerJobFramework\AbstractChainedJob as FrameworkAbstractChainedJob;

--- a/includes/Jobs/GenerateProductFeed.php
+++ b/includes/Jobs/GenerateProductFeed.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 namespace WooCommerce\Facebook\Jobs;
 
 use Automattic\WooCommerce\ActionSchedulerJobFramework\Utilities\BatchQueryOffset;

--- a/includes/Jobs/JobManager.php
+++ b/includes/Jobs/JobManager.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 namespace WooCommerce\Facebook\Jobs;
 
 use Automattic\WooCommerce\ActionSchedulerJobFramework\Proxies\ActionScheduler;

--- a/includes/Jobs/JobManager.php
+++ b/includes/Jobs/JobManager.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 namespace WooCommerce\Facebook\Jobs;
 

--- a/includes/Jobs/LoggingTrait.php
+++ b/includes/Jobs/LoggingTrait.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 namespace WooCommerce\Facebook\Jobs;
 
 use WC_Facebookcommerce;

--- a/includes/Jobs/LoggingTrait.php
+++ b/includes/Jobs/LoggingTrait.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 namespace WooCommerce\Facebook\Jobs;
 

--- a/includes/Jobs/ResetAllProductsFBSettings.php
+++ b/includes/Jobs/ResetAllProductsFBSettings.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 namespace WooCommerce\Facebook\Jobs;
 
 use Automattic\WooCommerce\ActionSchedulerJobFramework\Utilities\BatchQueryOffset;

--- a/includes/Jobs/ResetAllProductsFBSettings.php
+++ b/includes/Jobs/ResetAllProductsFBSettings.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 namespace WooCommerce\Facebook\Jobs;
 

--- a/includes/ProductSync/ProductExcludedException.php
+++ b/includes/ProductSync/ProductExcludedException.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 namespace WooCommerce\Facebook\ProductSync;
 

--- a/includes/ProductSync/ProductExcludedException.php
+++ b/includes/ProductSync/ProductExcludedException.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 namespace WooCommerce\Facebook\ProductSync;
 
 use Exception;

--- a/includes/ProductSync/ProductInvalidException.php
+++ b/includes/ProductSync/ProductInvalidException.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 namespace WooCommerce\Facebook\ProductSync;
 

--- a/includes/ProductSync/ProductInvalidException.php
+++ b/includes/ProductSync/ProductInvalidException.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 namespace WooCommerce\Facebook\ProductSync;
 
 use Exception;

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\ProductSync;

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Products\Sync;

--- a/includes/Utilities/DebugTools.php
+++ b/includes/Utilities/DebugTools.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 namespace WooCommerce\Facebook\Utilities;
 
 /**

--- a/includes/Utilities/DebugTools.php
+++ b/includes/Utilities/DebugTools.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 namespace WooCommerce\Facebook\Utilities;
 

--- a/includes/Utilities/Heartbeat.php
+++ b/includes/Utilities/Heartbeat.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 namespace WooCommerce\Facebook\Utilities;
 

--- a/includes/Utilities/Heartbeat.php
+++ b/includes/Utilities/Heartbeat.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 namespace WooCommerce\Facebook\Utilities;
 
 use WC_Queue_Interface;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,4 +1,10 @@
 <?xml version="1.0"?>
+<!--
+Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+This source code is licensed under the license found in the
+LICENSE file in the root directory of this source tree.
+-->
 <ruleset name="WordPress Coding Standards">
 	<description>WooCommerce dev PHP_CodeSniffer ruleset.</description>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+This source code is licensed under the license found in the
+LICENSE file in the root directory of this source tree.
+-->
 <phpunit
 	bootstrap="tests/bootstrap.php"
 	backupGlobals="false"

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import { defineConfig, devices } from '@playwright/test';
 
 const CUSTOMER_EVENTS_SPEC = '**/events-test.spec.js';

--- a/readme.txt
+++ b/readme.txt
@@ -53,3 +53,17 @@ When that happens, the site still recovers on the next request, but the disable 
 * Fix - Prevent duplicate AddToCart Pixel fires from repeated AJAX fragment execution by @cshing-meta in #3939
 
 [See changelog for all versions](https://raw.githubusercontent.com/facebook/facebook-for-woocommerce/refs/heads/main/changelog.txt).
+
+== Terms of Use ==
+
+Your use of this project is governed by [Meta's Terms of Use](https://opensource.fb.com/legal/terms).
+
+== Privacy Policy ==
+
+For information about how Meta collects and uses data, please review [Meta's Privacy Policy](https://opensource.fb.com/legal/privacy).
+
+== Copyright ==
+
+Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+
+Meta for WooCommerce is distributed under the terms of the GNU General Public License v2.0 (or later). See the LICENSE file in the plugin's source repository for the full license text.

--- a/tests/Unit/AbstractWPUnitTestWithOptionIsolationAndSafeFiltering.php
+++ b/tests/Unit/AbstractWPUnitTestWithOptionIsolationAndSafeFiltering.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Abstract test case for unit tests that require option isolation.
  */
 

--- a/tests/Unit/AbstractWPUnitTestWithSafeFiltering.php
+++ b/tests/Unit/AbstractWPUnitTestWithSafeFiltering.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Abstract test case for unit tests.
  */
 

--- a/tests/Unit/Admin/Abstract_Settings_ScreenTest.php
+++ b/tests/Unit/Admin/Abstract_Settings_ScreenTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 namespace WooCommerce\Facebook\Tests\Admin;
 
 use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;

--- a/tests/Unit/Admin/Enhanced_Catalog_Attribute_FieldsTest.php
+++ b/tests/Unit/Admin/Enhanced_Catalog_Attribute_FieldsTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Admin;

--- a/tests/Unit/Admin/Google_Product_Category_FieldTest.php
+++ b/tests/Unit/Admin/Google_Product_Category_FieldTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Admin;

--- a/tests/Unit/Admin/Notes/SettingsMovedTest.php
+++ b/tests/Unit/Admin/Notes/SettingsMovedTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Admin\Notes;

--- a/tests/Unit/Admin/SettingsTest.php
+++ b/tests/Unit/Admin/SettingsTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 namespace WooCommerce\Facebook\Tests\Admin;
 
 use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;

--- a/tests/Unit/Admin/Settings_Screens/Product_SyncTest.php
+++ b/tests/Unit/Admin/Settings_Screens/Product_SyncTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 namespace WooCommerce\Facebook\Tests\Admin\Settings_Screens;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Admin/Settings_Screens/ShopsTest.php
+++ b/tests/Unit/Admin/Settings_Screens/ShopsTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 namespace WooCommerce\Facebook\Tests\Admin\Settings_Screens;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Admin/Tasks/SetupTest.php
+++ b/tests/Unit/Admin/Tasks/SetupTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Admin\Tasks;

--- a/tests/Unit/Admin/WhatsApp_Integration_SettingsTest.php
+++ b/tests/Unit/Admin/WhatsApp_Integration_SettingsTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 namespace WooCommerce\Facebook\Tests\Admin;
 
 use WooCommerce\Facebook\Admin\WhatsApp_Integration_Settings;

--- a/tests/Unit/AdminTest.php
+++ b/tests/Unit/AdminTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare(strict_types=1);
 
 namespace WooCommerce\Facebook\Tests\Unit;

--- a/tests/Unit/Api/Exceptions/Request_Limit_ReachedTest.php
+++ b/tests/Unit/Api/Exceptions/Request_Limit_ReachedTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Api\Exceptions;

--- a/tests/Unit/Api/FBE/Configuration/Read/FBEConfigurationReadResponseTest.php
+++ b/tests/Unit/Api/FBE/Configuration/Read/FBEConfigurationReadResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Api\FBE\Configuration\Read;

--- a/tests/Unit/Api/FBE/Configuration/Update/UpdateConfigurationResponseTest.php
+++ b/tests/Unit/Api/FBE/Configuration/Update/UpdateConfigurationResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\FBE\Configuration\Update;

--- a/tests/Unit/Api/FBE/Installation/Delete/DeleteInstallationResponseTest.php
+++ b/tests/Unit/Api/FBE/Installation/Delete/DeleteInstallationResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\FBE\Installation\Delete;

--- a/tests/Unit/Api/FBE/Installation/Read/ReadInstallationResponseTest.php
+++ b/tests/Unit/Api/FBE/Installation/Read/ReadInstallationResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\FBE\Installation\Read;

--- a/tests/Unit/Api/MetaLog/MetaLogResponseTest.php
+++ b/tests/Unit/Api/MetaLog/MetaLogResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\MetaLog;

--- a/tests/Unit/Api/Pages/Read/PagesReadRequestTest.php
+++ b/tests/Unit/Api/Pages/Read/PagesReadRequestTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\Pages\Read;

--- a/tests/Unit/Api/Pages/Read/PagesReadResponseTest.php
+++ b/tests/Unit/Api/Pages/Read/PagesReadResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\Pages\Read;

--- a/tests/Unit/Api/Pixel/Events/RequestTest.php
+++ b/tests/Unit/Api/Pixel/Events/RequestTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Api\Pixel\Events;

--- a/tests/Unit/Api/Plugin/Settings/HandlerDisconnectTest.php
+++ b/tests/Unit/Api/Plugin/Settings/HandlerDisconnectTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\Plugin\Settings;

--- a/tests/Unit/Api/Plugin/Settings/Uninstall/RequestTest.php
+++ b/tests/Unit/Api/Plugin/Settings/Uninstall/RequestTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\Plugin\Settings\Uninstall;

--- a/tests/Unit/Api/Plugin/WhatsAppSettings/HandlerTest.php
+++ b/tests/Unit/Api/Plugin/WhatsAppSettings/HandlerTest.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Unit tests for the WhatsApp Settings REST handler onboarding-complete push endpoint.
  */
 

--- a/tests/Unit/Api/PostParseResponseValidationTest.php
+++ b/tests/Unit/Api/PostParseResponseValidationTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Api;

--- a/tests/Unit/Api/ProductCatalog/ItemsBatch/Create/ItemsBatchCreateResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ItemsBatch/Create/ItemsBatchCreateResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\ProductCatalog\ItemsBatch\Create;

--- a/tests/Unit/Api/ProductCatalog/ItemsBatch/Create/RequestTest.php
+++ b/tests/Unit/Api/ProductCatalog/ItemsBatch/Create/RequestTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace Api\ProductCatalog\ItemsBatch\Create;

--- a/tests/Unit/Api/ProductCatalog/ItemsBatch/Create/ResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ItemsBatch/Create/ResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace Api\ProductCatalog\ItemsBatch\Create;

--- a/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Create/ProductFeedUploadRequestTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Create/ProductFeedUploadRequestTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 use WooCommerce\Facebook\API\ProductCatalog\ProductFeedUploads\Create\Request;

--- a/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Create/ProductFeedUploadResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Create/ProductFeedUploadResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 use WooCommerce\Facebook\API\ProductCatalog\ProductFeedUploads\Create\Response;

--- a/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Create/ProductFeedUploadsCreateResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Create/ProductFeedUploadsCreateResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\ProductCatalog\ProductFeedUploads\Create;

--- a/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Read/ProductFeedUploadReadRequestTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Read/ProductFeedUploadReadRequestTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 use WooCommerce\Facebook\API\ProductCatalog\ProductFeedUploads\Read\Request;

--- a/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Read/ProductFeedUploadReadResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeedUploads/Read/ProductFeedUploadReadResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\ProductCatalog\ProductFeedUploads\Read;

--- a/tests/Unit/Api/ProductCatalog/ProductFeeds/Create/ProductFeedsCreateResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeeds/Create/ProductFeedsCreateResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\ProductCatalog\ProductFeeds\Create;

--- a/tests/Unit/Api/ProductCatalog/ProductFeeds/Read/ProductFeedReadRequestTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeeds/Read/ProductFeedReadRequestTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Api\ProductCatalog\ProductFeeds\Read;

--- a/tests/Unit/Api/ProductCatalog/ProductFeeds/Read/ProductFeedsReadResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeeds/Read/ProductFeedsReadResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\ProductCatalog\ProductFeeds\Read;

--- a/tests/Unit/Api/ProductCatalog/ProductFeeds/ReadAll/ProductFeedsReadAllResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductFeeds/ReadAll/ProductFeedsReadAllResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\ProductCatalog\ProductFeeds\ReadAll;

--- a/tests/Unit/Api/ProductCatalog/ProductGroups/Create/ProductGroupsCreateResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductGroups/Create/ProductGroupsCreateResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\ProductCatalog\ProductGroups\Create;

--- a/tests/Unit/Api/ProductCatalog/ProductGroups/Read/ProductGroupsReadResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductGroups/Read/ProductGroupsReadResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Api\ProductCatalog\ProductGroups\Read;

--- a/tests/Unit/Api/ProductCatalog/ProductGroups/Update/ProductGroupsUpdateResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductGroups/Update/ProductGroupsUpdateResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\ProductCatalog\ProductGroups\Update;

--- a/tests/Unit/Api/ProductCatalog/ProductSets/Create/ProductSetsCreateResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductSets/Create/ProductSetsCreateResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\ProductCatalog\ProductSets\Create;

--- a/tests/Unit/Api/ProductCatalog/ProductSets/Delete/ProductSetsDeleteRequestTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductSets/Delete/ProductSetsDeleteRequestTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Api\ProductCatalog\ProductSets\Delete;

--- a/tests/Unit/Api/ProductCatalog/ProductSets/Delete/ProductSetsDeleteResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductSets/Delete/ProductSetsDeleteResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\ProductCatalog\ProductSets\Delete;

--- a/tests/Unit/Api/ProductCatalog/ProductSets/Update/ProductSetsUpdateResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductSets/Update/ProductSetsUpdateResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\ProductCatalog\ProductSets\Update;

--- a/tests/Unit/Api/ProductCatalog/Products/Create/ProductsCreateResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/Products/Create/ProductsCreateResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\ProductCatalog\Products\Create;

--- a/tests/Unit/Api/ProductCatalog/Products/Create/RequestTest.php
+++ b/tests/Unit/Api/ProductCatalog/Products/Create/RequestTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Api\ProductCatalog\Products\Create;

--- a/tests/Unit/Api/ProductCatalog/Products/Create/ResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/Products/Create/ResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\ProductCatalog\Products\Create;

--- a/tests/Unit/Api/ProductCatalog/Products/Delete/ProductsDeleteRequestTest.php
+++ b/tests/Unit/Api/ProductCatalog/Products/Delete/ProductsDeleteRequestTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Api\ProductCatalog\Products\Delete;

--- a/tests/Unit/Api/ProductCatalog/Products/Delete/ProductsDeleteResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/Products/Delete/ProductsDeleteResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\ProductCatalog\Products\Delete;

--- a/tests/Unit/Api/ProductCatalog/Products/Delete/RequestTest.php
+++ b/tests/Unit/Api/ProductCatalog/Products/Delete/RequestTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 declare( strict_types=1 );
 

--- a/tests/Unit/Api/ProductCatalog/Products/Delete/RequestTest.php
+++ b/tests/Unit/Api/ProductCatalog/Products/Delete/RequestTest.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 declare( strict_types=1 );
 
 namespace Api\ProductCatalog\Products\Delete;

--- a/tests/Unit/Api/ProductCatalog/Products/Delete/ResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/Products/Delete/ResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 declare( strict_types=1 );
 

--- a/tests/Unit/Api/ProductCatalog/Products/Delete/ResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/Products/Delete/ResponseTest.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 declare( strict_types=1 );
 
 namespace Api\ProductCatalog\Products\Delete;

--- a/tests/Unit/Api/ProductCatalog/Products/Id/ProductsIdResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/Products/Id/ProductsIdResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Api\ProductCatalog\Products\Id;

--- a/tests/Unit/Api/ProductCatalog/Products/Update/ProductsUpdateResponseTest.php
+++ b/tests/Unit/Api/ProductCatalog/Products/Update/ProductsUpdateResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\ProductCatalog\Products\Update;

--- a/tests/Unit/Api/ProductCatalog/Products/Update/RequestTest.php
+++ b/tests/Unit/Api/ProductCatalog/Products/Update/RequestTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace Unit\Api\ProductCatalog\Products\Update;

--- a/tests/Unit/Api/REST/RestAPITest.php
+++ b/tests/Unit/Api/REST/RestAPITest.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Unit tests for REST API functionality.
  */
 

--- a/tests/Unit/Api/Traits/IdempotentRequestTraitTest.php
+++ b/tests/Unit/Api/Traits/IdempotentRequestTraitTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\Traits;

--- a/tests/Unit/Api/Traits/RateLimitedResponseTest.php
+++ b/tests/Unit/Api/Traits/RateLimitedResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\Traits;

--- a/tests/Unit/Api/User/Permissions/Delete/PermissionsDeleteResponseTest.php
+++ b/tests/Unit/Api/User/Permissions/Delete/PermissionsDeleteResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\User\Permissions\Delete;

--- a/tests/Unit/Api/User/UserResponseTest.php
+++ b/tests/Unit/Api/User/UserResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\User;

--- a/tests/Unit/ApiTest.php
+++ b/tests/Unit/ApiTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 use WooCommerce\Facebook\API;

--- a/tests/Unit/BootstrapDisableFlagClearStateTest.php
+++ b/tests/Unit/BootstrapDisableFlagClearStateTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests;

--- a/tests/Unit/BootstrapDisableFlagTest.php
+++ b/tests/Unit/BootstrapDisableFlagTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests;

--- a/tests/Unit/BootstrapDisableWindowEscalationTest.php
+++ b/tests/Unit/BootstrapDisableWindowEscalationTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests;

--- a/tests/Unit/CheckoutTest.php
+++ b/tests/Unit/CheckoutTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit;

--- a/tests/Unit/CommerceTest.php
+++ b/tests/Unit/CommerceTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit;

--- a/tests/Unit/CompatibilityCheckTest.php
+++ b/tests/Unit/CompatibilityCheckTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 namespace WooCommerce\Facebook\Tests;
 

--- a/tests/Unit/CompatibilityCheckTest.php
+++ b/tests/Unit/CompatibilityCheckTest.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 namespace WooCommerce\Facebook\Tests;
 
 class CompatibilityCheckTest extends AbstractWPUnitTestWithSafeFiltering {

--- a/tests/Unit/Debug/ProfilingLoggerProcessTest.php
+++ b/tests/Unit/Debug/ProfilingLoggerProcessTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Debug;

--- a/tests/Unit/Debug/ProfilingLoggerTest.php
+++ b/tests/Unit/Debug/ProfilingLoggerTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Debug;

--- a/tests/Unit/Events/AAMSettingsTest.php
+++ b/tests/Unit/Events/AAMSettingsTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Events;

--- a/tests/Unit/Events/EventSignalsStateTest.php
+++ b/tests/Unit/Events/EventSignalsStateTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Events;

--- a/tests/Unit/Events/EventTest.php
+++ b/tests/Unit/Events/EventTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Events;

--- a/tests/Unit/Events/FacebookCommerceEventsTrackerTest.php
+++ b/tests/Unit/Events/FacebookCommerceEventsTrackerTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Events;

--- a/tests/Unit/Events/NormalizerTest.php
+++ b/tests/Unit/Events/NormalizerTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Events;

--- a/tests/Unit/ExternalVersionUpdate/UpdateTest.php
+++ b/tests/Unit/ExternalVersionUpdate/UpdateTest.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Unit tests related to external version update.
  */
 

--- a/tests/Unit/FacebookCommercePixelIsolatedExecutionTest.php
+++ b/tests/Unit/FacebookCommercePixelIsolatedExecutionTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;

--- a/tests/Unit/FacebookCommercePixelTest.php
+++ b/tests/Unit/FacebookCommercePixelTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;

--- a/tests/Unit/FacebookCommerceTest.php
+++ b/tests/Unit/FacebookCommerceTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 require_once __DIR__ . '/../../facebook-commerce.php';

--- a/tests/Unit/Feed/FeedConfigurationDetectionTest.php
+++ b/tests/Unit/Feed/FeedConfigurationDetectionTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Feed;

--- a/tests/Unit/Framework/AdminMessageHandlerTest.php
+++ b/tests/Unit/Framework/AdminMessageHandlerTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Framework;

--- a/tests/Unit/Framework/Api/FrameworkAPIExceptionTest.php
+++ b/tests/Unit/Framework/Api/FrameworkAPIExceptionTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Framework\Api;

--- a/tests/Unit/Framework/Api/JSONResponseTest.php
+++ b/tests/Unit/Framework/Api/JSONResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 declare( strict_types=1 );
 

--- a/tests/Unit/Framework/Api/JSONResponseTest.php
+++ b/tests/Unit/Framework/Api/JSONResponseTest.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Framework\Api;

--- a/tests/Unit/Framework/Api/RequestTest.php
+++ b/tests/Unit/Framework/Api/RequestTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 declare( strict_types=1 );
 

--- a/tests/Unit/Framework/Api/RequestTest.php
+++ b/tests/Unit/Framework/Api/RequestTest.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Framework\Api;

--- a/tests/Unit/Framework/Api/ResponseTest.php
+++ b/tests/Unit/Framework/Api/ResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 declare( strict_types=1 );
 

--- a/tests/Unit/Framework/Api/ResponseTest.php
+++ b/tests/Unit/Framework/Api/ResponseTest.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Framework\Api;

--- a/tests/Unit/Framework/ErrorLogHandlerDisabledModeFallbackTest.php
+++ b/tests/Unit/Framework/ErrorLogHandlerDisabledModeFallbackTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Framework;

--- a/tests/Unit/Framework/ErrorLogHandlerPauseReplayTest.php
+++ b/tests/Unit/Framework/ErrorLogHandlerPauseReplayTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Framework {

--- a/tests/Unit/Framework/Plugin/CompatibilityTest.php
+++ b/tests/Unit/Framework/Plugin/CompatibilityTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 declare( strict_types=1 );
 

--- a/tests/Unit/Framework/Plugin/CompatibilityTest.php
+++ b/tests/Unit/Framework/Plugin/CompatibilityTest.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Framework\Plugin;

--- a/tests/Unit/Framework/Plugin/DependenciesTest.php
+++ b/tests/Unit/Framework/Plugin/DependenciesTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 declare( strict_types=1 );
 

--- a/tests/Unit/Framework/Plugin/DependenciesTest.php
+++ b/tests/Unit/Framework/Plugin/DependenciesTest.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Framework\Plugin;

--- a/tests/Unit/Framework/Plugin/PluginExceptionTest.php
+++ b/tests/Unit/Framework/Plugin/PluginExceptionTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Framework\Plugin;

--- a/tests/Unit/Framework/PluginCrashHandlerDedupReleaseTest.php
+++ b/tests/Unit/Framework/PluginCrashHandlerDedupReleaseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Framework;

--- a/tests/Unit/Framework/PluginCrashHandlerDisableFlagTest.php
+++ b/tests/Unit/Framework/PluginCrashHandlerDisableFlagTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Framework;

--- a/tests/Unit/Framework/PluginCrashHandlerQueuePriorityTest.php
+++ b/tests/Unit/Framework/PluginCrashHandlerQueuePriorityTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Framework;

--- a/tests/Unit/Framework/PluginCrashHandlerRegisterTest.php
+++ b/tests/Unit/Framework/PluginCrashHandlerRegisterTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 declare( strict_types=1 );
 

--- a/tests/Unit/Framework/PluginCrashHandlerRegisterTest.php
+++ b/tests/Unit/Framework/PluginCrashHandlerRegisterTest.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Framework;

--- a/tests/Unit/Framework/PluginCrashHandlerSanitizationTest.php
+++ b/tests/Unit/Framework/PluginCrashHandlerSanitizationTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Framework;

--- a/tests/Unit/Framework/Utilities/AsyncRequestTest.php
+++ b/tests/Unit/Framework/Utilities/AsyncRequestTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Framework\Utilities;

--- a/tests/Unit/Framework/Utilities/BackgroundJobHandlerTest.php
+++ b/tests/Unit/Framework/Utilities/BackgroundJobHandlerTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Framework\Utilities;

--- a/tests/Unit/Handlers/ConnectionConfigSyncTest.php
+++ b/tests/Unit/Handlers/ConnectionConfigSyncTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Handlers;

--- a/tests/Unit/Handlers/ConnectionDisconnectTest.php
+++ b/tests/Unit/Handlers/ConnectionDisconnectTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Handlers;

--- a/tests/Unit/Handlers/ConnectionFbeRedirectTest.php
+++ b/tests/Unit/Handlers/ConnectionFbeRedirectTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Handlers;

--- a/tests/Unit/Handlers/MetaExtensionTest.php
+++ b/tests/Unit/Handlers/MetaExtensionTest.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Unit tests for Meta Extension handler.
  */
 

--- a/tests/Unit/Handlers/WebHookTest.php
+++ b/tests/Unit/Handlers/WebHookTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Handlers;

--- a/tests/Unit/Handlers/WhatsAppConnectionTest.php
+++ b/tests/Unit/Handlers/WhatsAppConnectionTest.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Unit tests for WhatsAppConnection onboarding-state reader.
  */
 

--- a/tests/Unit/Handlers/WhatsAppExtensionBackfillTest.php
+++ b/tests/Unit/Handlers/WhatsAppExtensionBackfillTest.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Unit tests for the WhatsApp onboarding-state HEAD backfill (pull path).
  */
 

--- a/tests/Unit/Handlers/WhatsAppExtensionTest.php
+++ b/tests/Unit/Handlers/WhatsAppExtensionTest.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Unit tests for the WhatsApp customer_events onboarding gate.
  */
 

--- a/tests/Unit/Integrations/BookingsTest.php
+++ b/tests/Unit/Integrations/BookingsTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Integrations;

--- a/tests/Unit/Integrations/CostOfGoods/CostOfGoodsTest.php
+++ b/tests/Unit/Integrations/CostOfGoods/CostOfGoodsTest.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 declare(strict_types=1);
 
 namespace WooCommerce\Facebook\Tests\Unit\Integrations;

--- a/tests/Unit/Integrations/CostOfGoods/CostOfGoodsTest.php
+++ b/tests/Unit/Integrations/CostOfGoods/CostOfGoodsTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 declare(strict_types=1);
 

--- a/tests/Unit/Jobs/AbstractChainedJobTest.php
+++ b/tests/Unit/Jobs/AbstractChainedJobTest.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 namespace WooCommerce\Facebook\Tests\Unit\Jobs;
 
 use WooCommerce\Facebook\Jobs\AbstractChainedJob;

--- a/tests/Unit/Jobs/AbstractChainedJobTest.php
+++ b/tests/Unit/Jobs/AbstractChainedJobTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 namespace WooCommerce\Facebook\Tests\Unit\Jobs;
 

--- a/tests/Unit/LifecycleConfigSyncTest.php
+++ b/tests/Unit/LifecycleConfigSyncTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit;

--- a/tests/Unit/Locale/LocaleLanguageOverrideTest.php
+++ b/tests/Unit/Locale/LocaleLanguageOverrideTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Locale;

--- a/tests/Unit/LocaleTest.php
+++ b/tests/Unit/LocaleTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit;

--- a/tests/Unit/OnProductQuickEditSaveTest.php
+++ b/tests/Unit/OnProductQuickEditSaveTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 require_once __DIR__ . '/../../facebook-commerce.php';

--- a/tests/Unit/ProductSync/ProductExcludedExceptionTest.php
+++ b/tests/Unit/ProductSync/ProductExcludedExceptionTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\ProductSync;

--- a/tests/Unit/ProductSync/ProductInvalidExceptionTest.php
+++ b/tests/Unit/ProductSync/ProductInvalidExceptionTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\ProductSync;

--- a/tests/Unit/Product_CategoriesTest.php
+++ b/tests/Unit/Product_CategoriesTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit;

--- a/tests/Unit/Products/FeedTest.php
+++ b/tests/Unit/Products/FeedTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Products;

--- a/tests/Unit/Products/GoogleProductTaxonomyTest.php
+++ b/tests/Unit/Products/GoogleProductTaxonomyTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Products;

--- a/tests/Unit/Products/SyncTest.php
+++ b/tests/Unit/Products/SyncTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Products;

--- a/tests/Unit/ProductsTest.php
+++ b/tests/Unit/ProductsTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit;

--- a/tests/Unit/RequestTest.php
+++ b/tests/Unit/RequestTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\API\PublicKeyGet;

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit;

--- a/tests/Unit/RolloutSwitchesTest.php
+++ b/tests/Unit/RolloutSwitchesTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 use PHPUnit\Framework\TestCase;
 use WooCommerce\Facebook\API;
 use WooCommerce\Facebook\Framework\Api\Exception as ApiException;

--- a/tests/Unit/Utilities/DebugToolsTest.php
+++ b/tests/Unit/Utilities/DebugToolsTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit\Utilities;

--- a/tests/Unit/VariationCustomVideoUrlTest.php
+++ b/tests/Unit/VariationCustomVideoUrlTest.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Test file for variation custom video URL functionality
  *
  * @package MetaCommerce

--- a/tests/Unit/WCFacebookcommerceWarmConfigTest.php
+++ b/tests/Unit/WCFacebookcommerceWarmConfigTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Unit;

--- a/tests/Unit/WPMLTest.php
+++ b/tests/Unit/WPMLTest.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 use WooCommerce\Facebook\WPMLInjector;
 use WooCommerce\Facebook\WPMLLanguageStatus;
 

--- a/tests/Unit/WPMLTest.php
+++ b/tests/Unit/WPMLTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 use WooCommerce\Facebook\WPMLInjector;
 use WooCommerce\Facebook\WPMLLanguageStatus;

--- a/tests/Unit/fbUtilsTest.php
+++ b/tests/Unit/fbUtilsTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare(strict_types=1);
 
 

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare(strict_types=1);
 
 

--- a/tests/Unit/test-admin-sync-indicator.php
+++ b/tests/Unit/test-admin-sync-indicator.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 class Test_Admin_Sync_Indicator extends WP_Ajax_UnitTestCase {
     private $admin;

--- a/tests/Unit/test-admin-sync-indicator.php
+++ b/tests/Unit/test-admin-sync-indicator.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 class Test_Admin_Sync_Indicator extends WP_Ajax_UnitTestCase {
     private $admin;
     private $product;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests;

--- a/tests/e2e/events-test.spec.js
+++ b/tests/e2e/events-test.spec.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Facebook Events Test - Validates Pixel + CAPI events
  */
 

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const { chromium } = require('@playwright/test');
 const fs = require('fs');
 const path = require('path');

--- a/tests/e2e/helpers/js/auth/login.js
+++ b/tests/e2e/helpers/js/auth/login.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Authentication helpers for E2E tests
  */
 

--- a/tests/e2e/helpers/js/batch-monitor/index.js
+++ b/tests/e2e/helpers/js/batch-monitor/index.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Batch monitoring helpers for E2E tests
  */
 

--- a/tests/e2e/helpers/js/categories/crud.js
+++ b/tests/e2e/helpers/js/categories/crud.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Category CRUD helpers for E2E tests
  */
 

--- a/tests/e2e/helpers/js/checkout/purchase.js
+++ b/tests/e2e/helpers/js/checkout/purchase.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Checkout/purchase flow helpers for E2E tests
  */
 

--- a/tests/e2e/helpers/js/constants/timeouts.js
+++ b/tests/e2e/helpers/js/constants/timeouts.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * E2E Test Timeout Constants
  *
  * Centralized timeout values for consistent E2E test behavior.

--- a/tests/e2e/helpers/js/events/ajax-cart.js
+++ b/tests/e2e/helpers/js/events/ajax-cart.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * AJAX cart helpers for E2E event tests.
  */
 

--- a/tests/e2e/helpers/js/events/capture.js
+++ b/tests/e2e/helpers/js/events/capture.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * PixelCapture - Captures Pixel events from browser
  */
 

--- a/tests/e2e/helpers/js/events/field-contracts.js
+++ b/tests/e2e/helpers/js/events/field-contracts.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Event field contracts for Pixel + Conversions API (CAPI).
  *
  * This module defines field-presence contracts.

--- a/tests/e2e/helpers/js/events/product-types.js
+++ b/tests/e2e/helpers/js/events/product-types.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Event product helpers (variable/grouped fixtures and storefront interactions)
  */
 

--- a/tests/e2e/helpers/js/events/runtime.js
+++ b/tests/e2e/helpers/js/events/runtime.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Event runtime helpers (captured payloads, cart/session cleanup, temp customers, checkout flow)
  */
 

--- a/tests/e2e/helpers/js/events/setup.js
+++ b/tests/e2e/helpers/js/events/setup.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * TestSetup - Test initialization and utilities
  */
 

--- a/tests/e2e/helpers/js/events/signals.js
+++ b/tests/e2e/helpers/js/events/signals.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Frontend signal hold/release helpers for E2E tests.
  */
 

--- a/tests/e2e/helpers/js/events/validator.js
+++ b/tests/e2e/helpers/js/events/validator.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * EventValidator - Load and validate captured events
  */
 

--- a/tests/e2e/helpers/js/index.js
+++ b/tests/e2e/helpers/js/index.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * E2E Test Helpers - Barrel Export
  *
  * Location: tests/e2e/helpers/js/index.js

--- a/tests/e2e/helpers/js/plugin/connection.js
+++ b/tests/e2e/helpers/js/plugin/connection.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Facebook connection management helpers for E2E tests
  */
 

--- a/tests/e2e/helpers/js/plugin/options.js
+++ b/tests/e2e/helpers/js/plugin/options.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Facebook options UI helpers for E2E tests
  */
 

--- a/tests/e2e/helpers/js/plugin/sync.js
+++ b/tests/e2e/helpers/js/plugin/sync.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Facebook sync validation helpers for E2E tests
  */
 

--- a/tests/e2e/helpers/js/products/crud.js
+++ b/tests/e2e/helpers/js/products/crud.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Product CRUD helpers for E2E tests
  */
 

--- a/tests/e2e/helpers/js/products/feed.js
+++ b/tests/e2e/helpers/js/products/feed.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Product feed CSV generation helpers for E2E tests
  */
 

--- a/tests/e2e/helpers/js/products/navigation.js
+++ b/tests/e2e/helpers/js/products/navigation.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Product navigation helpers for E2E tests
  */
 

--- a/tests/e2e/helpers/js/utils/errors.js
+++ b/tests/e2e/helpers/js/utils/errors.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Error checking helpers for E2E tests
  */
 

--- a/tests/e2e/helpers/js/utils/logging.js
+++ b/tests/e2e/helpers/js/utils/logging.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Logging and screenshot helpers for E2E tests
  */
 

--- a/tests/e2e/helpers/js/utils/ui.js
+++ b/tests/e2e/helpers/js/utils/ui.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * UI interaction helpers for E2E tests
  */
 

--- a/tests/e2e/helpers/js/wordpress/exec.js
+++ b/tests/e2e/helpers/js/wordpress/exec.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * WordPress execution helpers for E2E tests
  */
 

--- a/tests/e2e/helpers/js/wordpress/plugins.js
+++ b/tests/e2e/helpers/js/wordpress/plugins.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Plugin management helpers for E2E tests
  */
 

--- a/tests/e2e/helpers/js/wordpress/themes.js
+++ b/tests/e2e/helpers/js/wordpress/themes.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * WordPress theme helpers for E2E tests
  */
 

--- a/tests/e2e/helpers/php/batch-monitor-plugin.php
+++ b/tests/e2e/helpers/php/batch-monitor-plugin.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Plugin Name: FB E2E Batch Monitor (Test Only)
  * Description: Intercepts Meta API batch requests during E2E tests
  * Version: 1.0.0-poc

--- a/tests/e2e/helpers/php/event-logger.php
+++ b/tests/e2e/helpers/php/event-logger.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Event Logger - Event logging for CAPI E2E tests
  *
  * Location: tests/e2e/helpers/php/event-logger.php

--- a/tests/e2e/helpers/php/process-sync-jobs.php
+++ b/tests/e2e/helpers/php/process-sync-jobs.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * E2E Helper — Process pending Facebook sync background jobs directly.
  *
  * The background job handler dispatches via a loopback HTTP request to

--- a/tests/e2e/helpers/php/product-creator.php
+++ b/tests/e2e/helpers/php/product-creator.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * E2E Product Creator - Creates WooCommerce products programmatically for testing
  *
  * Location: tests/e2e/helpers/php/product-creator.php

--- a/tests/e2e/helpers/php/sync-validator.php
+++ b/tests/e2e/helpers/php/sync-validator.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * E2E Facebook Sync Validator - For Products & Categories
  *
  * Validates sync between WooCommerce and Facebook with comprehensive debugging

--- a/tests/e2e/performance-sync.spec.js
+++ b/tests/e2e/performance-sync.spec.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const { test, expect } = require('@playwright/test');
 const {
   TIMEOUTS,

--- a/tests/e2e/plugin-level-tests.spec.js
+++ b/tests/e2e/plugin-level-tests.spec.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const { test, expect } = require('@playwright/test');
 const {
   TIMEOUTS,

--- a/tests/e2e/product-batch.spec.js
+++ b/tests/e2e/product-batch.spec.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const { test, expect } = require('@playwright/test');
 const { execSync } = require('child_process');
 

--- a/tests/e2e/product-category.spec.js
+++ b/tests/e2e/product-category.spec.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const { test, expect } = require('@playwright/test');
 const {
     TIMEOUTS,

--- a/tests/e2e/product-creation.spec.js
+++ b/tests/e2e/product-creation.spec.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const { test, expect } = require('@playwright/test');
 const {
   TIMEOUTS,

--- a/tests/e2e/product-deletion.spec.js
+++ b/tests/e2e/product-deletion.spec.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const { test, expect } = require('@playwright/test');
 const {
   TIMEOUTS,

--- a/tests/e2e/product-modification.spec.js
+++ b/tests/e2e/product-modification.spec.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const { test, expect } = require('@playwright/test');
 const {
   TIMEOUTS,

--- a/tests/e2e/scripts/run-local-events.sh
+++ b/tests/e2e/scripts/run-local-events.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+#
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
 set -euo pipefail
 
 # Reliable local runner for E2E events tests.

--- a/tests/e2e/sync-in-progress.spec.js
+++ b/tests/e2e/sync-in-progress.spec.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * E2E Tests for Background Sync In Progress
  *
  * Tests the happy-path scenarios when a product sync is in progress,

--- a/tests/e2e/variable-product-depth.spec.js
+++ b/tests/e2e/variable-product-depth.spec.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const { test, expect } = require('@playwright/test');
 const {
   TIMEOUTS,

--- a/tests/integration/COGS/001_WPFactoryCogsIntegrationTests.php
+++ b/tests/integration/COGS/001_WPFactoryCogsIntegrationTests.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 declare(strict_types=1);
 

--- a/tests/integration/COGS/001_WPFactoryCogsIntegrationTests.php
+++ b/tests/integration/COGS/001_WPFactoryCogsIntegrationTests.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 declare(strict_types=1);
 
 namespace WooCommerce\Facebook\Tests\Integration\COGS;

--- a/tests/integration/COGS/002_WooCCogsIntegrationTests.php
+++ b/tests/integration/COGS/002_WooCCogsIntegrationTests.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 declare(strict_types=1);
 

--- a/tests/integration/COGS/002_WooCCogsIntegrationTests.php
+++ b/tests/integration/COGS/002_WooCCogsIntegrationTests.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 declare(strict_types=1);
 
 namespace WooCommerce\Facebook\Tests\Integration\COGS;

--- a/tests/integration/COGS/003_CogsIntegrationTests.php
+++ b/tests/integration/COGS/003_CogsIntegrationTests.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 
 declare(strict_types=1);
 

--- a/tests/integration/COGS/003_CogsIntegrationTests.php
+++ b/tests/integration/COGS/003_CogsIntegrationTests.php
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 declare(strict_types=1);
 
 namespace WooCommerce\Facebook\Tests\Integration\COGS;

--- a/tests/integration/COGS/CogsIntegrationTestsBase.php
+++ b/tests/integration/COGS/CogsIntegrationTestsBase.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Integration\COGS;

--- a/tests/integration/Commerce/WCFacebookCommerceIntegrationTest.php
+++ b/tests/integration/Commerce/WCFacebookCommerceIntegrationTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 require_once __DIR__ . '/../../../facebook-commerce.php';

--- a/tests/integration/DataTransformation/ProductDataPreparationTest.php
+++ b/tests/integration/DataTransformation/ProductDataPreparationTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Integration\DataTransformation;

--- a/tests/integration/Feed/Localization/LanguageOverrideFeedGenerationTest.php
+++ b/tests/integration/Feed/Localization/LanguageOverrideFeedGenerationTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Integration\Feed\Localization;

--- a/tests/integration/Feed/Localization/LocalizationIntegrationTest.php
+++ b/tests/integration/Feed/Localization/LocalizationIntegrationTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Integration\Feed\Localization;

--- a/tests/integration/FeedGeneration/ProductFeedTest.php
+++ b/tests/integration/FeedGeneration/ProductFeedTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Integration\FeedGeneration;

--- a/tests/integration/IntegrationTestCase.php
+++ b/tests/integration/IntegrationTestCase.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Integration;

--- a/tests/integration/PixelEventsAPI/RequestIntegrationTest.php
+++ b/tests/integration/PixelEventsAPI/RequestIntegrationTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Integration\PixelEventsAPI;

--- a/tests/integration/ProductValidation/ProductValidatorTest.php
+++ b/tests/integration/ProductValidation/ProductValidatorTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Integration\ProductValidation;

--- a/tests/integration/WordPressIntegration/ProductHooksTest.php
+++ b/tests/integration/WordPressIntegration/ProductHooksTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 declare( strict_types=1 );
 
 namespace WooCommerce\Facebook\Tests\Integration\WordPressIntegration;

--- a/tests/js/multiple-images.test.js
+++ b/tests/js/multiple-images.test.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Tests for Multiple Images functionality in Meta for WooCommerce
  * 
  * These tests cover the JavaScript functionality for adding, removing, and managing

--- a/tests/js/pixel-events.test.js
+++ b/tests/js/pixel-events.test.js
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
  * Tests for Facebook Pixel Events Isolated Execution (pixel-events.js)
  *
  * These tests validate the isolated JavaScript execution context for pixel events,

--- a/tests/js/sync-indicator.test.js
+++ b/tests/js/sync-indicator.test.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const $ = require('jquery');
 
 describe('Sync Indicator', () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 // Load the default @wordpress/scripts config object
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 


### PR DESCRIPTION
## Summary

Resolves the open-source hygiene checks flagging missing copyright headers and missing license/legal info.

- **Copyright headers** — Added the standard Meta copyright header to **304** project source files (PHP/JS/CSS/shell/XML config) that were missing one. Matches the existing repo convention used by already-compliant files: `Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved` + the `LICENSE` reference.
- **README license** — Added a `## License` section pointing to GPLv2-or-later and the `LICENSE` file.
- **Plugin homepage (`readme.txt`)** — Added `Terms of Use`, `Privacy Policy`, and `Copyright` sections so the WordPress.org homepage carries an explicit `Meta Platforms, Inc. and affiliates` copyright statement and links to Meta's [Terms of Use](https://opensource.fb.com/legal/terms) and [Privacy Policy](https://opensource.fb.com/legal/privacy).

## Excluded (to be added to the Copyright Headers Exceptions list)

- `bin/install-wp-tests.sh` — third-party WP-CLI test scaffold
- `includes/Products/GoogleProductTaxonomy.php` — auto-generated data file

## Verification

- Re-ran header detection across all tracked source files: 0 remaining without a header (excluding the two above).
- `php -l` on all 246 modified PHP files: 0 syntax errors.