### PR TITLE
ci(e2e): stabilize product category catalog assertions

### DIFF
--- a/.github/workflows/product-creation-tests.yml
+++ b/.github/workflows/product-creation-tests.yml
@@ -132,8 +132,9 @@ jobs:
     runs-on: ubuntu-latest
     # Fail fast instead of letting a stuck step (e.g. a hung browser install) run
     # until GitHub's 6-hour default job timeout. plugin-events runs many browser
-    # projects sequentially, so it gets a larger budget.
-    timeout-minutes: ${{ matrix.test-group == 'plugin-events' && 90 || 45 }}
+    # projects sequentially, while product-category includes bounded waits for
+    # remote catalog propagation, so both receive a larger budget.
+    timeout-minutes: ${{ matrix.test-group == 'plugin-events' && 90 || matrix.test-group == 'product-category' && 90 || 45 }}
 
     strategy:
       fail-fast: false
@@ -444,10 +445,29 @@ jobs:
           ARRAY_LENGTH=$(echo "$ASSETS" | jq 'length')
           echo "Total available business asset sets: $ARRAY_LENGTH"
 
-          # Use run_number as selector - it's sequential (1, 2, 3, ...) across all workflow runs
-          # This ensures each concurrent run gets a different business asset set
-          SELECTOR="${{ github.run_number }}"
-          echo "Using GitHub Run Number as selector: $SELECTOR"
+          # Product category assertions depend on asynchronous catalog reads.
+          # Keep the supported and latest category shards away from the asset
+          # used by the rest of this workflow run, reducing unrelated catalog
+          # writes while product-set membership propagates.
+          REQUIRED_ASSET_COUNT=3
+          if [ "$ARRAY_LENGTH" -lt "$REQUIRED_ASSET_COUNT" ]; then
+            echo "::error title=E2E Assets Missing::Product category isolation requires at least $REQUIRED_ASSET_COUNT asset sets, found $ARRAY_LENGTH."
+            exit 1
+          fi
+
+          # Rotate the base asset between workflow runs and reruns. Category
+          # shards receive separate offsets so all three lanes are distinct.
+          SELECTOR=$(( ${{ github.run_number }} + ${{ github.run_attempt }} - 1 ))
+          ASSET_OFFSET=0
+          if [ "${{ matrix.test-group }}" = "product-category" ]; then
+            if [ "${{ matrix.version-set }}" = "supported" ]; then
+              ASSET_OFFSET=1
+            else
+              ASSET_OFFSET=2
+            fi
+          fi
+          SELECTOR=$((SELECTOR + ASSET_OFFSET))
+          echo "Using asset selector $SELECTOR (offset $ASSET_OFFSET)"
 
           # Calculate index using modulo
           INDEX=$((SELECTOR % ARRAY_LENGTH))

--- a/tests/e2e/helpers/js/index.js
+++ b/tests/e2e/helpers/js/index.js
@@ -71,6 +71,8 @@ const {
 // =============================================================================
 const {
   validateFacebookSync,
+  hasProductSetMembership,
+  waitForProductSetMembership,
   processPendingSyncJobs,
   validateCategorySync
 } = require('./plugin/sync');
@@ -239,6 +241,8 @@ const categories = {
 
 const facebook = {
   validateFacebookSync,
+  hasProductSetMembership,
+  waitForProductSetMembership,
   processPendingSyncJobs,
   validateCategorySync,
   getConnectionStatus,
@@ -367,6 +371,8 @@ module.exports = {
 
   // Facebook - Sync
   validateFacebookSync,
+  hasProductSetMembership,
+  waitForProductSetMembership,
   processPendingSyncJobs,
   validateCategorySync,
 

--- a/tests/e2e/helpers/js/plugin/sync.js
+++ b/tests/e2e/helpers/js/plugin/sync.js
@@ -16,6 +16,7 @@ const path = require('path');
 const execAsync = promisify(exec);
 
 let connectionPreflightChecked = false;
+let pendingSyncDrainPromise = null;
 
 async function ensureFacebookConnectionConfigured() {
   if (connectionPreflightChecked) {
@@ -149,6 +150,152 @@ async function validateFacebookSync(productId, productName, waitSeconds = 10, ma
 }
 
 /**
+ * Check whether any synced item belongs to the expected category-backed set.
+ *
+ * Variable products return one Facebook item per variation, so membership is
+ * satisfied when at least one returned item has the expected set.
+ *
+ * @param {Object} result - Product sync validation result
+ * @param {number|string} productSetRetailerId - Category term taxonomy ID
+ * @param {number|string|null} facebookProductSetId - Facebook product set ID
+ * @returns {'present'|'absent'|'unknown'} Observed membership state
+ */
+function getProductSetMembershipState(result, productSetRetailerId, facebookProductSetId = null) {
+  const facebookProducts = result?.raw_data?.facebook_data;
+  if (!Array.isArray(facebookProducts) || facebookProducts.length === 0) {
+    return 'unknown';
+  }
+
+  let allMembershipDataInspectable = true;
+  for (const product of facebookProducts) {
+    const productSets = product?.product_sets;
+    if (!Array.isArray(productSets)) {
+      allMembershipDataInspectable = false;
+      continue;
+    }
+
+    const membershipFound = productSets.some(productSet => {
+      const categoryMatches = String(productSet?.retailer_id) === String(productSetRetailerId);
+      const productSetMatches = facebookProductSetId === null
+        || String(productSet?.id) === String(facebookProductSetId);
+
+      return categoryMatches && productSetMatches;
+    });
+
+    if (membershipFound) {
+      return 'present';
+    }
+  }
+
+  return allMembershipDataInspectable ? 'absent' : 'unknown';
+}
+
+/**
+ * Check whether any synced item belongs to the expected category-backed set.
+ *
+ * @param {Object} result - Product sync validation result
+ * @param {number|string} productSetRetailerId - Category term taxonomy ID
+ * @param {number|string|null} facebookProductSetId - Facebook product set ID
+ * @returns {boolean} Whether the expected membership exists
+ */
+function hasProductSetMembership(result, productSetRetailerId, facebookProductSetId = null) {
+  return getProductSetMembershipState(result, productSetRetailerId, facebookProductSetId) === 'present';
+}
+
+/**
+ * Wait for a synced product to gain or lose a category-backed product set.
+ *
+ * Meta catalog writes are asynchronous. Poll the exact state the category
+ * tests assert instead of retrying the entire browser test or relying on a
+ * fixed sleep. Each probe performs one remote read so the interval controls
+ * the request rate and the total wait remains bounded.
+ *
+ * @param {Object} options - Product identity, expected set, and polling options
+ * @returns {Promise<Object>} Last successful product validation result
+ */
+async function waitForProductSetMembership({
+  productId,
+  productName,
+  productSetRetailerId,
+  facebookProductSetId = null,
+  expectedMembership = true,
+  timeoutMs = 360000,
+  pollIntervalMs = 20000,
+  drainPendingJobs = drainPendingSyncJobs,
+  validateProduct = validateFacebookSync,
+  wait = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds)),
+  now = Date.now,
+}) {
+  const drainResult = await drainPendingJobs();
+  if (!drainResult?.success) {
+    throw new Error(
+      `Failed to process pending sync jobs before validating product ${productId}: ${drainResult?.error || drainResult?.message || 'unknown error'}`
+    );
+  }
+
+  const deadline = now() + timeoutMs;
+  const expectedState = expectedMembership ? 'present' : 'absent';
+  let attempt = 0;
+  let lastResult = null;
+  let membershipState = 'unknown';
+
+  do {
+    attempt++;
+    lastResult = await validateProduct(productId, productName, 0, 1);
+    membershipState = getProductSetMembershipState(
+      lastResult,
+      productSetRetailerId,
+      facebookProductSetId
+    );
+
+    if (lastResult?.success && membershipState === expectedState) {
+      console.log(
+        `✅ Product ${productId} reached expected product set membership after ${attempt} attempt(s)`
+      );
+      return lastResult;
+    }
+
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0) {
+      break;
+    }
+
+    console.log(
+      `⏳ Product ${productId} is not yet ${expectedMembership ? 'in' : 'out of'} category set ${productSetRetailerId}; retrying...`
+    );
+    await wait(Math.min(pollIntervalMs, remainingMs));
+  } while (now() < deadline);
+
+  const syncStatus = lastResult?.sync_status ?? 'unavailable';
+  throw new Error(
+    `Timed out waiting for product ${productId} to be synced ${expectedMembership ? 'with' : 'without'} category set ${productSetRetailerId}. Last sync status: ${syncStatus}; membership state: ${membershipState}.`
+  );
+}
+
+/**
+ * Drain pending sync jobs once for concurrent catalog validators.
+ *
+ * Product category tests often validate multiple products with Promise.all().
+ * Reuse the same in-flight drain so the validators do not process the local
+ * queue concurrently. A later validation phase starts a fresh drain because a
+ * product or category mutation may have enqueued more work.
+ *
+ * @param {Function} processJobs - Queue processor override for tests
+ * @returns {Promise<Object>} Processing result
+ */
+async function drainPendingSyncJobs(processJobs = processPendingSyncJobs) {
+  if (!pendingSyncDrainPromise) {
+    pendingSyncDrainPromise = Promise.resolve()
+      .then(() => processJobs())
+      .finally(() => {
+        pendingSyncDrainPromise = null;
+      });
+  }
+
+  return pendingSyncDrainPromise;
+}
+
+/**
  * Validate category sync to Facebook product set
  * @param {number} categoryId - Category ID to validate
  * @param {string} categoryName - Category name for display
@@ -218,12 +365,12 @@ async function processPendingSyncJobs() {
 
   try {
     const phpDir = path.resolve(__dirname, '../../php');
-    const { stdout, stderr } = await execAsync(
+    const { stdout } = await execAsync(
       'php process-sync-jobs.php',
       { cwd: phpDir, timeout: 120000 }
     );
 
-    const result = JSON.parse(stdout);
+    const result = parseJsonFromOutput(stdout);
     if (result.success) {
       console.log(`✅ Processed ${result.jobs_processed} sync job(s)`);
     } else {
@@ -239,6 +386,10 @@ async function processPendingSyncJobs() {
 
 module.exports = {
   validateFacebookSync,
+  getProductSetMembershipState,
+  hasProductSetMembership,
+  waitForProductSetMembership,
+  drainPendingSyncJobs,
   processPendingSyncJobs,
   validateCategorySync
 };

--- a/tests/e2e/product-category.spec.js
+++ b/tests/e2e/product-category.spec.js
@@ -14,7 +14,8 @@ const {
     generateUniqueSKU,
     logTestStart,
     logTestEnd,
-    validateFacebookSync,
+    hasProductSetMembership,
+    waitForProductSetMembership,
     validateCategorySync,
     createTestProduct,
     createTestCategory,
@@ -23,6 +24,11 @@ const {
 } = require('./helpers/js');
 
 test.describe('Meta for WooCommerce - Product Category E2E Tests', () => {
+
+    test.describe.configure({
+        retries: 1,
+        timeout: 20 * 60 * 1000
+    });
 
     test.beforeEach(async ({ page }, testInfo) => {
         // Log test start first for proper chronological order
@@ -142,34 +148,41 @@ test.describe('Meta for WooCommerce - Product Category E2E Tests', () => {
 
             // Validate that the category has been synced as a set
             // verify that the products are still synced and belong to the category
-            const [product1Result, product2Result, categoryResult] = await Promise.all([
-                validateFacebookSync(product1Id, product1.productName, 5),
-                validateFacebookSync(product2Id, product2.productName, 5, 8),
-                validateCategorySync(categoryId, categoryName, 30)
-            ]);
-
+            const categoryResult = await validateCategorySync(categoryId, categoryName, 30);
             expect(categoryResult['success']).toBe(true);
             console.log(categoryResult['raw_data']['facebook_data']);
             console.log('✅ Category sync validated');
+
+            const productSetRetailerId = categoryResult['retailer_id'];
+            const facebookProductSetId = categoryResult['facebook_product_set_id'];
+            const [product1Result, product2Result] = await Promise.all([
+                waitForProductSetMembership({
+                    productId: product1Id,
+                    productName: product1.productName,
+                    productSetRetailerId,
+                    facebookProductSetId
+                }),
+                waitForProductSetMembership({
+                    productId: product2Id,
+                    productName: product2.productName,
+                    productSetRetailerId,
+                    facebookProductSetId
+                })
+            ]);
+
             expect(product1Result['success']).toBe(true);
-            console.log(product1Result['raw_data']['facebook_data'][0]['product_sets']);
-            const isProduct1InCorrectProductSet = product1Result['raw_data']['facebook_data'][0]['product_sets'].some(
-                set => {
-                    return Number(categoryId) === Number(set.retailer_id) && Number(set.id) === Number(categoryResult['facebook_product_set_id'])
-                }
+            const isProduct1InCorrectProductSet = hasProductSetMembership(
+                product1Result,
+                productSetRetailerId,
+                facebookProductSetId
             );
             expect(isProduct1InCorrectProductSet).toBe(true);
             console.log('✅ Product 1 sync validated');
             expect(product2Result['success']).toBe(true);
-            const isProduct2InCorrectProductSet = product2Result['raw_data']['facebook_data'].some(
-                product => {
-                    return product['product_sets'].some(
-                        set => {
-                            console.log(set);
-                            return Number(categoryId) === Number(set.retailer_id) && Number(set.id) === Number(categoryResult['facebook_product_set_id'])
-                        }
-                    )
-                }
+            const isProduct2InCorrectProductSet = hasProductSetMembership(
+                product2Result,
+                productSetRetailerId,
+                facebookProductSetId
             );
             expect(isProduct2InCorrectProductSet).toBe(true);
             console.log('✅ Product 2 sync validated');
@@ -233,13 +246,21 @@ test.describe('Meta for WooCommerce - Product Category E2E Tests', () => {
 
             // Store the Facebook product set ID for later verification
             const facebookProductSetId = initialCategoryResult['facebook_product_set_id'];
+            const productSetRetailerId = initialCategoryResult['retailer_id'];
             console.log(`📊 Facebook Product Set ID: ${facebookProductSetId}`);
 
             // Validate product 1 is in the category
-            const product1InitialResult = await validateFacebookSync(product1Id, product1.productName, 30);
+            const product1InitialResult = await waitForProductSetMembership({
+                productId: product1Id,
+                productName: product1.productName,
+                productSetRetailerId,
+                facebookProductSetId
+            });
             expect(product1InitialResult['success']).toBe(true);
-            const isProduct1InInitialSet = product1InitialResult['raw_data']['facebook_data'][0]['product_sets'].some(
-                set => Number(categoryId) === Number(set.retailer_id) && Number(set.id) === Number(facebookProductSetId)
+            const isProduct1InInitialSet = hasProductSetMembership(
+                product1InitialResult,
+                productSetRetailerId,
+                facebookProductSetId
             );
             expect(isProduct1InInitialSet).toBe(true);
             console.log('✅ Product 1 validated in category product set');
@@ -287,67 +308,65 @@ test.describe('Meta for WooCommerce - Product Category E2E Tests', () => {
             product2Id = product2.productId;
 
             // Step 6: Validate the name change synced to Facebook AND both products are in the category
-            // Retry the entire validation block because Facebook API propagation timing
-            // can cause transient failures for name updates and product_set membership.
             console.log('🔍 Step 6: Validating category name change synced to Facebook...');
-            let updateValidationPassed = false;
-            let lastUpdateError = null;
+            let updatedCategoryResult = null;
             for (let attempt = 1; attempt <= 3; attempt++) {
-                try {
-                    const updatedCategoryResult = await validateCategorySync(categoryId, updatedCategoryName, attempt === 1 ? 30 : 15);
+                updatedCategoryResult = await validateCategorySync(
+                    categoryId,
+                    updatedCategoryName,
+                    attempt === 1 ? 30 : 15
+                );
+                const facebookCategoryName = updatedCategoryResult?.['raw_data']?.['facebook_data']?.['name'];
+                const categoryIsUpdated = updatedCategoryResult?.['success']
+                    && String(updatedCategoryResult['facebook_product_set_id']) === String(facebookProductSetId)
+                    && facebookCategoryName === updatedCategoryName;
 
-                    // Verify category sync with updated name
-                    expect(updatedCategoryResult['success']).toBe(true);
-                    console.log('📊 Updated Category Facebook data:');
-                    console.log(updatedCategoryResult['raw_data']['facebook_data']);
-                    console.log('✅ Updated category name sync validated');
-
-                    // Verify the product set ID remains the same
-                    expect(updatedCategoryResult['facebook_product_set_id']).toBe(facebookProductSetId);
-                    console.log('✅ Verified product set ID remained consistent after name change');
-
-                    // Verify the name is updated in Facebook
-                    const facebookCategoryName = updatedCategoryResult['raw_data']['facebook_data']['name'];
-                    expect(facebookCategoryName).toBe(updatedCategoryName);
-                    console.log(`✅ Verified category name updated in Facebook: "${facebookCategoryName}"`);
-
-                    // Verify both products are in the updated category
-                    console.log('🔍 Verifying both products are in the updated category...');
-                    const [finalProduct1Result, finalProduct2Result] = await Promise.all([
-                        validateFacebookSync(product1Id, product1.productName, 30),
-                        validateFacebookSync(product2Id, product2.productName, 30)
-                    ]);
-
-                    // Verify product 1 is still in the category
-                    expect(finalProduct1Result['success']).toBe(true);
-                    const isProduct1InSet = finalProduct1Result['raw_data']['facebook_data'][0]['product_sets'].some(
-                        set => {
-                            return Number(categoryId) === Number(set.retailer_id) && Number(set.id) === Number(facebookProductSetId)
-                        }
-                    );
-                    expect(isProduct1InSet).toBe(true);
-                    console.log('✅ Product 1 still in the updated category');
-
-                    // Verify product 2 is in the category
-                    expect(finalProduct2Result['success']).toBe(true);
-                    const isProduct2InSet = finalProduct2Result['raw_data']['facebook_data'][0]['product_sets'].some(
-                        set => {
-                            return Number(categoryId) === Number(set.retailer_id) && Number(set.id) === Number(facebookProductSetId)
-                        }
-                    );
-                    expect(isProduct2InSet).toBe(true);
-                    console.log('✅ Product 2 is now in the updated category');
-
-                    updateValidationPassed = true;
+                if (categoryIsUpdated) {
                     break;
-                } catch (e) {
-                    lastUpdateError = e;
-                    if (attempt < 3) {
-                        console.log(`⚠️ Update validation attempt ${attempt}/3 failed: ${e.message}. Retrying...`);
-                    }
+                }
+
+                if (attempt < 3) {
+                    console.log(`⚠️ Category update validation attempt ${attempt}/3 was not yet consistent. Retrying...`);
                 }
             }
-            if (!updateValidationPassed) throw lastUpdateError;
+
+            expect(updatedCategoryResult).not.toBeNull();
+            expect(updatedCategoryResult['success']).toBe(true);
+            console.log('📊 Updated Category Facebook data:');
+            console.log(updatedCategoryResult['raw_data']['facebook_data']);
+            console.log('✅ Updated category name sync validated');
+
+            expect(updatedCategoryResult['facebook_product_set_id']).toBe(facebookProductSetId);
+            console.log('✅ Verified product set ID remained consistent after name change');
+
+            const facebookCategoryName = updatedCategoryResult['raw_data']['facebook_data']['name'];
+            expect(facebookCategoryName).toBe(updatedCategoryName);
+            console.log(`✅ Verified category name updated in Facebook: "${facebookCategoryName}"`);
+
+            console.log('🔍 Verifying both products are in the updated category...');
+            const [finalProduct1Result, finalProduct2Result] = await Promise.all([
+                waitForProductSetMembership({
+                    productId: product1Id,
+                    productName: product1.productName,
+                    productSetRetailerId,
+                    facebookProductSetId
+                }),
+                waitForProductSetMembership({
+                    productId: product2Id,
+                    productName: product2.productName,
+                    productSetRetailerId,
+                    facebookProductSetId
+                })
+            ]);
+
+            expect(finalProduct1Result['success']).toBe(true);
+            expect(hasProductSetMembership(finalProduct1Result, productSetRetailerId, facebookProductSetId)).toBe(true);
+            console.log('✅ Product 1 still in the updated category');
+
+            expect(finalProduct2Result['success']).toBe(true);
+            expect(hasProductSetMembership(finalProduct2Result, productSetRetailerId, facebookProductSetId)).toBe(true);
+            console.log('✅ Product 2 is now in the updated category');
+
             logTestEnd(testInfo, true);
         } catch (error) {
             console.log(`⚠️ Update category test failed: ${error.message}`);
@@ -403,25 +422,18 @@ test.describe('Meta for WooCommerce - Product Category E2E Tests', () => {
             console.log('✅ Initial category sync validated');
 
             const facebookProductSetId = initialCategoryResult['facebook_product_set_id'];
+            const productSetRetailerId = initialCategoryResult['retailer_id'];
             console.log(`📊 Facebook Product Set ID: ${facebookProductSetId}`);
 
             // Validate product is in the category
-            let initialProductResult;
-            let isProductInInitialSet = false;
-            for (let attempt = 1; attempt <= 3; attempt++) {
-                initialProductResult = await validateFacebookSync(productId, product.productName, attempt === 1 ? 30 : 15);
-                if (initialProductResult && initialProductResult['success']) {
-                    isProductInInitialSet = initialProductResult['raw_data']['facebook_data'][0]['product_sets'].some(
-                        set => Number(categoryId) === Number(set.retailer_id)
-                    );
-                    if (isProductInInitialSet) break;
-                }
-                if (attempt < 3) {
-                    console.log(`⚠️ Product-in-set check attempt ${attempt}/3 not yet consistent, retrying...`);
-                }
-            }
+            const initialProductResult = await waitForProductSetMembership({
+                productId,
+                productName: product.productName,
+                productSetRetailerId,
+                facebookProductSetId
+            });
             expect(initialProductResult['success']).toBe(true);
-            expect(isProductInInitialSet).toBe(true);
+            expect(hasProductSetMembership(initialProductResult, productSetRetailerId, facebookProductSetId)).toBe(true);
             console.log('✅ Product validated in category product set');
 
             // Step 4: Delete the test category via UI
@@ -464,12 +476,20 @@ test.describe('Meta for WooCommerce - Product Category E2E Tests', () => {
 
             // Step 6: Check the product no longer belongs to the category/product set
             console.log('🔍 Step 6: Verifying product no longer belongs to the category...');
-            const finalProductResult = await validateFacebookSync(productId, product.productName, 5);
+            const finalProductResult = await waitForProductSetMembership({
+                productId,
+                productName: product.productName,
+                productSetRetailerId,
+                facebookProductSetId,
+                expectedMembership: false
+            });
             expect(finalProductResult['success']).toBe(true);
 
             // Check if product still has the deleted category in its product sets
-            const isProductStillInSet = finalProductResult['raw_data']['facebook_data'][0]['product_sets'].some(
-                set => Number(categoryId) === Number(set.retailer_id)
+            const isProductStillInSet = hasProductSetMembership(
+                finalProductResult,
+                productSetRetailerId,
+                facebookProductSetId
             );
             expect(isProductStillInSet).toBe(false);
             console.log('✅ Verified product no longer belongs to the deleted category');

--- a/tests/js/e2e-product-set-sync-helper.test.js
+++ b/tests/js/e2e-product-set-sync-helper.test.js
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const {
+	drainPendingSyncJobs,
+	getProductSetMembershipState,
+	hasProductSetMembership,
+	waitForProductSetMembership,
+} = require("../e2e/helpers/js/plugin/sync");
+
+function createSyncResult({ success = true, productSets = [] } = {}) {
+	return {
+		success,
+		sync_status: success ? "synced" : "not_synced",
+		raw_data: {
+			facebook_data: productSets.map((sets) => ({
+				product_sets: sets,
+			})),
+		},
+	};
+}
+
+describe("E2E product set sync helper", () => {
+	let consoleLogSpy;
+
+	beforeEach(() => {
+		consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		consoleLogSpy.mockRestore();
+	});
+
+	test("matches category retailer and product set IDs across product variations", () => {
+		const result = createSyncResult({
+			productSets: [
+				[],
+				[
+					{
+						id: "987654321098765432",
+						retailer_id: "1234",
+					},
+				],
+			],
+		});
+
+		expect(
+			hasProductSetMembership(result, 1234, "987654321098765432")
+		).toBe(true);
+		expect(
+			hasProductSetMembership(result, 1234, "987654321098765433")
+		).toBe(false);
+	});
+
+	test("treats incomplete Facebook product set data as unknown", () => {
+		const result = {
+			success: true,
+			raw_data: {
+				facebook_data: [{}],
+			},
+		};
+
+		expect(getProductSetMembershipState(result, 42, "set-1")).toBe(
+			"unknown"
+		);
+	});
+
+	test("polls until the product is synced into the expected set", async () => {
+		const drainPendingJobs = jest.fn().mockResolvedValue({ success: true });
+		const validateProduct = jest
+			.fn()
+			.mockResolvedValueOnce(createSyncResult({ success: false }))
+			.mockResolvedValueOnce(createSyncResult({ productSets: [[]] }))
+			.mockResolvedValueOnce(
+				createSyncResult({
+					productSets: [[{ id: "set-1", retailer_id: "42" }]],
+				})
+			);
+		let currentTime = 0;
+		const wait = jest.fn(async (milliseconds) => {
+			currentTime += milliseconds;
+		});
+
+		const result = await waitForProductSetMembership({
+			productId: 100,
+			productName: "Test product",
+			productSetRetailerId: 42,
+			facebookProductSetId: "set-1",
+			timeoutMs: 100,
+			pollIntervalMs: 10,
+			drainPendingJobs,
+			validateProduct,
+			wait,
+			now: () => currentTime,
+		});
+
+		expect(result.success).toBe(true);
+		expect(drainPendingJobs).toHaveBeenCalledTimes(1);
+		expect(validateProduct).toHaveBeenCalledTimes(3);
+		expect(wait).toHaveBeenCalledTimes(2);
+	});
+
+	test("does not accept missing membership until the product itself is synced", async () => {
+		const drainPendingJobs = jest.fn().mockResolvedValue({ success: true });
+		const validateProduct = jest
+			.fn()
+			.mockResolvedValueOnce(createSyncResult({ success: false }))
+			.mockResolvedValueOnce(
+				createSyncResult({
+					productSets: [[{ id: "set-1", retailer_id: "42" }]],
+				})
+			)
+			.mockResolvedValueOnce(createSyncResult({ productSets: [[]] }));
+		let currentTime = 0;
+
+		const result = await waitForProductSetMembership({
+			productId: 100,
+			productName: "Test product",
+			productSetRetailerId: 42,
+			facebookProductSetId: "set-1",
+			expectedMembership: false,
+			timeoutMs: 100,
+			pollIntervalMs: 10,
+			drainPendingJobs,
+			validateProduct,
+			wait: async (milliseconds) => {
+				currentTime += milliseconds;
+			},
+			now: () => currentTime,
+		});
+
+		expect(result.success).toBe(true);
+		expect(validateProduct).toHaveBeenCalledTimes(3);
+	});
+
+	test("fails with the last observed state when the deadline expires", async () => {
+		const drainPendingJobs = jest.fn().mockResolvedValue({ success: true });
+		const validateProduct = jest
+			.fn()
+			.mockResolvedValue(createSyncResult({ success: false }));
+		let currentTime = 0;
+
+		await expect(
+			waitForProductSetMembership({
+				productId: 100,
+				productName: "Test product",
+				productSetRetailerId: 42,
+				facebookProductSetId: "set-1",
+				timeoutMs: 10,
+				pollIntervalMs: 10,
+				drainPendingJobs,
+				validateProduct,
+				wait: async (milliseconds) => {
+					currentTime += milliseconds;
+				},
+				now: () => currentTime,
+			})
+		).rejects.toThrow(
+			"Last sync status: not_synced; membership state: unknown"
+		);
+		expect(validateProduct).toHaveBeenCalledTimes(1);
+	});
+
+	test("fails before remote validation when the local queue cannot drain", async () => {
+		const validateProduct = jest.fn();
+
+		await expect(
+			waitForProductSetMembership({
+				productId: 100,
+				productName: "Test product",
+				productSetRetailerId: 42,
+				facebookProductSetId: "set-1",
+				drainPendingJobs: jest.fn().mockResolvedValue({
+					success: false,
+					error: "queue failed",
+				}),
+				validateProduct,
+			})
+		).rejects.toThrow("queue failed");
+		expect(validateProduct).not.toHaveBeenCalled();
+	});
+
+	test("shares concurrent queue drains and starts a fresh sequential drain", async () => {
+		let finishDrain;
+		const processJobs = jest.fn(
+			() =>
+				new Promise((resolve) => {
+					finishDrain = resolve;
+				})
+		);
+
+		const firstDrain = drainPendingSyncJobs(processJobs);
+		const secondDrain = drainPendingSyncJobs(processJobs);
+
+		await Promise.resolve();
+		expect(processJobs).toHaveBeenCalledTimes(1);
+		finishDrain({ success: true });
+		await expect(firstDrain).resolves.toEqual({ success: true });
+		await expect(secondDrain).resolves.toEqual({ success: true });
+
+		processJobs.mockResolvedValueOnce({ success: true });
+		await expect(drainPendingSyncJobs(processJobs)).resolves.toEqual({
+			success: true,
+		});
+		expect(processJobs).toHaveBeenCalledTimes(2);
+	});
+});


### PR DESCRIPTION
## Description

Stabilizes the `product-category` E2E shards after catalog writes were accepted but related products remained temporarily unavailable, or exposed stale product-set membership, during validation.

- Drains pending WooCommerce product-sync jobs before remote validation and shares one in-flight drain across concurrent product checks.
- Polls the exact expected state: the product must be fully synced and must contain, or no longer contain, the category's exact Meta product set.
- Uses the category `term_taxonomy_id` retailer ID and compares Meta IDs as strings to avoid unsafe integer coercion.
- Treats missing or malformed membership data as unknown, preventing category-deletion tests from passing when the product itself disappeared.
- Gives the supported and latest category shards separate Meta asset lanes within a workflow run and rotates the selected lanes on reruns.
- Replaces repeated whole-test replay with bounded condition polling, one Playwright retry, and an explicit job timeout.

This changes test infrastructure only. It does not modify plugin runtime behavior, WordPress user data, or database migrations.

### Type of change

- Fix (E2E test reliability)

## Checklist

- [x] I have commented the non-obvious synchronization behavior.
- [x] No production PHP files are changed.
- [x] No user-data processing or database migration behavior is changed.
- [x] I followed general Pull Request best practices.
- [x] I added focused JavaScript tests and all JavaScript tests pass locally.
- [ ] Full E2E validation against the shared Meta test assets is pending.
- [x] Documentation changes are not necessary because this affects test infrastructure only.

## Changelog entry

N/A — test infrastructure only.

## Test Plan

- [x] Run the complete JavaScript suite: 111 tests passed.
- [x] Run `node --check` on every changed JavaScript file.
- [x] Parse `.github/workflows/product-creation-tests.yml` as YAML.
- [x] Verify the three asset selectors remain distinct for the base, currently-supported category, and latest category lanes, including reruns.
- [x] Run `git diff --check`.
- [ ] Run both GitHub `product-category` E2E shards against the real Meta test assets.

### Expected CI behavior

Expected to pass:

- `E2E Tests - Currently supported - product-category`
- `E2E Tests - Latest - product-category`
- JavaScript unit tests and static validation checks

Expected failure behavior:

- If the local sync queue cannot be processed, the test fails immediately instead of polling unsent data.
- If a product never reaches the exact expected product-set state, the test fails after the bounded polling deadline.
- A missing product or incomplete `product_sets` response does not satisfy the category-deletion assertion.

Asset separation is intentionally scoped to contention within one workflow run. Concurrent workflow runs may still share the finite asset pool; exact state polling and unique generated fixtures remain the correctness safeguards in that case.

## Screenshots

Not applicable.
