### PR TITLE
Sync products to Meta catalog on WooCommerce REST API saves

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -398,6 +398,12 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			$this->events_tracker = new WC_Facebookcommerce_EventsTracker( $user_info, $aam_settings );
 		}
 
+		// Sync products created or updated outside the admin product editor, such as through the
+		// WooCommerce REST API. Those requests do not fire the admin-only woocommerce_process_product_meta
+		// hook used above, so without this the Meta catalog would miss REST API and programmatic changes.
+		add_action( 'woocommerce_update_product', array( $this, 'on_product_save_via_api' ), 40 );
+		add_action( 'woocommerce_new_product', array( $this, 'on_product_save_via_api' ), 40 );
+
 		// Update products on change of status.
 		add_action(
 			'transition_post_status',
@@ -1018,6 +1024,32 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 					break;
 			}
 		}
+	}
+
+	/**
+	 * Syncs a product to Facebook when it is created or updated through the WooCommerce REST API.
+	 *
+	 * The admin product editor schedules a sync via the woocommerce_process_product_meta hook, which
+	 * WooCommerce only fires for the admin product form. REST API (and other programmatic) saves do
+	 * not trigger that hook, so those changes never reached the Meta catalog. This handler runs on the
+	 * woocommerce_update_product / woocommerce_new_product actions, which do fire for REST API saves,
+	 * and delegates to on_product_publish(), honoring each product's existing sync settings.
+	 *
+	 * @since 3.7.3
+	 *
+	 * @internal
+	 *
+	 * @param int $product_id the product ID
+	 */
+	public function on_product_save_via_api( $product_id ) {
+		// The admin product editor and other request types are handled through their own hooks.
+		if ( ! Helper::is_rest_api_request() ) {
+			return;
+		}
+
+		// on_product_publish() bails when the plugin is not configured and only syncs products that
+		// should be synced, so there is nothing else to guard here.
+		$this->on_product_publish( (int) $product_id );
 	}
 
 	/**

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1035,6 +1035,17 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 * woocommerce_update_product / woocommerce_new_product actions, which do fire for REST API saves,
 	 * and delegates to on_product_publish(), honoring each product's existing sync settings.
 	 *
+	 * The woocommerce_update_product / woocommerce_new_product actions are low-level data-store hooks
+	 * fired by WC_Product::save() for *any* product save, including ones made in unprivileged contexts
+	 * such as a stock decrement during a Store API checkout. Two guards keep this handler scoped to a
+	 * genuine product edit made over the REST API:
+	 *
+	 * - is_rest_api_request() excludes the admin editor and other request types, which are already
+	 *   handled through their own hooks (and avoids double-processing admin saves).
+	 * - current_user_can( 'edit_product' ) mirrors the capability the WooCommerce REST products
+	 *   controller checks before a write, so guest/customer contexts (e.g. checkout stock changes over
+	 *   the Store API) do not trigger a sync.
+	 *
 	 * @since 3.7.3
 	 *
 	 * @internal
@@ -1044,6 +1055,12 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	public function on_product_save_via_api( $product_id ) {
 		// The admin product editor and other request types are handled through their own hooks.
 		if ( ! Helper::is_rest_api_request() ) {
+			return;
+		}
+
+		// Only sync for actors allowed to edit the product; skip unprivileged contexts such as
+		// stock changes made during a Store API checkout.
+		if ( ! current_user_can( 'edit_product', $product_id ) ) {
 			return;
 		}
 

--- a/tests/integration/Commerce/WCFacebookCommerceIntegrationTest.php
+++ b/tests/integration/Commerce/WCFacebookCommerceIntegrationTest.php
@@ -815,6 +815,79 @@ class WCFacebookCommerceIntegrationTest extends \WooCommerce\Facebook\Tests\Abst
 		$this->integration->on_product_publish( $product->get_id() );
 	}
 
+	/**
+	 * A product saved through the WooCommerce REST API must be synced to the Meta catalog.
+	 *
+	 * @return void
+	 */
+	public function test_on_product_save_via_api_syncs_product_on_rest_request() {
+		// Simulate a WooCommerce REST API request.
+		$this->add_filter_with_safe_teardown( 'woocommerce_is_rest_api_request', '__return_true' );
+
+		add_option( WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, 'facebook-page-id' );
+		add_option( WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, '1234567891011121314' );
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		add_post_meta( $product->get_id(), Products::SYNC_ENABLED_META_KEY, 'yes' );
+		add_post_meta( $product->get_id(), WC_Facebookcommerce_Integration::FB_PRODUCT_ITEM_ID, 'facebook-product-item-id' );
+
+		$this->connection_handler->expects( $this->once() )
+			->method( 'is_connected' )
+			->willReturn( true );
+
+		$validator = $this->createMock( ProductValidator::class );
+		$validator->expects( $this->once() )
+			->method( 'validate' );
+		$this->facebook_for_woocommerce->expects( $this->once() )
+			->method( 'get_product_sync_validator' )
+			->with( $product )
+			->willReturn( $validator );
+
+		$this->integration->product_catalog_id = '123123123123123123';
+		$facebook_product                      = new WC_Facebook_Product( $product->get_id() );
+		$facebook_product_data                 = $facebook_product->prepare_product( null, \WC_Facebook_Product::PRODUCT_PREP_TYPE_ITEMS_BATCH );
+
+		$requests = WC_Facebookcommerce_Utils::prepare_product_requests_items_batch( $facebook_product_data );
+
+		$this->api->expects( $this->once() )
+			->method( 'send_item_updates' )
+			->with(
+				$this->integration->get_product_catalog_id(),
+				$requests
+			)
+			->willReturn( new API\ProductCatalog\ItemsBatch\Create\Response( '{"handles":"abcxyz"}' ) );
+
+		$this->integration->on_product_save_via_api( $product->get_id() );
+	}
+
+	/**
+	 * A product save outside of a REST API request must not be synced by this handler; those
+	 * requests (e.g. the admin product editor) are handled through their own hooks.
+	 *
+	 * @return void
+	 */
+	public function test_on_product_save_via_api_does_nothing_outside_rest_request() {
+		// Ensure the request is not treated as a REST API request.
+		$this->add_filter_with_safe_teardown( 'woocommerce_is_rest_api_request', '__return_false' );
+
+		add_option( WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, 'facebook-page-id' );
+		add_option( WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, '1234567891011121314' );
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		add_post_meta( $product->get_id(), Products::SYNC_ENABLED_META_KEY, 'yes' );
+		add_post_meta( $product->get_id(), WC_Facebookcommerce_Integration::FB_PRODUCT_ITEM_ID, 'facebook-product-item-id' );
+
+		// The handler must bail before doing any sync work.
+		$this->facebook_for_woocommerce->expects( $this->never() )
+			->method( 'get_product_sync_validator' );
+		$this->api->expects( $this->never() )
+			->method( 'send_item_updates' );
+
+		$this->integration->on_product_save_via_api( $product->get_id() );
+	}
+
 
 	/**
 	 * Sunny day test with all the conditions evaluated to true and maximum conditions triggered.

--- a/tests/integration/Commerce/WCFacebookCommerceIntegrationTest.php
+++ b/tests/integration/Commerce/WCFacebookCommerceIntegrationTest.php
@@ -821,8 +821,9 @@ class WCFacebookCommerceIntegrationTest extends \WooCommerce\Facebook\Tests\Abst
 	 * @return void
 	 */
 	public function test_on_product_save_via_api_syncs_product_on_rest_request() {
-		// Simulate a WooCommerce REST API request.
+		// Simulate a WooCommerce REST API request made by a user allowed to edit products.
 		$this->add_filter_with_safe_teardown( 'woocommerce_is_rest_api_request', '__return_true' );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 
 		add_option( WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, 'facebook-page-id' );
 		add_option( WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, '1234567891011121314' );
@@ -870,6 +871,35 @@ class WCFacebookCommerceIntegrationTest extends \WooCommerce\Facebook\Tests\Abst
 	public function test_on_product_save_via_api_does_nothing_outside_rest_request() {
 		// Ensure the request is not treated as a REST API request.
 		$this->add_filter_with_safe_teardown( 'woocommerce_is_rest_api_request', '__return_false' );
+
+		add_option( WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, 'facebook-page-id' );
+		add_option( WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, '1234567891011121314' );
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		add_post_meta( $product->get_id(), Products::SYNC_ENABLED_META_KEY, 'yes' );
+		add_post_meta( $product->get_id(), WC_Facebookcommerce_Integration::FB_PRODUCT_ITEM_ID, 'facebook-product-item-id' );
+
+		// The handler must bail before doing any sync work.
+		$this->facebook_for_woocommerce->expects( $this->never() )
+			->method( 'get_product_sync_validator' );
+		$this->api->expects( $this->never() )
+			->method( 'send_item_updates' );
+
+		$this->integration->on_product_save_via_api( $product->get_id() );
+	}
+
+	/**
+	 * A REST API save made by a user without product edit permission must not be synced. This covers
+	 * unprivileged contexts that also fire woocommerce_update_product, such as a stock decrement during
+	 * a Store API checkout.
+	 *
+	 * @return void
+	 */
+	public function test_on_product_save_via_api_does_nothing_without_edit_permission() {
+		// A REST API request, but made by a customer who cannot edit products.
+		$this->add_filter_with_safe_teardown( 'woocommerce_is_rest_api_request', '__return_true' );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'customer' ) ) );
 
 		add_option( WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, 'facebook-page-id' );
 		add_option( WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID, '1234567891011121314' );


### PR DESCRIPTION
## Description

Fixes #3975 — product updates made through the WooCommerce REST API were saved in WooCommerce but never synced to the Meta catalog.

The sync was only scheduled from the admin-only `woocommerce_process_product_meta` hook (registered inside the `is_admin()` block at `facebook-commerce.php:315`/`:354`). WooCommerce fires that hook exclusively for the admin product editor form — REST API (`PUT /wp-json/wc/v3/products/{id}`) and other programmatic saves do not trigger it, so those changes never reached Meta.

## Change

- Register a handler on `woocommerce_update_product` and `woocommerce_new_product` — actions that **do** fire for REST API and programmatic saves — outside the `is_admin()` block.
- The handler (`on_product_save_via_api`) resolves the product IDs that should be synced and queues them through `get_products_sync_handler()->create_or_update_products()`. Variable products queue their syncable variations; ineligible/sync-disabled products are skipped.

### Scoping: two guards, not one

`woocommerce_update_product` / `woocommerce_new_product` are low-level data-store hooks fired by `WC_Product::save()` for **any** product save, regardless of actor — admin editor, `wc/v3` REST API, WP-CLI, importers, and programmatic saves. Notably they also fire on a **stock decrement during a Store API (`wc/store`) checkout**, which is a REST request made by an unauthenticated/customer context. Permission is normally enforced at the entry point (the `wc/v3` controller checks `edit_product` before writing), not at these hooks.

- `Framework\Helper::is_rest_api_request()` excludes the admin editor and other request types, which keep using their existing hooks — no double-processing.
- `current_user_can( 'edit_product', $product_id )` mirrors the capability the WooCommerce REST products controller enforces before a write, so guest/customer contexts do not trigger a sync.

An `is_rest_api_request()` guard on its own would have let a guest checkout stock change trigger a sync. That's not a privilege escalation — the sync uses the site's own Meta credentials and only pushes already-public catalog data — but it's an unintended context and a checkout-latency risk.

### Why queue instead of syncing inline

The handler originally delegated to `on_product_publish()`. For a simple product that path calls `send_item_updates` synchronously, so `POST /wp-json/wc/v3/products/batch` with 100 products meant 100 Graph calls inside the request. Queueing instead lets the sync handler collect everything saved during the request and dispatch a **single background job on `shutdown`** — the same mechanism the admin, quick edit, stock and full-catalog-sync paths already use.

The guards `on_product_publish()` applied are carried over explicitly: `is_configured()`, the catalog ID, and the per-product sync validator (so a product's stored sync settings are still honored, with no reliance on `$_POST` unlike the admin async path).

**One behaviour change to be aware of.** For variable products this drops the explicit `create_product_group()` call, so `fb_product_group_id` post meta is no longer written for products created purely over REST. Grouping in the catalog is unaffected — `prepare_product_variation_data_items_batch()` sets `item_group_id` and Meta's batch API creates the group from it, which is exactly how `create_or_update_all_products()` and the quick edit / visibility paths already operate. The only loss is the local reverse-lookup fallback in `Products::get_product_by_fb_product_id()`, which prefers `fb_product_item_id` anyway.

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
- [ ] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices.
- [ ] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [ ] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary).

> **Why three boxes are unchecked.** Tests were added but **not executed** — the integration suite needs a WordPress test install and MySQL, neither of which was available on the machine this was prepared on. `php -l` and `phpcs-changed --warning-severity=0` against the base are both clean; CI is the first real run of PHPUnit. The debug-log and QA passes on a live store have not been done either. Please treat CI plus the manual repro below as the gate.

## Changelog entry

Fix - Sync products to the Meta catalog when they are created or updated through the WooCommerce REST API.

## Test Plan

**Automated** — five integration tests in `WCFacebookCommerceIntegrationTest`:

- `test_on_product_save_via_api_syncs_product_on_rest_request` — an authorized REST save queues the product with the sync handler and makes no inline Graph call.
- `test_on_product_save_via_api_queues_variations_for_variable_product` — a variable product queues its syncable variations.
- `test_on_product_save_via_api_does_nothing_outside_rest_request` — a non-REST save bails before any sync work.
- `test_on_product_save_via_api_does_nothing_without_edit_permission` — a REST save by a customer without `edit_product` bails (covers Store API checkout stock changes).
- `test_on_product_save_via_api_does_nothing_for_excluded_product` — a product the validator excludes is not queued.

The REST tests set a real `$_SERVER['REQUEST_URI']` rather than filtering `woocommerce_is_rest_api_request`: `WC()->is_rest_api_request()` returns `false` on an empty `REQUEST_URI` *before* the filter runs, so filtering alone never reached the handler. `phpunit.xml.dist` sets `backupGlobals="false"`, so `tearDown()` restores the original URI.

**Manual repro:**

1. Connect the plugin and enable sync for a product.
2. `PUT /wp-json/wc/v3/products/{id}` changing `sale_price` or `name`.
3. Confirm the change appears in the Meta catalog (the sync now runs in the background job dispatched on shutdown, so allow for that).
4. `POST /wp-json/wc/v3/products/batch` updating several products — confirm one background job covers them all rather than a Graph call per product inside the request.
5. Place a guest order over the Store API for a stock-managed product and confirm the stock decrement does **not** trigger a catalog sync.

## Screenshots

N/A — no UI changes.

## Note / possible follow-up

This covers product-level create/update (price, name, description, images, etc.) and variable products saved via the parent endpoint. Updates sent directly to the variation endpoint (`/products/{id}/variations/{vid}`) fire `woocommerce_update_product_variation`; if desired, that can be wired to sync the parent in a follow-up.
