### PR TITLE
ci(e2e): harden shared catalog test execution

### DIFF
--- a/.github/workflows/product-creation-tests.yml
+++ b/.github/workflows/product-creation-tests.yml
@@ -120,7 +120,7 @@ jobs:
           echo "Resolved versions — WP: $WP_VERSION, WC: $WC_VERSION"
 
   e2e-tests:
-    name: E2E Tests - ${{ matrix.version-label }} - ${{ matrix.test-group }}
+    name: E2E Tests - ${{ matrix.version-label }} - ${{ matrix.test-group }} - Asset ${{ matrix.asset-index }}
     needs: [check-secrets, resolve-versions]
     if: ${{ needs.check-secrets.outputs.secrets-configured == 'true' }}
     # Run every shard on the standard GitHub-hosted runner. We previously
@@ -130,28 +130,102 @@ jobs:
     # never actually executing. The mysql:8.0 service container is multi-arch,
     # so this is no longer constrained to x86-only pools.
     runs-on: ubuntu-latest
-    # Fail fast instead of letting a stuck step (e.g. a hung browser install) run
-    # until GitHub's 6-hour default job timeout. plugin-events runs many browser
-    # projects sequentially, so it gets a larger budget.
-    timeout-minutes: ${{ matrix.test-group == 'plugin-events' && 90 || 45 }}
+    # Keep bounded job runtimes while allowing the catalog-heavy shards enough
+    # time to finish when Meta catalog propagation is slower than usual.
+    timeout-minutes: ${{ (matrix.test-group == 'plugin-events' || matrix.test-group == 'performance-sync' || matrix.test-group == 'product-crud') && 90 || (matrix.test-group == 'variable-product-depth' || matrix.test-group == 'product-category') && 60 || 45 }}
 
     strategy:
       fail-fast: false
-      # Cap how many shards run concurrently within a run to keep shared-test-asset
-      # contention reasonable (all shards now share the ubuntu-latest pool).
-      max-parallel: 8
+      # There are three independent Meta test asset sets. Limit each run to three
+      # active shards and spread those shards across the asset pool to reduce
+      # catalog contention.
+      max-parallel: 3
       matrix:
-        test-group: ['plugin-events', 'product-crud', 'variable-product-depth', 'product-batch', 'product-category', 'performance-sync']
-        version-set: ['supported', 'latest']
         include:
-          - version-set: 'supported'
+          - test-group: 'plugin-events'
+            version-set: 'supported'
             wp-version: ${{ needs.resolve-versions.outputs.wp-supported }}
             wc-version: ${{ needs.resolve-versions.outputs.wc-supported }}
             version-label: 'Currently supported'
-          - version-set: 'latest'
+            asset-index: 0
+            shard-index: 0
+          - test-group: 'plugin-events'
+            version-set: 'latest'
             wp-version: 'latest'
             wc-version: 'latest'
             version-label: 'Latest'
+            asset-index: 1
+            shard-index: 1
+          - test-group: 'product-crud'
+            version-set: 'supported'
+            wp-version: ${{ needs.resolve-versions.outputs.wp-supported }}
+            wc-version: ${{ needs.resolve-versions.outputs.wc-supported }}
+            version-label: 'Currently supported'
+            asset-index: 2
+            shard-index: 2
+          - test-group: 'product-crud'
+            version-set: 'latest'
+            wp-version: 'latest'
+            wc-version: 'latest'
+            version-label: 'Latest'
+            asset-index: 0
+            shard-index: 3
+          - test-group: 'variable-product-depth'
+            version-set: 'supported'
+            wp-version: ${{ needs.resolve-versions.outputs.wp-supported }}
+            wc-version: ${{ needs.resolve-versions.outputs.wc-supported }}
+            version-label: 'Currently supported'
+            asset-index: 1
+            shard-index: 4
+          - test-group: 'variable-product-depth'
+            version-set: 'latest'
+            wp-version: 'latest'
+            wc-version: 'latest'
+            version-label: 'Latest'
+            asset-index: 2
+            shard-index: 5
+          - test-group: 'product-batch'
+            version-set: 'supported'
+            wp-version: ${{ needs.resolve-versions.outputs.wp-supported }}
+            wc-version: ${{ needs.resolve-versions.outputs.wc-supported }}
+            version-label: 'Currently supported'
+            asset-index: 0
+            shard-index: 6
+          - test-group: 'product-batch'
+            version-set: 'latest'
+            wp-version: 'latest'
+            wc-version: 'latest'
+            version-label: 'Latest'
+            asset-index: 1
+            shard-index: 7
+          - test-group: 'product-category'
+            version-set: 'supported'
+            wp-version: ${{ needs.resolve-versions.outputs.wp-supported }}
+            wc-version: ${{ needs.resolve-versions.outputs.wc-supported }}
+            version-label: 'Currently supported'
+            asset-index: 2
+            shard-index: 8
+          - test-group: 'product-category'
+            version-set: 'latest'
+            wp-version: 'latest'
+            wc-version: 'latest'
+            version-label: 'Latest'
+            asset-index: 0
+            shard-index: 9
+          - test-group: 'performance-sync'
+            version-set: 'supported'
+            wp-version: ${{ needs.resolve-versions.outputs.wp-supported }}
+            wc-version: ${{ needs.resolve-versions.outputs.wc-supported }}
+            version-label: 'Currently supported'
+            asset-index: 1
+            shard-index: 10
+          - test-group: 'performance-sync'
+            version-set: 'latest'
+            wp-version: 'latest'
+            wc-version: 'latest'
+            version-label: 'Latest'
+            asset-index: 2
+            shard-index: 11
 
     services:
       mysql:
@@ -292,6 +366,24 @@ jobs:
             --admin_password=admin \
             --admin_email=test@example.com \
             --allow-root
+
+      - name: Isolate catalog object IDs for this shard
+        run: |
+          cd ${{ env.WORDPRESS_PATH }}
+
+          # Every runner starts from the same WordPress IDs, while several shards
+          # can write to the same remote catalog. Give each run/shard a distinct
+          # numeric range so one shard cannot overwrite or delete another shard's
+          # products or category-backed product sets.
+          RUN_ID_SUFFIX=$(( ${{ github.run_id }} % 100000000 ))
+          ID_BASE=$(( RUN_ID_SUFFIX * 100000 + ${{ matrix.shard-index }} * 5000 + 1000 ))
+          DB_PREFIX=$(wp db prefix --allow-root)
+
+          wp db query "ALTER TABLE ${DB_PREFIX}posts AUTO_INCREMENT = ${ID_BASE};"
+          wp db query "ALTER TABLE ${DB_PREFIX}terms AUTO_INCREMENT = ${ID_BASE};"
+          wp db query "ALTER TABLE ${DB_PREFIX}term_taxonomy AUTO_INCREMENT = ${ID_BASE};"
+
+          echo "✅ Reserved object ID range starting at ${ID_BASE} for shard ${{ matrix.shard-index }}"
 
       - name: Install WooCommerce
         run: |
@@ -444,13 +536,15 @@ jobs:
           ARRAY_LENGTH=$(echo "$ASSETS" | jq 'length')
           echo "Total available business asset sets: $ARRAY_LENGTH"
 
-          # Use run_number as selector - it's sequential (1, 2, 3, ...) across all workflow runs
-          # This ensures each concurrent run gets a different business asset set
-          SELECTOR="${{ github.run_number }}"
-          echo "Using GitHub Run Number as selector: $SELECTOR"
+          # The matrix spreads jobs across the three Meta test asset sets.
+          # Fail clearly if the secret no longer contains every configured lane.
+          REQUIRED_ASSET_COUNT=3
+          if [ "$ARRAY_LENGTH" -lt "$REQUIRED_ASSET_COUNT" ]; then
+            echo "::error title=E2E Assets Missing::Expected at least $REQUIRED_ASSET_COUNT asset sets, found $ARRAY_LENGTH."
+            exit 1
+          fi
 
-          # Calculate index using modulo
-          INDEX=$((SELECTOR % ARRAY_LENGTH))
+          INDEX="${{ matrix.asset-index }}"
           echo "Selected asset set index: $INDEX"
 
           # Extract the selected asset set
@@ -977,7 +1071,9 @@ jobs:
         if: matrix.test-group == 'product-crud'
         run: |
           cd ${{ env.PLUGIN_PATH }}
-          npx playwright test "product-(creation|modification|deletion).spec.js" --project=chromium-wp-admin --workers=2
+          # The local PHP server and WordPress database are shared by the suite.
+          # A single worker avoids concurrent product/catalog mutations.
+          npx playwright test "product-(creation|modification|deletion).spec.js" --project=chromium-wp-admin --workers=1
 
       - name: Run Variable Product Depth tests
         if: matrix.test-group == 'variable-product-depth'
@@ -999,6 +1095,10 @@ jobs:
 
       - name: Run Product Stress Sync tests
         if: matrix.test-group == 'performance-sync'
+        env:
+          # PRs exercise a representative batch while scheduled/manual runs retain
+          # the full stress workload.
+          PERFORMANCE_SIMPLE_BATCH_COUNT: ${{ github.event_name == 'pull_request' && '3' || '15' }}
         run: |
           cd ${{ env.PLUGIN_PATH }}
           npx playwright test performance-sync.spec.js --project=chromium-wp-admin --workers=1

--- a/tests/e2e/helpers/js/plugin/sync.js
+++ b/tests/e2e/helpers/js/plugin/sync.js
@@ -16,6 +16,7 @@ const path = require('path');
 const execAsync = promisify(exec);
 
 let connectionPreflightChecked = false;
+let pendingSyncDrainPromise = null;
 
 async function ensureFacebookConnectionConfigured() {
   if (connectionPreflightChecked) {
@@ -122,6 +123,7 @@ async function validateFacebookSync(productId, productName, waitSeconds = 10, ma
   console.log(`🔍 Validating Facebook sync for product ${displayName}...`);
 
   try {
+    await drainPendingSyncJobs();
     await ensureFacebookConnectionConfigured();
     const command = buildValidatorCommand('product', productId, waitSeconds, maxRetries);
     const { stdout } = await execAsync(command, {
@@ -168,6 +170,7 @@ async function validateCategorySync(categoryId, categoryName = null, waitSeconds
   console.log(`🔍 Validating category sync for ${displayName}...`);
 
   try {
+    await drainPendingSyncJobs();
     await ensureFacebookConnectionConfigured();
     const command = buildValidatorCommand('category', categoryId, waitSeconds, maxRetries);
     const { stdout } = await execAsync(command, {
@@ -204,6 +207,26 @@ async function validateCategorySync(categoryId, categoryName = null, waitSeconds
 }
 
 /**
+ * Drains pending sync jobs before reading Facebook catalog state.
+ *
+ * Multiple validators are often started together with Promise.all(). Reuse the
+ * same in-flight drain so they do not race while processing the local queue.
+ * A completed drain is not cached because later product/category mutations may
+ * enqueue new work that must be processed before the next validation.
+ *
+ * @return {Promise<Object>} Processing result
+ */
+async function drainPendingSyncJobs() {
+  if (!pendingSyncDrainPromise) {
+    pendingSyncDrainPromise = processPendingSyncJobs().finally(() => {
+      pendingSyncDrainPromise = null;
+    });
+  }
+
+  return pendingSyncDrainPromise;
+}
+
+/**
  * Process pending Facebook sync background jobs directly.
  *
  * The background job handler normally dispatches via a loopback HTTP request
@@ -218,12 +241,12 @@ async function processPendingSyncJobs() {
 
   try {
     const phpDir = path.resolve(__dirname, '../../php');
-    const { stdout, stderr } = await execAsync(
+    const { stdout } = await execAsync(
       'php process-sync-jobs.php',
       { cwd: phpDir, timeout: 120000 }
     );
 
-    const result = JSON.parse(stdout);
+    const result = parseJsonFromOutput(stdout);
     if (result.success) {
       console.log(`✅ Processed ${result.jobs_processed} sync job(s)`);
     } else {

--- a/tests/e2e/performance-sync.spec.js
+++ b/tests/e2e/performance-sync.spec.js
@@ -19,7 +19,6 @@ const {
   logTestStart,
   logTestEnd,
   validateFacebookSync,
-  processPendingSyncJobs,
   setProductTitle,
   setProductDescription,
   createTestProduct,
@@ -27,7 +26,7 @@ const {
   dismissWooInterferingOverlays
 } = require('./helpers/js');
 
-test.describe.serial('Meta for WooCommerce - Performance Sync E2E Tests', () => {
+test.describe('Meta for WooCommerce - Performance Sync E2E Tests', () => {
   test.beforeEach(async ({ page }, testInfo) => {
     logTestStart(testInfo);
     await page.setViewportSize({ width: 1280, height: 720 });
@@ -35,7 +34,7 @@ test.describe.serial('Meta for WooCommerce - Performance Sync E2E Tests', () => 
 
   const PERFORMANCE_CONFIG = {
     simpleBatch: {
-      count: 15,
+      count: Number.parseInt(process.env.PERFORMANCE_SIMPLE_BATCH_COUNT || '15', 10),
       descriptionRepeat: 15,
       price: '19.99',
       waitSeconds: 5,
@@ -191,9 +190,6 @@ test.describe.serial('Meta for WooCommerce - Performance Sync E2E Tests', () => 
     const validationAttempts = 3;
     let lastResult = null;
 
-    // Ensure queued jobs are processed in CI/single-threaded environments before validation.
-    await processPendingSyncJobs().catch(() => {});
-
     for (let attempt = 1; attempt <= validationAttempts; attempt++) {
       const result = maxRetries == null
         ? await validateFacebookSync(resolvedProductId, productName, waitSeconds)
@@ -208,9 +204,8 @@ test.describe.serial('Meta for WooCommerce - Performance Sync E2E Tests', () => 
       const syncStatus = result?.sync_status || 'unknown';
       if (attempt < validationAttempts) {
         console.warn(
-          `⚠️ Sync validator attempt ${attempt}/${validationAttempts} for product ${resolvedProductId} returned ${syncStatus}. Processing pending jobs and retrying...`
+          `⚠️ Sync validator attempt ${attempt}/${validationAttempts} for product ${resolvedProductId} returned ${syncStatus}. Retrying...`
         );
-        await processPendingSyncJobs().catch(() => {});
         await page.waitForTimeout(TIMEOUTS.NORMAL + TIMEOUTS.SHORT);
       }
     }

--- a/tests/e2e/product-batch.spec.js
+++ b/tests/e2e/product-batch.spec.js
@@ -17,7 +17,6 @@ const {
   logTestStart,
   logTestEnd,
   validateFacebookSync,
-  processPendingSyncJobs,
   generateProductFeedCSV,
   deleteFeedFile,
   generateUniqueSKU,
@@ -145,8 +144,6 @@ test.describe('Meta for WooCommerce - Product Batch Import E2E Tests', () => {
         let productValidated = false;
 
         for (let attempt = 1; attempt <= perProductAttempts; attempt++) {
-          await processPendingSyncJobs().catch(() => {});
-
           let result = null;
           try {
             result = await validateFacebookSync(productId, null, 5, 8);
@@ -575,8 +572,6 @@ test.describe('Meta for WooCommerce - Product Batch Import E2E Tests', () => {
         let productValidated = false;
 
         for (let attempt = 1; attempt <= perProductAttempts; attempt++) {
-          await processPendingSyncJobs().catch(() => {});
-
           let result = null;
           try {
             result = await validateFacebookSync(productId, null, 5, 8);

--- a/tests/e2e/product-deletion.spec.js
+++ b/tests/e2e/product-deletion.spec.js
@@ -15,7 +15,6 @@ const {
   logTestStart,
   logTestEnd,
   validateFacebookSync,
-  processPendingSyncJobs,
   createTestProduct,
   filterProducts,
   clickFirstProduct,
@@ -138,12 +137,6 @@ test.describe('Meta for WooCommerce - Product Deletion E2E Tests', () => {
       await page.waitForLoadState('networkidle', { timeout: TIMEOUTS.MAX });
       console.log('✅ Products moved to trash');
 
-      // Process the pending DELETE sync jobs directly.
-      // The background job handler dispatches via a loopback HTTP request which
-      // doesn't work on single-threaded PHP servers (like the built-in dev
-      // server used in CI), so we invoke the job handler directly via CLI.
-      await processPendingSyncJobs();
-
       const [simpleProductValidationResult, variableProductValidationResult] = await Promise.all([
         validateFacebookSync(simpleProductId, simpleProduct.productName, 30, 0),
         validateFacebookSync(variableProductId, variableProduct.productName, 30, 0)
@@ -194,10 +187,6 @@ test.describe('Meta for WooCommerce - Product Deletion E2E Tests', () => {
       const newDescription = 'This product is out of sync with Facebook';
       await setProductDescription(page, newDescription);
       await publishProduct(page);
-
-      // Process the pending DELETE sync job directly (loopback doesn't work
-      // on single-threaded PHP servers in CI).
-      await processPendingSyncJobs();
 
       const syncResultAfter = await validateFacebookSync(simpleProductId, simpleProduct.productName, 30, 0);
       expect(syncResultAfter['success']).toBe(false);
@@ -341,10 +330,6 @@ test.describe('Meta for WooCommerce - Product Deletion E2E Tests', () => {
       // Wait for the page to reload after bulk action
       await page.waitForLoadState('domcontentloaded', { timeout: TIMEOUTS.MAX });
       console.log('✅ Bulk edit completed');
-
-      // Process the pending DELETE sync jobs directly (loopback doesn't work
-      // on single-threaded PHP servers in CI).
-      await processPendingSyncJobs();
 
       // Validate that products are removed from the Facebook catalog
       console.log('🔍 Validating Facebook sync status after bulk exclusion...');

--- a/tests/e2e/variable-product-depth.spec.js
+++ b/tests/e2e/variable-product-depth.spec.js
@@ -19,14 +19,13 @@ const {
   logTestStart,
   logTestEnd,
   validateFacebookSync,
-  processPendingSyncJobs,
   execWP,
   setProductTitle,
   setProductDescription,
   dismissWooInterferingOverlays,
 } = require('./helpers/js');
 
-test.describe.serial('Variable Product Depth Tests', () => {
+test.describe('Variable Product Depth Tests', () => {
   test.beforeEach(async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== 'chromium-wp-admin', 'Variable product depth tests require wp-admin project');
 
@@ -408,7 +407,6 @@ test.describe.serial('Variable Product Depth Tests', () => {
 
     for (let attempt = 1; attempt <= attempts; attempt++) {
       await forceEnqueueVariableProductSync(productId);
-      await processPendingSyncJobs().catch(() => {});
 
       const result = await validateFacebookSync(
         productId,

--- a/tests/js/e2e-sync-helper.test.js
+++ b/tests/js/e2e-sync-helper.test.js
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const mockExecAsync = jest.fn();
+const mockExecSync = jest.fn();
+
+jest.mock("child_process", () => {
+	const { promisify } = jest.requireActual("util");
+	const exec = jest.fn();
+
+	exec[promisify.custom] = (...args) => mockExecAsync(...args);
+
+	return {
+		exec,
+		execSync: (...args) => mockExecSync(...args),
+	};
+});
+
+const PRODUCT_RESULT = {
+	success: true,
+	sync_status: "synced",
+	raw_data: {
+		facebook_data: [],
+	},
+};
+
+const UNSYNCED_PRODUCT_RESULT = {
+	success: false,
+	sync_status: "not_synced",
+	raw_data: {
+		facebook_data: [],
+	},
+};
+
+const CATEGORY_RESULT = {
+	success: true,
+	sync_status: "synced",
+	facebook_product_set_id: "set-123",
+	retailer_id: "456",
+	mismatches: [],
+	raw_data: {
+		facebook_data: {},
+	},
+};
+
+function successfulCommandResult(command) {
+	if (command.includes("process-sync-jobs.php")) {
+		return {
+			stdout: 'PHP notice before JSON\n{"success":true,"jobs_processed":1}',
+			stderr: "",
+		};
+	}
+
+	if (command.includes("FacebookSyncValidator")) {
+		return { stdout: JSON.stringify(PRODUCT_RESULT), stderr: "" };
+	}
+
+	if (command.includes("CategorySyncValidator")) {
+		return { stdout: JSON.stringify(CATEGORY_RESULT), stderr: "" };
+	}
+
+	return {
+		stdout: JSON.stringify({
+			connected: true,
+			access_token: true,
+			catalog_id: true,
+			pixel_id: true,
+		}),
+		stderr: "",
+	};
+}
+
+describe("E2E sync helper", () => {
+	let consoleLogSpy;
+	let consoleWarnSpy;
+
+	beforeEach(() => {
+		jest.resetModules();
+		mockExecAsync.mockReset();
+		mockExecSync.mockReset();
+		mockExecSync.mockReturnValue("/usr/local/bin/wp\n");
+		process.env.WORDPRESS_PATH = "/tmp/wordpress";
+		process.env.WP_CLI_PATH = "/usr/local/bin/wp";
+		delete process.env.PHP_BIN;
+		delete process.env.USE_PHP_NO_INI;
+
+		consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+		consoleWarnSpy = jest
+			.spyOn(console, "warn")
+			.mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		consoleLogSpy.mockRestore();
+		consoleWarnSpy.mockRestore();
+	});
+
+	test("drains pending jobs before product validation and preserves zero-retry arguments", async () => {
+		const commands = [];
+		mockExecAsync.mockImplementation(async (command) => {
+			commands.push(command);
+			if (command.includes("FacebookSyncValidator")) {
+				return {
+					stdout: JSON.stringify(UNSYNCED_PRODUCT_RESULT),
+					stderr: "",
+				};
+			}
+			return successfulCommandResult(command);
+		});
+
+		const {
+			validateFacebookSync,
+		} = require("../e2e/helpers/js/plugin/sync");
+		const result = await validateFacebookSync(123, "Deleted product", 0, 0);
+
+		expect(result).toEqual(UNSYNCED_PRODUCT_RESULT);
+		expect(commands[0]).toBe("php process-sync-jobs.php");
+		expect(commands[1]).toContain(
+			"get_connection_handler()->is_connected()"
+		);
+		expect(commands[2]).toContain("new FacebookSyncValidator(123, 0, 0)");
+	});
+
+	test("shares one queue drain across concurrent product and category validators", async () => {
+		const commands = [];
+		let finishDrain;
+
+		mockExecAsync.mockImplementation((command) => {
+			commands.push(command);
+
+			if (command.includes("process-sync-jobs.php")) {
+				return new Promise((resolve) => {
+					finishDrain = () =>
+						resolve(successfulCommandResult(command));
+				});
+			}
+
+			return Promise.resolve(successfulCommandResult(command));
+		});
+
+		const {
+			validateCategorySync,
+			validateFacebookSync,
+		} = require("../e2e/helpers/js/plugin/sync");
+
+		const productValidation = validateFacebookSync(123, "Product", 0, 1);
+		const categoryValidation = validateCategorySync(456, "Category", 0, 1);
+
+		expect(
+			commands.filter((command) =>
+				command.includes("process-sync-jobs.php")
+			)
+		).toHaveLength(1);
+
+		finishDrain();
+
+		await expect(productValidation).resolves.toEqual(PRODUCT_RESULT);
+		await expect(categoryValidation).resolves.toEqual(CATEGORY_RESULT);
+		expect(
+			commands.filter((command) =>
+				command.includes("process-sync-jobs.php")
+			)
+		).toHaveLength(1);
+		expect(
+			commands.some((command) =>
+				command.includes("FacebookSyncValidator")
+			)
+		).toBe(true);
+		expect(
+			commands.some((command) =>
+				command.includes("CategorySyncValidator")
+			)
+		).toBe(true);
+	});
+
+	test("continues validation when the best-effort queue drain fails", async () => {
+		const commands = [];
+		mockExecAsync.mockImplementation(async (command) => {
+			commands.push(command);
+
+			if (command.includes("process-sync-jobs.php")) {
+				throw new Error("queue drain timed out");
+			}
+
+			return successfulCommandResult(command);
+		});
+
+		const {
+			validateFacebookSync,
+		} = require("../e2e/helpers/js/plugin/sync");
+
+		await expect(
+			validateFacebookSync(789, "Product", 0, 1)
+		).resolves.toEqual(PRODUCT_RESULT);
+		expect(
+			commands.some((command) =>
+				command.includes("FacebookSyncValidator")
+			)
+		).toBe(true);
+		expect(consoleWarnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("queue drain timed out")
+		);
+	});
+});


### PR DESCRIPTION
## Description

Hardens the shared Meta catalog E2E pipeline against cross-shard contention and slow catalog propagation.

- Spreads the 12 E2E shards across three Meta test asset sets and caps each run at three active shards.
- Reserves unique WordPress product and category ID ranges per run/shard to prevent remote catalog collisions.
- Drains pending sync jobs before catalog validation and shares one drain across concurrent validators.
- Removes redundant explicit drains from callers.
- Avoids suite-wide retry replay, runs product CRUD with one worker, reduces the PR-only performance batch, and gives slower shards more appropriate timeouts.

This draft changes only test infrastructure and test code; it does not alter production behavior or user data handling.

### Type of change

- Tweak (test infrastructure reliability)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] No PHP production files are changed.
- [x] I followed general Pull Request best practices.
- [x] I added focused tests and all JavaScript unit tests pass locally.
- [ ] Full E2E validation is pending.
- [x] Documentation changes are not necessary because this affects test infrastructure only.

## Changelog entry

N/A — test infrastructure only.

## Test Plan

- [x] Run `npm run test:js -- --runInBand` (107 tests).
- [x] Run `node --check` on every changed JavaScript file.
- [x] Parse the workflow YAML and verify all 12 test/version combinations, balanced asset assignments, and unique shard indexes.
- [x] Verify the branch is one commit directly on latest `main` and its diff contains no Topics API or Privacy Sandbox changes.
- [x] Run `git diff --check origin/main...HEAD`.
- [ ] Run the full GitHub E2E matrix against the real Meta test assets.

## Screenshots

Not applicable.
