### PR TITLE
ci(e2e): report every browser project instead of aborting on the first failure

### DIFF
--- a/.github/workflows/product-creation-tests.yml
+++ b/.github/workflows/product-creation-tests.yml
@@ -827,19 +827,55 @@ jobs:
           FIREFOX_EXECUTABLE_PATH: ''
         run: |
           cd ${{ env.PLUGIN_PATH }}
-          npx playwright test plugin-level-tests.spec.js --project=chromium-wp-admin --workers=1
-          xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=chromium-wp-customer --workers=1
-          xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=chromium-wp-customer-classic-theme --workers=1
-          xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=chromium-wp-customer-block-theme --workers=1
-          xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=chromium-privacy-sandbox-wp-customer --workers=1
+
+          # This step runs a dozen browser projects back to back. The step shell is
+          # `bash -e`, so the first non-zero exit used to abort everything after it:
+          # a single failing project silently skipped the remaining projects and
+          # reported them as neither passed nor failed. Collect failures instead and
+          # fail once at the end, so every project always reports its own result.
+          set +e
+          failed_projects=()
+
+          note_rc() {  # note_rc <exit-code> <label>
+            if [ "$1" -eq 0 ]; then
+              echo "✅ passed: $2"
+            else
+              echo "❌ failed: $2 (exit $1)"
+              failed_projects+=("$2")
+            fi
+          }
+
+          run_project() {  # run_project <label> <command...>
+            local label="$1"
+            shift
+            echo "::group::E2E project: ${label}"
+            "$@"
+            local rc=$?
+            echo "::endgroup::"
+            note_rc "$rc" "${label}"
+            return 0
+          }
+
+          run_project "plugin-level-tests (chromium-wp-admin)" \
+            npx playwright test plugin-level-tests.spec.js --project=chromium-wp-admin --workers=1
+          run_project "events (chromium-wp-customer)" \
+            xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=chromium-wp-customer --workers=1
+          run_project "events (chromium-wp-customer-classic-theme)" \
+            xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=chromium-wp-customer-classic-theme --workers=1
+          run_project "events (chromium-wp-customer-block-theme)" \
+            xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=chromium-wp-customer-block-theme --workers=1
+          run_project "events (chromium-privacy-sandbox-wp-customer)" \
+            xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=chromium-privacy-sandbox-wp-customer --workers=1
 
           # Ensure Privacy Sandbox API tests are executed (not skipped) in CI.
-          xvfb-run --auto-servernum npx playwright test events-test.spec.js \
-            --headed \
-            --project=chromium-privacy-sandbox-wp-customer \
-            --workers=1 \
-            --grep "Privacy Sandbox - (Topics API available in Chromium|Protected Audience API shape in Chromium)" \
-            --reporter=json > /tmp/privacy-sandbox-api-report.json
+          run_project "privacy-sandbox API report" bash -c '
+            xvfb-run --auto-servernum npx playwright test events-test.spec.js \
+              --headed \
+              --project=chromium-privacy-sandbox-wp-customer \
+              --workers=1 \
+              --grep "Privacy Sandbox - (Topics API available in Chromium|Protected Audience API shape in Chromium)" \
+              --reporter=json > /tmp/privacy-sandbox-api-report.json
+          '
 
           # Diagnostic probe: verify APIs are exposed in the privacy-sandbox browser runtime.
           node - <<'NODE'
@@ -881,6 +917,7 @@ jobs:
             process.exit(1);
           });
           NODE
+          note_rc $? "privacy-sandbox capability probe"
 
           node - <<'NODE'
           const fs = require('fs');
@@ -945,14 +982,29 @@ jobs:
 
           console.log('Privacy Sandbox API tests executed without skips. Statuses:', statuses);
           NODE
+          note_rc $? "privacy-sandbox no-skip gate"
 
-          xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=edge-wp-customer --workers=1
-          xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=firefox-wp-customer --workers=1
-          xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=brave-wp-customer --workers=1
-          npx playwright test events-test.spec.js --project=android-pixel-wp-customer --workers=1
-          npx playwright test events-test.spec.js --project=safari-ios-wp-customer --workers=1
-          set -o pipefail
-          xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=opera-wp-customer --workers=1 2>&1 | tee /tmp/opera-playwright.log
+          run_project "events (edge-wp-customer)" \
+            xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=edge-wp-customer --workers=1
+          run_project "events (firefox-wp-customer)" \
+            xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=firefox-wp-customer --workers=1
+          run_project "events (brave-wp-customer)" \
+            xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=brave-wp-customer --workers=1
+          run_project "events (android-pixel-wp-customer)" \
+            npx playwright test events-test.spec.js --project=android-pixel-wp-customer --workers=1
+          run_project "events (safari-ios-wp-customer)" \
+            npx playwright test events-test.spec.js --project=safari-ios-wp-customer --workers=1
+          run_project "events (opera-wp-customer)" bash -c '
+            set -o pipefail
+            xvfb-run --auto-servernum npx playwright test events-test.spec.js --headed --project=opera-wp-customer --workers=1 2>&1 | tee /tmp/opera-playwright.log
+          '
+
+          if [ "${#failed_projects[@]}" -ne 0 ]; then
+            echo "::error::${#failed_projects[@]} E2E project run(s) failed in this shard:"
+            printf '::error::  - %s\n' "${failed_projects[@]}"
+            exit 1
+          fi
+          echo "All E2E project runs in this shard passed."
 
       - name: Dump Opera diagnostics (always)
         if: always() && matrix.test-group == 'plugin-events'


### PR DESCRIPTION
## Description

The `Run Plugin & Events tests` step runs **twelve** browser projects back to back in a single `run:` block. GitHub executes step scripts with `shell: /usr/bin/bash -e`, so the **first non-zero exit aborted the whole step** and every project after it was silently skipped — reported as neither passed nor failed.

This is not hypothetical:

| Where | First failing invocation | Projects silently skipped |
|---|---|---|
| `main` (nightly, 08-28 → 08-31) | #5 `chromium-privacy-sandbox` (obsolete Topics API test) | edge, firefox, brave, android-pixel, safari-ios, opera |
| PR #4014 (08-26) | #1 `plugin-level-tests` (flaky Select2 locator) | **all 11** `events-test` project runs |

So since 2026-08-27 the nightly job has not executed roughly half of the browser coverage it claims to run, and nothing in the CI output says so.

This change collects per-project results and fails **once at the end**, listing exactly which projects failed. A single flaky project can no longer erase the rest of the shard's coverage.

### Type of change

- Fix (non-breaking change which fixes an issue)

## Notes for the reviewer

- **No test, assertion, or product code changes.** Only the step's error handling.
- The step still exits non-zero whenever any project fails — this does not make CI more permissive.
- `set +e` is scoped to after the `cd`, so a failed `cd` still aborts immediately.
- The two `node` gates (capability probe and no-skip gate) are captured explicitly via `note_rc $?`, since heredocs can't route through the `run_project` wrapper.
- The opera invocation keeps its `set -o pipefail` inside the wrapped subshell, so `tee` cannot mask a failure.
- **Expect this to surface previously-hidden failures.** That is the point, but the first run may look worse than before because projects that were being skipped will now report honestly.
- **Related:** this guarantees the full tail runs on every job. Observed full-step durations are 68–76m against the `timeout-minutes: 90` cap, so the headroom is now thinner. If a run hits the cap, the follow-up is a timeout bump — deliberately not bundled here.
- **Independent of #4016.** Both are cut against `main` and both touch this step, so whichever lands second needs a trivial rebase. #4016 removes the Topics test that is currently the trigger on `main`; this PR makes any such trigger stop hiding the projects behind it.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] No PHP files are changed.
- [x] I followed general Pull Request best practices.
- [x] All existing JavaScript unit tests pass locally.
- [x] Documentation changes are not necessary because this affects test infrastructure only.

## Changelog entry

N/A — CI infrastructure only.

## Test Plan

- [x] Parse `.github/workflows/product-creation-tests.yml` as YAML and extract the step script.
- [x] `bash -n` on the extracted step script.
- [x] Behavioural check of the harness: a failing project does not stop later projects; `pipefail` still surfaces the left-hand exit code; heredoc gates are captured; an all-green run records no failures.
- [x] `npm run test:js -- --runInBand` (215 tests).
- [x] `git diff --check`.
- [ ] CI: confirm the six previously-unreachable browser projects actually report a result.
