### PR TITLE
Remove legacy page access token storage

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -320,22 +320,6 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	}
 
 	/**
-	 * Gets deprecated and removed hooks.
-	 *
-	 * @since 2.1.0
-	 *
-	 * @return array
-	 */
-	protected function get_deprecated_hooks() {
-		return array(
-			'wc_facebook_page_access_token' => array(
-				'version'     => '2.1.0',
-				'replacement' => false,
-			),
-		);
-	}
-
-	/**
 	 * Adds the setup task to the Tasklists.
 	 *
 	 * @since 2.6.29

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -33,10 +33,12 @@ require_once 'facebook-commerce-admin-notice.php';
 class WC_Facebookcommerce_Integration extends WC_Integration {
 
 	/**
-	 * The WordPress option name where the page access token is stored.
+	 * The WordPress option name where the legacy page access token is stored.
 	 *
-	 * @var string option name.
+	 * Retained for compatibility until the stored data is removed in T283387818.
+	 *
 	 * @deprecated 2.1.0
+	 * @var string option name
 	 */
 	const OPTION_PAGE_ACCESS_TOKEN = 'wc_facebook_page_access_token';
 

--- a/includes/API/Plugin/README.md
+++ b/includes/API/Plugin/README.md
@@ -327,7 +327,6 @@ public function render_message_handler() {
                 const requestBody = {
                     access_token: message.access_token,
                     merchant_access_token: message.access_token,
-                    page_access_token: message.access_token,
                     product_catalog_id: message.catalog_id,
                     pixel_id: message.pixel_id,
                     page_id: message.page_id,

--- a/includes/API/Plugin/Settings/Handler.php
+++ b/includes/API/Plugin/Settings/Handler.php
@@ -175,10 +175,6 @@ class Handler extends AbstractRESTEndpoint {
 			$options[ \WC_Facebookcommerce_Integration::OPTION_MERCHANT_ACCESS_TOKEN ] = $params['merchant_access_token'];
 		}
 
-		if ( ! empty( $params['page_access_token'] ) ) {
-			$options[ \WC_Facebookcommerce_Integration::OPTION_PAGE_ACCESS_TOKEN ] = $params['page_access_token'];
-		}
-
 		if ( ! empty( $params['page_id'] ) ) {
 			update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, $params['page_id'] );
 		}

--- a/includes/Admin/Settings_Screens/Shops.php
+++ b/includes/Admin/Settings_Screens/Shops.php
@@ -452,7 +452,6 @@ class Shops extends Abstract_Settings_Screen {
 					const requestBody = {
 						access_token: message.access_token,
 						merchant_access_token: message.access_token,
-						page_access_token: message.access_token,
 						product_catalog_id: message.catalog_id,
 						pixel_id: message.pixel_id,
 						page_id: message.page_id,

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -10,7 +10,6 @@
 
 namespace WooCommerce\Facebook\Handlers;
 
-use WooCommerce\Facebook\API;
 use WooCommerce\Facebook\API\Exceptions\ConnectApiException;
 use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
 use WooCommerce\Facebook\Framework\Helper;
@@ -77,9 +76,6 @@ class Connection {
 
 	/** @var string the merchant access token option name */
 	const OPTION_MERCHANT_ACCESS_TOKEN = 'wc_facebook_merchant_access_token';
-
-	/** @var string the page access token option name */
-	const OPTION_PAGE_ACCESS_TOKEN = 'wc_facebook_page_access_token';
 
 	/** @var string the Commerce manager ID option name */
 	const OPTION_COMMERCE_MANAGER_ID = 'wc_facebook_commerce_manager_id';
@@ -334,13 +330,7 @@ class Connection {
 		$page_id = sanitize_text_field( $response->get_page_id() );
 
 		if ( $page_id ) {
-
 			update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, $page_id );
-
-			// get and store a current access token for the configured page
-			$page_access_token = $this->retrieve_page_access_token( $page_id );
-
-			$this->update_page_access_token( $page_access_token );
 		}
 
 		if ( $response->get_pixel_id() ) {
@@ -573,7 +563,6 @@ class Connection {
 	 */
 	public function disconnect() {
 		$this->update_access_token( '' );
-		$this->update_page_access_token( '' );
 		$this->update_merchant_access_token( '' );
 		$this->update_system_user_id( '' );
 		$this->update_business_manager_id( '' );
@@ -585,56 +574,12 @@ class Connection {
 		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, '' );
 		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, '' );
 		facebook_for_woocommerce()->get_integration()->update_product_catalog_id( '' );
+		delete_option( \WC_Facebookcommerce_Integration::OPTION_PAGE_ACCESS_TOKEN );
 
 		// Clear facebook_config option to stop pixel tracking and prevent stale data
 		if ( class_exists( 'WC_Facebookcommerce_Pixel' ) ) {
 			delete_option( \WC_Facebookcommerce_Pixel::SETTINGS_KEY );
 		}
-	}
-
-
-	/**
-	 * Retrieves the configured page access token remotely.
-	 *
-	 * @since 2.1.0
-	 *
-	 * @param string $page_id desired Facebook page ID
-	 * @return string
-	 * @throws ApiException If the page access token could not be retrieved.
-	 */
-	private function retrieve_page_access_token( $page_id ) {
-		facebook_for_woocommerce()->log( 'Retrieving page access token' );
-		$api_url  = Api::GRAPH_API_URL . Api::API_VERSION;
-		$response = wp_remote_get( $api_url . '/me/accounts?access_token=' . $this->get_access_token() );
-		$body     = wp_remote_retrieve_body( $response );
-		$body     = json_decode( $body, true );
-		if ( ! is_array( $body ) || empty( $body['data'] ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
-			facebook_for_woocommerce()->log( print_r( $body, true ) );
-			throw new ApiException(
-				esc_html(
-					sprintf(
-						/* translators: Placeholders: %s - API error message */
-						__( 'Could not retrieve page access data. %s', 'facebook-for-woocommerce' ),
-						wp_remote_retrieve_response_message( $response )
-					)
-				)
-			);
-		}
-		$page_access_tokens = wp_list_pluck( $body['data'], 'access_token', 'id' );
-		// bail if the user isn't authorized to manage the page
-		if ( empty( $page_access_tokens[ $page_id ] ) ) {
-			throw new ApiException(
-				esc_html(
-					sprintf(
-					/* translators: Placeholders: %s - Facebook page ID */
-						__( 'Page %s not authorized.', 'facebook-for-woocommerce' ),
-						$page_id
-					)
-				)
-			);
-		}
-		return $page_access_tokens[ $page_id ];
 	}
 
 
@@ -656,27 +601,6 @@ class Connection {
 		 * @param Connection $connection connection handler instance
 		 */
 		return apply_filters( 'wc_facebook_connection_access_token', $access_token, $this );
-	}
-
-
-	/**
-	 * Gets the page access token.
-	 *
-	 * @since 2.1.0
-	 *
-	 * @return string
-	 */
-	public function get_page_access_token() {
-		$access_token = get_option( self::OPTION_PAGE_ACCESS_TOKEN, '' );
-		/**
-		 * Filters the page access token.
-		 *
-		 * @since 2.1.0
-		 *
-		 * @param string $access_token page access token
-		 * @param Connection $connection connection handler instance
-		 */
-		return (string) apply_filters( 'wc_facebook_connection_page_access_token', $access_token, $this );
 	}
 
 
@@ -1173,17 +1097,6 @@ class Connection {
 
 
 	/**
-	 * Stores the given page access token.
-	 *
-	 * @since 2.1.0
-	 *
-	 * @param string $value the access token
-	 */
-	public function update_page_access_token( $value ) {
-		update_option( self::OPTION_PAGE_ACCESS_TOKEN, is_string( $value ) ? $value : '' );
-	}
-
-	/**
 	 * Stores the given external business id.
 	 *
 	 * @since 2.6.13
@@ -1359,16 +1272,8 @@ class Connection {
 
 		if ( ! empty( $values->pages ) ) {
 			$page_id = current( $values->pages );
-			try {
-				update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, sanitize_text_field( $page_id ) );
-				$log_data[ \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID ] = sanitize_text_field( $page_id );
-				// get and store a current access token for the configured page
-				$page_access_token = $this->retrieve_page_access_token( $page_id );
-				$this->update_page_access_token( $page_access_token );
-				$log_data[ self::OPTION_PAGE_ACCESS_TOKEN ] = sanitize_text_field( $page_access_token );
-			} catch ( \Exception $e ) {
-				$this->get_plugin()->log( 'Could not request Page Token: ' . $e->getMessage() );
-			}
+			update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, sanitize_text_field( $page_id ) );
+			$log_data[ \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID ] = sanitize_text_field( $page_id );
 		}//end if
 
 		$this->get_plugin()->log( 'WebHook User event saved data' );

--- a/includes/Handlers/MetaExtension.php
+++ b/includes/Handlers/MetaExtension.php
@@ -34,7 +34,6 @@ class MetaExtension {
 	/** @var string Option names for Facebook settings */
 	const OPTION_ACCESS_TOKEN                    = 'wc_facebook_access_token';
 	const OPTION_MERCHANT_ACCESS_TOKEN           = 'wc_facebook_merchant_access_token';
-	const OPTION_PAGE_ACCESS_TOKEN               = 'wc_facebook_page_access_token';
 	const OPTION_SYSTEM_USER_ID                  = 'wc_facebook_system_user_id';
 	const OPTION_BUSINESS_MANAGER_ID             = 'wc_facebook_business_manager_id';
 	const OPTION_AD_ACCOUNT_ID                   = 'wc_facebook_ad_account_id';

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -75,7 +75,7 @@ class Lifecycle extends Framework\Lifecycle {
 		 * Versions prior to 1.10.0 did not set a version option, so the upgrade method needs to be called manually.
 		 * We do this by checking first if an old option exists, but a new one doesn't.
 		 */
-		if ( get_option( 'woocommerce_facebookcommerce_settings' ) && ! get_option( 'wc_facebook_page_access_token' ) ) {
+		if ( get_option( 'woocommerce_facebookcommerce_settings' ) && ! get_option( \WC_Facebookcommerce_Integration::OPTION_PAGE_ACCESS_TOKEN ) ) {
 			$this->upgrade( '1.9.15' );
 		}
 	}
@@ -107,7 +107,6 @@ class Lifecycle extends Framework\Lifecycle {
 		}
 		// migrate options from woocommerce_facebookcommerce_settings
 		$options = array(
-			'fb_api_key'                       => \WC_Facebookcommerce_Integration::OPTION_PAGE_ACCESS_TOKEN,
 			'fb_product_catalog_id'            => \WC_Facebookcommerce_Integration::OPTION_PRODUCT_CATALOG_ID,
 			'fb_external_merchant_settings_id' => \WC_Facebookcommerce_Integration::OPTION_EXTERNAL_MERCHANT_SETTINGS_ID,
 			'fb_feed_id'                       => \WC_Facebookcommerce_Integration::OPTION_FEED_ID,

--- a/tests/Unit/Api/REST/RestAPITest.php
+++ b/tests/Unit/Api/REST/RestAPITest.php
@@ -81,7 +81,7 @@ class RestAPITest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering 
         $test_data = [
             'merchant_access_token' => 'test_merchant_token',
             'access_token' => 'test_access_token',
-            'page_access_token' => 'test_page_token',
+            'page_access_token' => 'new_page_token',
             'product_catalog_id' => '123456',
             'pixel_id' => '789012',
             'msger_chat' => 'yes',
@@ -100,10 +100,12 @@ class RestAPITest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering 
         // Verify options are mapped correctly
         $this->assertEquals('test_access_token', $options['wc_facebook_access_token']);
         $this->assertEquals('test_merchant_token', $options['wc_facebook_merchant_access_token']);
+        $this->assertArrayNotHasKey('wc_facebook_page_access_token', $options);
         $this->assertEquals('123456', $options['wc_facebook_product_catalog_id']);
         $this->assertEquals('789012', $options['wc_facebook_commerce_merchant_settings_id']);
 
         // Test update_settings
+        update_option('wc_facebook_page_access_token', 'existing_page_token');
         $update_settings_method = $reflection->getMethod('update_settings');
         $update_settings_method->setAccessible(true);
         $update_settings_method->invokeArgs($handler, [$options]);
@@ -116,6 +118,7 @@ class RestAPITest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering 
         // Verify options were updated
         $this->assertEquals('test_access_token', get_option('wc_facebook_access_token'));
         $this->assertEquals('test_merchant_token', get_option('wc_facebook_merchant_access_token'));
+        $this->assertEquals('existing_page_token', get_option('wc_facebook_page_access_token'));
         $this->assertEquals('123456', get_option('wc_facebook_product_catalog_id'));
         $this->assertEquals('789012', get_option('wc_facebook_pixel_id'));
         $this->assertEquals('yes', get_option('wc_facebook_has_connected_fbe_2'));

--- a/tests/Unit/Handlers/ConnectionDisconnectTest.php
+++ b/tests/Unit/Handlers/ConnectionDisconnectTest.php
@@ -70,6 +70,21 @@ class ConnectionDisconnectTest extends AbstractWPUnitTestWithOptionIsolationAndS
 	}
 
 	/**
+	 * Test that disconnect clears the stored legacy page access token.
+	 */
+	public function test_disconnect_clears_legacy_page_access_token(): void {
+		$this->assertTrue(
+			add_option( \WC_Facebookcommerce_Integration::OPTION_PAGE_ACCESS_TOKEN, 'legacy_page_token' ),
+			'Failed to create the legacy page access token option.'
+		);
+
+		$connection = new Connection( $this->plugin_mock );
+		$connection->disconnect();
+
+		$this->assertFalse( get_option( \WC_Facebookcommerce_Integration::OPTION_PAGE_ACCESS_TOKEN, false ) );
+	}
+
+	/**
 	 * Test that disconnect works safely when facebook_config doesn't exist.
 	 */
 	public function test_disconnect_safe_when_facebook_config_missing(): void {

--- a/tests/Unit/Handlers/ConnectionPageAccessTokenTest.php
+++ b/tests/Unit/Handlers/ConnectionPageAccessTokenTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package MetaCommerce
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\Facebook\Tests\Unit\Handlers;
+
+use WooCommerce\Facebook\Handlers\Connection;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+
+/**
+ * Tests compatibility behavior for stored legacy page access tokens.
+ */
+class ConnectionPageAccessTokenTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+	/**
+	 * Ensures an install webhook updates the page ID without changing the legacy token.
+	 */
+	public function test_install_webhook_preserves_legacy_page_access_token(): void {
+		$plugin = $this->createMock( \WC_Facebookcommerce::class );
+		$plugin->method( 'log' );
+
+		update_option( \WC_Facebookcommerce_Integration::OPTION_PAGE_ACCESS_TOKEN, 'legacy_page_token' );
+
+		$data = (object) array(
+			'object' => Connection::WEBHOOK_SUBSCRIBED_OBJECT,
+			'entry'  => array(
+				(object) array(
+					'uid'     => 'system_user_id',
+					'changes' => array(
+						(object) array(
+							'field' => Connection::WEBHOOK_SUBSCRIBED_FIELD,
+							'value' => (object) array(
+								'access_token'          => 'system_user_token',
+								'merchant_access_token' => 'merchant_token',
+								'pages'                => array( 'page_id' ),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$connection = new Connection( $plugin );
+		$connection->fbe_install_webhook( $data );
+
+		$this->assertSame( 'page_id', get_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID ) );
+		$this->assertSame( 'legacy_page_token', get_option( \WC_Facebookcommerce_Integration::OPTION_PAGE_ACCESS_TOKEN ) );
+	}
+}

--- a/tests/e2e/events-test.spec.js
+++ b/tests/e2e/events-test.spec.js
@@ -62,15 +62,50 @@ function resolveThemeForProject(projectName) {
 
 function createPixelEventRequestRecorder(page, eventName) {
   const captured = [];
+  const requestContext = page.context();
 
   const readBodyParam = (request, key) => {
     const body = request.postData() || '';
-    if (!body || !body.includes('=')) {
+    if (!body) {
       return null;
     }
 
-    const form = new URLSearchParams(body);
-    return form.get(key);
+    if (!body.includes('name="')) {
+      return new URLSearchParams(body).get(key);
+    }
+
+    // Firefox sends Pixel beacon payloads as multipart/form-data.
+    const nameMarker = `name="${key}"`;
+    const nameStart = body.indexOf(nameMarker);
+    if (nameStart === -1) {
+      return null;
+    }
+
+    const headerEndCRLF = body.indexOf('\r\n\r\n', nameStart);
+    const headerEndLF = body.indexOf('\n\n', nameStart);
+    let valueStart = -1;
+
+    if (headerEndCRLF !== -1 && (headerEndLF === -1 || headerEndCRLF < headerEndLF)) {
+      valueStart = headerEndCRLF + 4;
+    } else if (headerEndLF !== -1) {
+      valueStart = headerEndLF + 2;
+    }
+
+    if (valueStart === -1) {
+      return null;
+    }
+
+    const boundaryCRLF = body.indexOf('\r\n--', valueStart);
+    const boundaryLF = body.indexOf('\n--', valueStart);
+    let valueEnd = -1;
+
+    if (boundaryCRLF !== -1 && (boundaryLF === -1 || boundaryCRLF < boundaryLF)) {
+      valueEnd = boundaryCRLF;
+    } else if (boundaryLF !== -1) {
+      valueEnd = boundaryLF;
+    }
+
+    return valueEnd === -1 ? null : body.slice(valueStart, valueEnd).trim() || null;
   };
 
   const onRequest = (request) => {
@@ -117,11 +152,12 @@ function createPixelEventRequestRecorder(page, eventName) {
     }
   };
 
-  page.on('request', onRequest);
+  // Match PixelCapture's context-level request observation.
+  requestContext.on('request', onRequest);
 
   return {
     getEvents: () => captured.slice(),
-    stop: () => page.off('request', onRequest),
+    stop: () => requestContext.off('request', onRequest),
   };
 }
 

--- a/tests/e2e/plugin-level-tests.spec.js
+++ b/tests/e2e/plugin-level-tests.spec.js
@@ -498,74 +498,89 @@ test.describe('WooCommerce Plugin level tests', () => {
     console.log('🎉 Disconnect and reconnect test passed!');
   });
 
-   test('Reset connection settings via WooCommerce Status Tools', async ({ page }) => {
+  test('Reset connection settings via WooCommerce Status Tools', async ({ page }) => {
     console.log('🔄 Testing Reset connection settings...');
 
-    // Navigate to WooCommerce Status Tools
-    await page.goto(`${process.env.WORDPRESS_URL}/wp-admin/admin.php?page=wc-status&tab=tools`, {
-      waitUntil: 'domcontentloaded',
-      timeout: TIMEOUTS.EXTRA_LONG
-    });
+    const legacyPageAccessTokenOption = 'wc_facebook_page_access_token';
+    await execWP(`update_option('${legacyPageAccessTokenOption}', 'legacy_page_token');`);
 
-    // Handle confirmation dialog
-    page.once('dialog', async dialog => {
-      console.log(`✅ Confirming dialog: ${dialog.message()}`);
-      await dialog.accept();
-    });
+    let reconnectResult;
 
-    // Click Reset settings button and wait for navigation
-    console.log('🔘 Clicking Reset settings button...');
-    const resetButton = page.locator('.wc_facebook_settings_reset input[type="submit"]');
-    await resetButton.waitFor({ state: 'visible', timeout: TIMEOUTS.LONG });
+    try {
+      // Navigate to WooCommerce Status Tools
+      await page.goto(`${process.env.WORDPRESS_URL}/wp-admin/admin.php?page=wc-status&tab=tools`, {
+        waitUntil: 'domcontentloaded',
+        timeout: TIMEOUTS.EXTRA_LONG
+      });
 
-    await resetButton.click();
-    await page.waitForLoadState('domcontentloaded', { timeout: TIMEOUTS.EXTRA_LONG });
+      // Handle confirmation dialog
+      page.once('dialog', async dialog => {
+        console.log(`✅ Confirming dialog: ${dialog.message()}`);
+        await dialog.accept();
+      });
 
-    console.log('✅ Page reloaded after reset action');
+      // Click Reset settings button and wait for navigation
+      console.log('🔘 Clicking Reset settings button...');
+      const resetButton = page.locator('.wc_facebook_settings_reset input[type="submit"]');
+      await resetButton.waitFor({ state: 'visible', timeout: TIMEOUTS.LONG });
 
-    // Navigate to options page to verify reset
-    await page.goto(`${process.env.WORDPRESS_URL}/wp-admin/options.php`, {
-      waitUntil: 'domcontentloaded',
-      timeout: TIMEOUTS.EXTRA_LONG
-    });
+      await resetButton.click();
+      await page.waitForLoadState('domcontentloaded', { timeout: TIMEOUTS.EXTRA_LONG });
 
-    // List of Facebook options that should be empty
-    const fbOptions = [
-      'wc_facebook_access_token',
-      'wc_facebook_page_access_token',
-      'wc_facebook_merchant_access_token',
-      'wc_facebook_system_user_id',
-      'wc_facebook_business_manager_id',
-      'wc_facebook_ad_account_id',
-      'wc_facebook_instagram_business_id',
-      'wc_facebook_commerce_merchant_settings_id',
-      'wc_facebook_external_business_id',
-      'wc_facebook_commerce_partner_integration_id',
-      'wc_facebook_page_id',
-      'wc_facebook_pixel_id',
-      'wc_facebook_product_catalog_id'
-    ];
+      console.log('✅ Page reloaded after reset action');
 
-    // Check each option is empty
-    console.log('🔍 Verifying all Facebook options are cleared...');
-    for (const option of fbOptions) {
-      const input = page.locator(`#${option}`);
-      const value = await input.inputValue();
+      // Navigate to options page to verify reset
+      await page.goto(`${process.env.WORDPRESS_URL}/wp-admin/options.php`, {
+        waitUntil: 'domcontentloaded',
+        timeout: TIMEOUTS.EXTRA_LONG
+      });
 
-      if (value !== '') {
-        throw new Error(`❌ ${option} not cleared. Value: ${value}`);
+      // List of Facebook options that should be empty
+      const fbOptions = [
+        'wc_facebook_access_token',
+        'wc_facebook_merchant_access_token',
+        'wc_facebook_system_user_id',
+        'wc_facebook_business_manager_id',
+        'wc_facebook_ad_account_id',
+        'wc_facebook_instagram_business_id',
+        'wc_facebook_commerce_merchant_settings_id',
+        'wc_facebook_external_business_id',
+        'wc_facebook_commerce_partner_integration_id',
+        'wc_facebook_page_id',
+        'wc_facebook_pixel_id',
+        'wc_facebook_product_catalog_id'
+      ];
+
+      // Check each option is empty
+      console.log('🔍 Verifying all Facebook options are cleared...');
+      for (const option of fbOptions) {
+        const input = page.locator(`#${option}`);
+        const value = await input.inputValue();
+
+        if (value !== '') {
+          throw new Error(`❌ ${option} not cleared. Value: ${value}`);
+        }
+      }
+
+      const { stdout } = await execWP(
+        `echo wp_json_encode(get_option('${legacyPageAccessTokenOption}', false));`
+      );
+      expect(JSON.parse(stdout)).toBe(false);
+
+      console.log('✅ All Facebook connection options cleared');
+      console.log('🎉 Reset connection settings test passed!');
+    } finally {
+      try {
+        reconnectResult = await reconnectAndVerify();
+      } finally {
+        await execWP(`delete_option('${legacyPageAccessTokenOption}');`);
       }
     }
 
-    console.log('✅ All Facebook connection options cleared');
-    console.log('🎉 Reset connection settings test passed!');
-
-    const reconnectResult = await reconnectAndVerify();
     // Assertions on reconnect
     expect(reconnectResult.success).toBe(true);
     expect(reconnectResult.before.connected).toBe(false);
     expect(reconnectResult.after.connected).toBe(true);
-
   });
 
   // Plugin compatibility test
@@ -875,7 +890,9 @@ test.describe('WooCommerce Plugin level tests', () => {
 
       // Select the global attribute from the dropdown
       console.log(`🔍 Selecting global attribute "${attributeName}"...`);
-      const productAttributeContainer = page.locator('span').filter({ hasText: 'Add existing' }).first();
+      const productAttributeContainer = page
+        .getByRole('combobox', { name: /Add (?:existing|global)/i })
+        .first();
       await productAttributeContainer.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
       await exactSearchSelect2Container(page, productAttributeContainer, attributeName);
       const selectAllAttrValuesBtn = page.getByRole('button', { name: 'Select all' });


### PR DESCRIPTION
## Description

Removes the legacy page access token pipeline as a self-contained change. The stored token has no production consumer, while current onboarding already delivers the active system-user token through Commerce Partner Hub.

This change:

- stops sending and storing `page_access_token` during Commerce Partner Hub onboarding;
- removes the unused getter, updater, deprecated hook metadata, and `/me/accounts` token refresh;
- retains `OPTION_PAGE_ACCESS_TOKEN` as a deprecated compatibility constant while stored legacy values remain;
- preserves Facebook page ID updates;
- stops migrating the old `fb_api_key` value into standalone page-token storage;
- preserves existing stored page-token values so a downgrade or compatibility update can recover the previous behavior;
- keeps token deletion limited to explicit merchant disconnect/reset actions.

Automatic database cleanup is intentionally deferred to a later, separately reviewed migration after a compatibility window. This PR does not delete existing values from `wc_facebook_page_access_token`, `woocommerce_facebookcommerce_settings`, or `woocommerce_facebookcommerce_legacy_settings` during upgrade.

Cleanup follow-up: [T283387818](https://www.internalfb.com/tasks/T283387818).

The removed getter and updater were public, so third-party callers outside this repository cannot be ruled out.

### Type of change

- Tweak (non-breaking change which fixes code modularity, linting or phpcs issues)

## Checklist

- [x] I have commented the compatibility behavior where it is not self-explanatory.
- [x] I have confirmed that my changes do not introduce new PHPCS warnings or errors.
- [x] I followed general pull request best practices.
- [x] I added focused unit and E2E coverage for the changed behavior.
- [x] I conducted repository-wide due diligence for page-token readers, writers, and cleanup paths.
- [x] I updated the embedded API documentation.
- [ ] Manual debug-log and dogfooding verification remains to be completed.

## Changelog entry

Remove obsolete page access token retrieval and storage.

## Test Plan

### Completed locally

- [x] `npm run lint:php` (zero errors; existing warnings are in untouched files)
- [x] `composer lint-branch -- origin/main`
- [x] `npm run test:js -- --runInBand --no-watchman` (104 tests passed)
- [x] PHP syntax checks for every changed PHP file
- [x] `git diff --check`
- [x] Repository-wide search confirms there is no production page-token retrieval, value getter, or storage writer
- [x] Repository-wide search confirms there is no automatic lifecycle cleanup

The local WordPress PHPUnit environment is not installed. PHP unit, integration, coding-standard, and Playwright E2E suites run in GitHub Actions for this branch.

### Manual verification

1. Install the PR build on a non-production WooCommerce site and connect it through the standard onboarding flow.
2. Seed a legacy value with `wp option update wc_facebook_page_access_token legacy-test-token`.
3. Submit or replay a settings update containing `page_access_token=new-test-token`.
4. Verify `wp option get wc_facebook_page_access_token` still returns `legacy-test-token`; new onboarding must not write or overwrite this option.
5. Verify the Facebook page ID and the supported merchant/system-user settings still update normally.
6. Reset or disconnect the Facebook integration.
7. Verify `wp option get wc_facebook_page_access_token` reports that the option does not exist.
8. Review plugin debug logs and confirm there are no new PHP warnings or fatal errors.

## Screenshots

Not applicable; no UI changes.