### PR TITLE
ci(e2e): drop describe.serial from variable-product-depth

### DIFF
--- a/tests/e2e/variable-product-depth.spec.js
+++ b/tests/e2e/variable-product-depth.spec.js
@@ -26,7 +26,15 @@ const {
   dismissWooInterferingOverlays,
 } = require('./helpers/js');
 
-test.describe.serial('Variable Product Depth Tests', () => {
+// Not `describe.serial`: this file already runs with --workers=1, so the tests
+// execute in declaration order either way. What `.serial` added was retry
+// semantics -- one failing test re-runs the WHOLE block, so each retry repeated
+// every already-passing test in the file. These tests build 8-variation products
+// and wait on catalog convergence, so a single late failure could re-run several
+// minutes of passing work twice and push the shard past its 45-minute timeout.
+// The tests share no mutable state, so retrying only the failed test is both
+// cheaper and more accurate.
+test.describe('Variable Product Depth Tests', () => {
   test.beforeEach(async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== 'chromium-wp-admin', 'Variable product depth tests require wp-admin project');
 


### PR DESCRIPTION
## Description

Same defect as `performance-sync` (fixed in #4016), in the second and last file that had it.

`test.describe.serial` makes Playwright re-run the **entire block** when any test in it fails, so each of the two retries repeats every already-passing test in the file.

That is expensive here: the four tests each build an 8-variation product through the admin UI and then wait on Meta catalog convergence. A late failure re-runs several minutes of passing work twice. `variable-product-depth` hit the **45-minute job timeout** on PR #4014's run with exactly this shape — three of four tests eventually passing, the shard killed mid-retry.

The same change on `performance-sync` in #4016 took that shard from a 45-minute timeout to a **23-minute pass**.

### Why it's safe

- The file already runs with `--workers=1` (`product-creation-tests.yml`), so declaration order is preserved without `.serial`.
- No mutable state at describe scope — verified; the tests each create and clean up their own product.

### Behaviour change worth noting

Under `.serial`, tests after a failure were **skipped**. They now run. That is the point: a failure in test 1 no longer hides the state of tests 2–4. Expect this to surface results that were previously invisible.

### Type of change

- Fix (non-breaking change which fixes an issue)

## Notes for the reviewer

- Independent of #4016 and #4020 — separate file, no conflicts, cut against `main`.
- After this lands, no spec in `tests/e2e/` uses `describe.serial`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] No PHP files are changed.
- [x] I followed general Pull Request best practices.
- [x] All existing JavaScript unit tests pass locally.
- [x] Documentation changes are not necessary because this affects test infrastructure only.

## Changelog entry

N/A — test infrastructure only.

## Test Plan

- [x] `node --check tests/e2e/variable-product-depth.spec.js`
- [x] `npm run test:js -- --runInBand` (104 tests)
- [x] `git diff --check`
- [x] Confirmed no other spec still uses `describe.serial`
- [ ] CI: `variable-product-depth` shard green