### PR TITLE
ci(e2e): fix every known cause of the red E2E pipeline

### DIFF
--- a/.github/workflows/product-creation-tests.yml
+++ b/.github/workflows/product-creation-tests.yml
@@ -827,19 +827,55 @@ jobs:
           FIREFOX_EXECUTABLE_PATH: ''
         run: |
           cd ${{ env.PLUGIN_PATH }}
-          npx playwright test plugin-level-tests.spec.js --project=chromium-wp-admin --workers=1
-          xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=chromium-wp-customer --workers=1
-          xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=chromium-wp-customer-classic-theme --workers=1
-          xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=chromium-wp-customer-block-theme --workers=1
-          xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=chromium-privacy-sandbox-wp-customer --workers=1
 
-          # Ensure Privacy Sandbox API tests are executed (not skipped) in CI.
-          xvfb-run --auto-servernum npx playwright test events-test.spec.js \
-            --headed \
-            --project=chromium-privacy-sandbox-wp-customer \
-            --workers=1 \
-            --grep "Privacy Sandbox - (Topics API available in Chromium|Protected Audience API shape in Chromium)" \
-            --reporter=json > /tmp/privacy-sandbox-api-report.json
+          # This step runs a dozen browser projects back to back. The step shell is
+          # `bash -e`, so the first non-zero exit used to abort everything after it:
+          # a single failing project silently skipped the remaining projects and
+          # reported them as neither passed nor failed. Collect failures instead and
+          # fail once at the end, so every project always reports its own result.
+          set +e
+          failed_projects=()
+
+          note_rc() {  # note_rc <exit-code> <label>
+            if [ "$1" -eq 0 ]; then
+              echo "✅ passed: $2"
+            else
+              echo "❌ failed: $2 (exit $1)"
+              failed_projects+=("$2")
+            fi
+          }
+
+          run_project() {  # run_project <label> <command...>
+            local label="$1"
+            shift
+            echo "::group::E2E project: ${label}"
+            "$@"
+            local rc=$?
+            echo "::endgroup::"
+            note_rc "$rc" "${label}"
+            return 0
+          }
+
+          run_project "plugin-level-tests (chromium-wp-admin)" \
+            npx playwright test plugin-level-tests.spec.js --project=chromium-wp-admin --workers=1
+          run_project "events (chromium-wp-customer)" \
+            xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=chromium-wp-customer --workers=1
+          run_project "events (chromium-wp-customer-classic-theme)" \
+            xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=chromium-wp-customer-classic-theme --workers=1
+          run_project "events (chromium-wp-customer-block-theme)" \
+            xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=chromium-wp-customer-block-theme --workers=1
+          run_project "events (chromium-privacy-sandbox-wp-customer)" \
+            xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=chromium-privacy-sandbox-wp-customer --workers=1
+
+          # Ensure the supported Privacy Sandbox API test is executed (not skipped) in CI.
+          run_project "privacy-sandbox API report" bash -c '
+            xvfb-run --auto-servernum npx playwright test events-test.spec.js \
+              --headed \
+              --project=chromium-privacy-sandbox-wp-customer \
+              --workers=1 \
+              --grep "Privacy Sandbox - Protected Audience API shape in Chromium" \
+              --reporter=json > /tmp/privacy-sandbox-api-report.json
+          '
 
           # Diagnostic probe: verify APIs are exposed in the privacy-sandbox browser runtime.
           node - <<'NODE'
@@ -850,8 +886,8 @@ jobs:
               channel: 'chrome',
               headless: true,
               args: [
-                '--enable-features=BrowsingTopics,InterestGroupStorage,AdInterestGroupAPI,Fledge,RunAdAuction,PrivacySandboxAdsAPIsOverride',
-                '--enable-blink-features=BrowsingTopics,InterestGroupStorage,AdInterestGroupAPI,RunAdAuction',
+                '--enable-features=InterestGroupStorage,AdInterestGroupAPI,Fledge,RunAdAuction,PrivacySandboxAdsAPIsOverride',
+                '--enable-blink-features=InterestGroupStorage,AdInterestGroupAPI,RunAdAuction',
                 '--test-third-party-cookie-phaseout',
                 ...(process.env.WORDPRESS_URL ? [`--unsafely-treat-insecure-origin-as-secure=${new URL(process.env.WORDPRESS_URL).origin}`] : []),
               ],
@@ -864,7 +900,6 @@ jobs:
 
               const probe = await page.evaluate(() => ({
                 isSecureContext: typeof window !== 'undefined' ? window.isSecureContext : null,
-                hasTopicsApi: typeof document !== 'undefined' && typeof document.browsingTopics === 'function',
                 hasJoinAdInterestGroup: typeof navigator !== 'undefined' && typeof navigator.joinAdInterestGroup === 'function',
                 hasRunAdAuction: typeof navigator !== 'undefined' && typeof navigator.runAdAuction === 'function',
                 hasLeaveAdInterestGroup: typeof navigator !== 'undefined' && typeof navigator.leaveAdInterestGroup === 'function',
@@ -881,6 +916,7 @@ jobs:
             process.exit(1);
           });
           NODE
+          note_rc $? "privacy-sandbox capability probe"
 
           node - <<'NODE'
           const fs = require('fs');
@@ -904,7 +940,6 @@ jobs:
           }
 
           const apiTitles = new Set([
-            'Privacy Sandbox - Topics API available in Chromium',
             'Privacy Sandbox - Protected Audience API shape in Chromium'
           ]);
 
@@ -933,8 +968,8 @@ jobs:
             walkSuite(suite);
           }
 
-          if (statuses.length < 2) {
-            console.error('Expected both Privacy Sandbox API tests to run, but did not find both in JSON report.');
+          if (statuses.length < 1) {
+            console.error('Expected the Privacy Sandbox API test to run, but did not find it in JSON report.');
             process.exit(1);
           }
 
@@ -943,16 +978,31 @@ jobs:
             process.exit(1);
           }
 
-          console.log('Privacy Sandbox API tests executed without skips. Statuses:', statuses);
+          console.log('Privacy Sandbox API test executed without skips. Statuses:', statuses);
           NODE
+          note_rc $? "privacy-sandbox no-skip gate"
 
-          xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=edge-wp-customer --workers=1
-          xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=firefox-wp-customer --workers=1
-          xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=brave-wp-customer --workers=1
-          npx playwright test events-test.spec.js --project=android-pixel-wp-customer --workers=1
-          npx playwright test events-test.spec.js --project=safari-ios-wp-customer --workers=1
-          set -o pipefail
-          xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=opera-wp-customer --workers=1 2>&1 | tee /tmp/opera-playwright.log
+          run_project "events (edge-wp-customer)" \
+            xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=edge-wp-customer --workers=1
+          run_project "events (firefox-wp-customer)" \
+            xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=firefox-wp-customer --workers=1
+          run_project "events (brave-wp-customer)" \
+            xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=brave-wp-customer --workers=1
+          run_project "events (android-pixel-wp-customer)" \
+            npx playwright test events-test.spec.js --project=android-pixel-wp-customer --workers=1
+          run_project "events (safari-ios-wp-customer)" \
+            npx playwright test events-test.spec.js --project=safari-ios-wp-customer --workers=1
+          run_project "events (opera-wp-customer)" bash -c '
+            set -o pipefail
+            xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=opera-wp-customer --workers=1 2>&1 | tee /tmp/opera-playwright.log
+          '
+
+          if [ "${#failed_projects[@]}" -ne 0 ]; then
+            echo "::error::${#failed_projects[@]} E2E project run(s) failed in this shard:"
+            printf '::error::  - %s\n' "${failed_projects[@]}"
+            exit 1
+          fi
+          echo "All E2E project runs in this shard passed."
 
       - name: Dump Opera diagnostics (always)
         if: always() && matrix.test-group == 'plugin-events'

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -39,8 +39,8 @@ const privacySandboxOrigin = process.env.WORDPRESS_URL
   : null;
 
 const privacySandboxArgs = [
-  '--enable-features=BrowsingTopics,InterestGroupStorage,AdInterestGroupAPI,Fledge,RunAdAuction,PrivacySandboxAdsAPIsOverride',
-  '--enable-blink-features=BrowsingTopics,InterestGroupStorage,AdInterestGroupAPI,RunAdAuction',
+  '--enable-features=InterestGroupStorage,AdInterestGroupAPI,Fledge,RunAdAuction,PrivacySandboxAdsAPIsOverride',
+  '--enable-blink-features=InterestGroupStorage,AdInterestGroupAPI,RunAdAuction',
   '--test-third-party-cookie-phaseout',
   ...(privacySandboxOrigin ? [`--unsafely-treat-insecure-origin-as-secure=${privacySandboxOrigin}`] : []),
 ];

--- a/tests/e2e/events-test.spec.js
+++ b/tests/e2e/events-test.spec.js
@@ -1338,34 +1338,6 @@ function getMajorBrowserVersion(versionString) {
     return match ? parseInt(match[1], 10) : NaN;
 }
 
-test('Privacy Sandbox - Topics API available in Chromium', async ({ page, browser }) => {
-    test.skip(!test.info().project.name.includes('privacy-sandbox'), 'Privacy Sandbox test only runs on privacy-sandbox project');
-
-    const chromiumMajor = getMajorBrowserVersion(browser.version());
-    test.skip(Number.isNaN(chromiumMajor) || chromiumMajor < 115, `Privacy Sandbox requires Chrome/Chromium >= 115 (detected ${browser.version()})`);
-
-    await page.goto('/');
-    await TestSetup.waitForPageReady(page);
-
-    const topicsResult = await page.evaluate(async () => {
-        const hasTopicsApi = typeof document !== 'undefined' && typeof document.browsingTopics === 'function';
-        if (!hasTopicsApi) {
-            return { hasTopicsApi, topicsCount: null, error: null };
-        }
-
-        try {
-            const topics = await document.browsingTopics();
-            return { hasTopicsApi, topicsCount: Array.isArray(topics) ? topics.length : 0, error: null };
-        } catch (error) {
-            return { hasTopicsApi, topicsCount: null, error: String(error?.message || error) };
-        }
-    });
-
-    expect(topicsResult.hasTopicsApi).toBe(true);
-    expect(topicsResult.error).toBeNull();
-    expect(typeof topicsResult.topicsCount).toBe('number');
-});
-
 test('Privacy Sandbox - Protected Audience API shape in Chromium', async ({ page, browser }) => {
     test.skip(!test.info().project.name.includes('privacy-sandbox'), 'Privacy Sandbox test only runs on privacy-sandbox project');
 

--- a/tests/e2e/helpers/js/wordpress/exec.js
+++ b/tests/e2e/helpers/js/wordpress/exec.js
@@ -102,8 +102,22 @@ async function checkWooCommerceLogs() {
   if (non200Lines) {
     const unexpectedErrors = [];
     // Print surrounding context (10 lines before/after) for each non-200 line
-    const lineNumbers = non200Lines.split('\n').map(l => parseInt(l.split(':')[0], 10)).filter(n => !isNaN(n));
-    for (const lineNum of lineNumbers) {
+    const entries = non200Lines
+      .split('\n')
+      .map(l => l.match(/^(\d+):code:\s*(\d+)/))
+      .filter(Boolean)
+      .map(m => ({ lineNum: Number(m[1]), code: Number(m[2]) }));
+    for (const { lineNum, code } of entries) {
+      // A 5xx is Meta's server failing, not a malformed request from the plugin
+      // (that would be a 4xx), and the API client retries it. Report it but do
+      // not fail on it: this test re-reads the same cumulative log file on every
+      // Playwright retry, so a single upstream blip would otherwise red the whole
+      // shard with no way for a retry to recover. A genuine Meta outage still
+      // surfaces through the sync assertions in the other specs.
+      if (code >= 500) {
+        console.log(`⏭️ Ignoring upstream ${code} at line ${lineNum} (Meta server error, not a plugin defect)`);
+        continue;
+      }
       const start = Math.max(1, lineNum - 5);
       const end = lineNum + 5;
       const context = execSync(

--- a/tests/e2e/performance-sync.spec.js
+++ b/tests/e2e/performance-sync.spec.js
@@ -27,7 +27,13 @@ const {
   dismissWooInterferingOverlays
 } = require('./helpers/js');
 
-test.describe.serial('Meta for WooCommerce - Performance Sync E2E Tests', () => {
+// Not `describe.serial`: this file already runs with --workers=1, so the tests
+// execute in declaration order either way. What `.serial` added was retry
+// semantics -- one failing test re-runs the WHOLE block, so a failure in the
+// 3-minute variable-product test re-ran the 14-minute batch test on each of the
+// two retries and blew the 45-minute job timeout. The tests share no mutable
+// state, so retrying only the failed test is both cheaper and more accurate.
+test.describe('Meta for WooCommerce - Performance Sync E2E Tests', () => {
   test.beforeEach(async ({ page }, testInfo) => {
     logTestStart(testInfo);
     await page.setViewportSize({ width: 1280, height: 720 });

--- a/tests/e2e/plugin-level-tests.spec.js
+++ b/tests/e2e/plugin-level-tests.spec.js
@@ -896,7 +896,11 @@ test.describe('WooCommerce Plugin level tests', () => {
       await productAttributeContainer.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
       await exactSearchSelect2Container(page, productAttributeContainer, attributeName);
       const selectAllAttrValuesBtn = page.getByRole('button', { name: 'Select all' });
-      await selectAllAttrValuesBtn.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
+      // EXTRA_LONG rather than the MEDIUM used by the pure-DOM waits around it:
+      // this button only renders once WooCommerce finishes an AJAX round-trip to
+      // load the global attribute's terms. Under CI contention that regularly
+      // exceeded 5s, which was the single most common flake in this shard.
+      await selectAllAttrValuesBtn.waitFor({ state: 'visible', timeout: TIMEOUTS.EXTRA_LONG });
       await selectAllAttrValuesBtn.click();
       console.log(`✅ Selected attribute: ${attributeName}`);
 

--- a/tests/e2e/product-deletion.spec.js
+++ b/tests/e2e/product-deletion.spec.js
@@ -199,7 +199,26 @@ test.describe('Meta for WooCommerce - Product Deletion E2E Tests', () => {
       // on single-threaded PHP servers in CI).
       await processPendingSyncJobs();
 
-      const syncResultAfter = await validateFacebookSync(simpleProductId, simpleProduct.productName, 30, 0);
+      // Exclusion propagates to the Meta catalog asynchronously, so a single
+      // probe races the delete. The sync validator already polls until an item
+      // APPEARS; this is the mirror case and needs the same treatment, otherwise
+      // any propagation lag is an instant failure that no Playwright retry can
+      // recover (the retry rebuilds the product and races again).
+      //
+      // Each probe is one API call (maxRetries=0), so a still-present item
+      // returns immediately -- the loop only costs wall clock while the catalog
+      // is genuinely lagging, and stops the moment the item is gone.
+      let syncResultAfter = await validateFacebookSync(simpleProductId, simpleProduct.productName, 30, 0);
+      const catalogDeletionDeadline = Date.now() + 2 * TIMEOUTS.MAX; // 2 minutes
+      while (
+        syncResultAfter?.raw_data?.facebook_data?.[0]?.found
+        && Date.now() < catalogDeletionDeadline
+      ) {
+        console.log('⏳ Product still present in the catalog; waiting for exclusion to propagate...');
+        await page.waitForTimeout(TIMEOUTS.LONG);
+        syncResultAfter = await validateFacebookSync(simpleProductId, simpleProduct.productName, 0, 0);
+      }
+
       expect(syncResultAfter['success']).toBe(false);
       expect(syncResultAfter['raw_data']['woo_data'][0]['title']).toBe(newTitle);
       try {

--- a/tests/e2e/variable-product-depth.spec.js
+++ b/tests/e2e/variable-product-depth.spec.js
@@ -26,7 +26,15 @@ const {
   dismissWooInterferingOverlays,
 } = require('./helpers/js');
 
-test.describe.serial('Variable Product Depth Tests', () => {
+// Not `describe.serial`: this file already runs with --workers=1, so the tests
+// execute in declaration order either way. What `.serial` added was retry
+// semantics -- one failing test re-runs the WHOLE block, so each retry repeated
+// every already-passing test in the file. These tests build 8-variation products
+// and wait on catalog convergence, so a single late failure could re-run several
+// minutes of passing work twice and push the shard past its 45-minute timeout.
+// The tests share no mutable state, so retrying only the failed test is both
+// cheaper and more accurate.
+test.describe('Variable Product Depth Tests', () => {
   test.beforeEach(async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== 'chromium-wp-admin', 'Variable product depth tests require wp-admin project');
 

--- a/tests/js/wc-log-validation.test.js
+++ b/tests/js/wc-log-validation.test.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Tests for checkWooCommerceLogs() non-200 classification.
+ *
+ * This helper backs the `Check WooCommerce logs for fatal errors and non-200
+ * responses` E2E test, which re-reads the same cumulative log file on every
+ * Playwright retry -- so anything it rejects reds the shard with no way for a
+ * retry to recover. The 4xx/5xx split is what keeps upstream Meta blips from
+ * doing that while still failing on requests the plugin itself got wrong.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { checkWooCommerceLogs } = require('../e2e/helpers/js/wordpress/exec');
+
+const today = new Date().toISOString().split('T')[0];
+
+function entry(code, message, extra = '') {
+  return [
+    '2026-09-01T03:24:57+00:00 NOTICE Response',
+    `code: ${code}`,
+    `message: ${message}`,
+    extra,
+  ].filter(Boolean).join('\n');
+}
+
+const OK = entry(200, 'OK', 'body: {"events_received":1}');
+
+/** Write a log file into a fresh temp dir and point WC_LOG_PATH at it. */
+function withLog(body) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wc-logs-'));
+  fs.writeFileSync(
+    path.join(dir, `facebook_for_woocommerce-${today}-deadbeef.log`),
+    `${body}\n`
+  );
+  process.env.WC_LOG_PATH = dir;
+  return dir;
+}
+
+describe('checkWooCommerceLogs non-200 classification', () => {
+  const originalLogPath = process.env.WC_LOG_PATH;
+  const dirs = [];
+
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    dirs.forEach(d => fs.rmSync(d, { recursive: true, force: true }));
+    if (originalLogPath === undefined) {
+      delete process.env.WC_LOG_PATH;
+    } else {
+      process.env.WC_LOG_PATH = originalLogPath;
+    }
+  });
+
+  const scenario = (body) => {
+    dirs.push(withLog(body));
+    return checkWooCommerceLogs();
+  };
+
+  it('passes when every response is a 200', async () => {
+    await expect(scenario([OK, OK].join('\n'))).resolves.toEqual({ success: true });
+  });
+
+  it('tolerates an upstream 5xx -- Meta server error, not a plugin defect', async () => {
+    const body = [
+      OK,
+      entry(500, 'Internal Server Error', 'body: {"error":{"code":1,"message":"An unknown error occurred","error_subcode":99}}'),
+      OK,
+    ].join('\n');
+    await expect(scenario(body)).resolves.toEqual({ success: true });
+  });
+
+  it('still fails on a 4xx -- the plugin sent a bad request', async () => {
+    const body = [OK, entry(400, 'Bad Request', 'body: {"error":{"code":100}}')].join('\n');
+    const result = await scenario(body);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Non-200 response codes found');
+  });
+
+  it('fails on a 4xx even when an upstream 5xx is also present', async () => {
+    const body = [
+      entry(500, 'Internal Server Error'),
+      entry(400, 'Bad Request', 'body: {"error":{"code":100}}'),
+    ].join('\n');
+    await expect(scenario(body)).resolves.toMatchObject({ success: false });
+  });
+
+  it('keeps ignoring the known transient 4xx via the context allowlist', async () => {
+    const body = [
+      OK,
+      entry(400, 'Bad Request', 'body: {"error":{"message":"Another upload already in progress"}}'),
+    ].join('\n');
+    await expect(scenario(body)).resolves.toEqual({ success: true });
+  });
+});


### PR DESCRIPTION
## Description

`main`'s nightly E2E has been red continuously. This is the single PR fixing **every** known cause. Each was identified from real CI logs, not inspection. Supersedes #4020 and #4022, both folded in and closed.

### Deterministic

**1. Obsolete Topics API test.** Chrome removed `document.browsingTopics()`, so `events-test.spec.js:1341` failed 3/3 attempts on *every* nightly run 08-26 → 08-31. Removes the test and its launch flags; narrows the Privacy Sandbox gate to the surviving Protected Audience test.

### Wall clock — the 45-minute job timeouts

**2. `performance-sync`** and **3. `variable-product-depth`** both used `test.describe.serial`, which re-runs the **entire block** when any test fails. Caught in the log:

| 03:48:50 | batch test **passes** (13.7m) |
| 03:54:13 | variable-product test **fails** (3m) |
| 03:54:14 | batch test **restarts** ← whole block retried |

3 × ~18m against a 45m budget. Both files already run `--workers=1`, so declaration order holds without `.serial`, and neither has mutable state at describe scope. This took `performance-sync` from a **45m timeout to a 23m pass**. No spec in `tests/e2e/` uses `describe.serial` after this.

### Flakes no retry could recover

**4. `Check WooCommerce logs`** re-reads the same **cumulative** log file every attempt, so once Meta wrote a 500 into it (`items_batch`, 42.6s, error code 1 / subcode 99) no retry could clear it — all three attempts failed identically. A 5xx is now reported but tolerated; **a 4xx still fails**, because that's the plugin sending a malformed request.

**5. `Exclude product from sync`** asserted on a *single probe* that the item was gone, while the sync validator polls until an item *appears*. Exclusion propagates asynchronously, so any lag failed instantly — and the retry just rebuilt the product and raced again. Now polls until absent with a 2-minute deadline; each probe is one API call, so a still-present item returns immediately.

**6. The `Select all` button** only renders after WooCommerce finishes an AJAX round-trip loading the attribute's terms, but was waited on with a 5s timeout. Under CI contention that regularly expired — the most common flake in this shard.

### Visibility

**7.** The step runs twelve browser projects under `bash -e`, so the first non-zero exit aborted the rest, reporting them as neither passed nor failed. On `main` the Topics failure (invocation 5) hid edge/firefox/brave/android-pixel/safari-ios/opera from 08-27 on; on #4014 a first-invocation flake hid **all eleven** `events-test` runs. Now collects per-project results and fails once at the end, naming what failed.

### Type of change

- Fix (non-breaking change which fixes an issue)

## Notes for the reviewer

- No plugin runtime or product code changes — test infrastructure only.
- The 4xx/5xx split is deliberately narrow, and `tests/js/wc-log-validation.test.js` pins the strict side: a 4xx fails, and a 4xx alongside a 5xx still fails.
- Item 7 will surface results that were previously invisible. When those six hidden projects finally ran, **all six passed** — but expect more honest reporting, not less.
- Item 3 also changes skip behaviour: under `.serial`, tests after a failure were skipped; they now run.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] No PHP files are changed.
- [x] I followed general Pull Request best practices.
- [x] All existing JavaScript unit tests pass locally.
- [x] Documentation changes are not necessary because this affects test infrastructure only.

## Changelog entry

N/A — test infrastructure only.

## Test Plan

- [x] `npm run test:js -- --runInBand` — 109 tests, 4 suites.
- [x] `tests/js/wc-log-validation.test.js` drives `checkWooCommerceLogs()` against real temp log files: 200-only passes, upstream 5xx tolerated, 4xx still fails, 4xx + 5xx still fails, transient allowlist intact.
- [x] Mutation-checked that test — disabling the 5xx branch fails exactly the 5xx case and nothing else.
- [x] Behavioural check of the bash failure-collector: a failing project doesn't stop later projects, `pipefail` still surfaces the left-hand exit code, heredoc gates are captured, an all-green run records no failures.
- [x] Parse the workflow as YAML, extract the step, `bash -n` it.
- [x] `node --check` on all changed JavaScript files.
- [x] Confirmed no spec still uses `describe.serial`.
- [x] **CI:** an earlier revision of this branch (Topics + items 2 and 4 only) went **12/12 green** on run `33538921289`, including a 66m `plugin-events` shard running all eleven invocations with zero failures.
- [ ] CI on this revision.