### PR TITLE
Stabilize Purchase and product catalog E2E tests

### DIFF
--- a/.github/workflows/product-creation-tests.yml
+++ b/.github/workflows/product-creation-tests.yml
@@ -78,6 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       secrets-configured: ${{ steps.check.outputs.configured }}
+      max-parallel: ${{ steps.check.outputs.max-parallel }}
+      use-parallel-assets: ${{ steps.check.outputs.use-parallel-assets }}
     steps:
       - name: Check if required secrets are configured
         id: check
@@ -87,11 +89,31 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           REPO_OWNER: ${{ github.repository_owner }}
         run: |
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+          echo "max-parallel=1" >> "$GITHUB_OUTPUT"
+          echo "use-parallel-assets=false" >> "$GITHUB_OUTPUT"
+
           if [ -n "$TEST_SITE_HOST" ] && [ -n "$FB_TEST_META_BUSINESS_ASSETS" ]; then
+            if ! echo "$FB_TEST_META_BUSINESS_ASSETS" | jq -e 'type == "array" and length > 0' > /dev/null; then
+              echo "::error title=Invalid Meta test assets::FB_TEST_META_BUSINESS_ASSETS must be a non-empty JSON array."
+              exit 1
+            fi
+
             echo "configured=true" >> $GITHUB_OUTPUT
             echo "✅ Required secrets are configured"
+
+            ASSET_COUNT=$(echo "$FB_TEST_META_BUSINESS_ASSETS" | jq 'length')
+            DISTINCT_CATALOG_COUNT=$(echo "$FB_TEST_META_BUSINESS_ASSETS" | jq \
+              '[.[0:3][].wc_facebook_product_catalog_id | select(type == "string" and length > 0)] | unique | length')
+
+            if [ "$ASSET_COUNT" -ge 3 ] && [ "$DISTINCT_CATALOG_COUNT" -eq 3 ]; then
+              echo "max-parallel=3" >> "$GITHUB_OUTPUT"
+              echo "use-parallel-assets=true" >> "$GITHUB_OUTPUT"
+              echo "✅ Three distinct catalogs found; E2E jobs will use three-way parallelism"
+            else
+              echo "::notice title=Sequential E2E mode::Found $ASSET_COUNT asset set(s) and $DISTINCT_CATALOG_COUNT distinct catalog(s) in the first three entries. E2E jobs will use the first catalog sequentially. Configure three distinct catalogs to enable parallel execution."
+            fi
           else
-            echo "configured=false" >> $GITHUB_OUTPUT
             # Fail if this is a scheduled run on the facebook repository
             if [ "$EVENT_NAME" = "schedule" ] && [ "$REPO_OWNER" = "facebook" ]; then
               echo "::error title=E2E Tests Failed::Scheduled run on facebook repository but required secrets (TEST_SITE_HOST, FB_TEST_META_BUSINESS_ASSETS) are not configured."
@@ -134,17 +156,16 @@ jobs:
     # suites legitimately exceed 45 minutes when Facebook propagation is slow.
     timeout-minutes: ${{ matrix.job_timeout }}
 
-    # Each lane maps to one dedicated Meta business asset set. Serialize jobs
-    # using the same lane across workflow runs so two shards never mutate the
-    # same catalog concurrently.
+    # With three distinct catalogs, run one shard per catalog in parallel. With
+    # fewer catalogs, every shard uses catalog 0 and runs sequentially. The
+    # concurrency group also protects each catalog across overlapping runs.
     concurrency:
-      group: facebook-for-woocommerce-e2e-meta-asset-${{ matrix.asset-slot }}
+      group: facebook-for-woocommerce-e2e-meta-asset-${{ needs.check-secrets.outputs.use-parallel-assets == 'true' && matrix.asset-slot || '0' }}
       queue: max
 
     strategy:
       fail-fast: false
-      # Three Meta asset sets are configured, so run at most one shard per asset.
-      max-parallel: 3
+      max-parallel: ${{ fromJSON(needs.check-secrets.outputs.max-parallel) }}
       matrix:
         test-group: ['plugin-events', 'product-crud', 'variable-product-depth', 'product-batch', 'product-category', 'performance-sync']
         version-set: ['supported', 'latest']
@@ -158,23 +179,23 @@ jobs:
             wc-version: 'latest'
             version-label: 'Latest'
           - test-group: 'plugin-events'
-            asset-slot: 0
             job_timeout: 90
+            asset-slot: 0
           - test-group: 'product-crud'
+            job_timeout: 90
             asset-slot: 1
-            job_timeout: 45
           - test-group: 'variable-product-depth'
-            asset-slot: 2
             job_timeout: 90
+            asset-slot: 2
           - test-group: 'product-batch'
+            job_timeout: 45
             asset-slot: 0
-            job_timeout: 45
           - test-group: 'product-category'
-            asset-slot: 1
             job_timeout: 45
+            asset-slot: 1
           - test-group: 'performance-sync'
-            asset-slot: 2
             job_timeout: 90
+            asset-slot: 2
 
     services:
       mysql:
@@ -459,22 +480,23 @@ jobs:
           echo "✅ PASS: No errors found in logs"
 
       - name: Select Meta Business Assets
+        env:
+          META_BUSINESS_ASSETS: ${{ secrets.FB_TEST_META_BUSINESS_ASSETS }}
+          ASSET_INDEX: ${{ needs.check-secrets.outputs.use-parallel-assets == 'true' && matrix.asset-slot || 0 }}
         run: |
           # Parse the JSON array of business assets
-          ASSETS='${{ secrets.FB_TEST_META_BUSINESS_ASSETS }}'
+          ASSETS="$META_BUSINESS_ASSETS"
 
           # Get the array length
           ARRAY_LENGTH=$(echo "$ASSETS" | jq 'length')
           echo "Total available business asset sets: $ARRAY_LENGTH"
 
-          # Each matrix lane requires its own catalog. Failing explicitly is
-          # safer than silently mapping multiple concurrent lanes to one asset.
-          if [ "$ARRAY_LENGTH" -lt 3 ]; then
-            echo "::error title=Insufficient Meta test assets::Expected at least 3 business asset sets, found $ARRAY_LENGTH."
+          if [ "$ARRAY_LENGTH" -lt 1 ]; then
+            echo "::error title=Missing Meta test assets::Expected at least 1 business asset set, found $ARRAY_LENGTH."
             exit 1
           fi
 
-          INDEX="${{ matrix.asset-slot }}"
+          INDEX="$ASSET_INDEX"
           echo "Selected asset set index: $INDEX"
 
           # Extract the selected asset set
@@ -544,8 +566,17 @@ jobs:
           wp option update wc_facebook_has_authorized_pages_read_engagement "yes" --allow-root
           wp option update wc_facebook_enable_product_sync "yes" --allow-root
 
+          # These suites exercise real-time Catalog Batch API sync. A legacy
+          # full-feed upload uses the same catalog, and Meta cannot fetch the
+          # private CI hostname, so keep it out of this run.
+          wp option update wc_facebook_legacy_feed_file_generation_enabled "no" --allow-root
+
           # Activate the plugin (this triggers automatic sync)
           wp plugin activate facebook-for-woocommerce --allow-root
+
+          # Remove a feed action if activation/heartbeat queued it before the
+          # settings above were observed.
+          wp eval "as_unschedule_all_actions('wc_facebook_regenerate_feed');" --allow-root
 
       - name: Verify no new errors after plugin activation
         run: |
@@ -1051,7 +1082,7 @@ jobs:
         if: matrix.test-group == 'product-crud'
         run: |
           cd ${{ env.PLUGIN_PATH }}
-          npx playwright test "product-(creation|modification|deletion).spec.js" --project=chromium-wp-admin --workers=2
+          npx playwright test "product-(creation|modification|deletion).spec.js" --project=chromium-wp-admin --workers=1
 
       - name: Run Variable Product Depth tests
         if: matrix.test-group == 'variable-product-depth'

--- a/.github/workflows/product-creation-tests.yml
+++ b/.github/workflows/product-creation-tests.yml
@@ -130,16 +130,21 @@ jobs:
     # never actually executing. The mysql:8.0 service container is multi-arch,
     # so this is no longer constrained to x86-only pools.
     runs-on: ubuntu-latest
-    # Fail fast instead of letting a stuck step (e.g. a hung browser install) run
-    # until GitHub's 6-hour default job timeout. plugin-events runs many browser
-    # projects sequentially, so it gets a larger budget.
-    timeout-minutes: ${{ matrix.test-group == 'plugin-events' && 90 || 45 }}
+    # Use explicit per-group budgets. Browser coverage and catalog stress/depth
+    # suites legitimately exceed 45 minutes when Facebook propagation is slow.
+    timeout-minutes: ${{ matrix.job_timeout }}
+
+    # Each lane maps to one dedicated Meta business asset set. Serialize jobs
+    # using the same lane across workflow runs so two shards never mutate the
+    # same catalog concurrently.
+    concurrency:
+      group: facebook-for-woocommerce-e2e-meta-asset-${{ matrix.asset-slot }}
+      queue: max
 
     strategy:
       fail-fast: false
-      # Cap how many shards run concurrently within a run to keep shared-test-asset
-      # contention reasonable (all shards now share the ubuntu-latest pool).
-      max-parallel: 8
+      # Three Meta asset sets are configured, so run at most one shard per asset.
+      max-parallel: 3
       matrix:
         test-group: ['plugin-events', 'product-crud', 'variable-product-depth', 'product-batch', 'product-category', 'performance-sync']
         version-set: ['supported', 'latest']
@@ -152,6 +157,24 @@ jobs:
             wp-version: 'latest'
             wc-version: 'latest'
             version-label: 'Latest'
+          - test-group: 'plugin-events'
+            asset-slot: 0
+            job_timeout: 90
+          - test-group: 'product-crud'
+            asset-slot: 1
+            job_timeout: 45
+          - test-group: 'variable-product-depth'
+            asset-slot: 2
+            job_timeout: 90
+          - test-group: 'product-batch'
+            asset-slot: 0
+            job_timeout: 45
+          - test-group: 'product-category'
+            asset-slot: 1
+            job_timeout: 45
+          - test-group: 'performance-sync'
+            asset-slot: 2
+            job_timeout: 90
 
     services:
       mysql:
@@ -444,13 +467,14 @@ jobs:
           ARRAY_LENGTH=$(echo "$ASSETS" | jq 'length')
           echo "Total available business asset sets: $ARRAY_LENGTH"
 
-          # Use run_number as selector - it's sequential (1, 2, 3, ...) across all workflow runs
-          # This ensures each concurrent run gets a different business asset set
-          SELECTOR="${{ github.run_number }}"
-          echo "Using GitHub Run Number as selector: $SELECTOR"
+          # Each matrix lane requires its own catalog. Failing explicitly is
+          # safer than silently mapping multiple concurrent lanes to one asset.
+          if [ "$ARRAY_LENGTH" -lt 3 ]; then
+            echo "::error title=Insufficient Meta test assets::Expected at least 3 business asset sets, found $ARRAY_LENGTH."
+            exit 1
+          fi
 
-          # Calculate index using modulo
-          INDEX=$((SELECTOR % ARRAY_LENGTH))
+          INDEX="${{ matrix.asset-slot }}"
           echo "Selected asset set index: $INDEX"
 
           # Extract the selected asset set

--- a/.github/workflows/product-creation-tests.yml
+++ b/.github/workflows/product-creation-tests.yml
@@ -179,7 +179,7 @@ jobs:
             wc-version: 'latest'
             version-label: 'Latest'
           - test-group: 'plugin-events'
-            job_timeout: 90
+            job_timeout: 120
             asset-slot: 0
           - test-group: 'product-crud'
             job_timeout: 90
@@ -336,6 +336,14 @@ jobs:
             --admin_password=admin \
             --admin_email=test@example.com \
             --allow-root
+
+          # Catalog E2E tests execute due sync events through the deterministic
+          # process-sync-jobs helper. Prevent request-triggered WP-Cron from
+          # racing that helper while unscheduling the same event. Plugin/events
+          # coverage keeps normal WP-Cron behavior.
+          if [ "${{ matrix.test-group }}" != "plugin-events" ]; then
+            wp config set DISABLE_WP_CRON true --raw --allow-root
+          fi
 
       - name: Install WooCommerce
         run: |

--- a/includes/API.php
+++ b/includes/API.php
@@ -434,11 +434,12 @@ class API extends Base {
 	 *
 	 * @param string $product_group_id product group ID
 	 * @param int    $limit max number of results returned per page of data
+	 * @param string $fields_string comma-separated fields to request for each product
 	 * @return API\Response|API\ProductCatalog\ProductGroups\Read\Response
 	 * @throws ApiException In case of a general API error or rate limit error.
 	 */
-	public function get_product_group_products( string $product_group_id, int $limit = 1000 ): API\ProductCatalog\ProductGroups\Read\Response {
-		$request = new API\ProductCatalog\ProductGroups\Read\Request( $product_group_id, $limit );
+	public function get_product_group_products( string $product_group_id, int $limit = 1000, string $fields_string = 'id,retailer_id' ): API\ProductCatalog\ProductGroups\Read\Response {
+		$request = new API\ProductCatalog\ProductGroups\Read\Request( $product_group_id, $limit, $fields_string );
 		$this->set_response_handler( API\ProductCatalog\ProductGroups\Read\Response::class );
 		return $this->perform_request( $request );
 	}

--- a/includes/API/ProductCatalog/ProductGroups/Read/Request.php
+++ b/includes/API/ProductCatalog/ProductGroups/Read/Request.php
@@ -24,8 +24,15 @@ class Request extends ApiRequest {
 	/**
 	 * @param string $product_group_id Facebook Product Group ID.
 	 * @param int    $limit Limit.
+	 * @param string $fields_string Comma-separated fields to request for each product.
 	 */
-	public function __construct( string $product_group_id, int $limit ) {
-		parent::__construct( "/{$product_group_id}/products?fields=id,retailer_id&limit={$limit}", 'GET' );
+	public function __construct( string $product_group_id, int $limit, string $fields_string = 'id,retailer_id' ) {
+		parent::__construct( "/{$product_group_id}/products", 'GET' );
+		$this->set_params(
+			[
+				'fields' => $fields_string,
+				'limit'  => $limit,
+			]
+		);
 	}
 }

--- a/tests/Unit/Api/ProductCatalog/ProductGroups/Read/RequestTest.php
+++ b/tests/Unit/Api/ProductCatalog/ProductGroups/Read/RequestTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\Facebook\Tests\Unit\Api\ProductCatalog\ProductGroups\Read;
+
+use WooCommerce\Facebook\API\ProductCatalog\ProductGroups\Read\Request;
+use WooCommerce\Facebook\Tests\AbstractWPUnitTestWithOptionIsolationAndSafeFiltering;
+
+/**
+ * Unit tests for the Product Group products request.
+ */
+class RequestTest extends AbstractWPUnitTestWithOptionIsolationAndSafeFiltering {
+
+	/**
+	 * The default request keeps the existing ID and retailer ID fields.
+	 */
+	public function test_default_fields() {
+		$request = new Request( 'group-123', 1000 );
+
+		$this->assertSame( 'GET', $request->get_method() );
+		$this->assertSame( '/group-123/products', $request->get_path() );
+		$this->assertSame(
+			[
+				'fields' => 'id,retailer_id',
+				'limit'  => 1000,
+			],
+			$request->get_params()
+		);
+	}
+
+	/**
+	 * Callers can request a coherent product-group snapshot with extra fields.
+	 */
+	public function test_custom_fields() {
+		$request = new Request( 'group-456', 50, 'id,retailer_id,name,price' );
+
+		$this->assertSame(
+			[
+				'fields' => 'id,retailer_id,name,price',
+				'limit'  => 50,
+			],
+			$request->get_params()
+		);
+	}
+}

--- a/tests/Unit/ApiTest.php
+++ b/tests/Unit/ApiTest.php
@@ -380,8 +380,17 @@ class ApiTest extends \WooCommerce\Facebook\Tests\AbstractWPUnitTestWithSafeFilt
 		$limit                     = 999;
 
 		$response = function( $result, $parsed_args, $url ) use ( $facebook_product_group_id, $limit ) {
+			$expected_query = http_build_query(
+				[
+					'fields' => 'id,retailer_id',
+					'limit'  => $limit,
+				],
+				'',
+				'&'
+			);
+
 			$this->assertEquals( 'GET', $parsed_args['method'] );
-			$this->assertEquals( "{$this->endpoint}{$this->version}/{$facebook_product_group_id}/products?fields=id,retailer_id&limit={$limit}", $url );
+			$this->assertEquals( "{$this->endpoint}{$this->version}/{$facebook_product_group_id}/products?{$expected_query}", $url );
 			return [
 				'body'     => '{"data":[{"id":"5678482592202667","retailer_id":"woo-vneck-tee-blue_107"},{"id":"5575513012507086","retailer_id":"woo-vneck-tee-green_106"},{"id":"5454083851373820","retailer_id":"woo-vneck-tee-red_105"}],"paging":{"cursors":{"before":"QVFIUmt2N3lKdWUycEM1c1ZA3eXF5YnJoeWxJZAFFMZAW1OVDZAieG4ycU5mMmV6NV9NY2syaWVxRnZAtRnpwOTVETVZANR21VTzUtZAXBLb25TcmNaaVpYTEYyMVJ3","after":"QVFIUmxJVmYwQUdmay1YUnRPdXROMjN5a3EyZAGhIVm1NX2VpVjBiMFRBMncxSjZAYWXowOVhYTjQ0VzY4X2tlQ2VIZAFNyT3ZARbk5LeWRPM242d2JFazZA4QVZA3"},"next":"https:\/\/graph.facebook.com\/' . $this->version . '\/5427299404026432\/products?fields=id\u00252Cretailer_id&limit=1000&after=QVFIUmxJVmYwQUdmay1YUnRPdXROMjN5a3EyZAGhIVm1NX2VpVjBiMFRBMncxSjZAYWXowOVhYTjQ0VzY4X2tlQ2VIZAFNyT3ZARbk5LeWRPM242d2JFazZA4QVZA3","previous":"https:\/\/graph.facebook.com\/' . $this->version . '\/5427299404026432\/products?fields=id\u00252Cretailer_id&limit=1000&before=QVFIUmt2N3lKdWUycEM1c1ZA3eXF5YnJoeWxJZAFFMZAW1OVDZAieG4ycU5mMmV6NV9NY2syaWVxRnZAtRnpwOTVETVZANR21VTzUtZAXBLb25TcmNaaVpYTEYyMVJ3"}}',
 				'response' => [

--- a/tests/e2e/events-test.spec.js
+++ b/tests/e2e/events-test.spec.js
@@ -572,7 +572,7 @@ test('Purchase - Variable Product', async ({ page }, testInfo) => {
 
       await clearCart(page);
       const targetVariation = fixture.variations.find(v => v.option === 'Large') || fixture.variations[0];
-      const { testId } = await TestSetup.init(page, 'Purchase', testInfo);
+      const { testId, pixelCapture } = await TestSetup.init(page, 'Purchase', testInfo);
 
       await page.goto(fixture.parentUrl);
       await TestSetup.waitForPageReady(page, TIMEOUTS.INSTANT);
@@ -590,7 +590,9 @@ test('Purchase - Variable Product', async ({ page }, testInfo) => {
       expect(cartItems.length).toBe(1);
       expect(String(cartItems[0].id)).toBe(String(targetVariation.id));
 
+      const eventPromise = pixelCapture.waitForEvent();
       await completeCheckoutFromCart(page);
+      await eventPromise;
 
       const validator = new EventValidator(testId);
       await validator.checkDebugLog();
@@ -598,10 +600,14 @@ test('Purchase - Variable Product', async ({ page }, testInfo) => {
       const result = ignoreKnownPurchaseUserDataGap(rawResult);
 
       const captured = await loadCapturedEvents(testId);
+      const pixelPurchase = getLatestEvent(captured.pixel, 'Purchase');
       const capiPurchase = getLatestEvent(captured.capi, 'Purchase');
+      const pixelContents = asArray(pixelPurchase?.custom_data?.contents);
       const contents = asArray(capiPurchase?.custom_data?.contents);
 
+      assertEventContainsRetailerId(pixelPurchase, targetVariation.retailer_id);
       assertEventContainsRetailerId(capiPurchase, targetVariation.retailer_id);
+      expect(pixelContents.some(item => String(item.id) === String(targetVariation.retailer_id) && Number(item.quantity) >= 1)).toBe(true);
       expect(contents.some(item => String(item.id) === String(targetVariation.retailer_id) && Number(item.quantity) >= 1)).toBe(true);
 
       TestSetup.logResult('Purchase (Variable Product)', result);
@@ -657,7 +663,7 @@ test('Purchase - Grouped Product', async ({ page }, testInfo) => {
 
       await clearCart(page);
       const child = fixture.children[0];
-      const { testId } = await TestSetup.init(page, 'Purchase', testInfo);
+      const { testId, pixelCapture } = await TestSetup.init(page, 'Purchase', testInfo);
 
       await page.goto(fixture.groupedUrl);
       await TestSetup.waitForPageReady(page, TIMEOUTS.INSTANT);
@@ -671,7 +677,9 @@ test('Purchase - Grouped Product', async ({ page }, testInfo) => {
       expect(cartItems.length).toBe(1);
       expect(String(cartItems[0].id)).toBe(String(child.id));
 
+      const eventPromise = pixelCapture.waitForEvent();
       await completeCheckoutFromCart(page);
+      await eventPromise;
 
       const validator = new EventValidator(testId);
       await validator.checkDebugLog();
@@ -679,10 +687,14 @@ test('Purchase - Grouped Product', async ({ page }, testInfo) => {
       const result = ignoreKnownPurchaseUserDataGap(rawResult);
 
       const captured = await loadCapturedEvents(testId);
+      const pixelPurchase = getLatestEvent(captured.pixel, 'Purchase');
       const capiPurchase = getLatestEvent(captured.capi, 'Purchase');
+      const pixelContents = asArray(pixelPurchase?.custom_data?.contents);
       const contents = asArray(capiPurchase?.custom_data?.contents);
 
+      assertEventContainsRetailerId(pixelPurchase, child.retailer_id);
       assertEventContainsRetailerId(capiPurchase, child.retailer_id);
+      expect(pixelContents.some(item => String(item.id) === String(child.retailer_id) && Number(item.quantity) >= 1)).toBe(true);
       expect(contents.some(item => String(item.id) === String(child.retailer_id) && Number(item.quantity) >= 1)).toBe(true);
 
       TestSetup.logResult('Purchase (Grouped Product)', result);
@@ -746,7 +758,7 @@ test('InitiateCheckout', async ({ page }, testInfo) => {
 });
 
 test('Purchase', async ({ page }, testInfo) => {
-    const { testId } = await TestSetup.init(page, 'Purchase',  testInfo);
+    const { testId, pixelCapture } = await TestSetup.init(page, 'Purchase',  testInfo);
 
     await page.goto(process.env.TEST_PRODUCT_URL);
     await TestSetup.waitForPageReady(page, TIMEOUTS.INSTANT);
@@ -756,7 +768,9 @@ test('Purchase', async ({ page }, testInfo) => {
     await page.waitForTimeout(TIMEOUTS.SHORT);
 
     console.log(`   💳 Completing checkout as guest`);
+    const eventPromise = pixelCapture.waitForEvent();
     await completeCheckoutFromCart(page);
+    await eventPromise;
 
     const validator = new EventValidator(testId);
     await validator.checkDebugLog();
@@ -768,7 +782,7 @@ test('Purchase', async ({ page }, testInfo) => {
 });
 
 test('Purchase - Multiple Place Order Clicks', async ({ page }, testInfo) => {
-    const { testId } = await TestSetup.init(page, 'Purchase',  testInfo);
+    const { testId, pixelCapture } = await TestSetup.init(page, 'Purchase',  testInfo);
 
     await page.goto(process.env.TEST_PRODUCT_URL);
     await TestSetup.waitForPageReady(page, TIMEOUTS.INSTANT);
@@ -853,6 +867,7 @@ test('Purchase - Multiple Place Order Clicks', async ({ page }, testInfo) => {
 
     // Click Place Order button 3 times rapidly
     const placeOrderButton = page.locator('.wc-block-components-checkout-place-order-button');
+    const eventPromise = pixelCapture.waitForEvent();
     console.log(`   🔄 Click #1`);
     await placeOrderButton.click();
     await page.waitForTimeout(100);
@@ -864,6 +879,7 @@ test('Purchase - Multiple Place Order Clicks', async ({ page }, testInfo) => {
 
     console.log(`   ⏳ Waiting for order to process...`);
     await page.waitForURL('**/checkout/order-received/**', { timeout: TIMEOUTS.EXTRA_LONG });
+    await eventPromise;
     await page.waitForTimeout(TIMEOUTS.NORMAL);
 
     const validator = new EventValidator(testId);
@@ -871,7 +887,7 @@ test('Purchase - Multiple Place Order Clicks', async ({ page }, testInfo) => {
     const rawResult = await validator.validate('Purchase', page);
     const result = ignoreKnownPurchaseUserDataGap(rawResult);
 
-    // Should still only have 1 Purchase event despite multiple clicks
+    // Multiple clicks must still produce exactly one Pixel and one CAPI Purchase event.
     TestSetup.logResult('Purchase (Deduplication)', result);
     expect(result.passed).toBe(true);
 });

--- a/tests/e2e/helpers/js/checkout/purchase.js
+++ b/tests/e2e/helpers/js/checkout/purchase.js
@@ -10,6 +10,7 @@
  */
 
 const { TIMEOUTS } = require('../constants/timeouts');
+const { execWP } = require('../wordpress/exec');
 
 /**
  * Complete a purchase flow from product to order confirmation
@@ -28,7 +29,9 @@ async function completePurchaseFlow(page, productUrl = null) {
   await page.waitForTimeout(TIMEOUTS.SHORT);
 
   console.log(`   💳 Navigating to checkout`);
-  await page.goto('/checkout', { waitUntil: 'domcontentloaded', timeout: TIMEOUTS.EXTRA_LONG });
+  const { stdout } = await execWP('echo wp_json_encode(wc_get_checkout_url());');
+  const checkoutUrl = JSON.parse(stdout.trim());
+  await page.goto(checkoutUrl, { waitUntil: 'domcontentloaded', timeout: TIMEOUTS.EXTRA_LONG });
   await page.evaluate(() => window.scrollBy(0, 400));
 
   console.log(`   📝 Filling billing address from environment variables`);
@@ -74,13 +77,19 @@ async function completePurchaseFlow(page, productUrl = null) {
 
   console.log(`   ⏳ Waiting for order to process...`);
   await page.click('.wc-block-components-checkout-place-order-button');
-  await page.waitForURL(/\/checkout\/order-received\/\d+/, { timeout: TIMEOUTS.EXTRA_LONG });
+  await page.waitForURL(url => (
+    /\/checkout\/order-received\/\d+/.test(url.pathname)
+      || /^\d+$/.test(url.searchParams.get('order-received') || '')
+  ), { timeout: TIMEOUTS.EXTRA_LONG });
 
   const orderReceivedUrl = page.url();
   console.log(`   ✅ Order completed: ${orderReceivedUrl}`);
 
-  const orderIdMatch = orderReceivedUrl.match(/order-received\/(\d+)/);
-  const orderId = orderIdMatch ? orderIdMatch[1] : null;
+  const parsedOrderUrl = new URL(orderReceivedUrl);
+  const orderIdMatch = parsedOrderUrl.pathname.match(/order-received\/(\d+)/);
+  const orderId = orderIdMatch
+    ? orderIdMatch[1]
+    : parsedOrderUrl.searchParams.get('order-received');
 
   return { orderReceivedUrl, orderId };
 }

--- a/tests/e2e/helpers/js/events/field-contracts.js
+++ b/tests/e2e/helpers/js/events/field-contracts.js
@@ -122,8 +122,15 @@ const EVENT_OVERLAYS = {
   },
 
   Purchase: {
-    channels: ['capi'],
+    channels: ['pixel', 'capi'],
+    // The browser Purchase hit carries the shared _fbp identifier, while checkout
+    // PII is attached to the server event and is not serialized into the Pixel
+    // request on the thank-you page.
+    user_data: {
+      pixel: ['fbp']
+    },
     custom_data: {
+      pixel: ['content_ids', 'content_type', 'content_name', 'value', 'currency', 'contents', 'order_id'],
       capi: ['content_ids', 'content_type', 'content_name', 'value', 'currency', 'contents', 'order_id']
     }
   },

--- a/tests/e2e/helpers/js/events/validator.js
+++ b/tests/e2e/helpers/js/events/validator.js
@@ -128,7 +128,7 @@ class EventValidator {
       this.validateCookies(p, c, errors);
       this.validateDataMatch(p, c, eventName, 'custom_data', errors);
       this.validateDataMatch(p, c, eventName, 'user_data', errors);
-      this.validateUserData(p, c, errors);
+      this.validateUserData(p, c, eventName, errors);
     }
 
     await this.validatePhpErrors(page, errors);
@@ -165,15 +165,7 @@ class EventValidator {
       errors.push(`Expected 1 Pixel event, found ${pixel.length}`);
     }
     if (fieldContract.channels.includes('capi') && capi.length !== 1) {
-      const uniqueEventIds = new Set(capi.map(e => e.event_id).filter(id => id));
-      if (uniqueEventIds.size === 1) {
-        const duplicateEventId = [...uniqueEventIds][0] || 'unknown';
-        console.warn(
-          `  ⚠️  Duplicate CAPI events detected for ${eventName}: count=${capi.length}, event_id=${duplicateEventId}. Allowing pass because duplicate records share the same event_id.`
-        );
-      } else {
-        errors.push(`Expected 1 CAPI event, found ${capi.length}`);
-      }
+      errors.push(`Expected 1 CAPI event, found ${capi.length}`);
     }
 
     if (errors.length === 0) {
@@ -416,9 +408,16 @@ class EventValidator {
     }
   }
 
-  validateUserData(pixel, capi, errors) {
-    this.validatePII(pixel, capi, errors, 'em');
-    this.validatePII(pixel, capi, errors, 'external_id');
+  validateUserData(pixel, capi, eventName, errors) {
+    const fieldContract = EVENT_FIELD_CONTRACTS[eventName];
+    const pixelFields = fieldContract?.pixel?.user_data || [];
+    const capiFields = fieldContract?.capi?.user_data || [];
+
+    for (const fieldName of ['em', 'external_id']) {
+      if (pixelFields.includes(fieldName) && capiFields.includes(fieldName)) {
+        this.validatePII(pixel, capi, errors, fieldName);
+      }
+    }
   }
 
   validatePII(pixel, capi, errors, field_name) {

--- a/tests/e2e/helpers/js/index.js
+++ b/tests/e2e/helpers/js/index.js
@@ -72,11 +72,13 @@ const {
 const {
   validateFacebookSync,
   processPendingSyncJobs,
-  validateCategorySync
+  validateCategorySync,
+  getProductCatalogRequestIds
 } = require('./plugin/sync');
 
 const {
   getConnectionStatus,
+  assertFacebookReconnectCredentialsConfigured,
   disconnectAndVerify,
   reconnectAndVerify,
   verifyProductsFacebookFieldsCleared
@@ -241,7 +243,9 @@ const facebook = {
   validateFacebookSync,
   processPendingSyncJobs,
   validateCategorySync,
+  getProductCatalogRequestIds,
   getConnectionStatus,
+  assertFacebookReconnectCredentialsConfigured,
   disconnectAndVerify,
   reconnectAndVerify,
   verifyProductsFacebookFieldsCleared,
@@ -369,9 +373,11 @@ module.exports = {
   validateFacebookSync,
   processPendingSyncJobs,
   validateCategorySync,
+  getProductCatalogRequestIds,
 
   // Facebook - Connection
   getConnectionStatus,
+  assertFacebookReconnectCredentialsConfigured,
   disconnectAndVerify,
   reconnectAndVerify,
   verifyProductsFacebookFieldsCleared,

--- a/tests/e2e/helpers/js/plugin/connection.js
+++ b/tests/e2e/helpers/js/plugin/connection.js
@@ -12,6 +12,41 @@
 const { TIMEOUTS } = require('../constants/timeouts');
 const { execWP } = require('../wordpress/exec');
 
+const REQUIRED_RECONNECT_CREDENTIALS = {
+  FB_ACCESS_TOKEN: 'accessToken',
+  FB_BUSINESS_MANAGER_ID: 'businessManagerId',
+  FB_EXTERNAL_BUSINESS_ID: 'externalBusinessId',
+  FB_PRODUCT_CATALOG_ID: 'productCatalogId',
+  FB_PIXEL_ID: 'pixelId',
+  FB_PAGE_ID: 'pageId',
+};
+
+function isUsableCredential(value) {
+  return typeof value === 'string'
+    && value.trim() !== ''
+    && !['undefined', 'null'].includes(value.trim().toLowerCase());
+}
+
+function getReconnectCredentials() {
+  const missing = Object.keys(REQUIRED_RECONNECT_CREDENTIALS)
+    .filter(name => !isUsableCredential(process.env[name]));
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Refusing to change the Facebook connection because required credentials are missing: ${missing.join(', ')}`
+    );
+  }
+
+  return Object.fromEntries(
+    Object.entries(REQUIRED_RECONNECT_CREDENTIALS)
+      .map(([environmentName, credentialName]) => [credentialName, process.env[environmentName]])
+  );
+}
+
+function assertFacebookReconnectCredentialsConfigured() {
+  getReconnectCredentials();
+}
+
 /**
  * Get connection status from Meta for WooCommerce
  * @returns {Promise<Object>} Connection status details
@@ -51,6 +86,9 @@ async function getConnectionStatus() {
  * @returns {Promise<Object>} Disconnection result
  */
 async function disconnectAndVerify() {
+  // Every current caller reconnects immediately afterwards. Fail before the
+  // destructive disconnect if the environment cannot restore the connection.
+  assertFacebookReconnectCredentialsConfigured();
   console.log('🔌 Disconnecting from Facebook...');
 
   const before = await getConnectionStatus();
@@ -107,14 +145,7 @@ async function reconnectAndVerify(options = {}) {
     return { before, after: before, success: true, skipped: true };
   }
 
-  const creds = {
-    accessToken: process.env.FB_ACCESS_TOKEN,
-    businessManagerId: process.env.FB_BUSINESS_MANAGER_ID,
-    externalBusinessId: process.env.FB_EXTERNAL_BUSINESS_ID,
-    productCatalogId: process.env.FB_PRODUCT_CATALOG_ID,
-    pixelId: process.env.FB_PIXEL_ID,
-    pageId: process.env.FB_PAGE_ID
-  };
+  const creds = getReconnectCredentials();
 
   console.log('   Deactivating plugin...');
   await execWP(`deactivate_plugins('facebook-for-woocommerce/facebook-for-woocommerce.php');`);
@@ -227,6 +258,7 @@ async function verifyProductsFacebookFieldsCleared() {
 
 module.exports = {
   getConnectionStatus,
+  assertFacebookReconnectCredentialsConfigured,
   disconnectAndVerify,
   reconnectAndVerify,
   verifyProductsFacebookFieldsCleared

--- a/tests/e2e/helpers/js/plugin/sync.js
+++ b/tests/e2e/helpers/js/plugin/sync.js
@@ -12,8 +12,12 @@
 const { exec, execSync } = require('child_process');
 const { promisify } = require('util');
 const path = require('path');
+const { execWP } = require('../wordpress/exec');
 
 const execAsync = promisify(exec);
+let syncProcessingQueue = Promise.resolve();
+const INITIAL_CATALOG_POLL_SECONDS = 120;
+const RETRY_CATALOG_POLL_SECONDS = 180;
 
 let connectionPreflightChecked = false;
 
@@ -33,11 +37,15 @@ async function ensureFacebookConnectionConfigured() {
   const phpNoIniFlag = usePhpNoIni ? '-n ' : '';
 
   const phpSnippet = [
+    '$is_configured = static function ($value) {',
+    '  $value = is_scalar($value) ? trim((string) $value) : "";',
+    '  return "" !== $value && !in_array(strtolower($value), ["undefined", "null"], true);',
+    '};',
     '$status = [',
     "  'connected' => facebook_for_woocommerce()->get_connection_handler()->is_connected(),",
-    "  'access_token' => (bool) get_option('wc_facebook_access_token'),",
-    "  'catalog_id' => (bool) get_option('wc_facebook_product_catalog_id'),",
-    "  'pixel_id' => (bool) get_option('wc_facebook_pixel_id'),",
+    "  'access_token' => $is_configured(get_option('wc_facebook_access_token')),",
+    "  'catalog_id' => $is_configured(get_option('wc_facebook_product_catalog_id')),",
+    "  'pixel_id' => $is_configured(get_option('wc_facebook_pixel_id')),",
     '];',
     'echo json_encode($status);',
   ].join(' ');
@@ -76,6 +84,80 @@ function parseJsonFromOutput(stdout) {
   return JSON.parse(trimmed.slice(firstBrace, lastBrace + 1));
 }
 
+function parseJsonArrayFromOutput(stdout) {
+  const trimmed = (stdout || '').trim();
+  const firstBracket = trimmed.indexOf('[');
+  const lastBracket = trimmed.lastIndexOf(']');
+
+  if (firstBracket === -1 || lastBracket === -1 || lastBracket < firstBracket) {
+    throw new Error(`No JSON array found in output: ${trimmed.slice(0, 240)}`);
+  }
+
+  return JSON.parse(trimmed.slice(firstBracket, lastBracket + 1));
+}
+
+/**
+ * Resolve the identifiers stored in product sync job request keys.
+ * UPDATE jobs use WooCommerce IDs, while DELETE jobs use retailer IDs.
+ * Variable products enqueue one request per variation.
+ *
+ * @param {number|number[]} productIds WooCommerce product IDs
+ * @param {'UPDATE'|'DELETE'} action Catalog action being awaited
+ * @returns {Promise<string[]>} Product sync request identifiers
+ */
+async function getProductCatalogRequestIds(productIds, action = 'UPDATE') {
+  const normalizedProductIds = [...new Set((Array.isArray(productIds) ? productIds : [productIds])
+    .map(productId => Number.parseInt(productId, 10))
+    .filter(productId => Number.isInteger(productId) && productId > 0))];
+  const normalizedAction = String(action).toUpperCase();
+
+  if (normalizedProductIds.length === 0) {
+    throw new Error('At least one valid WooCommerce product ID is required');
+  }
+
+  if (!['UPDATE', 'DELETE'].includes(normalizedAction)) {
+    throw new Error(`Unsupported catalog action: ${action}`);
+  }
+
+  const { stdout } = await execWP(`
+    $request_ids = [];
+
+    foreach ([${normalizedProductIds.join(',')}] as $product_id) {
+      $product = wc_get_product($product_id);
+      if (! $product instanceof \\WC_Product) {
+        continue;
+      }
+
+      $products = $product->is_type('variable')
+        ? array_filter(array_map('wc_get_product', $product->get_children()))
+        : [$product];
+
+      foreach ($products as $candidate) {
+        if (! $candidate instanceof \\WC_Product) {
+          continue;
+        }
+
+        $request_id = 'DELETE' === '${normalizedAction}'
+          ? \\WC_Facebookcommerce_Utils::get_fb_retailer_id($candidate)
+          : $candidate->get_id();
+
+        if ('' !== (string) $request_id) {
+          $request_ids[] = (string) $request_id;
+        }
+      }
+    }
+
+    echo wp_json_encode(array_values(array_unique($request_ids)));
+  `);
+
+  const requestIds = parseJsonArrayFromOutput(stdout).map(String).filter(Boolean);
+  if (requestIds.length === 0) {
+    throw new Error(`Unable to resolve ${normalizedAction} request IDs for product(s): ${normalizedProductIds.join(', ')}`);
+  }
+
+  return requestIds;
+}
+
 function buildValidatorCommand(mode, id, waitSeconds, maxRetries) {
   const wordpressPath = process.env.WORDPRESS_PATH;
   if (!wordpressPath) {
@@ -104,15 +186,60 @@ function varToPhpString(value) {
   return `'${String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
 }
 
+async function runProductSyncValidator(productId, waitSeconds, maxRetries, pollSeconds) {
+  const command = buildValidatorCommand('product', productId, waitSeconds, maxRetries);
+  const { stdout } = await execAsync(command, {
+    cwd: path.resolve(__dirname, '../../php'),
+    env: {
+      ...process.env,
+      FB_E2E_CATALOG_POLL_SECONDS: String(pollSeconds),
+    },
+  });
+
+  return parseJsonFromOutput(stdout);
+}
+
+function getMissingWooProductIds(result) {
+  if (result?.error || !result?.raw_data) {
+    return [];
+  }
+
+  const wooData = Array.isArray(result.raw_data.woo_data) ? result.raw_data.woo_data : [];
+  const facebookData = Array.isArray(result.raw_data.facebook_data) ? result.raw_data.facebook_data : [];
+
+  return [...new Set(wooData
+    .filter((_, index) => facebookData[index]?.found !== true && !facebookData[index]?.error)
+    .map(product => Number.parseInt(product.id, 10))
+    .filter(productId => Number.isInteger(productId) && productId > 0))];
+}
+
+async function queueProductCatalogUpdates(productIds) {
+  const normalizedProductIds = [...new Set(productIds
+    .map(productId => Number.parseInt(productId, 10))
+    .filter(productId => Number.isInteger(productId) && productId > 0))];
+
+  if (normalizedProductIds.length === 0) {
+    return;
+  }
+
+  await execWP(`
+    facebook_for_woocommerce()
+      ->get_products_sync_handler()
+      ->create_or_update_products([${normalizedProductIds.join(',')}]);
+  `);
+}
+
 /**
  * Validate Facebook sync for a product
  * @param {number} productId - Product ID to validate
  * @param {string} productName - Product name for display
  * @param {number} waitSeconds - Seconds to wait before validation
  * @param {number} maxRetries - Maximum retry attempts
+ * @param {Object} options - Optional validation controls
+ * @param {Array<number|string>} options.requestIds - Pre-resolved catalog request IDs
  * @returns {Promise<Object>} Validation result
  */
-async function validateFacebookSync(productId, productName, waitSeconds = 10, maxRetries = 6) {
+async function validateFacebookSync(productId, productName, waitSeconds = 10, maxRetries = 6, options = {}) {
   if (!productId) {
     console.warn('⚠️ No product ID provided for Facebook sync validation');
     return null;
@@ -123,13 +250,38 @@ async function validateFacebookSync(productId, productName, waitSeconds = 10, ma
 
   try {
     await ensureFacebookConnectionConfigured();
-    const command = buildValidatorCommand('product', productId, waitSeconds, maxRetries);
-    const { stdout } = await execAsync(command, {
-      cwd: path.resolve(__dirname, '../../php'),
-      env: process.env,
-    });
+    const expectedAction = maxRetries === 0 ? 'DELETE' : 'UPDATE';
+    const supportsMissingItemRecovery = maxRetries > 1;
+    const requestIds = [...new Set((options.requestIds || []).map(String).filter(Boolean))];
+    if (requestIds.length > 0) {
+      await waitForCatalogRequestIds(requestIds, expectedAction);
+    } else {
+      await waitForProductCatalogBatches(productId, expectedAction);
+    }
 
-    const result = parseJsonFromOutput(stdout);
+    let result = await runProductSyncValidator(
+      productId,
+      waitSeconds,
+      maxRetries,
+      supportsMissingItemRecovery ? INITIAL_CATALOG_POLL_SECONDS : 0
+    );
+
+    const missingProductIds = supportsMissingItemRecovery ? getMissingWooProductIds(result) : [];
+    if (!result.success && missingProductIds.length > 0) {
+      console.log(
+        `🔁 Meta finished the original batch but did not index WooCommerce ID(s) ` +
+        `${missingProductIds.join(', ')}; submitting one bounded recovery batch...`
+      );
+      await queueProductCatalogUpdates(missingProductIds);
+      await waitForProductCatalogBatches(missingProductIds, 'UPDATE');
+      result = await runProductSyncValidator(
+        productId,
+        0,
+        maxRetries,
+        RETRY_CATALOG_POLL_SECONDS
+      );
+    }
+
     console.log('📄 OUTPUT FROM FACEBOOK SYNC VALIDATOR:');
     const { raw_data, ...resultWithoutRawData } = result;
     console.log(JSON.stringify(resultWithoutRawData, null, 2));
@@ -213,13 +365,24 @@ async function validateCategorySync(categoryId, categoryName = null, waitSeconds
  *
  * @param {Object} options - Processing options
  * @param {boolean} options.waitForBatchCompletion - Wait until Meta finishes each submitted batch
+ * @param {Array<number|string>} options.requestIds - Sync request IDs whose completed job handles should also be checked
+ * @param {Array<string>} options.actions - Completed job actions to match (UPDATE and/or DELETE)
  * @returns {Promise<Object>} Processing result
  */
-async function processPendingSyncJobs({ waitForBatchCompletion = false } = {}) {
+function processPendingSyncJobs(options = {}) {
+  const processing = syncProcessingQueue.then(() => executePendingSyncJobs(options));
+  syncProcessingQueue = processing.catch(() => undefined);
+  return processing;
+}
+
+async function executePendingSyncJobs({ waitForBatchCompletion = false, requestIds = [], actions = ['UPDATE'] } = {}) {
   console.log('🔄 Processing pending Facebook sync background jobs...');
 
   try {
     const phpDir = path.resolve(__dirname, '../../php');
+    const normalizedRequestIds = [...new Set(requestIds.map(String).filter(Boolean))];
+    const normalizedActions = [...new Set(actions.map(action => String(action).toUpperCase()))]
+      .filter(action => ['UPDATE', 'DELETE'].includes(action));
     const { stdout } = await execAsync(
       'php process-sync-jobs.php',
       {
@@ -228,12 +391,17 @@ async function processPendingSyncJobs({ waitForBatchCompletion = false } = {}) {
         env: {
           ...process.env,
           FB_E2E_WAIT_FOR_BATCH_COMPLETION: waitForBatchCompletion ? '1' : '0',
+          FB_E2E_SYNC_REQUEST_IDS: normalizedRequestIds.join(','),
+          FB_E2E_SYNC_ACTIONS: normalizedActions.join(','),
         },
       }
     );
 
-    const result = JSON.parse(stdout);
+    const result = parseJsonFromOutput(stdout);
     if (result.success) {
+      if (result.sync_events_processed > 0) {
+        console.log(`✅ Processed ${result.sync_events_processed} due product sync event(s)`);
+      }
       console.log(`✅ Processed ${result.jobs_processed} sync job(s)`);
       if (waitForBatchCompletion && result.batch_count > 0) {
         console.log(`✅ Meta finished ${result.batch_count} submitted batch(es) without item errors`);
@@ -244,13 +412,56 @@ async function processPendingSyncJobs({ waitForBatchCompletion = false } = {}) {
     return result;
 
   } catch (error) {
-    console.warn(`⚠️ Sync job processing error: ${error.message}`);
-    return { success: false, error: error.message };
+    let processingError = error.message;
+
+    try {
+      const output = error.stdout ? String(error.stdout) : '';
+      const result = parseJsonFromOutput(output);
+      processingError = result.error || result.message || processingError;
+    } catch {
+      // Keep the process error when PHP did not emit a JSON result.
+    }
+
+    console.warn(`⚠️ Sync job processing error: ${processingError}`);
+    return { success: false, error: processingError };
   }
+}
+
+/**
+ * Drain the local queue, recover the latest completed job for every requested
+ * product item, and wait until Meta finishes the corresponding catalog batch.
+ *
+ * @param {number|number[]} productIds WooCommerce product IDs
+ * @param {'UPDATE'|'DELETE'} action Catalog action being awaited
+ * @returns {Promise<Object>} Processing result
+ */
+async function waitForProductCatalogBatches(productIds, action = 'UPDATE') {
+  const normalizedAction = String(action).toUpperCase();
+  const requestIds = await getProductCatalogRequestIds(productIds, normalizedAction);
+  return waitForCatalogRequestIds(requestIds, normalizedAction);
+}
+
+async function waitForCatalogRequestIds(requestIds, action = 'UPDATE') {
+  const normalizedAction = String(action).toUpperCase();
+  const result = await processPendingSyncJobs({
+    waitForBatchCompletion: true,
+    requestIds,
+    actions: [normalizedAction],
+  });
+
+  if (!result.success) {
+    throw new Error(
+      result.error || `Unable to complete ${normalizedAction} catalog batches for request IDs: ${requestIds.join(', ')}`
+    );
+  }
+
+  return result;
 }
 
 module.exports = {
   validateFacebookSync,
   processPendingSyncJobs,
-  validateCategorySync
+  validateCategorySync,
+  getProductCatalogRequestIds,
+  waitForProductCatalogBatches
 };

--- a/tests/e2e/helpers/js/plugin/sync.js
+++ b/tests/e2e/helpers/js/plugin/sync.js
@@ -211,21 +211,33 @@ async function validateCategorySync(categoryId, categoryName = null, waitSeconds
  * the built-in dev server used in CI). This function bypasses the loopback by
  * invoking the job handler directly via CLI.
  *
+ * @param {Object} options - Processing options
+ * @param {boolean} options.waitForBatchCompletion - Wait until Meta finishes each submitted batch
  * @returns {Promise<Object>} Processing result
  */
-async function processPendingSyncJobs() {
+async function processPendingSyncJobs({ waitForBatchCompletion = false } = {}) {
   console.log('🔄 Processing pending Facebook sync background jobs...');
 
   try {
     const phpDir = path.resolve(__dirname, '../../php');
-    const { stdout, stderr } = await execAsync(
+    const { stdout } = await execAsync(
       'php process-sync-jobs.php',
-      { cwd: phpDir, timeout: 120000 }
+      {
+        cwd: phpDir,
+        timeout: waitForBatchCompletion ? 360000 : 120000,
+        env: {
+          ...process.env,
+          FB_E2E_WAIT_FOR_BATCH_COMPLETION: waitForBatchCompletion ? '1' : '0',
+        },
+      }
     );
 
     const result = JSON.parse(stdout);
     if (result.success) {
       console.log(`✅ Processed ${result.jobs_processed} sync job(s)`);
+      if (waitForBatchCompletion && result.batch_count > 0) {
+        console.log(`✅ Meta finished ${result.batch_count} submitted batch(es) without item errors`);
+      }
     } else {
       console.warn(`⚠️ Sync job processing issue: ${result.message}`);
     }

--- a/tests/e2e/helpers/js/products/crud.js
+++ b/tests/e2e/helpers/js/products/crud.js
@@ -15,6 +15,10 @@ const path = require('path');
 
 const execAsync = promisify(exec);
 const { execWP } = require('../wordpress/exec');
+const {
+  getProductCatalogRequestIds,
+  processPendingSyncJobs,
+} = require('../plugin/sync');
 
 function shellEscape(value) {
   return `'${String(value).replace(/'/g, `'"'"'`)}'`;
@@ -114,10 +118,25 @@ async function cleanupProduct(productId) {
   if (!productId) return;
 
   console.log(`🧹 Cleaning up product ${productId}...`);
+  let requestIds = [];
+
+  try {
+    requestIds = await getProductCatalogRequestIds(productId, 'DELETE');
+  } catch (error) {
+    console.log(`⚠️ Could not resolve catalog deletion IDs for product ${productId}: ${error.message}`);
+  }
 
   try {
     const startTime = new Date();
     await execWP(`wp_delete_post(${productId}, true);`);
+    const syncResult = await processPendingSyncJobs({
+      waitForBatchCompletion: true,
+      requestIds,
+      actions: ['DELETE'],
+    });
+    if (!syncResult.success) {
+      throw new Error(syncResult.error || 'Meta product deletion did not complete');
+    }
     const endTime = new Date();
     console.log(`⏱️ Cleanup took ${endTime - startTime}ms`);
     console.log(`✅ Product ${productId} deleted from WooCommerce`);
@@ -137,11 +156,26 @@ async function cleanupProducts(productIds) {
   if (validIds.length === 0) return;
 
   console.log(`🧹 Batch cleaning up ${validIds.length} products...`);
+  let requestIds = [];
+
+  try {
+    requestIds = await getProductCatalogRequestIds(validIds, 'DELETE');
+  } catch (error) {
+    console.log(`⚠️ Could not resolve catalog deletion IDs: ${error.message}`);
+  }
 
   try {
     const startTime = new Date();
     const idsPhp = validIds.join(',');
     await execWP(`foreach ([${idsPhp}] as \\$id) { wp_delete_post(\\$id, true); }`);
+    const syncResult = await processPendingSyncJobs({
+      waitForBatchCompletion: true,
+      requestIds,
+      actions: ['DELETE'],
+    });
+    if (!syncResult.success) {
+      throw new Error(syncResult.error || 'Meta product deletions did not complete');
+    }
     const endTime = new Date();
     console.log(`⏱️ Batch cleanup took ${endTime - startTime}ms`);
     console.log(`✅ ${validIds.length} products deleted from WooCommerce`);

--- a/tests/e2e/helpers/js/products/navigation.js
+++ b/tests/e2e/helpers/js/products/navigation.js
@@ -127,7 +127,7 @@ async function publishProduct(page) {
     throw new Error(`Product save failed with HTTP ${saveCompletion.response.status()}`);
   }
 
-  await updateButton.waitFor({ state: 'visible', timeout: TIMEOUTS.LONG });
+  await updateButton.waitFor({ state: 'visible', timeout: TIMEOUTS.EXTRA_LONG });
   console.log('✅ Published product');
   return true;
 }

--- a/tests/e2e/helpers/js/products/navigation.js
+++ b/tests/e2e/helpers/js/products/navigation.js
@@ -81,24 +81,53 @@ async function publishProduct(page) {
   const publishButton = page.locator('#publish');
   await publishButton.waitFor({ state: 'visible', timeout: TIMEOUTS.LONG });
   await publishButton.waitFor({ state: 'attached', timeout: TIMEOUTS.LONG });
+  const isNewProduct = new URL(page.url()).pathname.endsWith('/post-new.php');
+  const updateButton = page.getByRole('button', { name: 'Update' });
+
+  const waitForSaveResponse = () => page.waitForResponse(response => {
+    const request = response.request();
+    return request.method() === 'POST' && new URL(response.url()).pathname.endsWith('/wp-admin/post.php');
+  }, {
+    timeout: TIMEOUTS.EXTRA_LONG
+  }).catch(() => null);
+
+  const waitForPublishedState = () => updateButton.waitFor({
+    state: 'visible',
+    timeout: TIMEOUTS.EXTRA_LONG
+  }).then(() => true).catch(() => false);
+
+  const waitForSaveCompletion = async () => {
+    if (!isNewProduct) {
+      return { response: await waitForSaveResponse(), published: false };
+    }
+
+    return Promise.race([
+      waitForSaveResponse().then(response => ({ response, published: false })),
+      waitForPublishedState().then(published => ({ response: null, published })),
+    ]);
+  };
+
+  let saveCompletionPromise = waitForSaveCompletion();
   await publishButton.click();
   console.log('Clicked Publish button');
-  let publishSuccess = true;
-  await page.waitForURL(/\/wp-admin\/post\.php\?post=\d+/, { timeout: TIMEOUTS.EXTRA_LONG }).catch(() => {
-    console.warn('⚠️ URL did not change after publishing. Current URL: ' + page.url())
-    publishSuccess = false;
-  });
+  let saveCompletion = await saveCompletionPromise;
 
-  if (!publishSuccess) {
-    console.warn(`⚠️ Encountered Wordpress Publish button bug. Clicking Publish did not change url. Current url: ${page.url()} Clicking Publish button again`);
+  if (!saveCompletion.response && !saveCompletion.published) {
+    console.warn(`⚠️ Product save request did not finish. Retrying Publish from ${page.url()}`);
+    saveCompletionPromise = waitForSaveCompletion();
     await publishButton.click();
-    await page.waitForTimeout(TIMEOUTS.MEDIUM);
+    saveCompletion = await saveCompletionPromise;
   }
 
-  let updateButton = page.getByRole('button', { name: 'Update' });
-  await updateButton.waitFor({ state: 'visible', timeout: TIMEOUTS.LONG });
+  if (!saveCompletion.response && !saveCompletion.published) {
+    throw new Error(`Product save request did not complete after retry. Current URL: ${page.url()}`);
+  }
 
-  await page.waitForLoadState('domcontentloaded', { timeout: TIMEOUTS.MAX });
+  if (saveCompletion.response && saveCompletion.response.status() >= 400) {
+    throw new Error(`Product save failed with HTTP ${saveCompletion.response.status()}`);
+  }
+
+  await updateButton.waitFor({ state: 'visible', timeout: TIMEOUTS.LONG });
   console.log('✅ Published product');
   return true;
 }

--- a/tests/e2e/helpers/php/process-sync-jobs.php
+++ b/tests/e2e/helpers/php/process-sync-jobs.php
@@ -29,6 +29,99 @@ if ( ! file_exists( $wp_path ) ) {
 
 require_once $wp_path;
 
+/**
+ * Waits until Meta has finished processing all submitted Catalog Batch API handles.
+ *
+ * @param string[] $handles Batch handles returned by /items_batch.
+ * @return array<int, array<string, mixed>> Sanitized final batch statuses.
+ * @throws Exception When a batch fails, contains invalid requests, or times out.
+ */
+function wait_for_meta_batch_completion( array $handles ) {
+	$handles = array_values( array_unique( array_filter( $handles ) ) );
+	if ( empty( $handles ) ) {
+		return [];
+	}
+
+	$integration = facebook_for_woocommerce()->get_integration();
+	$catalog_id  = $integration ? $integration->get_product_catalog_id() : '';
+	$api          = facebook_for_woocommerce()->get_api();
+	$access_token = $api ? $api->get_access_token() : '';
+
+	if ( empty( $catalog_id ) || empty( $access_token ) ) {
+		throw new Exception( 'Facebook catalog connection is not configured for batch status checks' );
+	}
+
+	$pending_handles = array_fill_keys( $handles, true );
+	$final_statuses  = [];
+	$deadline        = microtime( true ) + 300;
+
+	while ( ! empty( $pending_handles ) ) {
+		foreach ( array_keys( $pending_handles ) as $handle ) {
+			$url = add_query_arg(
+				[
+					'handle'                       => $handle,
+					'fields'                       => 'status,errors_total_count,warnings_total_count,ids_of_invalid_requests',
+					'load_ids_of_invalid_requests' => 'true',
+				],
+				\WooCommerce\Facebook\API::GRAPH_API_URL . \WooCommerce\Facebook\API::API_VERSION . "/{$catalog_id}/check_batch_request_status"
+			);
+
+			$response = wp_remote_get(
+				$url,
+				[
+					'headers' => [ 'Authorization' => "Bearer {$access_token}" ],
+					'timeout' => 30,
+				]
+			);
+
+			if ( is_wp_error( $response ) ) {
+				throw new Exception( 'Meta batch status request failed: ' . $response->get_error_message() );
+			}
+
+			$http_code = wp_remote_retrieve_response_code( $response );
+			$body      = json_decode( wp_remote_retrieve_body( $response ), true );
+			if ( 200 !== $http_code ) {
+				$message = $body['error']['message'] ?? "HTTP {$http_code}";
+				throw new Exception( 'Meta batch status request failed: ' . $message );
+			}
+
+			$data          = $body['data'][0] ?? $body;
+			$status        = strtolower( (string) ( $data['status'] ?? '' ) );
+			$error_count   = (int) ( $data['errors_total_count'] ?? 0 );
+			$invalid_count = count( (array) ( $data['ids_of_invalid_requests'] ?? [] ) );
+
+			if ( in_array( $status, [ 'failed', 'error' ], true ) ) {
+				throw new Exception( "Meta catalog batch ended with status {$status}" );
+			}
+
+			if ( 'finished' === $status ) {
+				if ( $error_count > 0 || $invalid_count > 0 ) {
+					throw new Exception( "Meta catalog batch finished with {$error_count} error(s) and {$invalid_count} invalid request(s)" );
+				}
+
+				$final_statuses[] = [
+					'status'                => $status,
+					'errors_total_count'    => $error_count,
+					'invalid_request_count' => $invalid_count,
+				];
+				unset( $pending_handles[ $handle ] );
+			}
+		}
+
+		if ( empty( $pending_handles ) ) {
+			break;
+		}
+
+		if ( microtime( true ) >= $deadline ) {
+			throw new Exception( 'Timed out waiting for Meta to finish catalog batches' );
+		}
+
+		sleep( 5 );
+	}
+
+	return $final_statuses;
+}
+
 try {
 	if ( ! function_exists( 'facebook_for_woocommerce' ) ) {
 		throw new Exception( 'Facebook plugin not loaded' );
@@ -36,6 +129,7 @@ try {
 
 	$handler        = facebook_for_woocommerce()->get_products_sync_background_handler();
 	$jobs_processed = 0;
+	$batch_handles  = [];
 
 	while ( true ) {
 		$job = $handler->get_job();
@@ -43,13 +137,23 @@ try {
 			break;
 		}
 
-		$handler->process_job( $job );
+		$processed_job = $handler->process_job( $job );
+		if ( ! empty( $processed_job->handles ) && is_array( $processed_job->handles ) ) {
+			$batch_handles = array_merge( $batch_handles, $processed_job->handles );
+		}
 		$jobs_processed++;
 	}
+
+	$batch_handles  = array_values( array_unique( $batch_handles ) );
+	$batch_statuses = '1' === getenv( 'FB_E2E_WAIT_FOR_BATCH_COMPLETION' )
+		? wait_for_meta_batch_completion( $batch_handles )
+		: [];
 
 	echo json_encode( [
 		'success'        => true,
 		'jobs_processed' => $jobs_processed,
+		'batch_count'    => count( $batch_handles ),
+		'batch_statuses' => $batch_statuses,
 		'message'        => $jobs_processed > 0
 			? "Processed {$jobs_processed} job(s)"
 			: 'No pending jobs found',

--- a/tests/e2e/helpers/php/process-sync-jobs.php
+++ b/tests/e2e/helpers/php/process-sync-jobs.php
@@ -88,6 +88,7 @@ function wait_for_meta_batch_completion( array $handles ) {
 			$data          = $body['data'][0] ?? $body;
 			$status        = strtolower( (string) ( $data['status'] ?? '' ) );
 			$error_count   = (int) ( $data['errors_total_count'] ?? 0 );
+			$warning_count = (int) ( $data['warnings_total_count'] ?? 0 );
 			$invalid_count = count( (array) ( $data['ids_of_invalid_requests'] ?? [] ) );
 
 			if ( in_array( $status, [ 'failed', 'error' ], true ) ) {
@@ -102,6 +103,7 @@ function wait_for_meta_batch_completion( array $handles ) {
 				$final_statuses[] = [
 					'status'                => $status,
 					'errors_total_count'    => $error_count,
+					'warnings_total_count'  => $warning_count,
 					'invalid_request_count' => $invalid_count,
 				];
 				unset( $pending_handles[ $handle ] );
@@ -122,12 +124,149 @@ function wait_for_meta_batch_completion( array $handles ) {
 	return $final_statuses;
 }
 
-try {
-	if ( ! function_exists( 'facebook_for_woocommerce' ) ) {
-		throw new Exception( 'Facebook plugin not loaded' );
+/**
+ * Gets the latest Catalog Batch API handle for every requested sync item.
+ *
+ * The async request can finish before this CLI helper starts, so get_job() no
+ * longer returns it. Completed jobs remain persisted and retain their handles.
+ *
+ * @param \WooCommerce\Facebook\Products\Sync\Background $handler Product sync job handler.
+ * @param string[] $request_ids Product IDs for UPDATE or retailer IDs for DELETE.
+ * @param string[] $actions Sync actions to match.
+ * @return array{handles: string[], missing_request_ids: string[]}
+ */
+function get_completed_request_batch_handles( $handler, array $request_ids, array $actions ) {
+	if ( empty( $request_ids ) ) {
+		return [
+			'handles'             => [],
+			'missing_request_ids' => [],
+		];
 	}
 
-	$handler        = facebook_for_woocommerce()->get_products_sync_background_handler();
+	$pending_request_keys = [];
+	foreach ( $request_ids as $request_id ) {
+		$pending_request_keys[ \WooCommerce\Facebook\Products\Sync::PRODUCT_INDEX_PREFIX . $request_id ] = $request_id;
+	}
+
+	$handles             = [];
+	$missing_request_ids = [];
+	$jobs                = $handler->get_jobs(
+		[
+			'status' => 'completed',
+			'order'  => 'DESC',
+		]
+	) ?: [];
+
+	foreach ( $jobs as $job ) {
+		$requests = isset( $job->requests ) && is_array( $job->requests ) ? $job->requests : [];
+		$matches  = [];
+
+		foreach ( $pending_request_keys as $request_key => $request_id ) {
+			if ( in_array( $requests[ $request_key ] ?? null, $actions, true ) ) {
+				$matches[ $request_key ] = $request_id;
+			}
+		}
+
+		if ( empty( $matches ) ) {
+			continue;
+		}
+
+		if ( ! empty( $job->handles ) && is_array( $job->handles ) ) {
+			$handles = array_merge( $handles, $job->handles );
+		} else {
+			$missing_request_ids = array_merge( $missing_request_ids, array_values( $matches ) );
+		}
+
+		foreach ( array_keys( $matches ) as $matched_request_key ) {
+			unset( $pending_request_keys[ $matched_request_key ] );
+		}
+
+		if ( empty( $pending_request_keys ) ) {
+			break;
+		}
+	}
+
+	return [
+		'handles'             => array_values( array_unique( array_filter( $handles ) ) ),
+		'missing_request_ids' => array_values(
+			array_unique(
+				array_merge( $missing_request_ids, array_values( $pending_request_keys ) )
+			)
+		),
+	];
+}
+
+/**
+ * Runs due async product-save events before draining the catalog sync queue.
+ *
+ * Product edits first schedule wc_facebook_async_sync, which in turn creates
+ * the catalog background job. WP-Cron is not guaranteed to run between E2E
+ * browser actions and this CLI helper, so process the due events directly.
+ *
+ * @return int Number of async product-save events processed.
+ */
+function process_due_product_sync_events() {
+	$hook             = 'wc_facebook_async_sync';
+	$events_processed = 0;
+	$deadline         = microtime( true ) + 5;
+
+	do {
+		$cron             = _get_cron_array();
+		$due_events       = [];
+		$next_run         = null;
+		$current_timestamp = time();
+
+		foreach ( $cron as $timestamp => $hooks ) {
+			if ( empty( $hooks[ $hook ] ) ) {
+				continue;
+			}
+
+			if ( (int) $timestamp > $current_timestamp ) {
+				$next_run = null === $next_run ? (int) $timestamp : min( $next_run, (int) $timestamp );
+				continue;
+			}
+
+			foreach ( $hooks[ $hook ] as $event ) {
+				$due_events[] = [
+					'timestamp' => (int) $timestamp,
+					'args'      => (array) ( $event['args'] ?? [] ),
+				];
+			}
+		}
+
+		foreach ( $due_events as $event ) {
+			wp_unschedule_event( $event['timestamp'], $hook, $event['args'] );
+			do_action_ref_array( $hook, $event['args'] );
+			++$events_processed;
+		}
+
+		if ( ! empty( $due_events ) ) {
+			continue;
+		}
+
+		if ( null === $next_run || $next_run > time() + 5 || microtime( true ) >= $deadline ) {
+			break;
+		}
+
+		usleep( 250000 );
+	} while ( microtime( true ) < $deadline );
+
+	if ( $events_processed > 0 ) {
+		$sync_handler = facebook_for_woocommerce()->get_products_sync_handler();
+		remove_action( 'shutdown', [ $sync_handler, 'schedule_sync' ] );
+		$sync_handler->schedule_sync();
+	}
+
+	return $events_processed;
+}
+
+/**
+ * Processes every sync job currently visible to the CLI request.
+ *
+ * @param \WooCommerce\Facebook\Products\Sync\Background $handler Product sync job handler.
+ * @return array{jobs_processed: int, handles: string[]}
+ */
+function process_available_sync_jobs( $handler ) {
 	$jobs_processed = 0;
 	$batch_handles  = [];
 
@@ -141,20 +280,92 @@ try {
 		if ( ! empty( $processed_job->handles ) && is_array( $processed_job->handles ) ) {
 			$batch_handles = array_merge( $batch_handles, $processed_job->handles );
 		}
-		$jobs_processed++;
+		++$jobs_processed;
 	}
 
-	$batch_handles  = array_values( array_unique( $batch_handles ) );
+	return [
+		'jobs_processed' => $jobs_processed,
+		'handles'        => array_values( array_unique( $batch_handles ) ),
+	];
+}
+
+try {
+	if ( ! function_exists( 'facebook_for_woocommerce' ) ) {
+		throw new Exception( 'Facebook plugin not loaded' );
+	}
+
+	$handler        = facebook_for_woocommerce()->get_products_sync_background_handler();
+	$jobs_processed = 0;
+	$batch_handles  = [];
+	$sync_events_processed = process_due_product_sync_events();
+	$request_ids    = array_values(
+		array_unique(
+			array_filter(
+				array_map( 'trim', explode( ',', (string) getenv( 'FB_E2E_SYNC_REQUEST_IDS' ) ) ),
+				function ( $request_id ) {
+					return '' !== $request_id;
+				}
+			)
+		)
+	);
+	$actions        = array_values(
+		array_intersect(
+			[
+				\WooCommerce\Facebook\Products\Sync::ACTION_UPDATE,
+				\WooCommerce\Facebook\Products\Sync::ACTION_DELETE,
+			],
+			array_filter( array_map( 'strtoupper', explode( ',', (string) getenv( 'FB_E2E_SYNC_ACTIONS' ) ) ) )
+		)
+	);
+	if ( empty( $actions ) ) {
+		$actions = [ \WooCommerce\Facebook\Products\Sync::ACTION_UPDATE ];
+	}
+
+	$processing_result = process_available_sync_jobs( $handler );
+	$jobs_processed    += $processing_result['jobs_processed'];
+	$batch_handles      = array_merge( $batch_handles, $processing_result['handles'] );
+
+	$batch_lookup = ! empty( $request_ids )
+		? get_completed_request_batch_handles( $handler, $request_ids, $actions )
+		: [
+			'handles'             => array_values( array_unique( $batch_handles ) ),
+			'missing_request_ids' => [],
+		];
+
+	// The normal async handler can claim a job between the queue drain and the
+	// completed-job lookup. Give it a short bounded window to persist its handle,
+	// while continuing to process any jobs that become available to this request.
+	if ( '1' === getenv( 'FB_E2E_WAIT_FOR_BATCH_COMPLETION' ) && ! empty( $request_ids ) ) {
+		$job_lookup_deadline = microtime( true ) + 30;
+
+		while ( ! empty( $batch_lookup['missing_request_ids'] ) && microtime( true ) < $job_lookup_deadline ) {
+			usleep( 500000 );
+			$processing_result = process_available_sync_jobs( $handler );
+			$jobs_processed    += $processing_result['jobs_processed'];
+			$batch_lookup       = get_completed_request_batch_handles( $handler, $request_ids, $actions );
+		}
+	}
+
+	$batch_handles       = $batch_lookup['handles'];
+	$missing_request_ids = $batch_lookup['missing_request_ids'];
+
+	if ( '1' === getenv( 'FB_E2E_WAIT_FOR_BATCH_COMPLETION' ) && ! empty( $missing_request_ids ) ) {
+		throw new Exception( 'No completed Catalog Batch API handles found for request IDs: ' . implode( ', ', $missing_request_ids ) );
+	}
+
 	$batch_statuses = '1' === getenv( 'FB_E2E_WAIT_FOR_BATCH_COMPLETION' )
 		? wait_for_meta_batch_completion( $batch_handles )
 		: [];
 
 	echo json_encode( [
-		'success'        => true,
-		'jobs_processed' => $jobs_processed,
-		'batch_count'    => count( $batch_handles ),
-		'batch_statuses' => $batch_statuses,
-		'message'        => $jobs_processed > 0
+		'success'               => true,
+		'sync_events_processed' => $sync_events_processed,
+		'jobs_processed'        => $jobs_processed,
+		'batch_count'           => count( $batch_handles ),
+		'batch_statuses'        => $batch_statuses,
+		'request_ids'           => $request_ids,
+		'actions'               => $actions,
+		'message'               => $jobs_processed > 0
 			? "Processed {$jobs_processed} job(s)"
 			: 'No pending jobs found',
 	] );

--- a/tests/e2e/helpers/php/sync-validator.php
+++ b/tests/e2e/helpers/php/sync-validator.php
@@ -41,6 +41,9 @@ if (!defined('ABSPATH')) {
  */
 class FacebookSyncValidator {
 
+    private const POLL_INTERVAL_SECONDS = 10;
+    private const MAX_POLL_SECONDS = 300;
+
     private $product_id;
     private $product;
     private $integration;
@@ -204,12 +207,12 @@ class FacebookSyncValidator {
         // $this->debug("WooCommerce data: " . json_encode($woo_data, JSON_PRETTY_PRINT));
 
         // Get Facebook data using full retailer ID
-        $facebook_data = $this->fetchFacebookData($retailer_id, 'simple');
+        $facebook_data = $this->fetchFacebookData([$retailer_id]);
 
         return [
             'type' => 'simple',
             'woo_data' => [$woo_data],
-            'facebook_data' => [$facebook_data]
+            'facebook_data' => $facebook_data
         ];
     }
 
@@ -219,7 +222,7 @@ class FacebookSyncValidator {
     private function getVariableProductData() {
         $failed_variations = [];
         $woo_data_array = [];
-        $facebook_data_array = [];
+        $retailer_ids = [];
 
         // Set parent retailer_id for result tracking
         $this->result['retailer_id']  = WC_Facebookcommerce_Utils::get_fb_retailer_id($this->product);
@@ -234,7 +237,7 @@ class FacebookSyncValidator {
             try {
                 $var_retailer_id = WC_Facebookcommerce_Utils::get_fb_retailer_id($variation);
                 $woo_data_array[] = $this->extractWooCommerceFields($variation, $var_retailer_id);
-                $facebook_data_array[] = $this->fetchFacebookData($var_retailer_id, 'variable');
+                $retailer_ids[] = $var_retailer_id;
 
                 $this->debug("Extracted variation {$variation_id} data successfully");
             } catch (Exception $e) {
@@ -256,6 +259,22 @@ class FacebookSyncValidator {
         if (count($failed_variations) > 0) {
             $this->debug("Failed to process variations: " . implode(', ', $failed_variations));
         }
+
+        // Poll every variation within one shared retry window. Previously each
+        // missing variation exhausted the complete exponential backoff before
+        // the next variation was checked, multiplying the validation duration.
+        $product_group_id = (string)get_post_meta(
+            $this->product_id,
+            WC_Facebookcommerce_Integration::FB_PRODUCT_GROUP_ID,
+            true
+        );
+        if ($product_group_id) {
+            $this->debug("Polling Facebook product group {$product_group_id} as one variation snapshot");
+        } else {
+            $this->debug("Facebook product group ID is unavailable; falling back to retailer_id lookups");
+        }
+
+        $facebook_data_array = $this->fetchFacebookData($retailer_ids, $product_group_id);
 
         return [
             'type' => 'variable',
@@ -291,61 +310,167 @@ class FacebookSyncValidator {
     }
 
     /**
-     * Fetch Facebook data via API using the full retailer ID.
+     * Fetch Facebook data for all retailer IDs within one shared retry window.
      */
-    private function fetchFacebookData($retailer_id, $context = 'simple') {
-        global $wp_url;
-
+    private function fetchFacebookData($retailer_ids, $product_group_id = '') {
         $api = facebook_for_woocommerce()->get_api();
         $catalog_id = $this->integration->get_product_catalog_id();
         $fields = 'id,name,price,description,availability,retailer_id,condition,brand,color,size,image_url,product_group{id},product_sets{id,retailer_id}';
-
-        $retry_count = 0;
+        $requested_retailer_ids = array_map('strval', $retailer_ids);
+        $unique_retailer_ids = array_values(array_unique($requested_retailer_ids));
+        $facebook_data = [];
+        $poll_timeout_seconds = $this->getPollTimeoutSeconds();
+        $deadline = microtime(true) + $poll_timeout_seconds;
+        $attempt = 0;
+        $complete_snapshot_count = 0;
+        $required_complete_snapshots = count($unique_retailer_ids) > 1 ? 2 : 1;
+        $stable_snapshot_found = false;
 
         do {
-            try {
-                $response = $api->get_product_facebook_fields($catalog_id, $retailer_id, $fields);
+            $attempt++;
+            $current_facebook_data = [];
+            $missing_retailer_ids = [];
+            $has_api_error = false;
 
-                if ($response && $response->response_data && isset($response->response_data['data'][0])) {
-                    $fb_data = $response->response_data['data'][0];
-                    $this->debug(
-                        $retry_count === 0
-                            ? "Successfully fetched Facebook data for retailer_id: {$retailer_id}"
-                            : "Successfully fetched Facebook data for retailer_id: {$retailer_id} on retry #" . ($retry_count + 1)
-                    );
+            if ($product_group_id) {
+                try {
+                    $response = $api->get_product_group_products($product_group_id, 1000, $fields);
+                    $group_products = $response->response_data['data'] ?? [];
 
-                    return [
-                        'id' => $fb_data['id'] ?? null,
-                        'name' => $fb_data['name'] ?? '',
-                        'price' => $fb_data['price'] ?? '',
-                        'description' => $fb_data['description'] ?? '',
-                        'availability' => $fb_data['availability'] ?? '',
-                        'retailer_id' => $fb_data['retailer_id'] ?? '',
-                        'condition' => $fb_data['condition'] ?? '',
-                        'brand' => $fb_data['brand'] ?? '',
-                        'color' => $fb_data['color'] ?? '',
-                        'size' => $fb_data['size'] ?? '',
-                        'image_url' => (!empty($fb_data['image_url'])) ? $fb_data['image_url'] : ($wp_url . '/wp-content/uploads/woocommerce-placeholder.webp'),
-                        'product_group_id' => $fb_data['product_group']['id'] ?? null,
-                        'product_sets' => $fb_data['product_sets']['data'],
-                        'found' => true
-                    ];
+                    foreach ($group_products as $group_product) {
+                        $retailer_id = (string)($group_product['retailer_id'] ?? '');
+                        if ($retailer_id && in_array($retailer_id, $unique_retailer_ids, true)) {
+                            $current_facebook_data[$retailer_id] = $this->formatFacebookData($group_product);
+                        }
+                    }
+
+                    foreach ($unique_retailer_ids as $retailer_id) {
+                        if (!isset($current_facebook_data[$retailer_id])) {
+                            $current_facebook_data[$retailer_id] = ['found' => false];
+                            $missing_retailer_ids[] = $retailer_id;
+                        }
+                    }
+                } catch (Exception $e) {
+                    $has_api_error = true;
+                    foreach ($unique_retailer_ids as $retailer_id) {
+                        $current_facebook_data[$retailer_id] = ['found' => false, 'error' => $e->getMessage()];
+                        $missing_retailer_ids[] = $retailer_id;
+                    }
+                    $this->debug("Facebook product group API error: " . $e->getMessage());
                 }
-            } catch (Exception $e) {
-                $this->debug("Facebook API error for retailer_id {$retailer_id}: " . $e->getMessage());
-                return ['found' => false, 'error' => $e->getMessage()];
+            } else {
+                foreach ($unique_retailer_ids as $retailer_id) {
+                    try {
+                        $response = $api->get_product_facebook_fields($catalog_id, $retailer_id, $fields);
+
+                        if ($response && $response->response_data && isset($response->response_data['data'][0])) {
+                            $current_facebook_data[$retailer_id] = $this->formatFacebookData($response->response_data['data'][0]);
+                        } else {
+                            $current_facebook_data[$retailer_id] = ['found' => false];
+                            $missing_retailer_ids[] = $retailer_id;
+                        }
+                    } catch (Exception $e) {
+                        $current_facebook_data[$retailer_id] = ['found' => false, 'error' => $e->getMessage()];
+                        $missing_retailer_ids[] = $retailer_id;
+                        $has_api_error = true;
+                        $this->debug("Facebook API error for retailer_id {$retailer_id}: " . $e->getMessage());
+                    }
+                }
             }
 
-            $retry_count++;
-            if ($retry_count < $this->max_retries) {
-                $backoff_seconds = pow(2, $retry_count);
-                $this->debug("Facebook API retry attempt #{$retry_count} of {$this->max_retries} for retailer_id: {$retailer_id} (waiting {$backoff_seconds}s)");
-                sleep($backoff_seconds);
-            }
-        } while ($retry_count < $this->max_retries);
+            // Use one complete catalog snapshot. An ID observed on an earlier
+            // attempt may disappear from the eventually consistent query, so
+            // latching individual successes can produce a false positive.
+            $facebook_data = $current_facebook_data;
 
-        $this->debug("No Facebook data found for retailer_id: {$retailer_id}");
-        return ['found' => false];
+            if (count($missing_retailer_ids) === 0) {
+                $complete_snapshot_count++;
+                if ($complete_snapshot_count >= $required_complete_snapshots) {
+                    $stable_snapshot_found = true;
+                    $this->debug("Successfully fetched all Facebook data in {$complete_snapshot_count} consecutive snapshot(s), ending on attempt #{$attempt}");
+                    break;
+                }
+
+                $this->debug("Facebook API attempt #{$attempt} returned a complete snapshot; confirming stability");
+            } else {
+                $complete_snapshot_count = 0;
+            }
+
+            // Preserve API errors as distinct failures instead of retrying an
+            // authentication or request error for the entire poll window.
+            if ($has_api_error) {
+                break;
+            }
+
+            $remaining_seconds = $deadline - microtime(true);
+            if ($remaining_seconds <= 0) {
+                break;
+            }
+
+            $sleep_seconds = min(self::POLL_INTERVAL_SECONDS, max(1, (int) ceil($remaining_seconds)));
+            if (count($missing_retailer_ids) === 0) {
+                $this->debug("Waiting {$sleep_seconds}s to confirm the complete catalog snapshot remains stable");
+            } else {
+                $missing_ids = implode(', ', $missing_retailer_ids);
+                $this->debug("Facebook API attempt #{$attempt} did not find retailer_ids: [{$missing_ids}] (waiting {$sleep_seconds}s; {$poll_timeout_seconds}s shared poll window)");
+            }
+            sleep($sleep_seconds);
+        } while (true);
+
+        if (!$stable_snapshot_found && $complete_snapshot_count > 0) {
+            $this->debug("A complete catalog snapshot was observed but could not be confirmed on a consecutive poll");
+            foreach ($facebook_data as $retailer_id => $data) {
+                $facebook_data[$retailer_id]['found'] = false;
+                $facebook_data[$retailer_id]['unstable'] = true;
+            }
+        }
+
+        foreach ($facebook_data as $retailer_id => $data) {
+            if (!($data['found'] ?? false) && !isset($data['error'])) {
+                $this->debug("No Facebook data found for retailer_id: {$retailer_id} after {$attempt} attempts within a {$poll_timeout_seconds}s shared poll window");
+            }
+        }
+
+        return array_map(function($retailer_id) use ($facebook_data) {
+            return $facebook_data[$retailer_id];
+        }, $requested_retailer_ids);
+    }
+
+    /**
+     * Convert the legacy retry setting into its previous total wait budget,
+     * capped so a validator cannot consume an entire Playwright test timeout.
+     */
+    private function getPollTimeoutSeconds() {
+        if ($this->max_retries <= 1) {
+            return 0;
+        }
+
+        $retry_budget = pow(2, min($this->max_retries, 10)) - 2;
+        return (int) min(self::MAX_POLL_SECONDS, $retry_budget);
+    }
+
+    /**
+     * Normalize one Facebook catalog response for field comparison.
+     */
+    private function formatFacebookData($fb_data) {
+        global $wp_url;
+
+        return [
+            'id' => $fb_data['id'] ?? null,
+            'name' => $fb_data['name'] ?? '',
+            'price' => $fb_data['price'] ?? '',
+            'description' => $fb_data['description'] ?? '',
+            'availability' => $fb_data['availability'] ?? '',
+            'retailer_id' => $fb_data['retailer_id'] ?? '',
+            'condition' => $fb_data['condition'] ?? '',
+            'brand' => $fb_data['brand'] ?? '',
+            'color' => $fb_data['color'] ?? '',
+            'size' => $fb_data['size'] ?? '',
+            'image_url' => (!empty($fb_data['image_url'])) ? $fb_data['image_url'] : ($wp_url . '/wp-content/uploads/woocommerce-placeholder.webp'),
+            'product_group_id' => $fb_data['product_group']['id'] ?? null,
+            'product_sets' => $fb_data['product_sets']['data'] ?? [],
+            'found' => true
+        ];
     }
 
 

--- a/tests/e2e/helpers/php/sync-validator.php
+++ b/tests/e2e/helpers/php/sync-validator.php
@@ -310,6 +310,61 @@ class FacebookSyncValidator {
     }
 
     /**
+     * Find the product group created for a WooCommerce retailer ID.
+     *
+     * Catalog batch status can be finished while the filtered products edge
+     * still returns no item. The product-group edge becomes authoritative
+     * sooner and lets the validator read the group's products directly.
+     */
+    private function findFacebookProductGroupId($catalog_id, $retailer_id) {
+        $api = facebook_for_woocommerce()->get_api();
+        $access_token = $api ? $api->get_access_token() : '';
+
+        if (!$access_token) {
+            throw new Exception('Facebook access token is unavailable for product group lookup');
+        }
+
+        $url = add_query_arg(
+            [
+                'filter' => wp_json_encode(['retailer_id' => ['eq' => (string)$retailer_id]]),
+                'fields' => 'id,retailer_id',
+                // Meta currently returns the newest groups even when the
+                // retailer filter is not applied, so verify matches locally.
+                'limit' => 100
+            ],
+            \WooCommerce\Facebook\API::GRAPH_API_URL
+                . \WooCommerce\Facebook\API::API_VERSION
+                . "/{$catalog_id}/product_groups"
+        );
+
+        $response = wp_remote_get(
+            $url,
+            [
+                'headers' => ['Authorization' => "Bearer {$access_token}"],
+                'timeout' => 30
+            ]
+        );
+
+        if (is_wp_error($response)) {
+            throw new Exception($response->get_error_message());
+        }
+
+        $response_code = wp_remote_retrieve_response_code($response);
+        $body = json_decode(wp_remote_retrieve_body($response), true);
+        if (200 !== $response_code) {
+            throw new Exception($body['error']['message'] ?? "HTTP {$response_code}");
+        }
+
+        foreach ((array)($body['data'] ?? []) as $group) {
+            if ((string)($group['retailer_id'] ?? '') === (string)$retailer_id) {
+                return (string)($group['id'] ?? '');
+            }
+        }
+
+        return '';
+    }
+
+    /**
      * Fetch Facebook data for all retailer IDs within one shared retry window.
      */
     private function fetchFacebookData($retailer_ids, $product_group_id = '') {
@@ -323,7 +378,7 @@ class FacebookSyncValidator {
         $deadline = microtime(true) + $poll_timeout_seconds;
         $attempt = 0;
         $complete_snapshot_count = 0;
-        $required_complete_snapshots = count($unique_retailer_ids) > 1 ? 2 : 1;
+        $required_complete_snapshots = $product_group_id ? 1 : (count($unique_retailer_ids) > 1 ? 2 : 1);
         $stable_snapshot_found = false;
 
         do {
@@ -331,6 +386,24 @@ class FacebookSyncValidator {
             $current_facebook_data = [];
             $missing_retailer_ids = [];
             $has_api_error = false;
+
+            if (!$product_group_id && !empty($this->result['retailer_id'])) {
+                try {
+                    $product_group_id = $this->findFacebookProductGroupId(
+                        $catalog_id,
+                        $this->result['retailer_id']
+                    );
+
+                    if ($product_group_id) {
+                        $required_complete_snapshots = 1;
+                        $this->debug("Discovered Facebook product group {$product_group_id} from the catalog group edge");
+                    }
+                } catch (Exception $e) {
+                    // Fall back to the existing product search. Any connection
+                    // failure there remains a distinct validation error.
+                    $this->debug("Facebook product group lookup failed: " . $e->getMessage());
+                }
+            }
 
             if ($product_group_id) {
                 try {
@@ -374,6 +447,27 @@ class FacebookSyncValidator {
                         $missing_retailer_ids[] = $retailer_id;
                         $has_api_error = true;
                         $this->debug("Facebook API error for retailer_id {$retailer_id}: " . $e->getMessage());
+                    }
+                }
+
+                // A retailer-id lookup can become visible before its siblings
+                // and exposes the authoritative product group ID. Switch to the
+                // group endpoint as soon as that happens so subsequent polling
+                // reads one coherent variation snapshot instead of independent
+                // eventually-consistent search results.
+                if (!$has_api_error && count($missing_retailer_ids) > 0) {
+                    foreach ($current_facebook_data as $data) {
+                        if (!empty($data['product_group_id'])) {
+                            $product_group_id = (string)$data['product_group_id'];
+                            $required_complete_snapshots = 1;
+                            $this->debug("Discovered Facebook product group {$product_group_id}; switching to group snapshot polling");
+                            break;
+                        }
+                    }
+
+                    if ($product_group_id) {
+                        $facebook_data = $current_facebook_data;
+                        continue;
                     }
                 }
             }
@@ -437,16 +531,21 @@ class FacebookSyncValidator {
     }
 
     /**
-     * Convert the legacy retry setting into its previous total wait budget,
-     * capped so a validator cannot consume an entire Playwright test timeout.
+     * Use one bounded propagation window for every positive catalog lookup.
+     * The legacy retry argument is retained so callers can pass zero when they
+     * expect an item to be absent, but it no longer shortens positive checks.
      */
     private function getPollTimeoutSeconds() {
         if ($this->max_retries <= 1) {
             return 0;
         }
 
-        $retry_budget = pow(2, min($this->max_retries, 10)) - 2;
-        return (int) min(self::MAX_POLL_SECONDS, $retry_budget);
+        $poll_override = getenv('FB_E2E_CATALOG_POLL_SECONDS');
+        if (false !== $poll_override && is_numeric($poll_override)) {
+            return (int)min(self::MAX_POLL_SECONDS, max(0, (int)$poll_override));
+        }
+
+        return self::MAX_POLL_SECONDS;
     }
 
     /**

--- a/tests/e2e/performance-sync.spec.js
+++ b/tests/e2e/performance-sync.spec.js
@@ -11,6 +11,7 @@ const {
   baseURL,
   safeScreenshot,
   cleanupProduct,
+  cleanupProducts,
   generateProductName,
   generateUniqueSKU,
   extractProductIdFromUrl,
@@ -231,7 +232,7 @@ test.describe('Meta for WooCommerce - Performance Sync E2E Tests', () => {
     return lastResult;
   }
 
-  async function createAndPublishSimpleProduct(page, { titleSuffix, descriptionRepeat = 20 }) {
+  async function createAndPublishSimpleProduct(page, { titleSuffix, descriptionRepeat = 20, validateSync = true }) {
     let productId = null;
 
     try {
@@ -263,13 +264,15 @@ test.describe('Meta for WooCommerce - Performance Sync E2E Tests', () => {
       await publishProduct(page);
 
       productId = await resolveProductId(page);
-      await assertNoFatalAndSync(
-        page,
-        productId,
-        productName,
-        PERFORMANCE_CONFIG.simpleBatch.waitSeconds,
-        PERFORMANCE_CONFIG.simpleBatch.maxRetries
-      );
+      if (validateSync) {
+        await assertNoFatalAndSync(
+          page,
+          productId,
+          productName,
+          PERFORMANCE_CONFIG.simpleBatch.waitSeconds,
+          PERFORMANCE_CONFIG.simpleBatch.maxRetries
+        );
+      }
 
       return { productId, productName, sku };
     } catch (error) {
@@ -372,20 +375,35 @@ test.describe('Meta for WooCommerce - Performance Sync E2E Tests', () => {
         const product = await createAndPublishSimpleProduct(page, {
           titleSuffix: `Batch-${i + 1}`,
           descriptionRepeat: PERFORMANCE_CONFIG.simpleBatch.descriptionRepeat,
+          validateSync: false,
         });
         created.push(product);
       }
 
       expect(created.length).toBe(PERFORMANCE_CONFIG.simpleBatch.count);
+      await checkForPhpErrors(page);
+
+      // Validate the batch together. Serial propagation windows made this
+      // single test exceed Playwright's per-test timeout before the batch was
+      // even created, and did not exercise queue buildup as intended.
+      const results = await Promise.all(created.map(item => validateFacebookSync(
+        item.productId,
+        item.productName,
+        PERFORMANCE_CONFIG.simpleBatch.waitSeconds,
+        PERFORMANCE_CONFIG.simpleBatch.maxRetries
+      )));
+      for (const result of results) {
+        expect(result?.success).toBe(true);
+      }
+
       logTestEnd(testInfo, true);
     } catch (error) {
       logTestEnd(testInfo, false);
       throw error;
     } finally {
-      for (const item of created) {
-        if (item.productId) {
-          await cleanupProduct(item.productId);
-        }
+      const productIds = created.map(item => item.productId).filter(Boolean);
+      if (productIds.length > 0) {
+        await cleanupProducts(productIds);
       }
     }
   });

--- a/tests/e2e/plugin-level-tests.spec.js
+++ b/tests/e2e/plugin-level-tests.spec.js
@@ -16,6 +16,7 @@ const {
   checkForPhpErrors,
   checkForJsErrors,
   completePurchaseFlow,
+  assertFacebookReconnectCredentialsConfigured,
   disconnectAndVerify,
   reconnectAndVerify,
   verifyProductsFacebookFieldsCleared,
@@ -500,6 +501,10 @@ test.describe('WooCommerce Plugin level tests', () => {
 
   test('Reset connection settings via WooCommerce Status Tools', async ({ page }) => {
     console.log('🔄 Testing Reset connection settings...');
+
+    // This test clears the live connection and restores it in finally. Refuse
+    // to start unless the restore credentials are actually available.
+    assertFacebookReconnectCredentialsConfigured();
 
     const legacyPageAccessTokenOption = 'wc_facebook_page_access_token';
     await execWP(`update_option('${legacyPageAccessTokenOption}', 'legacy_page_token');`);

--- a/tests/e2e/product-deletion.spec.js
+++ b/tests/e2e/product-deletion.spec.js
@@ -15,6 +15,7 @@ const {
   logTestStart,
   logTestEnd,
   validateFacebookSync,
+  getProductCatalogRequestIds,
   processPendingSyncJobs,
   createTestProduct,
   filterProducts,
@@ -68,6 +69,14 @@ test.describe('Meta for WooCommerce - Product Deletion E2E Tests', () => {
       expect(simpleProductPreDeleteResult['success']).toBe(true);
       expect(variableProductPreDeleteResult['success']).toBe(true);
       console.log('✅ Initial sync validation successful. Both products are synced to Facebook.')
+
+      // Capture DELETE identifiers while the variable parent still exposes
+      // its variations. WooCommerce no longer returns those children after
+      // the parent is moved to trash.
+      const [simpleDeleteRequestIds, variableDeleteRequestIds] = await Promise.all([
+        getProductCatalogRequestIds(simpleProductId, 'DELETE'),
+        getProductCatalogRequestIds(variableProductId, 'DELETE')
+      ]);
 
       // Navigate to Products page
       console.log('📋 Navigating to Products page...');
@@ -138,15 +147,13 @@ test.describe('Meta for WooCommerce - Product Deletion E2E Tests', () => {
       await page.waitForLoadState('networkidle', { timeout: TIMEOUTS.MAX });
       console.log('✅ Products moved to trash');
 
-      // Process the pending DELETE sync jobs directly.
-      // The background job handler dispatches via a loopback HTTP request which
-      // doesn't work on single-threaded PHP servers (like the built-in dev
-      // server used in CI), so we invoke the job handler directly via CLI.
-      await processPendingSyncJobs();
-
       const [simpleProductValidationResult, variableProductValidationResult] = await Promise.all([
-        validateFacebookSync(simpleProductId, simpleProduct.productName, 30, 0),
-        validateFacebookSync(variableProductId, variableProduct.productName, 30, 0)
+        validateFacebookSync(simpleProductId, simpleProduct.productName, 30, 0, {
+          requestIds: simpleDeleteRequestIds
+        }),
+        validateFacebookSync(variableProductId, variableProduct.productName, 30, 0, {
+          requestIds: variableDeleteRequestIds
+        })
       ]);
       expect(simpleProductValidationResult['success']).toBe(false);
       expect(variableProductValidationResult['success']).toBe(false);

--- a/tests/e2e/variable-product-depth.spec.js
+++ b/tests/e2e/variable-product-depth.spec.js
@@ -20,7 +20,6 @@ const {
   logTestEnd,
   validateFacebookSync,
   processPendingSyncJobs,
-  execWP,
   setProductTitle,
   setProductDescription,
   dismissWooInterferingOverlays,
@@ -374,40 +373,6 @@ test.describe('Variable Product Depth Tests', () => {
     }
   }
 
-  async function forceEnqueueVariableProductSync(productId) {
-    if (!productId) {
-      return;
-    }
-
-    try {
-      await execWP(`
-        $product_id = ${Number(productId)};
-        $product = wc_get_product($product_id);
-        if ( ! $product ) {
-          echo json_encode(['ok' => false, 'reason' => 'missing_product']);
-          return;
-        }
-
-        $sync = facebook_for_woocommerce()->get_products_sync_handler();
-        if ( $product->is_type('variable') ) {
-          $sync->create_or_update_all_products_for_bulk_edit([$product_id]);
-        } else {
-          $sync->create_or_update_products([$product_id]);
-        }
-
-        $job = $sync->schedule_sync();
-        echo json_encode([
-          'ok' => true,
-          'job_created' => ! empty($job),
-          'product_id' => $product_id,
-        ]);
-      `);
-      console.log(`🔁 Forced sync enqueue for variable product ${productId}`);
-    } catch (error) {
-      console.warn(`⚠️ Failed to force enqueue sync for product ${productId}: ${error.message}`);
-    }
-  }
-
   async function validateVariableProductSync(productId, productName, options = {}) {
     const attempts = options.attempts || 1;
     const waitBetweenAttemptsMs = options.waitBetweenAttemptsMs || (TIMEOUTS.NORMAL + TIMEOUTS.SHORT);
@@ -415,8 +380,13 @@ test.describe('Variable Product Depth Tests', () => {
     let lastResult = null;
 
     for (let attempt = 1; attempt <= attempts; attempt++) {
-      await forceEnqueueVariableProductSync(productId);
-      await processPendingSyncJobs().catch(() => {});
+      // Publishing and editing products must enqueue their own native sync. Only
+      // drain that queue here: forcing another sync masks enqueue regressions and
+      // submits duplicate writes while Meta is still indexing the first batch.
+      const processingResult = await processPendingSyncJobs({ waitForBatchCompletion: true });
+      if (!processingResult.success) {
+        throw new Error(`Unable to process native product sync jobs: ${processingResult.error || processingResult.message || 'unknown error'}`);
+      }
 
       const result = await validateFacebookSync(
         productId,
@@ -480,39 +450,49 @@ test.describe('Variable Product Depth Tests', () => {
     const productName = generateProductName('VariableDepth');
     const expectedVariationCount = getVariationCount(VARIABLE_PRODUCT_CONFIG.attributes);
     const variationDefinitions = buildVariationDefinitions(expectedVariationCount);
+    let productId = null;
 
-    await page.goto(`${baseURL}/wp-admin/post-new.php?post_type=product`, {
-      waitUntil: 'domcontentloaded',
-      timeout: TIMEOUTS.MAX,
-    });
+    try {
+      await page.goto(`${baseURL}/wp-admin/post-new.php?post_type=product`, {
+        waitUntil: 'domcontentloaded',
+        timeout: TIMEOUTS.MAX,
+      });
 
-    await waitForProductEditor(page);
-    await setProductTitle(page, productName);
-    await setProductDescription(page, 'Advanced variable product depth test with multiple attributes and variation-level updates.');
+      await waitForProductEditor(page);
+      await setProductTitle(page, productName);
+      await setProductDescription(page, 'Advanced variable product depth test with multiple attributes and variation-level updates.');
 
-    await page.selectOption('#product-type', 'variable');
-    await page.locator('#_sku').fill(generateUniqueSKU('variable-depth-parent'));
+      await page.selectOption('#product-type', 'variable');
+      await page.locator('#_sku').fill(generateUniqueSKU('variable-depth-parent'));
 
-    await setupAttributes(page, VARIABLE_PRODUCT_CONFIG.attributes);
-    await generateAllVariations(page, expectedVariationCount);
-    await assignVariationData(page, variationDefinitions);
+      await setupAttributes(page, VARIABLE_PRODUCT_CONFIG.attributes);
+      await generateAllVariations(page, expectedVariationCount);
+      await assignVariationData(page, variationDefinitions);
 
-    await publishProduct(page);
+      await publishProduct(page);
 
-    const productId = await resolveProductId(page);
-    await checkForPhpErrors(page);
+      productId = await resolveProductId(page);
+      await checkForPhpErrors(page);
 
-    const syncResult = await validateVariableProductSync(productId, productName);
-    assertVariationAttributeMapping(syncResult, expectedVariationCount);
-    assertExpectedVariationPricesInSync(syncResult, variationDefinitions.map(item => item.price));
+      const syncResult = await validateVariableProductSync(productId, productName);
+      assertVariationAttributeMapping(syncResult, expectedVariationCount);
+      assertExpectedVariationPricesInSync(syncResult, variationDefinitions.map(item => item.price));
 
-    return {
-      productId,
-      productName,
-      expectedVariationCount,
-      variationDefinitions,
-      syncResult,
-    };
+      return {
+        productId,
+        productName,
+        expectedVariationCount,
+        variationDefinitions,
+        syncResult,
+      };
+    } catch (error) {
+      // Callers only receive the product ID after this helper returns. Clean up
+      // here when initial sync validation fails before that can happen.
+      if (productId) {
+        await cleanupProduct(productId);
+      }
+      throw error;
+    }
   }
 
   async function goToProductEditPage(page, productId) {


### PR DESCRIPTION
## Description

This PR improves the reliability of the Purchase and product catalog E2E suites.

Purchase tests now require both Pixel and CAPI events, validate both channels, and detect duplicate CAPI records even when they share an `event_id`.

Catalog tests now follow the plugin’s native synchronization lifecycle, wait for batch completion, and validate variable products from a consistent product-group snapshot. The workflow also avoids sharing one catalog across parallel jobs, preserves project-specific diagnostics, and allows slower WooCommerce product saves to finish.

Both the legacy and new feed synchronization paths remain supported. No new dependencies are required. A single configured catalog runs sequentially, while three distinct catalogs enable parallel execution.

### Type of change

- Fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have commented my code, particularly in hard-to-understand areas, if any.
- [X] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [X] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [X] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [X] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [X] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).

## Changelog entry

Improve the reliability of Purchase event and product catalog E2E validation.

## Test Plan

- Ran all four Purchase E2E scenarios locally.
- Verified that duplicate CAPI records fail validation.
- Ran the variable-product deletion and regeneration test against the connected Meta catalog.
- Confirmed the product transitions from eight variations to seven and back to eight successfully.
- Confirmed the focused variable-product test passes without retries.

Verified all four Purchase scenarios pass, including variable, grouped, standard, and multiple-click checkout flows. Also confirmed directly that one CAPI record passes while two records with the same `event_id` fail validation.