### PR TITLE
test(e2e): cover adding a new attribute to an already-synced variable product

### DIFF
--- a/tests/e2e/variable-product-depth.spec.js
+++ b/tests/e2e/variable-product-depth.spec.js
@@ -21,6 +21,7 @@ const {
   validateFacebookSync,
   processPendingSyncJobs,
   execWP,
+  createTestProduct,
   setProductTitle,
   setProductDescription,
   dismissWooInterferingOverlays,
@@ -872,6 +873,107 @@ test.describe.serial('Variable Product Depth Tests', () => {
       logTestEnd(testInfo, true);
     } catch (error) {
       await safeScreenshot(page, 'variable-product-depth-delete-regenerate-failure.png');
+      logTestEnd(testInfo, false);
+      throw error;
+    } finally {
+      if (productId) {
+        await cleanupProduct(productId);
+      }
+    }
+  });
+
+  test('Add a new attribute to an already-synced variable product and verify catalog updates', async ({ page }, testInfo) => {
+    let productId = null;
+
+    try {
+      // 1. Create and sync a Color-only variable product (the programmatic default:
+      //    a "Color" attribute with Red/Blue/Green -> 3 variations, no size).
+      const product = await createTestProduct({ productType: 'variable', price: '42.00' });
+      productId = product.productId;
+      console.log(`✅ Created variable product ${productId}: "${product.productName}"`);
+
+      const baseline = await validateVariableProductSync(productId, product.productName, { attempts: 3 });
+      expect(baseline.raw_data.woo_data).toHaveLength(3);
+      for (const wooItem of baseline.raw_data.woo_data) {
+        // No size attribute exists yet, so every catalog variation's size is empty.
+        expect(normalizeText(wooItem.size)).toBe('');
+      }
+      console.log('✅ Baseline synced: 3 Color-only variations, no size attribute');
+
+      // 2. Add a NEW "Size" attribute to the already-synced product and rebuild its
+      //    variations as the Color x Size cartesian product (Red/Blue x Small/Large = 4),
+      //    each with a stable SKU so retailer IDs are deterministic for matching.
+      //    Done programmatically: the WooCommerce variations metabox is dialog/blockUI
+      //    heavy and flaky to drive via the UI for a "confirm catalog reflects it" check.
+      const addAttrResult = await execWP(`
+        $parent_id = ${Number(productId)};
+        $product = wc_get_product($parent_id);
+        if ( ! $product || ! $product->is_type('variable') ) {
+          echo json_encode(['ok' => false, 'reason' => 'bad_parent']);
+          return;
+        }
+
+        // Append a new variation-defining "Size" attribute, preserving existing ones.
+        $attributes = $product->get_attributes();
+        $size = new WC_Product_Attribute();
+        $size->set_name('Size'); // label contains "size" -> maps to the catalog size field
+        $size->set_options(['Small', 'Large']);
+        $size->set_visible(true);
+        $size->set_variation(true);
+        $attributes['size'] = $size;
+        $product->set_attributes($attributes);
+        $product->save();
+
+        // Remove the old Color-only variations and rebuild as Color x Size so every
+        // variation is fully specified (avoids "Any Size" variations with empty values).
+        foreach ($product->get_children() as $old_vid) {
+          wp_delete_post($old_vid, true);
+        }
+
+        $created = [];
+        $price = 42;
+        foreach (['Red', 'Blue'] as $color) {
+          foreach (['Small', 'Large'] as $size_value) {
+            $variation = new WC_Product_Variation();
+            $variation->set_parent_id($parent_id);
+            $variation->set_attributes(['color' => $color, 'size' => $size_value]);
+            $variation->set_regular_price((string) $price);
+            $variation->set_price((string) $price);
+            $variation->set_sku('e2e-' . strtolower($color) . '-' . strtolower($size_value) . '-' . $parent_id);
+            $variation->set_manage_stock(true);
+            $variation->set_stock_quantity(10);
+            $variation->set_stock_status('instock');
+            $created[] = $variation->save();
+            $price++;
+          }
+        }
+        $product = wc_get_product($parent_id);
+        $product->save();
+
+        echo json_encode(['ok' => true, 'count' => count($created)]);
+      `);
+
+      const addAttr = JSON.parse(addAttrResult.stdout);
+      expect(addAttr.ok, `Failed to add Size attribute: ${addAttrResult.stdout}`).toBe(true);
+      expect(addAttr.count).toBe(4);
+      console.log('✅ Added Size attribute and rebuilt 4 Color x Size variations');
+
+      // 3. Re-sync and assert the catalog reflects the new attribute: 4 variations,
+      //    each carrying its size (matched to Woo by retailer_id) with color preserved.
+      const after = await validateVariableProductSync(productId, product.productName, { attempts: 4 });
+      assertVariationAttributeMapping(after, 4);
+      expect(after.raw_data.woo_data).toHaveLength(4);
+
+      for (const fbItem of after.raw_data.facebook_data.filter(item => item && item.found !== false)) {
+        expect(normalizeText(fbItem.size), 'New Size attribute should be populated on every synced variation').not.toBe('');
+      }
+      const syncedSizes = new Set(after.raw_data.facebook_data.map(item => normalizeText(item.size)));
+      expect(syncedSizes.has('small') && syncedSizes.has('large')).toBe(true);
+      console.log('✅ New Size attribute propagated to all 4 catalog variations');
+
+      logTestEnd(testInfo, true);
+    } catch (error) {
+      await safeScreenshot(page, 'add-attribute-to-synced-variable-product-failure.png');
       logTestEnd(testInfo, false);
       throw error;
     } finally {


### PR DESCRIPTION
## Summary

Fills the one genuinely-remaining Action 5 automation gap from the "reducing manual regression scope" review: **guide step 9.1** — add a *new* variation-defining attribute to an *already-synced* variable product and confirm the Meta catalog reflects it. Existing tests set attributes at creation (`variable-product-depth`) or edit existing variations (`product-modification`), but none cover this transition.

### Test (in the `variable-product-depth` suite)
1. Create + sync a Color-only variable product (the programmatic default: 3 variations, no size).
2. **Programmatically** add a `Size` attribute and rebuild variations as the Color×Size cartesian product (4 variations) with stable SKUs. Done via `execWP` because the WooCommerce variations metabox is dialog/blockUI-heavy and flaky to drive through the UI for a catalog-outcome check — the suite already force-enqueues sync programmatically (`forceEnqueueVariableProductSync`).
3. Re-sync and assert the catalog now has **4** variations, each carrying its `size` (matched to Woo by `retailer_id`, `color` preserved), with both `small` and `large` present — reusing the suite's `validateVariableProductSync` + `assertVariationAttributeMapping` helpers.

### Why `Size`
The E2E sync validator only surfaces `color` and `size` among variation attributes (`sync-validator.php` field list), so a newly-added `Size` is observable in the catalog; `pattern`/`material`/`custom_data:*` axes are not. The attribute-mapping logic keys off the attribute *label* (`get_attribute_by_type`), so a label containing "size" maps to the catalog `size` field.

### Notes
- Not gated by the all-products-sync rollout switch — attribute/variation content syncs for every eligible product (confirmed; the switch governs sync *eligibility*, not which attributes are included).
- Runs on `chromium-wp-admin` (the suite's project gate). CI is the verification against the live catalog.

This is the last of the Action 5 items that was both active and cleanly automatable; the others were obsolete (Manage iframe), being removed (category/tag exclusion, PR #3991), already covered (hide-out-of-stock), or infeasible in CI (native image mutation — localhost host, Meta can't fetch images).